### PR TITLE
Remove background-color from label.block

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,6 @@ fieldset span.text-gray-500{
 .gr-panel div.flex-col div.justify-between label, label.block span{
     position: absolute;
     top: -0.4em;
-    background-color: rgb(249 250 251);
     line-height: 0.7em;
     padding: 0 0.5em;
     margin: 0;


### PR DESCRIPTION
On my browser it causes this (due to the dark theme probably) :
<img width="139" alt="image" src="https://user-images.githubusercontent.com/100234619/187541054-0701707c-22e8-428e-a798-733ce0963e80.png">
