### PR TITLE
Don't iterate over scripts if it doesn't exist

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -29,6 +29,9 @@ scripts = []
 
 
 def load_scripts(basedir):
+    if not os.path.exists(basedir):
+        return
+
     for filename in os.listdir(basedir):
         path = os.path.join(basedir, filename)
 


### PR DESCRIPTION
Currently, the code iterates over /scripts even if it doesn't exist, which causes a FileNotFoundError. This makes it return if that is the case.

Fixes #58

Edit: I guess another possible solution would be to make a scripts inside the repo and have a .gitkeep so git doesn't drop it. This might be preferable.