### PR TITLE
Allow import of webui as library

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -169,4 +169,10 @@ demo = modules.ui.create_ui(
     run_pnginfo=run_pnginfo
 )
 
-demo.launch(share=cmd_opts.share)
+
+def launch_server():
+    demo.launch(share=cmd_opts.share)
+
+
+if __name__ == "__main__":
+    launch_server()


### PR DESCRIPTION
This PR changes the behavior of the webui script depending on whether it is executed directly by the Python interpreter or imported by another Python script.
If executed directly, nothing changes.
If imported, the web server is not launched.
I prefer importing from an external Python script over pasting a script into the GUI because it's better integrated into existing command line tools which I use heavily in my workflows.
If you believe this change to be redundant, feel free to close this PR.