### PR TITLE
Also use alpha channel from img2img input image as mask

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -1,5 +1,5 @@
 import math
-from PIL import Image
+from PIL import Image, ImageOps, ImageChops
 
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 from modules.shared import opts, state
@@ -16,7 +16,9 @@ def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index
 
     if is_inpaint:
         image = init_img_with_mask['image']
-        mask = init_img_with_mask['mask']
+        alpha_mask = ImageOps.invert(image.split()[-1]).convert('L').point(lambda x: 255 if x > 0 else 0, mode='1')
+        mask = ImageChops.lighter(alpha_mask, init_img_with_mask['mask'].convert('L')).convert('RGBA')
+        image = image.convert('RGB')
     else:
         image = init_img
         mask = None

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -323,7 +323,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                 with gr.Group():
                     switch_mode = gr.Radio(label='Mode', elem_id="img2img_mode", choices=['Redraw whole image', 'Inpaint a part of image', 'Loopback', 'SD upscale'], value='Redraw whole image', type="index", show_label=False)
                     init_img = gr.Image(label="Image for img2img", source="upload", interactive=True, type="pil")
-                    init_img_with_mask = gr.Image(label="Image for inpainting with mask", elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool="sketch", visible=False)
+                    init_img_with_mask = gr.Image(label="Image for inpainting with mask", elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool="sketch", visible=False, image_mode="RGBA")
                     resize_mode = gr.Radio(label="Resize mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
 
                 steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20)


### PR DESCRIPTION
If you add an image with an alpha channel to img2img, it is also used for masking. This lets you do the masking with a proper image editor instead of the terrible Gradio one.

Any pixel with any transparency is treated as part of the mask, so partial transparency doesn't create a partial mask. But it is useful for editors that do not save color information in completely transparent areas.

If you use both an alpha channel and the Gradio mask they are combined.