### PR TITLE
Fix not being able to have spaces directory

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -35,7 +35,7 @@ echo Unable to create venv in directory %VENV_DIR%
 goto :show_stdout_stderr
 
 :activate_venv
-set PYTHON=%~dp0%VENV_DIR%\Scripts\Python.exe
+set PYTHON="%~dp0%VENV_DIR%\Scripts\Python.exe"
 %PYTHON% --version
 echo venv %PYTHON%
 goto :install_torch


### PR DESCRIPTION
Adds quotes around the PYTHON path so that there can be spaces in parent folders.

This fixes #57 