### PR TITLE
Turn the loopback denoising strength change factor into a parameter rather than hardcoding to 0.95. Set the default to 1.

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -11,7 +11,7 @@ from modules.ui import plaintext_to_html
 import modules.images as images
 import modules.scripts
 
-def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, mode: int, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, height: int, width: int, resize_mode: int, upscaler_index: str, upscale_overlap: int, inpaint_full_res: bool, inpainting_mask_invert: int, *args):
+def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, mode: int, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, denoising_strength_change_factor: float, seed: int, height: int, width: int, resize_mode: int, upscaler_index: str, upscale_overlap: int, inpaint_full_res: bool, inpainting_mask_invert: int, *args):
     is_inpaint = mode == 1
     is_loopback = mode == 2
     is_upscale = mode == 3
@@ -50,7 +50,10 @@ def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index
         denoising_strength=denoising_strength,
         inpaint_full_res=inpaint_full_res,
         inpainting_mask_invert=inpainting_mask_invert,
-        extra_generation_params={"Denoising Strength": denoising_strength}
+        extra_generation_params={
+            "Denoising strength": denoising_strength,
+            "Denoising strength change factor": denoising_strength_change_factor
+        }
     )
 
     if is_loopback:
@@ -99,7 +102,7 @@ def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index
 
             p.init_images = [init_img]
             p.seed = processed.seed + 1
-            p.denoising_strength = max(p.denoising_strength * 0.95, 0.1)
+            p.denoising_strength = min(max(p.denoising_strength * denoising_strength_change_factor, 0.1), 1)
             history.append(processed.images[0])
 
         grid = images.image_grid(history, batch_size, rows=1)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -349,7 +349,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
 
                 with gr.Group():
                     cfg_scale = gr.Slider(minimum=1.0, maximum=15.0, step=0.5, label='CFG Scale', value=7.0)
-                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising Strength', value=0.75)
+                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.75)
+                    denoising_strength_change_factor = gr.Slider(minimum=0.9, maximum=1.1, step=0.01, label='Denoising strength change factor', value=1, visible=False)
 
                 with gr.Group():
                     height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
@@ -396,6 +397,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     sd_upscale_overlap: gr_show(is_upscale),
                     inpaint_full_res: gr_show(is_inpaint),
                     inpainting_mask_invert: gr_show(is_inpaint),
+                    denoising_strength_change_factor: gr_show(is_loopback),
                 }
 
             switch_mode.change(
@@ -412,6 +414,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     sd_upscale_overlap,
                     inpaint_full_res,
                     inpainting_mask_invert,
+                    denoising_strength_change_factor,
                 ]
             )
 
@@ -433,6 +436,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     batch_size,
                     cfg_scale,
                     denoising_strength,
+                    denoising_strength_change_factor,
                     seed,
                     height,
                     width,

--- a/script.js
+++ b/script.js
@@ -26,7 +26,8 @@ titles = {
     "latent nothing": "fill it with latent space zeroes",
     "Inpaint at full resolution": "Upscale masked region to target resolution, do inpainting, downscale back and paste into original image",
 
-    "Denoising Strength": "Determines how little respect the algorithm should have for image's content. At 0, nothing will change, and at 1 you'll get an unrelated image.",
+    "Denoising strength": "Determines how little respect the algorithm should have for image's content. At 0, nothing will change, and at 1 you'll get an unrelated image.",
+    "Denoising strength change factor": "In loopback mode, on each loop the denoising strength is multiplied by this value. <1 means decreasing variety so your sequence will converge on a fixed picture. >1 means increasing variety so your sequence will become more and more chaotic.",
 
     "Interrupt": "Stop processing images and return any results accumulated so far.",
     "Save": "Write image to a directory (default - log/images) and generation parameters into csv file.",


### PR DESCRIPTION
I noticed that with loopback, even with a high denoising strength, images sequences tend to eventually converge onto a single image, as though the denoising strength progressively decreases. 

Turns out it does, because it's scaled by 0.95 on each loop: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/img2img.py#L102

To illustrate, here's a sequence with denoising strength 0.8 (quite high). You can see it starts off changing significantly on each frame but then converges: https://looptube.io/?videoId=VYO1VD2Qwyc

The denoising strength at each frame is (i.e. the noise applied to the previous frame to generate this frame) is 0.8*0.95^frame_number. So by the 30th frame denoising strength is <0.2. 

This can be a desirable effect, but isn't what I always want nor what I'd expect. I therefore made that 0.95 scaling factor configurable. Here's the same video with the factor set to 1.0, meaning the denoising strength stays at 0.8. You can still see frames sort of relate to each other, but the rate of change is constant, as expected: https://looptube.io/?videoId=wNF640AoGF8

Here are examples with the new parameter:
- At its min value of 0.9 where variation nearly immediately drops to nothing because denoising strength drops to 0.1 after a few frames: https://looptube.io/?videoId=Oc1aDsuIgB4
- At its max value of 1.1 where variation immediately jumps to "total destruction" of the previous frame image because denoising strength jumps to 1 after a few frames: https://looptube.io/?videoId=iNSIQHc0v_8 (As an an aside, I'm not sure why it seems to settle back into a pattern after a few frames - this may indicate that passing in the max value of 1 for denoising strength doesn't do exactly what we'd expect. More investigation required.)

All loopbacks videos use:
- Initial image: https://imgur.com/a/MRUwTPm
- Prompt: Sad man sitting at a desk with a monster next to him.
- Params: Steps: 8, Sampler: Euler a, CFG scale: 7, Seeds: 1-30, Denoising strength: 0.8, Denoising strength change factor: (varies by video)

(FWIW I'm not wedded to surfacing the parameter in this way. The exponential impact of this param is a bit hard to grok. We could alternatively make it linear increment/decrement on each loop.. or even just remove the factor altogether and leave this kind of tweaking to custom scripts. But IMO it shouldn't stay hardcoded at 0.95.)