### PR TITLE
More informative progress printing

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -52,6 +52,7 @@ def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index
         inpainting_mask_invert=inpainting_mask_invert,
         extra_generation_params={"Denoising Strength": denoising_strength}
     )
+    print(f"\nimg2img: {prompt}", file=shared.progress_print_out)
 
     if is_loopback:
         output_images, info = None, None
@@ -168,5 +169,6 @@ def img2img(prompt: str, init_img, init_img_with_mask, steps: int, sampler_index
         if processed is None:
             processed = process_images(p)
 
+    shared.total_tqdm.clear()
 
     return processed.images, processed.js(), plaintext_to_html(processed.info)

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -6,6 +6,7 @@ import modules.ui as ui
 import gradio as gr
 
 from modules.processing import StableDiffusionProcessing
+from modules import shared
 
 class Script:
     filename = None
@@ -136,6 +137,8 @@ class ScriptRunner:
 
         script_args = args[script.args_from:script.args_to]
         processed = script.run(p, *script_args)
+
+        shared.total_tqdm.clear()
 
         return processed
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -70,13 +70,14 @@ def extended_tdqm(sequence, *args, desc=None, **kwargs):
     state.sampling_steps = len(sequence)
     state.sampling_step = 0
 
-    for x in tqdm.tqdm(sequence, *args, desc=state.job, **kwargs):
+    for x in tqdm.tqdm(sequence, *args, desc=state.job, file=shared.progress_print_out, **kwargs):
         if state.interrupted:
             break
 
         yield x
 
         state.sampling_step += 1
+        shared.total_tqdm.update()
 
 
 ldm.models.diffusion.ddim.tqdm = lambda *args, desc=None, **kwargs: extended_tdqm(*args, desc=desc, **kwargs)
@@ -146,13 +147,14 @@ def extended_trange(count, *args, **kwargs):
     state.sampling_steps = count
     state.sampling_step = 0
 
-    for x in tqdm.trange(count, *args, desc=state.job, **kwargs):
+    for x in tqdm.trange(count, *args, desc=state.job, file=shared.progress_print_out, **kwargs):
         if state.interrupted:
             break
 
         yield x
 
         state.sampling_step += 1
+        shared.total_tqdm.update()
 
 
 class KDiffusionSampler:

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -25,12 +25,15 @@ def txt2img(prompt: str, negative_prompt: str, steps: int, sampler_index: int, r
         tiling=tiling,
     )
 
+    print(f"\ntxt2img: {prompt}", file=shared.progress_print_out)
     processed = modules.scripts.scripts_txt2img.run(p, *args)
 
     if processed is not None:
         pass
     else:
         processed = process_images(p)
+
+    shared.total_tqdm.clear()
 
     return processed.images, processed.js(), plaintext_to_html(processed.info)
 


### PR DESCRIPTION
IMPORTANT: I cannot test whether my implementation works with the prompt matrix script because it is broken on my machine, see https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/157 .
=============================================

Currently there is one tqdm progress bar for each batch on the console.
This PR adds an additional tqdm progress bar for the entire job (similar to the one in webui), allowing users to get an ETA for when a job finishes.
At the beginning of a job there is also a short print to indicate the type of job that is being processed.

What it looks like:
![Screenshot_20220908_153015](https://user-images.githubusercontent.com/18492268/189140190-5b710f08-c46a-48e0-922a-821957af0228.png)

Notably the location to which the progress information is printed is determined by a variable in `modules.shared` (default is `sys.stdout`).
The reason for this is twofold:

1. By default tqdm uses `sys.stderr` which may cause the progress bars and the other prints to become separated.
2. It allows me to re-route the progress prints to a separate terminal.

My understanding of the code is limited so I'm not sure if my placement of the prints and `total_tqdm.clear()` are optimal; rearrange them if necessary.