### PR TITLE
Removed mention of CUDA in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A browser interface based on Gradio library for Stable Diffusion.
 [Detailed feature showcase with images, art by Greg Rutkowski](https://github.com/AUTOMATIC1111/stable-diffusion-webui-feature-showcase)
 
 - Original txt2img and img2img modes
-- One click install and run script (but you still must install python, git and CUDA)
+- One click install and run script (but you still must install python and git)
 - Outpainting
 - Inpainting
 - Prompt matrix


### PR DESCRIPTION
The requirement to install CUDA was removed with https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/e92d4cf7476f1897fce376916dfb40755ea7920f#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63 so that mention in README should be superfluous