### PR TITLE
Fix job_count logic, only one progress bar if job_count is 1

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -187,7 +187,7 @@ class TotalTQDM:
         )
 
     def update(self):
-        if not opts.multiple_tqdm:
+        if not opts.multiple_tqdm or state.job_count < 2:
             return
         if self._tqdm is None:
             self.reset()


### PR DESCRIPTION
This PR does three things:

1. `0` is always used as the value for `state.job_count` if no job is running.
2. The check whether `state.job_count` is at the default value is removed when a new job starts running. I see no functional reason for the check, especially considering that such checks are absent in img2img and the scripts. (though it's also not causing problems for regular webui usage). However, it is causing issues when running `modules.txt2img.txt2img` directly (progress bar is not being updated correctly, theoretically I could fix this on my end).
3. If `state.job_count` is smaller than 2, the progress bar for the total progress is not shown.