### PR TITLE
Add a samples filename format option

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -243,16 +243,32 @@ def sanitize_filename_part(text):
     return text.replace(' ', '_').translate({ord(x): '' for x in invalid_filename_chars})[:128]
 
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, pnginfo_section_name='parameters'):
+def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, pnginfo_section_name='parameters', process_info=None):
     # would be better to add this as an argument in future, but will do for now
     is_a_grid = basename != ""
 
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
-        file_decoration = f"-{seed}"
+        file_decoration = opts.samples_filename_format or "[SEED]"
     else:
-        file_decoration = f"-{seed}-{sanitize_filename_part(prompt)[:128]}"
+        file_decoration = opts.samples_filename_format or "[SEED]-[PROMPT]"
+        #file_decoration = f"-{seed}-{sanitize_filename_part(prompt)[:128]}"
+
+    #Add new filenames tags here
+    file_decoration = "-" + file_decoration
+    if seed is not None:
+        file_decoration = file_decoration.replace("[SEED]", str(seed))
+    if prompt is not None:
+        file_decoration = file_decoration.replace("[PROMPT]", sanitize_filename_part(prompt)[:128])
+        file_decoration = file_decoration.replace("[PROMPT_SPACES]", prompt.translate({ord(x): '' for x in invalid_filename_chars})[:128])
+    if process_info is not None:
+        file_decoration = file_decoration.replace("[STEPS]", str(process_info.steps))
+        file_decoration = file_decoration.replace("[CFG]", str(process_info.cfg_scale))
+        file_decoration = file_decoration.replace("[WIDTH]", str(process_info.width))
+        file_decoration = file_decoration.replace("[HEIGHT]", str(process_info.height))
+        file_decoration = file_decoration.replace("[SAMPLER]", str(process_info.sampler))
+
 
     if extension == 'png' and opts.enable_pnginfo and info is not None:
         pnginfo = PngImagePlugin.PngInfo()

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -279,7 +279,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     image = image.convert('RGB')
 
                 if opts.samples_save and not p.do_not_save_samples:
-                    images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i))
+                    images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), process_info = Processed(p, output_images, all_seeds[0], infotext()))
 
                 output_images.append(image)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -89,6 +89,7 @@ class Options:
 
     data = None
     data_labels = {
+        "samples_filename_format": OptionInfo("", "Samples filename format using following tags: [STEPS],[CFG],[PROMPT],[PROMPT_SPACES],[WIDTH],[HEIGHT],[SAMPLER],[SEED]. Leave blank for default."),
         "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to two directories below"),
         "outdir_txt2img_samples": OptionInfo("outputs/txt2img-images", 'Output directory for txt2img images'),
         "outdir_img2img_samples": OptionInfo("outputs/img2img-images", 'Output directory for img2img images'),


### PR DESCRIPTION
Adds a "Samples filename format" option in the settings. This format can be defined by tags for maximum flexibility and scalability.

All parameters vary depending on our needs and experiments. Some people play a lot with steps, others with CFG, or image dimensions. And it is very handy to have this information in the filenames. This PR adds a parameter to configure the filenames to your taste, using tags. For now, supported tags are: [STEPS],[CFG],[PROMPT],[PROMPT_SPACES],[WIDTH],[HEIGHT],[SAMPLER],[SEED]. Leave the field blank for default behavior.
 
It will also make addition of new tags easier later.

Note: [PROMPT_SPACES] is the same thing as [PROMPT], except that spaces are not replaced by underscores, making copying and pasting prompts from filenames easier. I personally use this format:

`[SEED]-[STEPS]-[CFG]-[SAMPLER]-[PROMPT_SPACES]`


