### PR TITLE
Add support for multiple variation seeds

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -11,7 +11,7 @@ from modules.ui import plaintext_to_html
 import modules.images as images
 import modules.scripts
 
-def img2img(prompt: str, negative_prompt: str, prompt_style: str, init_img, init_img_with_mask, init_mask, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, mode: int, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, denoising_strength_change_factor: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, height: int, width: int, resize_mode: int, upscaler_index: str, upscale_overlap: int, inpaint_full_res: bool, inpainting_mask_invert: int, *args):
+def img2img(prompt: str, negative_prompt: str, prompt_style: str, init_img, init_img_with_mask, init_mask, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, mode: int, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, denoising_strength_change_factor: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, fixed_subseeds:str, fixed_subseed_strengths:str, height: int, width: int, resize_mode: int, upscaler_index: str, upscale_overlap: int, inpaint_full_res: bool, inpainting_mask_invert: int, *args):
     is_inpaint = mode == 1
     is_loopback = mode == 2
     is_upscale = mode == 3
@@ -44,6 +44,8 @@ def img2img(prompt: str, negative_prompt: str, prompt_style: str, init_img, init
         subseed_strength=subseed_strength,
         seed_resize_from_h=seed_resize_from_h,
         seed_resize_from_w=seed_resize_from_w,
+        fixed_subseeds=fixed_subseeds,
+        fixed_subseed_strengths=fixed_subseed_strengths,
         sampler_index=sampler_index,
         batch_size=batch_size,
         n_iter=n_iter,

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -60,11 +60,12 @@ class StableDiffusionProcessing:
         self.overlay_images = overlay_images
         self.paste_to = None
 
-        if len(fixed_subseeds) > len(fixed_subseed_strengths):
-            fixed_subseeds = fixed_subseeds[:len(fixed_subseed_strengths)-1]
-        for fs in range(len(fixed_subseeds)):
-            if not (0 <= fixed_subseed_strengths[fs] <= 1):
-                fixed_subseed_strengths[fs] = 0
+
+        if len(self.fixed_subseeds) > len(self.fixed_subseed_strengths):
+            self.fixed_subseeds = self.fixed_subseeds[:len(self.fixed_subseed_strengths)-1]
+        for fs in range(len(self.fixed_subseeds)):
+            if not (0 <= self.fixed_subseed_strengths[fs] <= 1):
+                self.fixed_subseed_strengths[fs] = 0
 
     def init(self, seed):
         pass

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -122,8 +122,6 @@ def create_random_tensors(shape, seeds, subseeds=None, subseed_strength=0.0, see
 
         fixed_subnoises = []
         for fs in range(len(fixed_subseeds)):
-            print("Why is this doing something?")
-            print(fs, fixed_subseeds, fixed_subnoises)
             torch.manual_seed(fixed_subseeds[fs])
             fixed_subnoises.append(torch.randn(noise_shape, device=shared.device))
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -175,15 +175,19 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     else:
         all_prompts = p.batch_size * p.n_iter * [p.prompt]
 
-    if type(p.seed) == list:
-        all_seeds = p.seed
-    else:
-        all_seeds = [int(p.seed + x) for x in range(len(all_prompts))]
-
     if type(p.subseed) == list:
         all_subseeds = p.subseed
     else:
         all_subseeds = [int(p.subseed + x) for x in range(len(all_prompts))]
+
+    if type(p.seed) == list:
+        all_seeds = p.seed
+    else:
+        if p.subseed_strength > 0:
+            all_seeds = [p.seed] * len(all_prompts)
+        else:
+            all_seeds = [int(p.seed + x) for x in range(len(all_prompts))]
+
 
     def infotext(iteration=0, position_in_batch=0):
         index = position_in_batch + iteration * p.batch_size

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -6,7 +6,7 @@ import modules.processing as processing
 from modules.ui import plaintext_to_html
 
 
-def txt2img(prompt: str, negative_prompt: str, prompt_style: int, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, height: int, width: int, *args):
+def txt2img(prompt: str, negative_prompt: str, prompt_style: int, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, fixed_subseeds:str, fixed_subseed_strengths:str, height: int, width: int, *args):
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
@@ -19,6 +19,8 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: int, steps: int, sa
         subseed_strength=subseed_strength,
         seed_resize_from_h=seed_resize_from_h,
         seed_resize_from_w=seed_resize_from_w,
+        fixed_subseeds=fixed_subseeds,
+        fixed_subseed_strengths=fixed_subseed_strengths,
         sampler_index=sampler_index,
         batch_size=batch_size,
         n_iter=n_iter,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -197,13 +197,19 @@ def visit(x, func, path=""):
 def create_seed_inputs():
     with gr.Row():
         seed = gr.Number(label='Seed', value=-1)
-        subseed = gr.Number(label='Variation seed', value=-1, visible=False)
-        seed_checkbox = gr.Checkbox(label="Extra", elem_id="subseed_show", value=False)
+        seed_resize_checkbox = gr.Checkbox(label="Extra", elem_id="seed_resize_show", value=False)
 
     with gr.Row():
-        subseed_strength = gr.Slider(label='Variation strength', value=0.0, minimum=0, maximum=1, step=0.01, visible=False)
         seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0, visible=False)
         seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0, visible=False)
+
+    with gr.Row():
+        subseed = gr.Number(label='Variation seed', value=-1, visible=False)
+        subseed_strength = gr.Slider(label='Variation strength', value=0.0, minimum=0, maximum=1, step=0.01, visible=False)
+
+    with gr.Row():
+        fixed_subseeds = gr.Textbox(placeholder='Fixed variation seeds, separated by commas', show_label=False, visible=False)
+        fixed_subseed_strengths = gr.Textbox(placeholder='Fixed variation strengths, separated by commas', show_label=False, visible=False)
 
     def change_visiblity(show):
 
@@ -212,20 +218,24 @@ def create_seed_inputs():
             subseed_strength: gr_show(show),
             seed_resize_from_h: gr_show(show),
             seed_resize_from_w: gr_show(show),
+            fixed_subseeds: gr_show(show),
+            fixed_subseed_strengths: gr_show(show),
         }
 
-    seed_checkbox.change(
+    seed_resize_checkbox.change(
         change_visiblity,
-        inputs=[seed_checkbox],
+        inputs=[seed_resize_checkbox],
         outputs=[
             subseed,
             subseed_strength,
             seed_resize_from_h,
-            seed_resize_from_w
+            seed_resize_from_w,
+            fixed_subseeds,
+            fixed_subseed_strengths
         ]
     )
 
-    return seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w
+    return seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, fixed_subseeds, fixed_subseed_strengths
 
 
 def add_style(style_name, text):
@@ -271,7 +281,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
                     width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)
 
-                seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w = create_seed_inputs()
+                seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, fixed_subseeds, fixed_subseed_strengths = create_seed_inputs()
 
                 with gr.Group():
                     custom_inputs = modules.scripts.scripts_txt2img.setup_ui(is_img2img=False)
@@ -313,7 +323,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     batch_size,
                     cfg_scale,
                     seed,
-                    subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w,
+                    subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, fixed_subseeds, fixed_subseed_strengths,
                     height,
                     width,
                 ] + custom_inputs,
@@ -415,7 +425,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
                     width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)
 
-                seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w = create_seed_inputs()
+                seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, fixed_subseeds, fixed_subseed_strengths = create_seed_inputs()
 
                 with gr.Group():
                     custom_inputs = modules.scripts.scripts_img2img.setup_ui(is_img2img=True)
@@ -521,7 +531,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     denoising_strength,
                     denoising_strength_change_factor,
                     seed,
-                    subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w,
+                    subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, fixed_subseeds, fixed_subseed_strengths,
                     height,
                     width,
                     resize_mode,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -197,7 +197,7 @@ def visit(x, func, path=""):
 def create_seed_inputs():
     with gr.Row():
         seed = gr.Number(label='Seed', value=-1)
-        seed_resize_checkbox = gr.Checkbox(label="Extra", elem_id="seed_resize_show", value=False)
+        seed_resize_checkbox = gr.Checkbox(label="Extra", elem_id="subseed_show", value=False)
 
     with gr.Row():
         seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0, visible=False)


### PR DESCRIPTION
Adds a list of variation seeds, so users can slowly hone in on an exact variation.

Step one, find a variation you like.
![step1](https://user-images.githubusercontent.com/54990384/189541305-f685bd9e-3c26-4f59-b237-1b6950fd751a.png)

Step two, copy the variation and its strength into the appropriate textboxes, then generate again.
![step2](https://user-images.githubusercontent.com/54990384/189541335-9f167c3e-9404-4dd2-a47c-33d10b83cc9c.png)

Step three, repeat with smaller and smaller variation strengths, separating each with commas, until you've honed in on a variation you like.
![step3](https://user-images.githubusercontent.com/54990384/189541352-833053cd-2903-4007-a40a-3be692bd726f.png)

This PR also prevents the seed from incrementing while variation strength is above 0, otherwise you simply wind up applying variations to multiple seeds.
