### PR TITLE
Add --hide-ui-dir-config command line flag

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -42,6 +42,7 @@ parser.add_argument("--listen", action='store_true', help="launch gradio with 0.
 parser.add_argument("--port", type=int, help="launch gradio with given server port, you need root/admin rights for ports < 1024, defaults to 7860 if available", default=None)
 parser.add_argument("--show-negative-prompt", action='store_true', help="does not do anything", default=False)
 parser.add_argument("--ui-config-file", type=str, help="filename to use for ui configuration", default=os.path.join(script_path, 'ui-config.json'))
+parser.add_argument("--hide-ui-dir-config", action='store_true', help="hide directory configuration from webui", default=False)
 
 cmd_opts = parser.parse_args()
 
@@ -91,18 +92,19 @@ class Options:
             self.component_args = component_args
 
     data = None
+    hide_dirs = {"visible": False} if cmd_opts.hide_ui_dir_config else None
     data_labels = {
-        "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to two directories below"),
-        "outdir_txt2img_samples": OptionInfo("outputs/txt2img-images", 'Output directory for txt2img images'),
-        "outdir_img2img_samples": OptionInfo("outputs/img2img-images", 'Output directory for img2img images'),
-        "outdir_extras_samples": OptionInfo("outputs/extras-images", 'Output directory for images from extras tab'),
-        "outdir_grids": OptionInfo("", "Output directory for grids; if empty, defaults to two directories below"),
-        "outdir_txt2img_grids": OptionInfo("outputs/txt2img-grids", 'Output directory for txt2img grids'),
-        "outdir_img2img_grids": OptionInfo("outputs/img2img-grids", 'Output directory for img2img grids'),
+        "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to two directories below", component_args=hide_dirs),
+        "outdir_txt2img_samples": OptionInfo("outputs/txt2img-images", 'Output directory for txt2img images', component_args=hide_dirs),
+        "outdir_img2img_samples": OptionInfo("outputs/img2img-images", 'Output directory for img2img images', component_args=hide_dirs),
+        "outdir_extras_samples": OptionInfo("outputs/extras-images", 'Output directory for images from extras tab', component_args=hide_dirs),
+        "outdir_grids": OptionInfo("", "Output directory for grids; if empty, defaults to two directories below", component_args=hide_dirs),
+        "outdir_txt2img_grids": OptionInfo("outputs/txt2img-grids", 'Output directory for txt2img grids', component_args=hide_dirs),
+        "outdir_img2img_grids": OptionInfo("outputs/img2img-grids", 'Output directory for img2img grids', component_args=hide_dirs),
         "save_to_dirs": OptionInfo(False, "When writing images, create a directory with name derived from the prompt"),
         "grid_save_to_dirs": OptionInfo(False, "When writing grids, create a directory with name derived from the prompt"),
         "save_to_dirs_prompt_len": OptionInfo(10, "When using above, how many words from prompt to put into directory name", gr.Slider, {"minimum": 1, "maximum": 32, "step": 1}),
-        "outdir_save": OptionInfo("log/images", "Directory for saving images using the Save button"),
+        "outdir_save": OptionInfo("log/images", "Directory for saving images using the Save button", component_args=hide_dirs),
         "samples_save": OptionInfo(True, "Save indiviual samples"),
         "samples_format": OptionInfo('png', 'File format for individual samples'),
         "grid_save": OptionInfo(True, "Save image grids"),


### PR DESCRIPTION
Adds `--hide-ui-dir-config` flag to disable editing directory configs from the web UI. This can be set to prevent users from setting the directory to somewhere they shouldn't, for public (or semi-public) interfaces.

Directories are still read from config.json, so the server admin can still set them in the web UI and then relaunch with the hide flag, or edit the config manually.

Also:
- fix OptionInfo `component_args` keyword argument not being read if `component` isn't also set
- ensure that hidden settings aren't still read from the web UI (otherwise they could still be changed by tampering with the interface)