### PR TITLE
Update requirements_versions.txt

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,4 +1,4 @@
-basicsr==1.3.5
+basicsr==1.4.2
 gfpgan
 gradio==3.3
 numpy==1.23.3


### PR DESCRIPTION
Resolves realesrgan conflicts

Fixes the following error when launching webui.bat:

```
The conflict is caused by:
    The user requested basicsr==1.3.5
    realesrgan 0.2.5.0 depends on basicsr>=1.4.2
```