### PR TITLE
Add --gradio-auth command line argument to enable Gradio authentication

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -43,6 +43,7 @@ parser.add_argument("--ui-config-file", type=str, help="filename to use for ui c
 parser.add_argument("--hide-ui-dir-config", action='store_true', help="hide directory configuration from webui", default=False)
 parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui settings", default=os.path.join(script_path, 'config.json'))
 parser.add_argument("--gradio-debug",  action='store_true', help="launch gradio with --debug option")
+parser.add_argument("--auth", type=str, help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
 
 cmd_opts = parser.parse_args()
 

--- a/webui.py
+++ b/webui.py
@@ -115,7 +115,8 @@ def webui():
         run_pnginfo=modules.extras.run_pnginfo
     )
 
-    demo.launch(share=cmd_opts.share, server_name="0.0.0.0" if cmd_opts.listen else None, server_port=cmd_opts.port, debug=cmd_opts.gradio_debug)
+    auth = [tuple(cred.split(':')) for cred in cmd_opts.auth.strip('"').split(',')] if cmd_opts.auth else None
+    demo.launch(share=cmd_opts.share, server_name="0.0.0.0" if cmd_opts.listen else None, server_port=cmd_opts.port, debug=cmd_opts.gradio_debug, auth=auth)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows you to pass in Gradio authentication like:
`--gradio-auth username:password`
Supports multiple sets of credentials by comma-delimiting, like:
`--gradio-auth user1:pass1,user2:pass2`...

Implements #315