### PR TITLE
Fix ugly img2img resize options

### DIFF
--- a/style.css
+++ b/style.css
@@ -160,3 +160,7 @@ input[type="range"]{
   border-radius: 8px;
 }
 
+.flex-wrap {
+  flex-wrap: unset;
+}
+

--- a/style.css
+++ b/style.css
@@ -45,6 +45,7 @@ button{
 
 #img2img_prompt, #txt2img_prompt, #img2img_negative_prompt, #txt2img_negative_prompt{
     border: none !important;
+    width: 50%;
 }
 #img2img_prompt textarea, #txt2img_prompt textarea, #img2img_negative_prompt textarea, #txt2img_negative_prompt textarea{
     border: none !important;
@@ -130,11 +131,6 @@ input[type="range"]{
   text-align: center;
   display: block;
   margin-bottom: 0.5em;
-}
-
-#txt2img_negative_prompt, #img2img_negative_prompt{
-    flex: 0.3;
-    min-width: 10em;
 }
 
 .progressDiv{


### PR DESCRIPTION
The resize options look ugly on my computer. Brave browser, Linux Mint, 17'' display, 1920x1080. This commit fixes the issue.

Before:
![Before](https://user-images.githubusercontent.com/112222186/189700088-b4e15318-2588-429f-9738-4a597c52391e.png)

After:
![After](https://user-images.githubusercontent.com/112222186/189700098-bf2d1639-8a47-40ff-9a36-2d164c7f676c.png)
