### PR TITLE
Swap width and height sliders in the UI

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -202,8 +202,8 @@ def create_seed_inputs():
 
     with gr.Row():
         subseed_strength = gr.Slider(label='Variation strength', value=0.0, minimum=0, maximum=1, step=0.01, visible=False)
-        seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0, visible=False)
         seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0, visible=False)
+        seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0, visible=False)
 
     def change_visiblity(show):
 
@@ -273,8 +273,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                 cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0)
 
                 with gr.Group():
-                    height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
                     width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)
+                    height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
 
                 seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w = create_seed_inputs()
 
@@ -418,8 +418,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                     denoising_strength_change_factor = gr.Slider(minimum=0.9, maximum=1.1, step=0.01, label='Denoising strength change factor', value=1, visible=False)
 
                 with gr.Group():
-                    height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
                     width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)
+                    height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
 
                 seed, subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w = create_seed_inputs()
 


### PR DESCRIPTION
Minor change, swaps the sliders for width and height so width is on top like in most image editors. Note that size is already stored as {width}x{height} in the metadata, it makes sense to have width first in the UI too.

![640x960](https://user-images.githubusercontent.com/84907027/189742768-774350ed-17e9-48f3-a40b-2b5fcce47623.png)