### PR TITLE
[UI] Option to increase images height for character generation

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -128,6 +128,7 @@ class Options:
         "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),
         "upscale_at_full_resolution_padding": OptionInfo(16, "Inpainting at full resolution: padding, in pixels, for the masked region.", gr.Slider, {"minimum": 0, "maximum": 128, "step": 4}),
         "show_progressbar": OptionInfo(True, "Show progressbar"),
+        "preview_height": OptionInfo(False, "Enable taller image previews"),
         "show_progress_every_n_steps": OptionInfo(0, "Show show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
         "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job. Broken in PyCharm console."),
         "face_restoration_model": OptionInfo(None, "Face restoration model", gr.Radio, lambda: {"choices": [x.name() for x in face_restorers]}),

--- a/script.js
+++ b/script.js
@@ -93,15 +93,15 @@ function addTitles(root){
             img2img_preview = gradioApp().getElementById('img2img_preview')
             img2img_gallery = gradioApp().getElementById('img2img_gallery')
 
-            if(txt2img_preview != null && txt2img_gallery != null){
-                txt2img_preview.style.width = txt2img_gallery.clientWidth + "px"
-                txt2img_preview.style.height = txt2img_gallery.clientHeight + "px"
-            }
+            // if(txt2img_preview != null && txt2img_gallery != null){
+            //     txt2img_preview.style.width = txt2img_gallery.clientWidth + "px"
+            //     txt2img_preview.style.height = txt2img_gallery.clientHeight + "px"
+            // }
 
-            if(img2img_preview != null && img2img_gallery != null){
-                img2img_preview.style.width = img2img_gallery.clientWidth + "px"
-                img2img_preview.style.height = img2img_gallery.clientHeight + "px"
-            }
+            // if(img2img_preview != null && img2img_gallery != null){
+            //     img2img_preview.style.width = img2img_gallery.clientWidth + "px"
+            //     img2img_preview.style.height = img2img_gallery.clientHeight + "px"
+            // }
 
 
             window.setTimeout(requestProgress, 500)

--- a/style.css
+++ b/style.css
@@ -160,3 +160,29 @@ input[type="range"]{
   border-radius: 8px;
 }
 
+#component-50 > div:nth-child(1) {
+    height: 600px !important;
+}
+
+#txt2img_gallery,
+#img2img_gallery {
+    height: 600px;
+}
+
+#txt2img_gallery .absolute.inset-0.z-10.flex.flex-col,
+#img2img_gallery .absolute.inset-0.z-10.flex.flex-col {
+    max-height: 600px;
+}
+
+#text2img_gallery .overflow-y-auto {
+    max-height: 600px;
+}
+
+#img2img_preview 
+#txt2img_preview {
+    height: 600px;
+}
+
+#component-80 .h-60.bg-gray-200 {
+    height: 500px;
+}


### PR DESCRIPTION
This PR is not complete as it is my first time in python, but it needs a way to add proper CSS class from the new "taller_images" setting, which is usefull when generating characters for example.
This PR modified the base styles, but if we add a top-layer ".tall-images" (when settings enabled) we can encapsulate the new CSS with it.

Any help on how to finish this MR please to add such CSS classes ? Thanks a lot.

Also, if there is a better way to target proper div instead of using tailwind classes, by adding some class using gradio API, that would be great.

![31b04f7a4f543d47c53e68dfa83f76e9](https://user-images.githubusercontent.com/5550556/189834286-a0d514f8-16c3-4b0c-a899-1804a8ec3164.jpg)

![7d6203743cd1a8c97a46eab4f23df314](https://user-images.githubusercontent.com/5550556/189834292-113ef184-a15f-4149-bde4-a2104d30be8f.jpg)
