### PR TITLE
Better handling of images indexes

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -277,6 +277,18 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     return x
 
+def get_next_sequence_number(path):
+    """
+    Determines and returns the next sequence number to use when saving an image in the specified directory.
+
+    The sequence starts at 0.
+    """
+    result = -1
+    for p in os.listdir(path):
+        if p.endswith(('.png', '.jpg')):
+            result = max(int(p.split('-')[0]), result)
+            
+    return result + 1
 
 def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, pnginfo_section_name='parameters', p=None, existing_info=None):
     # would be better to add this as an argument in future, but will do for now
@@ -313,11 +325,11 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     os.makedirs(path, exist_ok=True)
 
-    filecount = len([x for x in os.listdir(path) if os.path.splitext(x)[1] == '.' + extension])
+    basecount = get_next_sequence_number(path)
     fullfn = "a.png"
     fullfn_without_extension = "a"
     for i in range(500):
-        fn = f"{filecount+i:05}" if basename == '' else f"{basename}-{filecount+i:04}"
+        fn = f"{basecount+i:05}" if basename == '' else f"{basename}-{basecount+i:04}"
         fullfn = os.path.join(path, f"{fn}{file_decoration}.{extension}")
         fullfn_without_extension = os.path.join(path, f"{fn}{file_decoration}")
         if not os.path.exists(fullfn):

--- a/modules/images.py
+++ b/modules/images.py
@@ -277,22 +277,23 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     return x
 
-def get_next_sequence_number(path, checkAtEnd = False):
+def get_next_sequence_number(path, basename):
     """
     Determines and returns the next sequence number to use when saving an image in the specified directory.
-    set checkAtEnd to True if the sequence is at the end of the filename
 
     The sequence starts at 0.
     """
     result = -1
+    if basename != '':
+        basename = basename + "-"
+
+    prefix_length = len(basename)
     for p in os.listdir(path):
-        l = os.path.splitext(p)[0].split('-')
-        try:
-            if checkAtEnd:
-                result = max(int(l[-1]), result)
-            else:
+        if p.startswith(basename):
+            l = os.path.splitext(p[prefix_length:])[0].split('-') #splits the filename (removing the basename first if one is defined, so the sequence number is always the first element)
+            try:
                 result = max(int(l[0]), result)
-        except ValueError:
+            except ValueError:
                 pass
 
     return result + 1
@@ -332,7 +333,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     os.makedirs(path, exist_ok=True)
 
-    basecount = get_next_sequence_number(path, basename != '')
+    basecount = get_next_sequence_number(path, basename)
     fullfn = "a.png"
     fullfn_without_extension = "a"
     for i in range(500):

--- a/modules/images.py
+++ b/modules/images.py
@@ -277,17 +277,24 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     return x
 
-def get_next_sequence_number(path):
+def get_next_sequence_number(path, checkAtEnd = False):
     """
     Determines and returns the next sequence number to use when saving an image in the specified directory.
+    set checkAtEnd to True if the sequence is at the end of the filename
 
     The sequence starts at 0.
     """
     result = -1
     for p in os.listdir(path):
-        if p.endswith(('.png', '.jpg')):
-            result = max(int(p.split('-')[0]), result)
-            
+        l = os.path.splitext(p)[0].split('-')
+        try:
+            if checkAtEnd:
+                result = max(int(l[-1]), result)
+            else:
+                result = max(int(l[0]), result)
+        except ValueError:
+                pass
+
     return result + 1
 
 def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, pnginfo_section_name='parameters', p=None, existing_info=None):
@@ -325,7 +332,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     os.makedirs(path, exist_ok=True)
 
-    basecount = get_next_sequence_number(path)
+    basecount = get_next_sequence_number(path, basename != '')
     fullfn = "a.png"
     fullfn_without_extension = "a"
     for i in range(500):


### PR DESCRIPTION
Filenames start with an index number, which is handy for file sorting by name. Until now, this index was computed by counting the number of files in the output directory + 1. However, if you made a generation, then deleted some files you were not interested in, then generated again, the index was starting again with a lower value than the last index used, mixing everything up.

This PR changes the way the index is computed, always determining the highest index present in the directory, then adding 1 to it.