### PR TITLE
format exif string

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -325,8 +325,8 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     if extension.lower() in ("jpg", "jpeg", "webp"):
         exif_bytes = piexif.dump({
             "Exif": {
-                piexif.ExifIFD.UserComment: info.encode("utf8"),
-            }
+                piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(info)
+            },
         })
     else:
         exif_bytes = None


### PR DESCRIPTION
* UserComment needs an ID code at the start of the tag area. This is provided by piexif.helper.UserComment, otherwise an "Warning 	 Invalid EXIF text encoding for UserComment" is thrown upon reading the exif data in outside image viewers