### PR TITLE
x/y grid - Add count based range syntax and legend toggle

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -78,7 +78,7 @@ axis_options = [
 ]
 
 
-def draw_xy_grid(p, xs, ys, x_label, y_label, cell):
+def draw_xy_grid(p, xs, ys, x_label, y_label, cell, draw_legend):
     res = []
 
     ver_texts = [[images.GridAnnotation(y_label(y))] for y in ys]
@@ -99,7 +99,8 @@ def draw_xy_grid(p, xs, ys, x_label, y_label, cell):
             res.append(processed.images[0])
 
     grid = images.image_grid(res, rows=len(ys))
-    grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
+    if draw_legend:
+        grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
 
     first_pocessed.images = [grid]
 
@@ -126,10 +127,12 @@ class Script(scripts.Script):
         with gr.Row():
             y_type = gr.Dropdown(label="Y type", choices=[x.label for x in current_axis_options], value=current_axis_options[4].label, visible=False, type="index", elem_id="y_type")
             y_values = gr.Textbox(label="Y values", visible=False, lines=1)
+        
+        draw_legend = gr.Checkbox(label='Draw legend', value=True)
+            
+        return [x_type, x_values, y_type, y_values, draw_legend]
 
-        return [x_type, x_values, y_type, y_values]
-
-    def run(self, p, x_type, x_values, y_type, y_values):
+    def run(self, p, x_type, x_values, y_type, y_values, draw_legend):
         modules.processing.fix_seed(p)
         p.batch_size = 1
 
@@ -205,7 +208,8 @@ class Script(scripts.Script):
             ys=ys,
             x_label=lambda x: x_opt.format_value(p, x_opt, x),
             y_label=lambda y: y_opt.format_value(p, y_opt, y),
-            cell=cell
+            cell=cell,
+            draw_legend=draw_legend
         )
 
         if opts.grid_save:

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -109,6 +109,9 @@ def draw_xy_grid(p, xs, ys, x_label, y_label, cell):
 re_range = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*")
 re_range_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\(([+-]\d+(?:.\d*)?)\s*\))?\s*")
 
+re_range_count = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\[(\d+)\s*\])?\s*")
+re_range_count_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\[(\d+(?:.\d*)?)\s*\])?\s*")
+
 class Script(scripts.Script):
     def title(self):
         return "X/Y plot"
@@ -138,6 +141,7 @@ class Script(scripts.Script):
 
                 for val in valslist:
                     m = re_range.fullmatch(val)
+                    mc = re_range_count.fullmatch(val)
                     if m is not None:
 
                         start = int(m.group(1))
@@ -145,6 +149,12 @@ class Script(scripts.Script):
                         step = int(m.group(3)) if m.group(3) is not None else 1
 
                         valslist_ext += list(range(start, end, step))
+                    elif mc is not None:
+                        start = int(mc.group(1))
+                        end   = int(mc.group(2))
+                        num   = int(mc.group(3)) if mc.group(3) is not None else 1
+                        
+                        valslist_ext += [int(x) for x in np.linspace(start = start, stop = end, num = num).tolist()]
                     else:
                         valslist_ext.append(val)
 
@@ -154,12 +164,19 @@ class Script(scripts.Script):
 
                 for val in valslist:
                     m = re_range_float.fullmatch(val)
+                    mc = re_range_count_float.fullmatch(val)
                     if m is not None:
                         start = float(m.group(1))
                         end = float(m.group(2))
                         step = float(m.group(3)) if m.group(3) is not None else 1
 
                         valslist_ext += np.arange(start, end + step, step).tolist()
+                    elif mc is not None:
+                        start = float(mc.group(1))
+                        end   = float(mc.group(2))
+                        num   = int(mc.group(3)) if mc.group(3) is not None else 1
+                        
+                        valslist_ext += np.linspace(start = start, stop = end, num = num).tolist()
                     else:
                         valslist_ext.append(val)
 


### PR DESCRIPTION
Alongside ranges being expressed in the current

`start-end (+step)`

syntax this also adds a clearer

`start-end [count]`

syntax to generate `count` values between `start` and `end`

Also includes an option to toggle the legend off.

![image](https://user-images.githubusercontent.com/35278260/190148977-132bfe38-cde4-4737-8fde-803190e994fc.png)

![image](https://user-images.githubusercontent.com/35278260/190154286-1e9ac7e2-60c2-43ba-95bf-703ae050c9a2.png)
