### PR TITLE
Construct CompVisDenoiser with quantization for better output

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -173,7 +173,7 @@ def extended_trange(count, *args, **kwargs):
 
 class KDiffusionSampler:
     def __init__(self, funcname, sd_model):
-        self.model_wrap = k_diffusion.external.CompVisDenoiser(sd_model)
+        self.model_wrap = k_diffusion.external.CompVisDenoiser(sd_model, quantize=True)
         self.funcname = funcname
         self.func = getattr(k_diffusion.sampling, self.funcname)
         self.model_wrap_cfg = CFGDenoiser(self.model_wrap)

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -173,7 +173,7 @@ def extended_trange(count, *args, **kwargs):
 
 class KDiffusionSampler:
     def __init__(self, funcname, sd_model):
-        self.model_wrap = k_diffusion.external.CompVisDenoiser(sd_model, quantize=True)
+        self.model_wrap = k_diffusion.external.CompVisDenoiser(sd_model, quantize=True if shared.opts.enable_quantization else False)
         self.funcname = funcname
         self.func = getattr(k_diffusion.sampling, self.funcname)
         self.model_wrap_cfg = CFGDenoiser(self.model_wrap)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -125,6 +125,7 @@ class Options:
         "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),
         "add_model_hash_to_info": OptionInfo(False, "Add model hash to generation information"),
         "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
+        "enable_quantization": OptionInfo(True, "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds. Requires restart to apply."),
         "font": OptionInfo("", "Font for image grids that have text"),
         "enable_emphasis": OptionInfo(True, "Use (text) to make model pay more attention to text and [text] to make it pay less attention"),
         "save_txt": OptionInfo(False, "Create a text file next to every image with generation parameters."),


### PR DESCRIPTION
This PR enables quantization in CompVisDenoiser for K samplers for better/cleaner/sharper output. See https://github.com/Birch-san/stable-diffusion/commit/f52429abe0c8f5da4918aed51e5aeba15eaacbe0 and https://github.com/crowsonkb/k-diffusion/pull/23

Comparisons (zoomed %400)

Before:
![before](https://user-images.githubusercontent.com/36072735/190191394-87627677-8bdd-485f-a7c1-f3a6af352254.png)

After:
![after](https://user-images.githubusercontent.com/36072735/190191442-1023dead-d033-47e3-bc56-f328f360270f.png)