### PR TITLE
Improved directory sanitization with --hide_ui_dir_config

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -13,7 +13,7 @@ import string
 
 import modules.shared
 from modules import sd_samplers, shared
-from modules.shared import opts
+from modules.shared import opts, cmd_opts
 
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
 
@@ -276,6 +276,9 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     x = x.replace("[model_hash]", shared.sd_model_hash)
     x = x.replace("[date]", datetime.date.today().isoformat())
+
+    if cmd_opts.hide_ui_dir_config:
+        x = re.sub(r'^[\\/]+|\.{2,}[\\/]+|[\\/]+\.{2,}', '', x)
 
     return x
 


### PR DESCRIPTION
Fixes an issue where it's still possible to write to arbitrary directories through careful use of `..` in `Images filename pattern
`/`Directory name pattern` to go up a directory, even when `--hide_ui_dir_config` is toggled on.

I've conditionalized the replacement only to run when  `--hide_ui_dir_config` is enabled since without that flag, you're explicitly able to write to arbitrary directories anyway.

The intention of the flag is to keep output contained to directories configured _outside_ of the web interface, so worst-case scenario of some troll getting into a public web UI is that they generate some stupid images in a known directory, and maybe cause you to have to reset `config.json`; without that flag (and this fix), someone could write arbitrarily-named files anywhere they want, which could be a disaster to clean up.

I spent _way_ too long fiddling with the regex, but it has to cover:
- `\` or `/`, which at the start of `Directory name pattern` will cause the output to end up in the drive root, for some reason
- .. followed by one or more slash
- one or more slash followed by ..

and also _not_ interfere with otherwise valid input.

so that e.g. some horror passed in like this:
`\../\\\/\/\/sdf\\\..\\/\../\./..\/\/.\.ertxz/\../\/\/\./\./.\.nbvx/../.\/./\/.\one.dot.is.valid\\/....\/\./..../two..dots..is..also..valid\/.\/.\.///\/\/\..\..\..\testdir\\\...\/../..ksmdsh.\/\./\\/\/\...././\\/\../\../\.\/\fhgjk\/.\/.\..\.\..\\/..\/.\/\.xcvbn\this.is.fine\asdfg\\.\....\/\..././/...../\//..cvb/...\.../\\...\\.....//..././/.....[date]\..\./.`
gets sanitized down to
`sdf/\.\/\/.\.ertxz/\/\/\./\./.\.nbvx/.\/./\/.\one.dot.is.valid\/\./two..dots..is..also..valid\/.\/.\.\testdirksmdsh.\/\././\.\/\fhgjk\/.\/.\.\/.\/\.xcvbn\this.is.fine\asdfg\\./.cvb/.2022-09-14\./.`
and ends up writing to
`sdf\.ertxz\.nbvx\one.dot.is.valid\two..dots..is..also..valid\testdirksmdsh\fhgjk\.xcvbn\this.is.fine\asdfg\.cvb\.2022-09-14`
which is still a horror, but at least one that's contained to the appropriate directory as defined in config.json.