### PR TITLE
Comment out empty envars in user config.

### DIFF
--- a/webui-user.sh
+++ b/webui-user.sh
@@ -16,7 +16,7 @@ export COMMANDLINE_ARGS=()
 python_cmd="python3"
 
 # git executable
-export GIT=""
+#export GIT=""
 
 # python3 venv without trailing slash (defaults to ${install_dir}/${clone_dir}/venv)
 venv_dir="venv"
@@ -25,16 +25,16 @@ venv_dir="venv"
 export TORCH_COMMAND=(python3 -m pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113)
 
 # Requirements file to use for stable-diffusion-webui
-export REQS_FILE=""
+#export REQS_FILE=""
 
 # Fixed git repos
-export K_DIFFUSION_PACKAGE=""
-export GFPGAN_PACKAGE=""
+#export K_DIFFUSION_PACKAGE=""
+#export GFPGAN_PACKAGE=""
 
 # Fixed git commits
-export STABLE_DIFFUSION_COMMIT_HASH=""
-export TAMING_TRANSFORMERS_COMMIT_HASH=""
-export CODEFORMER_COMMIT_HASH=""
-export BLIP_COMMIT_HASH=""
+#export STABLE_DIFFUSION_COMMIT_HASH=""
+#export TAMING_TRANSFORMERS_COMMIT_HASH=""
+#export CODEFORMER_COMMIT_HASH=""
+#export BLIP_COMMIT_HASH=""
 
 ###########################################


### PR DESCRIPTION
Setting empty envars causes the `os.environ.get('ENVAR', "some default")` pattern in launch.py to ignore it's fallback value.