### PR TITLE
exif fix for webp

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -356,6 +356,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     image.save(fullfn, quality=opts.jpeg_quality, pnginfo=pnginfo, exif=exif_bytes)
 
+    if extension.lower() == "webp":
+        piexif.insert(exif_bytes, fullfn)
+
     target_side_length = 4000
     oversize = image.width > target_side_length or image.height > target_side_length
     if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > 4 * 1024 * 1024):


### PR DESCRIPTION
* fix for odd error only in webp files whereby piexif.insert inserts the bytes correctly, but image.save inserts extra "Exif" in the image metadata which results in an error on reading