### PR TITLE
pass dtype to torch.zeros as well

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -57,7 +57,7 @@ def split_cross_attention_forward(self, x, context=None, mask=None):
     q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
     del q_in, k_in, v_in
 
-    r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device. dtype=q.dtype)
+    r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
 
     stats = torch.cuda.memory_stats(q.device)
     mem_active = stats['active_bytes.all.current']

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -57,7 +57,7 @@ def split_cross_attention_forward(self, x, context=None, mask=None):
     q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
     del q_in, k_in, v_in
 
-    r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device)
+    r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device. dtype=q.dtype)
 
     stats = torch.cuda.memory_stats(q.device)
     mem_active = stats['active_bytes.all.current']


### PR DESCRIPTION
This PR adds dtype to `r1` in cross attention to make sure we keep using FP16. I've tested and saw an incredibly marginal speedup, %3, but it doesn't hurt anything and is still a performance improvement.

This is in the same vein as my previous attention updates.