### PR TITLE
Commadn Line args now pass to down to launch.py

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -2,6 +2,7 @@
 
 if not defined PYTHON (set PYTHON=python)
 if not defined VENV_DIR (set VENV_DIR=venv)
+if not defined COMMANDLINE_ARGS (set COMMANDLINE_ARGS=%*)
 
 mkdir tmp 2>NUL
 
@@ -31,7 +32,7 @@ goto :launch
 :skip_venv
 
 :launch
-%PYTHON% launch.py
+%PYTHON% launch.py %COMMANDLINE_ARGS%
 pause
 exit /b
 


### PR DESCRIPTION
I noticed setting port and listen command line arguments when launching webui.bat had stopped working. I think this was lost when moving most of the functionality to launch.py.