### PR TITLE
image.save parameter fix

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -345,7 +345,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         if not os.path.exists(fullfn):
             break
 
-    def exif_bytes():
+    def create_exif_bytes():
         return piexif.dump({
             "Exif": {
                 piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(info or "", encoding="unicode")
@@ -353,7 +353,8 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         })
 
     if extension.lower() in ("jpg", "jpeg", "webp"):
-        image.save(fullfn, quality=opts.jpeg_quality, exif_bytes=exif_bytes())
+        exif_bytes = create_exif_bytes()
+        image.save(fullfn, quality=opts.jpeg_quality, exif=exif_bytes)
     else:
         image.save(fullfn, quality=opts.jpeg_quality, pnginfo=pnginfo)
 
@@ -370,7 +371,11 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         elif oversize:
             image = image.resize((image.width * target_side_length // image.height, target_side_length), LANCZOS)
 
-        image.save(fullfn_without_extension + ".jpg", quality=opts.jpeg_quality, exif_bytes=exif_bytes())
+        if exif_bytes in locals():
+            pass
+        else:
+            exif_bytes = create_exif_bytes()
+        image.save(fullfn_without_extension + ".jpg", quality=opts.jpeg_quality, exif=exif_bytes)
 
     if opts.save_txt and info is not None:
         with open(f"{fullfn_without_extension}.txt", "w", encoding="utf8") as file:


### PR DESCRIPTION
* image.save takes exif as a parameter
* piexif takes the bytes as a parameter, not the exif_bytes function itself
* reduce calls to create_exif_bytes