### PR TITLE
Add randomness and denoising strength support to alternative img2img

### DIFF
--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -105,25 +105,13 @@ class Script(scripts.Script):
             sampler = samplers[p.sampler_index].constructor(p.sd_model)
 
             sigmas = sampler.model_wrap.get_sigmas(p.steps)
-
-            t_enc = int(min(p.denoising_strength, 0.999) * p.steps)
             
             noise_dt = combined_noise - ( p.init_latent / sigmas[0] )
-            noise_dt = noise_dt * sigmas[p.steps - t_enc - 1]
-
-            noise = p.init_latent + noise_dt
-
-            sigma_sched = sigmas[p.steps - t_enc - 1:]
-
-            sampler.model_wrap_cfg.mask = p.mask
-            sampler.model_wrap_cfg.nmask = p.nmask
-            sampler.model_wrap_cfg.init_latent = p.init_latent
-
-            if hasattr(K.sampling, 'trange'):
-                K.sampling.trange = lambda *args, **kwargs: sd_samplers.extended_trange(*args, **kwargs)
-
+            
             p.seed = p.seed + 1
-            return sampler.func(sampler.model_wrap_cfg, noise, sigma_sched, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=sampler.callback_state)
+            
+            return sampler.sample_img2img(p, p.init_latent, noise_dt, conditioning, unconditional_conditioning)
+
 
         p.sample = sample_extra
 


### PR DESCRIPTION
This PR adds two things to the `img2imgalt.py` script:

1. Denoising strength now has an effect. Similar to regular img2img, smaller denoising strength means that you only apply a bit of the noise. 
2. A "randomness" slider. Allows you to linearly interpolate between the reconstruction noise and completely random noise. This gives more control for "how close" you want the new image to be to the reconstruction. 

Notes for reviewers:
- I don't know if I implemented seeding correctly / in a good way here.  I'm not very familiar with this repo yet.  
   I increment the `p.seed` variable every time the `random_extra`  function is called and use `processing.create_random_tensors` method to generate the noise.
- ~Much of the new code is similar to `sample_img2img` in `KDiffusionSampler` in `sd_samplers.py`. It may be possible to introduce some new method in `KDiffusionSampler`  to reduce code duplication. I haven't tried this since I don't want to risk introducing any new bugs, but it may be worth considering.~
- One thing that doesn't seem to work is "batch size", but I'm not sure if that worked before either. 