### PR TITLE
Prevent uploading previous output from javascript

### DIFF
--- a/script.js
+++ b/script.js
@@ -177,7 +177,7 @@ function submit(){
     window.setTimeout(requestProgress, 500)
 
     res = []
-    for(var i=0;i<arguments.length;i++){
+    for(var i=0;i<arguments.length - 3;i++){
         res.push(arguments[i])
     }
     return res


### PR DESCRIPTION
As it is currently, txt2img and img2img send back the previous output args (txt2img_gallery, generation_info, html_info) whenever you generate a new image. This can lead to uploading a huge gallery of previously generated images, which leads to an unnecessary delay between submitting and beginning to generate.