### PR TITLE
Polish seed UI options

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -11,6 +11,8 @@ titles = {
 	"Batch size": "How many image to create in a single batch",
     "CFG Scale": "Classifier Free Guidance Scale - how strongly the image should conform to prompt - lower values produce more creative results",
     "Seed": "A value that determines the output of random number generator - if you create an image with same parameters and seed as another image, you'll get the same result",
+    "\u{1f3b2}\ufe0f": "Set seed to -1, which will cause a new random number to be used every time",
+    "\u267b\ufe0f": "Reuse seed from last generation, mostly useful if it was randomed",
 
     "Inpaint a part of image": "Draw a mask over an image, and the script will regenerate the masked area with content according to prompt",
     "SD upscale": "Upscale image normally, split result into tiles, improve each tile using img2img, merge whole image back",

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -83,11 +83,13 @@ class StableDiffusionProcessing:
 
 
 class Processed:
-    def __init__(self, p: StableDiffusionProcessing, images_list, seed, info):
+    def __init__(self, p: StableDiffusionProcessing, images_list, seed, subseed, info):
         self.images = images_list
         self.prompt = p.prompt
         self.negative_prompt = p.negative_prompt
         self.seed = seed
+        self.subseed = subseed
+        self.subseed_strength = p.subseed_strength
         self.info = info
         self.width = p.width
         self.height = p.height
@@ -100,6 +102,8 @@ class Processed:
             "prompt": self.prompt if type(self.prompt) != list else self.prompt[0],
             "negative_prompt": self.negative_prompt if type(self.negative_prompt) != list else self.negative_prompt[0],
             "seed": int(self.seed if type(self.seed) != list else self.seed[0]),
+            "subseed": int(self.subseed if type(self.subseed) != list else self.subseed[0]),
+            "subseed_strength": self.subseed_strength,
             "width": self.width,
             "height": self.height,
             "sampler": self.sampler,
@@ -352,7 +356,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                 images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], all_prompts[0], opts.grid_format, info=infotext(), short_filename=not opts.grid_extended_filename, p=p)
 
     devices.torch_gc()
-    return Processed(p, output_images, all_seeds[0], infotext())
+    return Processed(p, output_images, all_seeds[0], all_subseeds[0], infotext())
 
 
 class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -2,7 +2,7 @@ transformers==4.19.2
 diffusers==0.2.4
 basicsr==1.3.5
 gfpgan
-gradio==3.3
+gradio==3.3.1
 numpy==1.23.3
 Pillow==9.2.0
 realesrgan==0.2.5.0

--- a/style.css
+++ b/style.css
@@ -43,9 +43,31 @@
     margin-right: auto;
 }
 
+#random_seed, #random_subseed, #reuse_seed, #reuse_subseed{
+    min-width: auto;
+    flex-grow: 0;
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+}
+
+#seed_row, #subseed_row{
+    gap: 0.5rem;
+}
+
+#subseed_show_box{
+    min-width: auto;
+    flex-grow: 0;
+}
+
+#subseed_show_box > div{
+    border: 0;
+    height: 100%;
+}
+
 #subseed_show{
-    min-width: 6em;
-    max-width: 6em;
+    min-width: auto;
+    flex-grow: 0;
+    padding: 0;
 }
 
 #subseed_show label{


### PR DESCRIPTION
Added a checkbox for random seed, instead using the "magic number" of -1 for this. Writing a valid number in either of the seed boxes automatically turns off random.

Moved variation seed to a row so that it is grouped with variation strength, since these work together.

Added boxes that display last seed, and last variation seed, with buttons that copy these to the seed/vseed inputs.