### PR TITLE
Add full size 'lightbox' preview modal when left clicking on gallery previews

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,6 +74,35 @@ function gradioApp(){
 
 global_progressbar = null
 
+function closeModal() {
+  gradioApp().getElementById("lightboxModal").style.display = "none";
+}
+
+function showModal(elem) {
+  gradioApp().getElementById("modalImage").src = elem.src
+  gradioApp().getElementById("lightboxModal").style.display = "block";
+}
+
+function showGalleryImage(){
+    setTimeout(function() {
+        fullImg_preview = gradioApp().querySelectorAll('img.w-full.object-contain')
+        
+        if(fullImg_preview != null){
+            fullImg_preview.forEach(function function_name(e) {
+                if(e && e.parentElement.tagName == 'DIV'){
+                    e.style.cursor='pointer'
+
+                    elemfunc = function(elem){
+                        elem.onclick = function(){showModal(elem)};
+                    }
+                    elemfunc(e)
+                }
+            });
+        }
+
+    }, 100);
+}
+
 function addTitles(root){
 	root.querySelectorAll('span, button, select').forEach(function(span){
 		tooltip = titles[span.textContent];
@@ -115,8 +144,18 @@ function addTitles(root){
                 img2img_preview.style.width = img2img_gallery.clientWidth + "px"
                 img2img_preview.style.height = img2img_gallery.clientHeight + "px"
             }
+		
+            fullImg_preview = gradioApp().querySelectorAll('img.w-full')
 
+            if(fullImg_preview != null){
 
+                fullImg_preview.forEach(function function_name(e) {
+                    if(e && e.parentElement.tagName == 'BUTTON'){
+                        e.onclick = showGalleryImage;
+                    }
+                });
+            }
+		
             window.setTimeout(requestProgress, 500)
         });
         mutationObserver.observe( progressbar, { childList:true, subtree:true })
@@ -129,6 +168,27 @@ document.addEventListener("DOMContentLoaded", function() {
         addTitles(gradioApp());
     });
     mutationObserver.observe( gradioApp(), { childList:true, subtree:true })
+	
+    const modalFragment = document.createDocumentFragment();
+    const modal = document.createElement('div')
+    modal.onclick = closeModal;
+    
+    const modalClose = document.createElement('span')
+    modalClose.className = 'modalClose cursor';
+    modalClose.innerHTML = '&times;'
+    modalClose.onclick = closeModal;
+    modal.id = "lightboxModal";
+    modal.appendChild(modalClose)
+
+    const modalImage = document.createElement('img')
+    modalImage.id = 'modalImage';
+    modalImage.onclick = closeModal;
+    modal.appendChild(modalImage)
+
+    gradioApp().getRootNode().appendChild(modal)
+    
+    document.body.appendChild(modalFragment);
+	
 });
 
 function selected_gallery_index(){

--- a/script.js
+++ b/script.js
@@ -103,6 +103,12 @@ function showGalleryImage(){
     }, 100);
 }
 
+function galleryImageHandler(e){
+    if(e && e.parentElement.tagName == 'BUTTON'){
+        e.onclick = showGalleryImage;
+    }
+}
+
 function addTitles(root){
 	root.querySelectorAll('span, button, select').forEach(function(span){
 		tooltip = titles[span.textContent];
@@ -145,22 +151,17 @@ function addTitles(root){
                 img2img_preview.style.height = img2img_gallery.clientHeight + "px"
             }
 		
-            fullImg_preview = gradioApp().querySelectorAll('img.w-full')
-
-            if(fullImg_preview != null){
-
-                fullImg_preview.forEach(function function_name(e) {
-                    if(e && e.parentElement.tagName == 'BUTTON'){
-                        e.onclick = showGalleryImage;
-                    }
-                });
-            }
-		
             window.setTimeout(requestProgress, 500)
         });
         mutationObserver.observe( progressbar, { childList:true, subtree:true })
 	}
+	
+	fullImg_preview = gradioApp().querySelectorAll('img.w-full')
 
+	    if(fullImg_preview != null){
+		fullImg_preview.forEach(galleryImageHandler);
+	}
+	
 }
 
 document.addEventListener("DOMContentLoaded", function() {

--- a/style.css
+++ b/style.css
@@ -184,7 +184,7 @@ input[type="range"]{
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: black;
+  background-color: rgba(20, 20, 20, 0.95);
 }
 
 .modalClose {

--- a/style.css
+++ b/style.css
@@ -174,3 +174,40 @@ input[type="range"]{
   border-radius: 8px;
 }
 
+#lightboxModal{
+  display: none;
+  position: fixed;
+  z-index: 900;
+  padding-top: 100px;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: black;
+}
+
+.modalClose {
+  color: white;
+  position: absolute;
+  top: 10px;
+  right: 25px;
+  font-size: 35px;
+  font-weight: bold;
+}
+
+.modalClose:hover,
+.modalClose:focus {
+  color: #999;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+#modalImage {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: auto;
+    width: auto;
+}
+


### PR DESCRIPTION
Adds js and css to add in a modal window that displays the full resolution version of the ouput image when the preview is clicked.

![image](https://user-images.githubusercontent.com/35278260/190832203-a2005004-ecc3-4870-abe8-6452d7971928.png)

![image](https://user-images.githubusercontent.com/35278260/190832220-511da633-54e5-48a1-bc15-93fcd265ccc8.png)

Or for images smaller than fullscreen centered:

![image](https://user-images.githubusercontent.com/35278260/190832325-8d290abf-374a-4fcb-8f1d-080213797f38.png)

Works on the 'Extras' tab with upscales too, if the image is too wide for the screen it's fit to width:

![image](https://user-images.githubusercontent.com/35278260/190837005-47da2ed8-af73-4472-900b-df397d7b6a64.png)
