### PR TITLE
Add VRAM monitoring

### DIFF
--- a/modules/memmon.py
+++ b/modules/memmon.py
@@ -1,0 +1,77 @@
+import threading
+import time
+from collections import defaultdict
+
+import torch
+
+
+class MemUsageMonitor(threading.Thread):
+    run_flag = None
+    device = None
+    disabled = False
+    opts = None
+    data = None
+
+    def __init__(self, name, device, opts):
+        threading.Thread.__init__(self)
+        self.name = name
+        self.device = device
+        self.opts = opts
+
+        self.daemon = True
+        self.run_flag = threading.Event()
+        self.data = defaultdict(int)
+
+    def run(self):
+        if self.disabled:
+            return
+
+        while True:
+            self.run_flag.wait()
+
+            torch.cuda.reset_peak_memory_stats()
+            self.data.clear()
+
+            if self.opts.memmon_poll_rate <= 0:
+                self.run_flag.clear()
+                continue
+
+            self.data["min_free"] = torch.cuda.mem_get_info()[0]
+
+            while self.run_flag.is_set():
+                free, total = torch.cuda.mem_get_info()  # calling with self.device errors, torch bug?
+                self.data["min_free"] = min(self.data["min_free"], free)
+
+                time.sleep(1 / self.opts.memmon_poll_rate)
+
+    def dump_debug(self):
+        print(self, 'recorded data:')
+        for k, v in self.read().items():
+            print(k, -(v // -(1024 ** 2)))
+
+        print(self, 'raw torch memory stats:')
+        tm = torch.cuda.memory_stats(self.device)
+        for k, v in tm.items():
+            if 'bytes' not in k:
+                continue
+            print('\t' if 'peak' in k else '', k, -(v // -(1024 ** 2)))
+
+        print(torch.cuda.memory_summary())
+
+    def monitor(self):
+        self.run_flag.set()
+
+    def read(self):
+        free, total = torch.cuda.mem_get_info()
+        self.data["total"] = total
+
+        torch_stats = torch.cuda.memory_stats(self.device)
+        self.data["active_peak"] = torch_stats["active_bytes.all.peak"]
+        self.data["reserved_peak"] = torch_stats["reserved_bytes.all.peak"]
+        self.data["system_peak"] = total - self.data["min_free"]
+
+        return self.data
+
+    def stop(self):
+        self.run_flag.clear()
+        return self.read()

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -12,6 +12,7 @@ from modules.paths import script_path, sd_path
 from modules.devices import get_optimal_device
 import modules.styles
 import modules.interrogate
+import modules.memmon
 
 sd_model_file = os.path.join(script_path, 'model.ckpt')
 if not os.path.exists(sd_model_file):
@@ -138,6 +139,7 @@ class Options:
         "show_progressbar": OptionInfo(True, "Show progressbar"),
         "show_progress_every_n_steps": OptionInfo(0, "Show show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
         "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job. Broken in PyCharm console."),
+        "memmon_poll_rate": OptionInfo(8, "VRAM usage polls per second during generation. Set to 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 40, "step":1}),
         "face_restoration_model": OptionInfo(None, "Face restoration model", gr.Radio, lambda: {"choices": [x.name() for x in face_restorers]}),
         "code_former_weight": OptionInfo(0.5, "CodeFormer weight parameter; 0 = maximum effect; 1 = minimum effect", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}),
         "save_images_before_face_restoration": OptionInfo(False, "Save a copy of image before doing face restoration."),
@@ -217,3 +219,6 @@ class TotalTQDM:
 
 
 total_tqdm = TotalTQDM()
+
+mem_mon = modules.memmon.MemUsageMonitor("MemMon", device, opts)
+mem_mon.start()

--- a/style.css
+++ b/style.css
@@ -1,5 +1,21 @@
 .output-html p {margin: 0 0.5em;}
-.performance { font-size: 0.85em; color: #444; }
+
+.performance {
+    font-size: 0.85em;
+    color: #444;
+    display: flex;
+    justify-content: space-between;
+    white-space: nowrap;
+}
+
+.performance .time {
+    margin-right: 0;
+}
+
+.performance .vram {
+    margin-left: 0;
+    text-align: right;
+}
 
 #generate{
     min-height: 4.5em;


### PR DESCRIPTION
Adapted (and improved) my old VRAM monitoring code that I originally posted in an anonymous pastebin fork a few weeks ago.

Output looks like this (w/ mouseover tooltip):
![image](https://user-images.githubusercontent.com/2722970/190841084-9b4606ed-6eae-4922-ad04-44c018369970.png)
I also tried to make it look okay when the column gets squished:
![image](https://user-images.githubusercontent.com/2722970/190841101-4a4b6747-e41a-4edf-9840-b4f658fc42b0.png)

We exchanged a couple of posts about this a while back, and I recall you didn't like the idea of spawning a separate thread for polling.
However, I've since looked through PyTorch to see if it has some better way to handle this, but there isn't anything. There's some semi-useful data you can grab that's recorded by Torch's memory allocator, but nothing regarding the whole system—and on my system, Torch's own peak usage statistics always seem to come up 1-2GB short anyway, even when accounting for other processes. Peak total system usage is ultimately the most important stat, so I don't think it would be reasonable to ignore it.

I added a `memmon_poll_rate` option to the settings menu to control poll rate, which can be set to 0 to turn polling completely off. I'm not really sure it needs to have a setting though, since I literally cannot measure any performance impact between polling being turned off, or set to 100k+ polls per second. As long as there's _any_ sleep in the polling loop at all, it's fine. I'm kind of inclined to just hide the setting (i.e. `"visible": False`) to keep UI clutter down, or cut it entirely and hardcode polling rate.

Let me know if anything needs fixing, it looks good from my end.