### PR TITLE
Corrected indentation error in images.py

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -346,7 +346,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             break
 
     def create_exif_bytes():
-    def exif_bytes():
+      def exif_bytes():
         return piexif.dump({
             "Exif": {
                 piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(info or "", encoding="unicode")


### PR DESCRIPTION
Corrected indentation error on line 349:

venv "F:\stable-diffusion-webui\venv\Scripts\Python.exe" Python 3.10.6 (tags/v3.10.6:9c7b4bd, Aug  1 2022, 21:53:49) [MSC v.1932 64 bit (AMD64)] Commit hash: 3c665b8dd6da07c60af7783f0e0dd1dec714a9b4 Installing requirements for Web UI
Launching Web UI with arguments:
Traceback (most recent call last):
  File "F:\stable-diffusion-webui\launch.py", line 127, in <module>
    start_webui()
  File "F:\stable-diffusion-webui\launch.py", line 123, in start_webui
    import webui
  File "F:\stable-diffusion-webui\webui.py", line 15, in <module>
    import modules.ui
  File "F:\stable-diffusion-webui\modules\ui.py", line 25, in <module>
    import modules.realesrgan_model as realesrgan
  File "F:\stable-diffusion-webui\modules\realesrgan_model.py", line 7, in <module>
    import modules.images
  File "F:\stable-diffusion-webui\modules\images.py", line 349
    def exif_bytes():
    ^
IndentationError: expected an indented block after function definition on line 348 Press any key to continue . . .