### PR TITLE
Fix process_image issues with features which push image counts that aren't (batch_size * n_iter) + textbox for prompt from file. 

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -188,7 +188,11 @@ def fix_seed(p):
 def process_images(p: StableDiffusionProcessing) -> Processed:
     """this is the main loop that both txt2img and img2img use; it calls func_init once inside all the scopes and func_sample once per batch"""
 
-    assert p.prompt is not None
+    if type(p.prompt) == list:
+        assert(len(p.prompt) > 0)
+    else:
+        assert p.prompt is not None
+        
     devices.torch_gc()
 
     fix_seed(p)
@@ -264,6 +268,9 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
             prompts = all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
             seeds = all_seeds[n * p.batch_size:(n + 1) * p.batch_size]
             subseeds = all_subseeds[n * p.batch_size:(n + 1) * p.batch_size]
+
+            if (len(prompts) == 0):
+                break
 
             #uc = p.sd_model.get_learned_conditioning(len(prompts) * [p.negative_prompt])
             #c = p.sd_model.get_learned_conditioning(prompts)

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -13,28 +13,42 @@ from modules.shared import opts, cmd_opts, state
 
 class Script(scripts.Script):
     def title(self):
-        return "Prompts from file"
+        return "Prompts from file or textbox"
 
     def ui(self, is_img2img):
+        # This checkbox would look nicer as two tabs, but there are two problems:
+        # 1) There is a bug in Gradio 3.3 that prevents visibility from working on Tabs
+        # 2) Even with Gradio 3.3.1, returning a control (like Tabs) that can't be used as input
+        #    causes a AttributeError: 'Tabs' object has no attribute 'preprocess' assert,
+        #    due to the way Script assumes all controls returned can be used as inputs.
+        # Therefore, there's no good way to use grouping components right now,
+        # so we will use a checkbox! :)
+        checkbox_txt = gr.Checkbox(label="Show Textbox", value=False)
         file = gr.File(label="File with inputs", type='bytes')
+        prompt_txt = gr.TextArea(label="Prompts")
+        checkbox_txt.change(fn=lambda x: [gr.File.update(visible = not x), gr.TextArea.update(visible = x)], inputs=[checkbox_txt], outputs=[file, prompt_txt])
+        return [checkbox_txt, file, prompt_txt]
 
-        return [file]
-
-    def run(self, p, data: bytes):
-        lines = [x.strip() for x in data.decode('utf8', errors='ignore').split("\n")]
+    def run(self, p, checkbox_txt, data: bytes, prompt_txt: str):
+        if (checkbox_txt):
+            lines = [x.strip() for x in prompt_txt.splitlines()]
+        else:
+            lines = [x.strip() for x in data.decode('utf8', errors='ignore').split("\n")]
         lines = [x for x in lines if len(x) > 0]
 
-        batch_count = math.ceil(len(lines) / p.batch_size)
-        print(f"Will process {len(lines) * p.n_iter} images in {batch_count * p.n_iter} batches.")
+        img_count = len(lines) * p.n_iter
+        batch_count = math.ceil(img_count / p.batch_size)
+        loop_count = math.ceil(batch_count / p.n_iter)
+        print(f"Will process {img_count} images in {batch_count} batches.")
 
         p.do_not_save_grid = True
 
         state.job_count = batch_count
 
         images = []
-        for batch_no in range(batch_count):
-            state.job = f"{batch_no + 1} out of {batch_count * p.n_iter}"
-            p.prompt = lines[batch_no*p.batch_size:(batch_no+1)*p.batch_size] * p.n_iter
+        for loop_no in range(loop_count):
+            state.job = f"{loop_no + 1} out of {loop_count}"
+            p.prompt = lines[loop_no*p.batch_size:(loop_no+1)*p.batch_size] * p.n_iter
             proc = process_images(p)
             images += proc.images
 


### PR DESCRIPTION
* Fix process_images where the number of images is not a multiple of (batch_size * n_iter), which would cause us to throw an exception. (#603)
* Add a textbox option to Prompts from file (ease of use and it makes it much easier to use on a mobile device)
* Fix the fact that Prompts from file was sometimes passing an empty batch. 