### PR TITLE
Block event propagation when lightbox is triggered

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,35 +83,53 @@ function closeModal() {
 function showModal(event) {
   var source = event.target || event.srcElement;
   gradioApp().getElementById("modalImage").src = source.src
-  gradioApp().getElementById("lightboxModal").style.display = "block";
+  var lb = gradioApp().getElementById("lightboxModal")
+  lb.style.display = "block";
+  lb.focus()
   event.stopPropagation()
 }
 
-
-function showGalleryImage(){
-    setTimeout(function() {
-        fullImg_preview = gradioApp().querySelectorAll('img.w-full.object-contain')
-        
-        if(fullImg_preview != null){
-            fullImg_preview.forEach(function function_name(e) {
-                if(e && e.parentElement.tagName == 'DIV'){
-
-                    e.style.cursor='pointer'
-
-                    e.addEventListener('click', function (evt) {
-                      showModal(evt)
-
-                    },true);
-                }
-            });
-        }
-
-    }, 100);
+function negmod(n, m) {
+  return ((n % m) + m) % m;
 }
 
-function galleryImageHandler(e){
-    if(e && e.parentElement.tagName == 'BUTTON'){
-        e.onclick = showGalleryImage;
+function modalImageSwitch(offset){
+  var galleryButtons = gradioApp().querySelectorAll(".gallery-item.transition-all")
+
+  if(galleryButtons.length>1){
+      var currentButton  = gradioApp().querySelector(".gallery-item.transition-all.\\!ring-2")
+
+      var result = -1
+      galleryButtons.forEach(function(v, i){ if(v==currentButton) { result = i } })
+
+      if(result != -1){
+        nextButton = galleryButtons[negmod((result+offset),galleryButtons.length)]
+        nextButton.click()
+        gradioApp().getElementById("modalImage").src = nextButton.children[0].src
+        setTimeout( function(){gradioApp().getElementById("lightboxModal").focus()},10)
+      }
+  }
+
+}
+
+function modalNextImage(event){
+  modalImageSwitch(1)
+  event.stopPropagation()
+}
+
+function modalPrevImage(event){
+  modalImageSwitch(-1)  
+  event.stopPropagation()
+}
+
+function modalKeyHandler(event){
+    switch (event.key) {
+        case "ArrowLeft":
+            modalPrevImage(event)
+            break;
+        case "ArrowRight":
+            modalNextImage(event)
+            break;
     }
 }
 
@@ -185,12 +203,34 @@ document.addEventListener("DOMContentLoaded", function() {
     modalClose.innerHTML = '&times;'
     modalClose.onclick = closeModal;
     modal.id = "lightboxModal";
+    modal.tabIndex=0
+    modal.addEventListener('keydown', modalKeyHandler, true)
     modal.appendChild(modalClose)
 
     const modalImage = document.createElement('img')
     modalImage.id = 'modalImage';
     modalImage.onclick = closeModal;
+    modalImage.tabIndex=0
+    modalImage.addEventListener('keydown', modalKeyHandler, true)
     modal.appendChild(modalImage)
+
+    const modalPrev = document.createElement('a')
+    modalPrev.className = 'modalPrev';
+    modalPrev.innerHTML = '&#10094;'
+    modalPrev.tabIndex=0
+    modalPrev.addEventListener('click',modalPrevImage,true);
+    modalPrev.addEventListener('keydown', modalKeyHandler, true)
+    modal.appendChild(modalPrev)
+
+    const modalNext = document.createElement('a')
+    modalNext.className = 'modalNext';
+    modalNext.innerHTML = '&#10095;'
+    modalNext.tabIndex=0
+    modalNext.addEventListener('click',modalNextImage,true);
+    modalNext.addEventListener('keydown', modalKeyHandler, true)
+
+    modal.appendChild(modalNext)
+
 
     gradioApp().getRootNode().appendChild(modal)
     

--- a/script.js
+++ b/script.js
@@ -133,6 +133,33 @@ function modalKeyHandler(event){
     }
 }
 
+function showGalleryImage(){
+    setTimeout(function() {
+        fullImg_preview = gradioApp().querySelectorAll('img.w-full.object-contain')
+        
+        if(fullImg_preview != null){
+            fullImg_preview.forEach(function function_name(e) {
+                if(e && e.parentElement.tagName == 'DIV'){
+
+                    e.style.cursor='pointer'
+
+                    e.addEventListener('click', function (evt) {
+                      showModal(evt)
+
+                    },true);
+                }
+            });
+        }
+
+    }, 100);
+}
+
+function galleryImageHandler(e){
+    if(e && e.parentElement.tagName == 'BUTTON'){
+        e.onclick = showGalleryImage;
+    }
+}
+
 function addTitles(root){
 	root.querySelectorAll('span, button, select').forEach(function(span){
 		tooltip = titles[span.textContent];

--- a/script.js
+++ b/script.js
@@ -80,10 +80,13 @@ function closeModal() {
   gradioApp().getElementById("lightboxModal").style.display = "none";
 }
 
-function showModal(elem) {
-  gradioApp().getElementById("modalImage").src = elem.src
+function showModal(event) {
+  var source = event.target || event.srcElement;
+  gradioApp().getElementById("modalImage").src = source.src
   gradioApp().getElementById("lightboxModal").style.display = "block";
+  event.stopPropagation()
 }
+
 
 function showGalleryImage(){
     setTimeout(function() {
@@ -92,12 +95,13 @@ function showGalleryImage(){
         if(fullImg_preview != null){
             fullImg_preview.forEach(function function_name(e) {
                 if(e && e.parentElement.tagName == 'DIV'){
+
                     e.style.cursor='pointer'
 
-                    elemfunc = function(elem){
-                        elem.onclick = function(){showModal(elem)};
-                    }
-                    elemfunc(e)
+                    e.addEventListener('click', function (evt) {
+                      showModal(evt)
+
+                    },true);
                 }
             });
         }

--- a/style.css
+++ b/style.css
@@ -230,3 +230,29 @@ input[type="range"]{
     width: auto;
 }
 
+.modalPrev,
+.modalNext {
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  width: auto;
+  padding: 16px;
+  margin-top: -50px;
+  color: white;
+  font-weight: bold;
+  font-size: 20px;
+  transition: 0.6s ease;
+  border-radius: 0 3px 3px 0;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.modalNext {
+  right: 0;
+  border-radius: 3px 0 0 3px;
+}
+
+.modalPrev:hover,
+.modalNext:hover {
+  background-color: rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
Prevents incorrect switching to the next image when a preview is first clicked for full screen display in the lightbox.

Also adds previous and next arrows and right+left keyboard shortcuts.

![image](https://user-images.githubusercontent.com/35278260/190868853-8479c0bb-9612-4390-9c16-192f2fbe0e9e.png)
