### PR TITLE
Fix gallery not scrolling left

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,18 @@
     object-fit: scale-down;
 }
 
+.justify-center.overflow-x-scroll {
+    justify-content: left;
+}
+
+.justify-center.overflow-x-scroll button:first-of-type {
+    margin-left: auto;
+}
+
+.justify-center.overflow-x-scroll button:last-of-type {
+    margin-right: auto;
+}
+
 #subseed_show{
     min-width: 6em;
     max-width: 6em;


### PR DESCRIPTION
Fixes that thing where the gallery doesn't scroll to the left in "selected" mode, provided there are more than 17 images or whatever.
![image](https://user-images.githubusercontent.com/2722970/190865997-4a72e9d4-00fc-4f12-8eed-1658d3e577e6.png)
It's a side-effect of `justify-content: center;`.

In theory it could be fixed more cleanly just by doing this:
```css
.justify-center {
    justify-content: safe center;
}
```
and that would be it, but that only works in Firefox, so instead we have to make do with a small hack (per some older [Mozilla docs](https://web.archive.org/web/20171022090301/https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes#Flex_Item_Considerations)).

First, we set the container element to justify left, instead of center:
```css
.justify-center.overflow-x-scroll {
    justify-content: left;
}
```
![image](https://user-images.githubusercontent.com/2722970/190866587-bd6f5803-eef1-4f4e-86a8-c08ce1d2790d.png)
But now it's not centered, so we fix that by adding a margin to the first and last element (which in this case are buttons):
```css
.justify-center.overflow-x-scroll button:first-of-type {
    margin-left: auto;
}

.justify-center.overflow-x-scroll button:last-of-type {
    margin-right: auto;
}
```
![image](https://user-images.githubusercontent.com/2722970/190867312-a8c8b3c4-acab-4e2b-a269-b5256f318b5e.png)
Perfect
