### PR TITLE
Make image gallery bigger on 2k+ displays

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,6 +21,12 @@
     min-height: 4.5em;
 }
 
+@media screen and (min-width: 2500px) {
+    #txt2img_gallery, #img2img_gallery {
+        min-height: 768px;
+    }
+}
+
 #txt2img_gallery img, #img2img_gallery img{
     object-fit: scale-down;
 }


### PR DESCRIPTION
If you have a screen with a width of 2560px or more, the display shall now be a bit bigger. 

There are more changes that could be made to the styling, for example, the prompt and negative prompt textboxes start out with 2 lines. Which means that no matter how small your prompt is, it will always have at least 2 lines. A lot of empty space if you only have 1 line of prompt and 1 line of negative prompt. (That's an easy enough change to make, but I wasn't sure if there's a specific reason you put them at 2 lines)

Additionally, there's a... trend (?) of putting a bunch of things into the negative prompt. To the point where the negative prompt box grows into 5-6 lines, or more if you have a small screen which makes for a very bad effect of the prompt textbox growing to crazy heights. I am unsure whether this is actually effective since I haven't really studied how the negative prompt works, but anyhow, one possible fix for that would be to let the textbox grow to say, 3 lines, but then with a javascript script re-enable scrolling and lock it's height.

Would you be interested in a PR that included that? 