### PR TITLE
fix pasting of images from the clipboard in img2img (fixes #645)

### DIFF
--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -54,5 +54,6 @@ window.addEventListener('paste', e => {
             input.dispatchEvent(new Event('change'))
         });
     [...gradioApp().querySelectorAll('[data-testid="image"]')]
+        .filter(imgWrap => !imgWrap.closest('.\\!hidden'))
         .forEach(imgWrap => dropReplaceImage( imgWrap, files ));
 });


### PR DESCRIPTION
Prevents pasting into all image inputs on the page by filtering for hidden inputs first

fixes #645