### PR TITLE
Fix webui.sh not working

### DIFF
--- a/webui-user.sh
+++ b/webui-user.sh
@@ -22,7 +22,7 @@ python_cmd="python3"
 venv_dir="venv"
 
 # install command for torch
-export TORCH_COMMAND="python3 -m pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
+export TORCH_COMMAND="pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
 
 # Requirements file to use for stable-diffusion-webui
 #export REQS_FILE=""

--- a/webui.sh
+++ b/webui.sh
@@ -44,7 +44,7 @@ fi
 # install command for torch
 if [[ -z "${TORCH_COMMAND}" ]]
 then
-    export TORCH_COMMAND="python3 -m pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
+    export TORCH_COMMAND="pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
 fi
 
 # Do not reinstall existing pip packages on Debian/Ubuntu


### PR DESCRIPTION
Launch.py was trying to do python3 -m python3 -m pip

Why does webui.sh call webui-user.sh instead of the other way around? Why is webui-user.sh an .sh file if it doesn't actually do anything when you run it anyhow? 

This is completely backwards compared to how it works in WIndows.