### PR TITLE
.gitignore - Exclude checkpoint files in models folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 /venv
 /tmp
 /model.ckpt
+/models/*.ckpt
 /GFPGANv1.3.pth
 /ui-config.json
 /outputs


### PR DESCRIPTION
Add checkpoint files under the models folder as exclusions to git, so users don't see them as pending git changes.