### PR TITLE
replace existing image via paste or drop in inpaint mode (fixes #649)

### DIFF
--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -9,7 +9,7 @@ function dropReplaceImage( imgWrap, files ) {
         return;
     }
 
-    imgWrap.querySelector('.modify-upload button + button')?.click();
+    imgWrap.querySelector('.modify-upload button + button, .touch-none + div button + button')?.click();
     window.requestAnimationFrame( () => {
         const fileInput = imgWrap.querySelector('input[type="file"]');
         if ( fileInput ) {


### PR DESCRIPTION
DOM structure is a bit different for the mask image used for inpainting than the other images, that's why replacing the current image when pasting or dropping didn't work in this case.

fixes #649