### PR TITLE
Move memmon tooltip to hints.js

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -70,15 +70,26 @@ titles = {
     "Create style": "Save current prompts as a style. If you add the token {prompt} to the text, the style use that as placeholder for your prompt when you use the style in the future.",
 
     "Checkpoint name": "Loads weights from checkpoint before making images. You can either use hash or a part of filename (as seen in settings) for checkpoint name. Recommended to use with Y axis for less switching.",
+
+    "vram": "Torch active: Peak amount of VRAM used by Torch during generation, excluding cached data.\nTorch reserved: Peak amount of VRAM allocated by Torch, including all active and cached data.\nSys VRAM: Peak amount of VRAM allocation across all applications / total GPU VRAM (peak utilization%).",
 }
 
 
 onUiUpdate(function(){
-	gradioApp().querySelectorAll('span, button, select').forEach(function(span){
+	gradioApp().querySelectorAll('span, button, select, p').forEach(function(span){
 		tooltip = titles[span.textContent];
 
 		if(!tooltip){
 		    tooltip = titles[span.value];
+		}
+
+		if(!tooltip){
+			for (const c of span.classList) {
+				if (c in titles) {
+					tooltip = titles[c];
+					break;
+				}
+			}
 		}
 
 		if(tooltip){

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -151,11 +151,8 @@ def wrap_gradio_call(func):
             sys_peak = mem_stats['system_peak']
             sys_total = mem_stats['total']
             sys_pct = round(sys_peak/max(sys_total, 1) * 100, 2)
-            vram_tooltip = "Torch active: Peak amount of VRAM used by Torch during generation, excluding cached data.&#013;" \
-                           "Torch reserved: Peak amount of VRAM allocated by Torch, including all active and cached data.&#013;" \
-                           "Sys VRAM: Peak amount of VRAM allocation across all applications / total GPU VRAM (peak utilization%)."
 
-            vram_html = f"<p class='vram' title='{vram_tooltip}'>Torch active/reserved: {active_peak}/{reserved_peak} MiB, <wbr>Sys VRAM: {sys_peak}/{sys_total} MiB ({sys_pct}%)</p>"
+            vram_html = f"<p class='vram'>Torch active/reserved: {active_peak}/{reserved_peak} MiB, <wbr>Sys VRAM: {sys_peak}/{sys_total} MiB ({sys_pct}%)</p>"
         else:
             vram_html = ''
 


### PR DESCRIPTION
so it's with the other tooltips, and doesn't have to be re-sent from the server every time.

Also, allowed tooltips in `hints.js` to be applied by matching a class name if all else fails. It does take slightly longer to process, but negligible in practice—I profiled it and had to manually run the onUiUpdate code like 1000 times before I could measure a few ms difference.

~~Unrelated but including it here anyway because it's small: replaced the `x` glyph with `×` in output info for resolutions, because it's the standard mathematical operator for these sort of things, and I think e.g. `512×512` looks nicer than `512x512`.~~

---
also I just noticed that pretty much every .js file is a random assortment of 2 spaces, 4 spaces, and tabs for indentation, sometimes transitioning from one to another on the same line, but I also don't really want to screw with git blame history just to fix it.