### PR TITLE
Automatically show PNGinfo when uploading image

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -98,6 +98,9 @@ def run_extras(image, image_folder, gfpgan_visibility, codeformer_visibility, co
 
 
 def run_pnginfo(image):
+    if image is None:
+        return '', '', ''
+
     items = image.info
 
     if "exif" in image.info:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -806,6 +806,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
         ],
         allow_flagging="never",
         analytics_enabled=False,
+        live=True,
     )
 
     def create_setting_component(key):


### PR DESCRIPTION
Removes the need for the user to select the "Show Info" button, by making it auto trigger `run_pnginfo` when an image is uploaded.

closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/507