### PR TITLE
Send a browser notification when the images are ready

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -1,0 +1,34 @@
+// Monitors the gallery and sends a browser notification when the leading image is new.
+
+let lastHeadImg = null;
+
+onUiUpdate(function(){
+    const galleryPreviews = gradioApp().querySelectorAll('img.h-full.w-full.overflow-hidden');
+
+    if (galleryPreviews == null) return;
+
+    const headImg = galleryPreviews[0]?.src;
+
+    if (headImg == null || headImg == lastHeadImg) return;
+
+    lastHeadImg = headImg;
+
+    if (document.hasFocus()) return;
+
+    // Multiple copies of the images are in the DOM when one is selected. Dedup with a Set to get the real number generated.
+    const imgs = new Set(Array.from(galleryPreviews).map(img => img.src));
+
+    const notification = new Notification(
+        'Stable Diffusion',
+        {
+            body: `Generated ${imgs.size > 1 ? imgs.size - 1 : 1} image${imgs.size > 1 ? 's' : ''}`,
+            icon: headImg,
+            image: headImg,
+        }
+    );
+
+    notification.onclick = function(_){
+        parent.focus();
+        this.close();
+    };
+});

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -876,6 +876,14 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
             outputs=[result]
         )
 
+        request_notifications = gr.Button(value='Request browser notifications')
+        request_notifications.click(
+            fn=lambda: None,
+            inputs=[],
+            outputs=[],
+            _js='() => Notification.requestPermission()'
+        )
+
     interfaces = [
         (txt2img_interface, "txt2img", "txt2img"),
         (img2img_interface, "img2img", "img2img"),


### PR DESCRIPTION
Sends a notification when the browser is unfocused and the leading gallery image changes. 

Permission needs to be granted by clicking "Request browser notifications" in Settings.

<img width="374" alt="screen" src="https://user-images.githubusercontent.com/801452/191125692-1e1de49f-2ddd-407b-b511-5e464dd87a12.png">

(Gradio support for notifications/alerts is being tracked here: https://github.com/gradio-app/gradio/issues/2173)