### PR TITLE
Allow reusing original filename stem during Extras batch process

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -303,7 +303,7 @@ def get_next_sequence_number(path, basename):
 
     return result + 1
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None):
+def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None):
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
@@ -335,15 +335,19 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     os.makedirs(path, exist_ok=True)
 
-    basecount = get_next_sequence_number(path, basename)
-    fullfn = "a.png"
-    fullfn_without_extension = "a"
-    for i in range(500):
-        fn = f"{basecount+i:05}" if basename == '' else f"{basename}-{basecount+i:04}"
-        fullfn = os.path.join(path, f"{fn}{file_decoration}.{extension}")
-        fullfn_without_extension = os.path.join(path, f"{fn}{file_decoration}")
-        if not os.path.exists(fullfn):
-            break
+    if forced_filename is None:
+        basecount = get_next_sequence_number(path, basename)
+        fullfn = "a.png"
+        fullfn_without_extension = "a"
+        for i in range(500):
+            fn = f"{basecount+i:05}" if basename == '' else f"{basename}-{basecount+i:04}"
+            fullfn = os.path.join(path, f"{fn}{file_decoration}.{extension}")
+            fullfn_without_extension = os.path.join(path, f"{fn}{file_decoration}")
+            if not os.path.exists(fullfn):
+                break
+    else:
+        fullfn = os.path.join(path, f"{forced_filename}.{extension}")
+        fullfn_without_extension = os.path.join(path, forced_filename)
 
     def exif_bytes():
         return piexif.dump({

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -161,6 +161,7 @@ class Options:
         "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Radio, lambda: {"choices": [x.title for x in modules.sd_models.checkpoints_list.values()]}),
         "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
         "js_modal_lightbox_initialy_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
+        "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process"),
     }
 
     def __init__(self):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -161,7 +161,7 @@ class Options:
         "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Radio, lambda: {"choices": [x.title for x in modules.sd_models.checkpoints_list.values()]}),
         "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
         "js_modal_lightbox_initialy_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
-        "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process"),
+        "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process"),
     }
 
     def __init__(self):


### PR DESCRIPTION
Instead of creating sequential filename during batch, I needed, and I think it can be useful to other, to keep the original filename
For instance, F_100.png is upscaled into [outputdir]/F_100.png instead of the default [outputdir]/00001.png

Default behaviour is the same as today, numeric only. An option is added to enable this new behaviour.