### PR TITLE
Add option to always log generation info

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -138,4 +138,8 @@ def img2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
 
     shared.total_tqdm.clear()
 
-    return processed.images, processed.js(), plaintext_to_html(processed.info)
+    generation_info_js = processed.js()
+    if opts.samples_log_stdout:
+        print(generation_info_js)
+
+    return processed.images, generation_info_js, plaintext_to_html(processed.info)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -125,6 +125,7 @@ class Options:
         "outdir_img2img_grids": OptionInfo("outputs/img2img-grids", 'Output directory for img2img grids', component_args=hide_dirs),
         "outdir_save": OptionInfo("log/images", "Directory for saving images using the Save button", component_args=hide_dirs),
         "samples_save": OptionInfo(True, "Always save all generated images"),
+        "samples_log_stdout": OptionInfo(False, "Always print all generation info to standard output"),
         "save_selected_only": OptionInfo(False, "When using 'Save' button, only save a single selected image"),
         "samples_format": OptionInfo('png', 'File format for individual samples'),
         "filter_nsfw": OptionInfo(False, "Filter NSFW content"),

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -44,5 +44,9 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
 
     shared.total_tqdm.clear()
 
-    return processed.images, processed.js(), plaintext_to_html(processed.info)
+    generation_info_js = processed.js()
+    if opts.samples_log_stdout:
+        print(generation_info_js)
+
+    return processed.images, generation_info_js, plaintext_to_html(processed.info)
 


### PR DESCRIPTION
When enabled, prints generation info (prompt, seed, sampler, etc) to stdout.