### PR TITLE
Add option to save before color correction. This helps with some posterisation issues in img2img loopback.

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -311,7 +311,7 @@ def get_next_sequence_number(path, basename):
 
     return result + 1
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None):
+def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix=""):
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
@@ -322,7 +322,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     if file_decoration != "":
         file_decoration = "-" + file_decoration.lower()
 
-    file_decoration = apply_filename_pattern(file_decoration, p, seed, prompt)
+    file_decoration = apply_filename_pattern(file_decoration, p, seed, prompt) + suffix
 
     if extension == 'png' and opts.enable_pnginfo and info is not None:
         pnginfo = PngImagePlugin.PngInfo()

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -20,6 +20,7 @@ import modules.shared as shared
 import modules.face_restoration
 import modules.images as images
 import modules.styles
+import logging
 
 
 # some of those options should not be changed at all because they would break the model, so I removed them from options.
@@ -28,11 +29,13 @@ opt_f = 8
 
 
 def setup_color_correction(image):
+    logging.info("Calibrating color correction.")
     correction_target = cv2.cvtColor(np.asarray(image.copy()), cv2.COLOR_RGB2LAB)
     return correction_target
 
 
 def apply_color_correction(correction, image):
+    logging.info("Applying color correction.")
     image = Image.fromarray(cv2.cvtColor(exposure.match_histograms(
         cv2.cvtColor(
             np.asarray(image),
@@ -367,7 +370,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
                 if p.color_corrections is not None and i < len(p.color_corrections):
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
-                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
+                        images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.overlay_images is not None and i < len(p.overlay_images):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -357,7 +357,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
                 if p.restore_faces:
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_face_restoration:
-                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p)
+                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-face-restoration")
 
                     devices.torch_gc()
 
@@ -366,6 +366,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                 image = Image.fromarray(x_sample)
 
                 if p.color_corrections is not None and i < len(p.color_corrections):
+                    if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
+                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.overlay_images is not None and i < len(p.overlay_images):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -139,6 +139,7 @@ class Options:
         "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),
         "add_model_hash_to_info": OptionInfo(False, "Add model hash to generation information"),
         "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
+        "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
         "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies (normally you'd do less with less denoising)."),
         "enable_quantization": OptionInfo(False, "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds. Requires restart to apply."),
         "font": OptionInfo("", "Font for image grids that have text"),


### PR DESCRIPTION
There have been a few complaints in bug reports about degraded image quality with color correction on (e.g #641, #799, #710). This PR add an option to save the image prior to applying the color correction. It also includes a small change to the file save logic to allow suffixes for the "special" saves without color correction and face restoration.

**Why?**

For single image generation, you can just disable color correction and be done, so this option isn't useful.

However, it is useful in loopback mode, where you **need** color correction to avoid progressive magenta skew  (especially with long loops and relatively low denoise strength).

By saving the image before color correction is applied, we can avoid the degradation caused by color correction for that particular frame, whilst still resetting the histogram in the input to the next frame to avoid the magenta skew.

This solves the issue whereby a user may see a colourful image appear in the UI during a progressive render, only to find it washed out when they retrieve the final output file.

To illustrate, here are 3 side-by-side versions of a loopback all using the same input, prompt and params but with differences in color correction. The 3 versions are: color correction disabled (left), current save behavior (middle), proposed additional save behaviour (right).  Each centre frame is what is actually fed back into the loopback, but the right frame is likely to be the most desirable output for user consumption.

https://user-images.githubusercontent.com/74455/191753387-74579480-8582-411d-84dc-a0f2a02acad8.mp4

- Input image: https://i.imgur.com/eYgtatG.png
- Prompt: Sensational photo portrait with (realistic skin tones) and a stunning background
- Params: Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 57, Size: 512x512, Denoising strength: 0.5, Denoising strength change factor: 1
- Post processing: `ffmpeg -framerate 5 -pattern_type glob -i $DIR_NAME/'*.png' -vf "drawtext=fontfile=Verdana.ttf: text='$DIR_NAME; frame %{frame_num}': start_number=1: x=w-tw*1.1: y=h-lh*1.5: fontcolor=blue: fontsize=20: box=1: boxcolor=white@0.4: boxborderw=5"  -c:v libx264 -pix_fmt yuv420p  ./$DIR_NAME.mp4`

You can see clearly in some frames that saving in this way avoids posterisation, for example frame 19:

<img width="1021" alt="Screen Shot 2022-09-22 at 11 02 12 pm" src="https://user-images.githubusercontent.com/74455/191754367-446a30c5-e443-4a08-96dc-84a5a723aaa4.png">

This also allows each image in the loop to express some color changes, as illustrated here. The input is black&white but the prompt is requesting color, and this is fulfilled by some frames - but would be completely hidden without this PR. As per the caveats below, it still doesn't allow progressive colorisation of the input. (You can see this happening without color correction on the left but it gets ruined by the magenta skew.)

https://user-images.githubusercontent.com/74455/191758945-84ac756d-a55f-4bbc-b619-cf7fd187069c.mp4

- Input image: https://i.imgur.com/1d6ib3F.png
- Prompt: Strange (colorful) photo of an eccentric person.
- Params: Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 41, Size: 512x512, Denoising strength: 0.5, Denoising strength change factor: 1

As an aside, this change co-exists with the option to save images prior to face restoration, allowing you to compare various points in the pipeline:

https://user-images.githubusercontent.com/74455/191761500-29540023-9598-49c3-88a2-95e5888c91c6.mp4


### How?

At the risk of labouring the point of what this change does, here's an overview of the current behaviour:
<img width="939" alt="Screen Shot 2022-09-22 at 10 51 06 pm" src="https://user-images.githubusercontent.com/74455/191757517-ea1d36e2-5244-4761-a10f-478855e8c69c.png">

And here's what the change does:
<img width="1021" alt="Screen Shot 2022-09-22 at 11 18 34 pm" src="https://user-images.githubusercontent.com/74455/191757704-5b268b1f-b228-4891-a40e-9dd8ff838d86.png">


### Caveats

- Users have to enable the option
- Users will now get 2 files for each loop. They will need to understand the difference. I'd personally be open to keeping **only** the pre-cc save, but I understand that many users will want to see exactly what is used as the input for the next loop. We could consider flipping the options, so this new save point is the default, and the post-cc save is the optional extra.
- This still doesn't allow **desirable** progressive color change during the loop. For example, you might want to progressively colorise a black&white photo in a loopback loop. That won't work. Only 1 frame gets to express its color and the palette is reset to the original on each loop. I'm exploring some options to improve this (e.g. only apply color correction every N frames) but ultimately it would be better to fix the root cause i.e. the magenta skew.



