### PR TITLE
Fixed directory name generation process.

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -59,6 +59,7 @@ titles = {
 
     "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
     "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
+    "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
 
     "Loopback": "Process an image, use it as an input, repeat.",
     "Loops": "How many times to repeat processing an image and using it as input for the next iteration",

--- a/modules/images.py
+++ b/modules/images.py
@@ -249,7 +249,6 @@ invalid_filename_prefix = ' '
 invalid_filename_postfix = ' .'
 re_nonletters = re.compile(r'[\s'+string.punctuation+']+')
 max_filename_part_length = 128
-max_prompt_words = 8
 
 
 def sanitize_filename_part(text, replace_spaces=True):
@@ -263,6 +262,8 @@ def sanitize_filename_part(text, replace_spaces=True):
 
 
 def apply_filename_pattern(x, p, seed, prompt):
+    max_prompt_words = opts.directories_max_prompt_words
+
     if seed is not None:
         x = x.replace("[seed]", str(seed))
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -116,6 +116,7 @@ class Options:
         "save_to_dirs": OptionInfo(False, "Save images to a subdirectory"),
         "grid_save_to_dirs": OptionInfo(False, "Save grids to subdirectory"),
         "directories_filename_pattern": OptionInfo("", "Directory name pattern"),
+        "directories_max_prompt_words": OptionInfo(8, "Max prompt words", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1}),
         "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to two directories below", component_args=hide_dirs),
         "outdir_txt2img_samples": OptionInfo("outputs/txt2img-images", 'Output directory for txt2img images', component_args=hide_dirs),
         "outdir_img2img_samples": OptionInfo("outputs/img2img-images", 'Output directory for img2img images', component_args=hide_dirs),


### PR DESCRIPTION
Added "Max prompt words" to config and modified it to be used in the directory name generation process.

This was a feature that existed in the past but had been removed.
The reason we want to restore it is that the default setting makes it difficult to distinguish between folders.

Also, added a warning statement to the tooltip about the maximum length of the system file path.