### PR TITLE
resize mask canvases to fit underlying image (fixes #668)

### DIFF
--- a/javascript/imageMaskFix.js
+++ b/javascript/imageMaskFix.js
@@ -1,0 +1,45 @@
+/**
+ * temporary fix for https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/668
+ * @see https://github.com/gradio-app/gradio/issues/1721
+ */
+window.addEventListener( 'resize', () => imageMaskResize());
+function imageMaskResize() {
+    const canvases = gradioApp().querySelectorAll('#img2maskimg .touch-none canvas');
+    if ( ! canvases.length ) {
+    canvases_fixed = false;
+    window.removeEventListener( 'resize', imageMaskResize );
+    return;
+    }
+
+    const wrapper = canvases[0].closest('.touch-none');
+    const previewImage = wrapper.previousElementSibling;
+
+    if ( ! previewImage.complete ) {
+        previewImage.addEventListener( 'load', () => imageMaskResize());
+        return;
+    }
+
+    const w = previewImage.width;
+    const h = previewImage.height;
+    const nw = previewImage.naturalWidth;
+    const nh = previewImage.naturalHeight;
+    const portrait = nh > nw;
+    const factor = portrait;
+
+    const wW = Math.min(w, portrait ? h/nh*nw : w/nw*nw);
+    const wH = Math.min(h, portrait ? h/nh*nh : w/nw*nh);
+
+    wrapper.style.width = `${wW}px`;
+    wrapper.style.height = `${wH}px`;
+    wrapper.style.left = `${(w-wW)/2}px`;
+    wrapper.style.top = `${(h-wH)/2}px`;
+
+    canvases.forEach( c => {
+        c.style.width = c.style.height = '';
+        c.style.maxWidth = '100%';
+        c.style.maxHeight = '100%';
+        c.style.objectFit = 'contain';
+    });
+ }
+  
+ onUiUpdate(() => imageMaskResize());


### PR DESCRIPTION
The canvas elements used for img2img mask drawing were not being scaled correctly, especially for extreme widescreen aspect ratios, resulting in the mask position being possibly way off from the intended position.
This is basically an issue with gradio itself and they seem to be aware of it (https://github.com/gradio-app/gradio/issues/1721), but while we are waiting for an overhaul of the mask handling from that side, this is intended as a temporary fix to make mask drawing useful meanwhile.

The only downside is that the brush size will scale with the image, so it will always stay the same relatively, but can be very small visually on the canvas for larger image sizes.

(fixes #668)