### PR TITLE
Update .gitignore to ignore downloaded GFPGAN models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 /model.ckpt
 /models/*.ckpt
 /GFPGANv1.3.pth
+/gfpgan/weights/*.pth
 /ui-config.json
 /outputs
 /config.json


### PR DESCRIPTION
Specifically, adds `/gfpgan/weights/*.pth` to .gitignore.