### PR TITLE
Change default bug report template label to bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug-report
 assignees: ''
 
 ---


### PR DESCRIPTION
For later confirmation or denial as an actual bug.

Cleans up the issues listing and allows confirmed bugs to be filtered.