### PR TITLE
fix ldsr

### DIFF
--- a/modules/ldsr_model.py
+++ b/modules/ldsr_model.py
@@ -63,5 +63,5 @@ def upscale_with_ldsr(image):
     pre_scale = shared.opts.ldsr_pre_down
     post_scale = shared.opts.ldsr_post_down
 
-    image = LDSR_obj.super_resolution(image, ddim_steps, pre_scale, post_scale)
+    image = LDSR_obj.superResolution(image, ddim_steps, pre_scale, post_scale)
     return image


### PR DESCRIPTION
This PR fixes a typo in ldsr_model.py which led to LDSR erroring out.

LDSR still needs a lot more work - there's no reason why it should run as slowly as it does - some quick performance wins can be gained from casting it to fp16. Split attention will also probably work with it - it currently uses the default CompVis attention.