### PR TITLE
Fix preview images position

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,7 +143,20 @@ button{
     right: 0;
     margin-left: auto;
     margin-right: auto;
+    margin-top: 35px;
     z-index: 100;
+}
+
+@media screen and (min-width: 768px) {
+    #txt2img_preview, #img2img_preview {
+        position: absolute;
+    }
+}
+
+@media screen and (max-width: 767px) {
+    #txt2img_preview, #img2img_preview {
+        position: relative;
+    }
 }
 
 #txt2img_preview div.left-0.top-0, #img2img_preview div.left-0.top-0{

--- a/style.css
+++ b/style.css
@@ -145,6 +145,9 @@ button{
     margin-right: auto;
     margin-top: 35px;
     z-index: 100;
+    border: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
 }
 
 @media screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -143,7 +143,7 @@ button{
     right: 0;
     margin-left: auto;
     margin-right: auto;
-    margin-top: 35px;
+    margin-top: 34px;
     z-index: 100;
     border: none;
     border-top-left-radius: 0;


### PR DESCRIPTION
When you enable the option to show image creation progress every N sampling steps the images position will be a little off:

**Before**
<img width="1299" alt="before" src="https://user-images.githubusercontent.com/7781056/192031234-e2b65db1-55ec-416e-9d39-a42ae45ddff9.png">

**After**
<img width="1299" alt="after" src="https://user-images.githubusercontent.com/7781056/192031285-3d0f6f80-60da-46c1-a2a9-d3e19ab3c265.png">

In a mobile device the preview images will be on top of another UI component so I changed the position to be relative only for mobile:

**Before**
<img width="441" alt="mobile-before" src="https://user-images.githubusercontent.com/7781056/192031520-0f69c80a-27de-4788-9633-1a933a3c60d0.png">

**After**
<img width="441" alt="mobile-after" src="https://user-images.githubusercontent.com/7781056/192031541-afa8895f-2a30-4f73-b1e2-19732166b983.png">
