### PR TITLE
Remove double loading message

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -49,7 +49,6 @@ sample_img2img = sample_img2img if os.path.exists(sample_img2img) else None
 
 css_hide_progressbar = """
 .wrap .m-12 svg { display:none!important; }
-.wrap .m-12::before { content:"Loading..." }
 .progress-bar { display:none!important; }
 .meta-text { display:none!important; }
 """


### PR DESCRIPTION
Extremely small PR, when you open the Web UI it shows a duplicated "Loading..." message:

<img width="247" alt="double-loading" src="https://user-images.githubusercontent.com/7781056/192066919-121e08d4-f551-44dc-8b04-8d7daeadb519.png">

Now it should show the "Loading..." message once:

<img width="279" alt="loading" src="https://user-images.githubusercontent.com/7781056/192067349-34d752c6-29ab-4398-8a1a-7c830141b6ed.png">
