### PR TITLE
Clear no longer needed VRAM during a 'highres fix' generation created…

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -488,6 +488,11 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
         self.sampler = samplers[self.sampler_index].constructor(self.sd_model)
         noise = create_random_tensors(samples.shape[1:], seeds=seeds, subseeds=subseeds, subseed_strength=subseed_strength, seed_resize_from_h=self.seed_resize_from_h, seed_resize_from_w=self.seed_resize_from_w, p=self)
+
+        # GC now before running the next img2img to prevent running out of memory
+        x = None
+        devices.torch_gc()
+        
         samples = self.sampler.sample_img2img(self, samples, noise, conditioning, unconditional_conditioning, steps=self.steps)
 
         return samples


### PR DESCRIPTION
… during the first sampling before doing the second (img2img) sampling. Makes it possible to use the feature on an 8GB card.