### PR TITLE
Prompt blending

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -133,7 +133,7 @@ def get_learned_conditioning(prompts, steps):
             continue
 
         cond_schedule = []
-        for promtStep,promptText in prompt_schedule:
+        for end_at_step,promptText in prompt_schedule:
             weighted_subprompts = split_weighted_subprompts(promptText, shared.opts.prompt_blending_normalize)
 
             if shared.opts.prompt_blending_enable and len(weighted_subprompts) > 1:
@@ -146,7 +146,7 @@ def get_learned_conditioning(prompts, steps):
             else:
                 cond = shared.sd_model.get_learned_conditioning([promptText])
 
-            cond_schedule.append(ScheduledPromptConditioning(promtStep, cond[0]))
+            cond_schedule.append(ScheduledPromptConditioning(end_at_step, cond[0]))
 
         cache[prompt] = cond_schedule
         res.append(cond_schedule)

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -134,9 +134,12 @@ def get_learned_conditioning(prompts, steps):
 
         cond_schedule = []
         for end_at_step,promptText in prompt_schedule:
-            weighted_subprompts = split_weighted_subprompts(promptText, shared.opts.prompt_blending_normalize)
+            
+            weighted_subprompts = []
+            if shared.opts.prompt_blending_enable:
+                weighted_subprompts = split_weighted_subprompts(promptText, shared.opts.prompt_blending_normalize)
 
-            if shared.opts.prompt_blending_enable and len(weighted_subprompts) > 1:
+            if len(weighted_subprompts) > 1:
                 texts = [p.text for p in weighted_subprompts]
                 cond = shared.sd_model.get_learned_conditioning(texts)
                 c = torch.zeros_like(cond[0])

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -135,7 +135,7 @@ def get_learned_conditioning(prompts, steps):
         cond_schedule = []
         for promtStep,promptText in prompt_schedule:
             weighted_subprompts = split_weighted_subprompts(promptText, shared.opts.prompt_blending_normalize)
-            print(weighted_subprompts)
+
             if shared.opts.prompt_blending_enable and len(weighted_subprompts) > 1:
                 texts = [p.text for p in weighted_subprompts]
                 cond = shared.sd_model.get_learned_conditioning(texts)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -215,6 +215,10 @@ options_templates.update(options_section(('ui', "User interface"), {
     "js_modal_lightbox_initialy_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
 }))
 
+options_templates.update(options_section(('prompt-blend', "Prompt Blending"), {
+    "prompt_blending_enable": OptionInfo(False, "Enable Prompt Blending with 'prompt@weight' syntax."),
+    "prompt_blending_normalize": OptionInfo(True, "Automatically normalize prompt blending weights to 1."),
+}))
 
 class Options:
     data = None


### PR DESCRIPTION
Prompt blending suggested by @amotile in #930 

Implemented as an optional `prompt1@weight1 prompt2@weight2` syntax, default off in the settings.

Some examples:

Various raw unblended elements of dragons:

![image](https://user-images.githubusercontent.com/35278260/192078188-8c713382-1acc-4fe2-9426-b0350c7168d0.png)

And those prompts 'blended' in varying combinations:

![image](https://user-images.githubusercontent.com/35278260/192078203-7b4b9e59-2d77-4d7e-aff1-b2194e54c47a.png)

