### PR TITLE
Support negative prompt appearing on the last line in pasted generation parameters

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -36,6 +36,10 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         else:
             prompt += line
 
+    if lastline.startswith("Negative prompt:"):
+        negative_prompt += lastline[16:].strip()
+        lastline = ""
+
     if len(prompt) > 0:
         res["Prompt"] = prompt
 


### PR DESCRIPTION
Sometimes people share prompts with just the positive and negative sides and no line of config params. In such cases the negative prompt gets interpreted as config. This change detects this condition and adds it to the negative prompt directly.