### PR TITLE
Disable 'batch img2img' when launched with --hide-ui-dir-config

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -108,6 +108,8 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
     p.extra_generation_params["Mask blur"] = mask_blur
 
     if is_batch:
+        assert not shared.cmd_opts.hide_ui_dir_config, "Launched with --hide-ui-dir-config, batch img2img disabled"
+
         process_batch(p, img2img_batch_input_dir, img2img_batch_output_dir, args)
 
         processed = Processed(p, [], p.seed, "")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -116,7 +116,7 @@ def options_section(section_identifer, options_dict):
     return options_dict
 
 
-hide_dirs = {"visible": False} if cmd_opts.hide_ui_dir_config else None
+hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}
 
 options_templates = {}
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -578,9 +578,10 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
                             inpaint_full_res_padding = gr.Slider(label='Inpaint at full resolution padding, pixels', minimum=0, maximum=256, step=4, value=32)
 
                     with gr.TabItem('Batch img2img', id='batch'):
-                        gr.HTML("<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.</p>")
-                        img2img_batch_input_dir = gr.Textbox(label="Input directory")
-                        img2img_batch_output_dir = gr.Textbox(label="Output directory")
+                        hidden = '<br>Disabled when launched with --hide-ui-dir-config.' if shared.cmd_opts.hide_ui_dir_config else ''
+                        gr.HTML(f"<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.{hidden}</p>")
+                        img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs)
+                        img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
 
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")


### PR DESCRIPTION
Just keeping up the crusade of having the `--hide-ui-dir-config` flag prevent remote users from modifying arbitrary directories.

I thought about having the flag limit output to some specific directory, but then it occurred to me that I can't think of a sane place to limit input to without adding _another_ config option.
The `batch img2img` feature isn't constructively useful without arbitrary read/write access on the machine anyway, and since this flag is intended for a server launched with `--share` and/or `--listen`, it shouldn't really matter that this feature is turned off anyway.

I do wonder if `--share` and/or `--listen` should _imply_ (at least the functionality of) `--hide-ui-dir-config`, and we change the flag to `--show-ui-dir-config` or something for turning _on_ arbitrary directory access in those cases. I don't think it's good practice for an obvious security vulnerability to be _opt-out_.
_At the very least_, `--share` and/or `--listen` without `--gradio-auth` should turn `--hide-ui-dir-config` on by default?