### PR TITLE
Set custom script keys

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -119,6 +119,7 @@ class ScriptRunner:
                 continue
 
             for control in controls:
+                control.custom_script_source = os.path.basename(script.filename)
                 control.visible = False
 
             inputs += controls

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1038,6 +1038,9 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo):
     def loadsave(path, x):
         def apply_field(obj, field, condition=None):
             key = path + "/" + field
+
+            if getattr(obj,'custom_script_source',None) is not None:
+              key = 'customscript/' + obj.custom_script_source + '/' + key
             
             if getattr(obj,'do_not_save_to_config',False):
               return


### PR DESCRIPTION
Separation of config values from custom scripts by extending their key in the config file - invalidates existing keys.

