### PR TITLE
Fix token max length

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -300,7 +300,7 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
         remade_batch_tokens = []
         id_start = self.wrapped.tokenizer.bos_token_id
         id_end = self.wrapped.tokenizer.eos_token_id
-        maxlen = self.wrapped.max_length - 2
+        maxlen = self.wrapped.max_length
         used_custom_terms = []
 
         cache = {}


### PR DESCRIPTION
Currently the text encoder is accepting 2 too few tokens than it could (73 instead of 75, excluding start and end tokens).
This is because the special tokens are counted twice.

## Before
73 tokens
![image](https://user-images.githubusercontent.com/24762404/192130618-16d4d8c1-66ab-438a-9c06-bcceae3bc413.png)
74 tokens
![image](https://user-images.githubusercontent.com/24762404/192130553-8706acfe-4a8c-49e1-9973-2e77b4233f58.png)

## After
75 tokens
![image](https://user-images.githubusercontent.com/24762404/192130372-3a430ab9-57f3-4d3d-a554-3d622e18de62.png)
76 tokens
![image](https://user-images.githubusercontent.com/24762404/192130417-cfecdf51-75d1-4cd6-9551-85f19edc7349.png)


