### PR TITLE
Added [job_timestamp] pattern for directory and file names

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -57,8 +57,8 @@ titles = {
 
     "Interrogate": "Reconstruct prompt from existing image and put it into the prompt field.",
 
-    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
-    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
+    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_id]; leave empty for default.",
+    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_id]; leave empty for default.",
     "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
     "Length of job id": "Sets the number of characters to be used for the [job_id] option",    
 

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -57,14 +57,12 @@ titles = {
 
     "Interrogate": "Reconstruct prompt from existing image and put it into the prompt field.",
 
-    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_id]; leave empty for default.",
-    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_id]; leave empty for default.",
+    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_timestamp]; leave empty for default.",
+    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [job_timestamp]; leave empty for default.",
     "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
-    "Length of job id": "Sets the number of characters to be used for the [job_id] option",    
 
     "Loopback": "Process an image, use it as an input, repeat.",
     "Loops": "How many times to repeat processing an image and using it as input for the next iteration",
-
 
     "Style 1": "Style to apply; styles have components for both positive and negative prompts and apply to both",
     "Style 2": "Style to apply; styles have components for both positive and negative prompts and apply to both",

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -60,6 +60,7 @@ titles = {
     "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
     "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date]; leave empty for default.",
     "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
+    "Length of job id": "Sets the number of characters to be used for the [job_id] option",    
 
     "Loopback": "Process an image, use it as an input, repeat.",
     "Loops": "How many times to repeat processing an image and using it as input for the next iteration",

--- a/modules/images.py
+++ b/modules/images.py
@@ -295,6 +295,7 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     x = x.replace("[model_hash]", shared.sd_model.sd_model_hash)
     x = x.replace("[date]", datetime.date.today().isoformat())
+    x = x.replace("[job_id]", shared.state.job_id)
 
     if cmd_opts.hide_ui_dir_config:
         x = re.sub(r'^[\\/]+|\.{2,}[\\/]+|[\\/]+\.{2,}', '', x)

--- a/modules/images.py
+++ b/modules/images.py
@@ -295,7 +295,7 @@ def apply_filename_pattern(x, p, seed, prompt):
 
     x = x.replace("[model_hash]", shared.sd_model.sd_model_hash)
     x = x.replace("[date]", datetime.date.today().isoformat())
-    x = x.replace("[job_id]", shared.state.job_id)
+    x = x.replace("[job_timestamp]", shared.state.job_timestamp)
 
     if cmd_opts.hide_ui_dir_config:
         x = re.sub(r'^[\\/]+|\.{2,}[\\/]+|[\\/]+\.{2,}', '', x)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -4,6 +4,7 @@ import json
 import os
 import gradio as gr
 import tqdm
+import random
 
 import modules.artists
 from modules.paths import script_path, sd_path
@@ -65,6 +66,7 @@ class State:
     job = ""
     job_no = 0
     job_count = 0
+    job_id = 0
     sampling_step = 0
     sampling_steps = 0
     current_latent = None
@@ -78,6 +80,8 @@ class State:
         self.job_no += 1
         self.sampling_step = 0
         self.current_image_sampling_step = 0
+    def gen_job_id(self):
+        return ''.join(random.choices('0123456789abcdefghijklmnopqrstuvwxyz', k=opts.job_id_length))
 
 
 state = State()
@@ -114,7 +118,6 @@ def options_section(section_identifer, options_dict):
         v.section = section_identifer
 
     return options_dict
-
 
 hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}
 
@@ -156,6 +159,7 @@ options_templates.update(options_section(('saving-to-dirs', "Saving to a directo
     "grid_save_to_dirs": OptionInfo(False, "Save grids to subdirectory"),
     "directories_filename_pattern": OptionInfo("", "Directory name pattern"),
     "directories_max_prompt_words": OptionInfo(8, "Max prompt words", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1}),
+    "job_id_length": OptionInfo(5, "Length of job id", gr.Slider, {"minimum": 5, "maximum": 20, "step": 1}),
 }))
 
 options_templates.update(options_section(('upscaling', "Upscaling"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -117,8 +117,8 @@ def options_section(section_identifer, options_dict):
     for k, v in options_dict.items():
         v.section = section_identifer
 
-
     return options_dict
+
 
 hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -117,6 +117,7 @@ def options_section(section_identifer, options_dict):
     for k, v in options_dict.items():
         v.section = section_identifer
 
+
     return options_dict
 
 hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -4,7 +4,7 @@ import json
 import os
 import gradio as gr
 import tqdm
-import random
+import datetime
 
 import modules.artists
 from modules.paths import script_path, sd_path
@@ -66,7 +66,7 @@ class State:
     job = ""
     job_no = 0
     job_count = 0
-    job_id = 0
+    job_timestamp = 0
     sampling_step = 0
     sampling_steps = 0
     current_latent = None
@@ -80,8 +80,8 @@ class State:
         self.job_no += 1
         self.sampling_step = 0
         self.current_image_sampling_step = 0
-    def gen_job_id(self):
-        return ''.join(random.choices('0123456789abcdefghijklmnopqrstuvwxyz', k=opts.job_id_length))
+    def get_job_timestamp(self):
+        return datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
 
 state = State()
@@ -160,7 +160,6 @@ options_templates.update(options_section(('saving-to-dirs', "Saving to a directo
     "grid_save_to_dirs": OptionInfo(False, "Save grids to subdirectory"),
     "directories_filename_pattern": OptionInfo("", "Directory name pattern"),
     "directories_max_prompt_words": OptionInfo(8, "Max prompt words", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1}),
-    "job_id_length": OptionInfo(5, "Length of job id", gr.Slider, {"minimum": 5, "maximum": 20, "step": 1}),
 }))
 
 options_templates.update(options_section(('upscaling', "Upscaling"), {

--- a/webui.py
+++ b/webui.py
@@ -50,7 +50,7 @@ def wrap_gradio_gpu_call(func):
         shared.state.sampling_step = 0
         shared.state.job_count = -1
         shared.state.job_no = 0
-        shared.state.job_id = shared.state.gen_job_id()
+        shared.state.job_timestamp = shared.state.get_job_timestamp()
         shared.state.current_latent = None
         shared.state.current_image = None
         shared.state.current_image_sampling_step = 0

--- a/webui.py
+++ b/webui.py
@@ -50,6 +50,7 @@ def wrap_gradio_gpu_call(func):
         shared.state.sampling_step = 0
         shared.state.job_count = -1
         shared.state.job_no = 0
+        shared.state.job_id = shared.state.gen_job_id()
         shared.state.current_latent = None
         shared.state.current_image = None
         shared.state.current_image_sampling_step = 0


### PR DESCRIPTION
Closes #802 

Decided to have a go at my own feature request. I'm inexperienced working with larger codebases like this, but I don't think it should break anything.
Tested in txt2img and img2img at different job_id lengths set in the settings, and it works as expected.