### PR TITLE
Adding support for brace-expansion in prompts

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -15,3 +15,4 @@ font-roboto
 timm==0.6.7
 fairscale==0.4.9
 piexif==1.1.3
+braceexpand

--- a/scripts/braceExpansion.py
+++ b/scripts/braceExpansion.py
@@ -1,0 +1,42 @@
+import math
+import os
+import sys
+import traceback
+
+import modules.scripts as scripts
+import gradio as gr
+
+from modules.processing import Processed, process_images
+from PIL import Image
+from modules.shared import opts, cmd_opts, state
+
+from braceexpand import braceexpand
+
+
+class Script(scripts.Script):
+    def title(self):
+        return "Prompts with brace expand"
+
+    def ui(self, is_img2img):
+        return []
+
+    def run(self, p):
+        lines = list(braceexpand(p.prompt))
+
+        img_count = len(lines) * p.n_iter
+        batch_count = math.ceil(img_count / p.batch_size)
+        loop_count = math.ceil(batch_count / p.n_iter)
+        print(f"Will process {img_count} images in {batch_count} batches.")
+
+        p.do_not_save_grid = True
+
+        state.job_count = batch_count
+
+        images = []
+        for loop_no in range(loop_count):
+            state.job = f"{loop_no + 1} out of {loop_count}"
+            p.prompt = lines[loop_no*p.batch_size:(loop_no+1)*p.batch_size] * p.n_iter
+            proc = process_images(p)
+            images += proc.images
+
+        return Processed(p, images, p.seed, "")


### PR DESCRIPTION
There is currently no **user-friendly** way to try the effect of multiple tokens in a single prompt (X/Y plot and other scripts are not satisfactory IMO)

I propose to add a support for that feature though bash-like brace expansion.

For instance, with this script, the prompt `{A wise man, An idiot} watching {the moon, his finger}`  will generate 4 images with respectively the prompts `A wise man watching the moon` , `A wise man watching his finger`, `An idiot watching the moon` and `An idiot watching his finger`

I made this modification a separate script in order to leave the base code untouched but this could easily be merged to the main prompt if wished.