### PR TITLE
Ddim_eta + grab bag of extra sampler params

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -78,7 +78,14 @@ class StableDiffusionProcessing:
         self.paste_to = None
         self.color_corrections = None
         self.denoising_strength: float = 0
-
+        
+        self.ddim_eta = opts.ddim_eta
+        self.ddim_discretize = opts.ddim_discretize
+        self.s_churn = opts.s_churn
+        self.s_tmin = opts.s_tmin
+        self.s_tmax = float('inf') # not representable as a standard ui option
+        self.s_noise = opts.s_noise
+        
         if not seed_enable_extras:
             self.subseed = -1
             self.subseed_strength = 0
@@ -117,6 +124,13 @@ class Processed:
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
 
+        self.ddim_eta = p.ddim_eta
+        self.ddim_discretize = p.ddim_discretize
+        self.s_churn = p.s_churn
+        self.s_tmin = p.s_tmin
+        self.s_tmax = p.s_tmax
+        self.s_noise = p.s_noise
+        
         self.prompt = self.prompt if type(self.prompt) != list else self.prompt[0]
         self.negative_prompt = self.negative_prompt if type(self.negative_prompt) != list else self.negative_prompt[0]
         self.seed = int(self.seed if type(self.seed) != list else self.seed[0])

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -120,9 +120,9 @@ class VanillaStableDiffusionSampler:
 
         # existing code fails with cetain step counts, like 9
         try:
-            self.sampler.make_schedule(ddim_num_steps=steps, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps,  ddim_eta=opts.ddim_eta, ddim_discretize=opts.ddim_discretize, verbose=False)
         except Exception:
-            self.sampler.make_schedule(ddim_num_steps=steps+1, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps+1,ddim_eta=opts.ddim_eta, ddim_discretize=opts.ddim_discretize, verbose=False)
 
         x1 = self.sampler.stochastic_encode(x, torch.tensor([t_enc] * int(x.shape[0])).to(shared.device), noise=noise)
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -125,9 +125,9 @@ class VanillaStableDiffusionSampler:
 
         # existing code fails with cetain step counts, like 9
         try:
-            self.sampler.make_schedule(ddim_num_steps=steps,  ddim_eta=opts.ddim_eta, ddim_discretize=opts.ddim_discretize, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps,  ddim_eta=p.ddim_eta, ddim_discretize=p.ddim_discretize, verbose=False)
         except Exception:
-            self.sampler.make_schedule(ddim_num_steps=steps+1,ddim_eta=opts.ddim_eta, ddim_discretize=opts.ddim_discretize, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps+1,ddim_eta=p.ddim_eta, ddim_discretize=p.ddim_discretize, verbose=False)
 
         x1 = self.sampler.stochastic_encode(x, torch.tensor([t_enc] * int(x.shape[0])).to(shared.device), noise=noise)
 
@@ -277,8 +277,8 @@ class KDiffusionSampler:
 
         extra_params_kwargs = {}
         for val in self.extra_params:
-          if hasattr(opts,val):
-            extra_params_kwargs[val] = getattr(opts,val)
+          if hasattr(p,val):
+            extra_params_kwargs[val] = getattr(p,val)
 
         return self.func(self.model_wrap_cfg, xi, sigma_sched, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs)
 
@@ -299,8 +299,8 @@ class KDiffusionSampler:
 
         extra_params_kwargs = {}
         for val in self.extra_params:
-          if hasattr(opts,val):
-            extra_params_kwargs[val] = getattr(opts,val)
+          if hasattr(p,val):
+            extra_params_kwargs[val] = getattr(p,val)
 
         samples = self.func(self.model_wrap_cfg, x, sigmas, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs)
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -38,9 +38,9 @@ samplers = [
 samplers_for_img2img = [x for x in samplers if x.name != 'PLMS']
 
 sampler_extra_params = {
-    'sample_euler':['s_churn','s_tmin','s_noise'],
-    'sample_heun' :['s_churn','s_tmin','s_noise'],
-    'sample_dpm_2':['s_churn','s_tmin','s_noise'],
+    'sample_euler':['s_churn','s_tmin','s_tmax','s_noise'],
+    'sample_heun' :['s_churn','s_tmin','s_tmax','s_noise'],
+    'sample_dpm_2':['s_churn','s_tmin','s_tmax','s_noise'],
 }
 
 def setup_img2img_steps(p, steps=None):

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -154,9 +154,9 @@ class VanillaStableDiffusionSampler:
 
         # existing code fails with cetin step counts, like 9
         try:
-            samples_ddim, _ = self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x)
+            samples_ddim, _ = self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.ddim_eta)
         except Exception:
-            samples_ddim, _ = self.sampler.sample(S=steps+1, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x)
+            samples_ddim, _ = self.sampler.sample(S=steps+1, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.ddim_eta)
 
         return samples_ddim
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -222,6 +222,9 @@ options_templates.update(options_section(('ui', "User interface"), {
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {
   "ddim_eta": OptionInfo(0.0, "img2img ddim eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
   "ddim_discretize": OptionInfo('uniform', "img2img ddim discretize", gr.Radio, {"choices": ['uniform','quad']}),
+  's_churn': OptionInfo(0.0, "sigma churn", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+  's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+  's_noise': OptionInfo(1.0, "sigma noise", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
 }))
 
 class Options:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -220,8 +220,8 @@ options_templates.update(options_section(('ui', "User interface"), {
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {
-  "ddim_eta": OptionInfo(0.0, "img2img ddim eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
-  "ddim_discretize": OptionInfo('uniform', "img2img ddim discretize", gr.Radio, {"choices": ['uniform','quad']}),
+  "ddim_eta": OptionInfo(0.0, "DDIM eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+  "ddim_discretize": OptionInfo('uniform', "img2img DDIM discretize", gr.Radio, {"choices": ['uniform','quad']}),
   's_churn': OptionInfo(0.0, "sigma churn", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
   's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
   's_noise': OptionInfo(1.0, "sigma noise", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -219,6 +219,10 @@ options_templates.update(options_section(('ui', "User interface"), {
     "js_modal_lightbox_initialy_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
 }))
 
+options_templates.update(options_section(('sampler-params', "Sampler parameters"), {
+  "ddim_eta": OptionInfo(0.0, "img2img ddim eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+  "ddim_discretize": OptionInfo('uniform', "img2img ddim discretize", gr.Radio, {"choices": ['uniform','quad']}),
+}))
 
 class Options:
     data = None

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -86,7 +86,12 @@ axis_options = [
     AxisOption("Prompt S/R", str, apply_prompt, format_value),
     AxisOption("Sampler", str, apply_sampler, format_value),
     AxisOption("Checkpoint name", str, apply_checkpoint, format_value),
-    AxisOptionImg2Img("Denoising", float, apply_field("denoising_strength"), format_value_add_label), #  as it is now all AxisOptionImg2Img items must go after AxisOption ones
+    AxisOption("Sigma Churn", float, apply_field("s_churn"),  format_value_add_label),
+    AxisOption("Sigma min",   float, apply_field("s_tmin"),   format_value_add_label),
+    AxisOption("Sigma max",   float, apply_field("s_tmax"),   format_value_add_label),
+    AxisOption("Sigma noise", float, apply_field("s_noise"),  format_value_add_label),
+    AxisOptionImg2Img("Denoising", float, apply_field("denoising_strength"), format_value_add_label),
+    AxisOptionImg2Img("DDIM Eta", float, apply_field("ddim_eta"), format_value_add_label) #  as it is now all AxisOptionImg2Img items must go after AxisOption ones
 ]
 
 

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -90,8 +90,8 @@ axis_options = [
     AxisOption("Sigma min",   float, apply_field("s_tmin"),   format_value_add_label),
     AxisOption("Sigma max",   float, apply_field("s_tmax"),   format_value_add_label),
     AxisOption("Sigma noise", float, apply_field("s_noise"),  format_value_add_label),
-    AxisOptionImg2Img("Denoising", float, apply_field("denoising_strength"), format_value_add_label),
-    AxisOptionImg2Img("DDIM Eta", float, apply_field("ddim_eta"), format_value_add_label) #  as it is now all AxisOptionImg2Img items must go after AxisOption ones
+    AxisOption("DDIM Eta",    float, apply_field("ddim_eta"), format_value_add_label),
+    AxisOptionImg2Img("Denoising", float, apply_field("denoising_strength"), format_value_add_label),#  as it is now all AxisOptionImg2Img items must go after AxisOption ones
 ]
 
 


### PR DESCRIPTION
@yschroeder mentioned them in #1050 presented here as new options but for a final implementation they'd be optionally exposed on the img2img page but some are a bit niche for that.

ddim_eta applies to txt2img and img2img with DDIM only

sigma churn, sigma tmin, sigma tmax  and sigma noise apply to euler, heun & dpm2

sigma tmin, sigma tmax and sigma noise only have an effect when sigma churn > 0

Totally arbitrary img2img effects:

Increasing ddim_eta:
![image](https://user-images.githubusercontent.com/35278260/192271346-3dcd794d-8cf4-456a-8ba7-3ebcf57faf9b.png)

ddim discretize 'uniform' vs 'quad'
![image](https://user-images.githubusercontent.com/35278260/192272329-c114b59b-4977-4d84-88ea-1c5a62622eb1.png)

increasing sigma churn on euler:
![image](https://user-images.githubusercontent.com/35278260/192273466-e176af20-2204-4283-9732-355e6dd2afc7.png)

Totally arbitrary txt2img effects:

```
elf wearing ornate intricate detailed carved stained glass (((armor))), determined face, heavy makeup, led runes, inky swirling mist, gemstones, ((magic mist background)), ((eyeshadow)), (angry), detailed, intricate,(Alphonse Mucha), (Charlie Bowater), (Daniel Ridgway Knight), (Albert Lynch), (Richard S. Johnson)
Negative prompt: ugly, fat, obese, chubby, (((deformed))), [blurry], bad anatomy, disfigured, poorly drawn face, mutation, mutated, (extra_limb), (ugly), (poorly drawn hands), messy drawing, large_breasts, penis, nose, eyes, lips, eyelashes, text, red_eyes
Steps: 20, Sampler: Euler, CFG scale: 7, Seed: 3548984829, Size: 768x1024, Model hash: 7460a6fa, Denoising strength: 0.7
```

increasing sigma churn Euler:
![image](https://user-images.githubusercontent.com/35278260/192276219-8e77ccf0-b32d-4324-bfec-48b262e5047c.png)

txt2img eta increments 0.0-1.0 on DDIM:
![download](https://user-images.githubusercontent.com/35278260/192335204-33912cc4-dbb4-41ad-b42c-afeff5e0febf.png)

