### PR TITLE
Grids saving to subdirectory when setting unchecked

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -406,7 +406,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                 index_of_first_image = 1
 
             if opts.grid_save:
-                images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], all_prompts[0], opts.grid_format, info=infotext(), short_filename=not opts.grid_extended_filename, p=p)
+                images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], all_prompts[0], opts.grid_format, info=infotext(), short_filename=not opts.grid_extended_filename, p=p, grid=True)
 
     devices.torch_gc()
     return Processed(p, output_images, all_seeds[0], infotext(), subseed=all_subseeds[0], all_prompts=all_prompts, all_seeds=all_seeds, all_subseeds=all_subseeds, index_of_first_image=index_of_first_image)


### PR DESCRIPTION
#1086 

Grids currently save to a subdirectory when the "Save images to subdirectory" setting is checked but the "Save grids to subdirectory" setting isn't. This change passes along the existing grid flag to resolve the issue.