### PR TITLE
Disable wandb sentry logging

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -3,6 +3,8 @@
 if not defined PYTHON (set PYTHON=python)
 if not defined VENV_DIR (set VENV_DIR=venv)
 
+set ERROR_REPORTING=FALSE
+
 mkdir tmp 2>NUL
 
 %PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt

--- a/webui.sh
+++ b/webui.sh
@@ -41,6 +41,9 @@ then
     venv_dir="venv"
 fi
 
+# Disable sentry logging
+export ERROR_REPORTING=FALSE
+
 # Do not reinstall existing pip packages on Debian/Ubuntu
 export PIP_IGNORE_INSTALLED=0
 


### PR DESCRIPTION
wandb has a http call to a 'sentry' telemetry endpoint on import.
This environment variable disables it.