### PR TITLE
Add button that removes images from gallery, but breaks seed re-use

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -15,6 +15,7 @@ titles = {
     "\u267b\ufe0f": "Reuse seed from last generation, mostly useful if it was randomed",
     "\u{1f3a8}": "Add a random artist to the prompt.",
     "\u2199\ufe0f": "Read generation parameters from prompt into user interface.",
+    "\u{1F5D1}": "Remove selected image from gallery. Does NOT delete the file. !!!Breaks reuse seed button!!!",
 
     "Inpaint a part of image": "Draw a mask over an image, and the script will regenerate the masked area with content according to prompt",
     "SD upscale": "Upscale image normally, split result into tiles, improve each tile using img2img, merge whole image back",

--- a/style.css
+++ b/style.css
@@ -134,6 +134,16 @@ button{
     border: none !important;
 }
 
+#image_options {
+    gap: 0.6rem;
+}
+
+#image_options > #delete_button {
+    min-width: auto;
+    flex-grow: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
 
 #img2maskimg .h-60{
     height: 30rem;


### PR DESCRIPTION
This or similar features have been requested a few times (#1051, #758, #95) so I tried to implement it.

Currently my code adds this button:
![image](https://user-images.githubusercontent.com/72598914/192300952-5aff6290-91ec-4c2a-a906-091ff0871efd.png)

Clicking on it will successfully remove the image you have selected from the gallery, but it will also cause the reuse seed button to no longer give accurate results (because it relies on the position of the images compared to the original seed, the position which is now incorrect due to the missing image/images)

In order to make it work, it would require a re-write of the reuse seed code to use some other method of determining the seed. Which should be doable. But I first wanted to hear other people's opinions. 