### PR TITLE
refactored image paste handling to fill unset images successively, then replace last existing image (fixes #981)

### DIFF
--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -68,13 +68,19 @@ window.addEventListener('paste', e => {
     if ( ! isValidImageList( files ) ) {
         return;
     }
-    [...gradioApp().querySelectorAll('input[type=file][accept="image/x-png,image/gif,image/jpeg"]')]
-        .filter(input => !input.matches('.\\!hidden input[type=file]'))
-        .forEach(input => {
-            input.files = files;
-            input.dispatchEvent(new Event('change'))
-        });
-    [...gradioApp().querySelectorAll('[data-testid="image"]')]
-        .filter(imgWrap => !imgWrap.closest('.\\!hidden'))
-        .forEach(imgWrap => dropReplaceImage( imgWrap, files ));
+
+    const visibleImageFields = [...gradioApp().querySelectorAll('[data-testid="image"]')]
+        .filter(el => uiElementIsVisible(el));
+    if ( ! visibleImageFields.length ) {
+        return;
+    }
+    
+    const firstFreeImageField = visibleImageFields
+        .filter(el => el.querySelector('input[type=file]'))?.[0];
+
+    dropReplaceImage(
+        firstFreeImageField ?
+        firstFreeImageField :
+        visibleImageFields[visibleImageFields.length - 1]
+    , files );
 });

--- a/script.js
+++ b/script.js
@@ -39,3 +39,24 @@ document.addEventListener("DOMContentLoaded", function() {
     });
     mutationObserver.observe( gradioApp(), { childList:true, subtree:true })
 });
+
+/**
+ * checks that a UI element is not in another hidden element or tab content
+ */
+function uiElementIsVisible(el) {
+    let isVisible = !el.closest('.\\!hidden');
+    if ( ! isVisible ) {
+        return false;
+    }
+
+    while( isVisible = el.closest('.tabitem')?.style.display !== 'none' ) {
+        if ( ! isVisible ) {
+            return false;
+        } else if ( el.parentElement ) {
+            el = el.parentElement
+        } else {
+            break;
+        }
+    }
+    return isVisible;
+}


### PR DESCRIPTION
I refactored the code that handles pasting images. It now has less redundant code and also the behaviour has changed when there are multiple image fields to fill (e.g. Inpaint with Upload Mask enabled):
First, all fields that have not yet been assigned an image will be filled from the clipboard, one at a time with each paste event. When all fields are assigned an image, only the last one will change.

We might want to think about a better solution for the future, where you can specify which image field you want to paste into, e.g. by pointing the mouse cursor over it.

(fixes #981)