### PR TITLE
force Euler method for the "img2img alternative test" script

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -183,3 +183,40 @@ onUiUpdate(function(){
 
     json_elem.parentElement.style.display="none"
 })
+
+/**
+ * force Euler method for the "img2img alternative test" script
+ */
+let prev_sampling_method;
+onUiTabChange(function() {
+    const currentTab = get_uiCurrentTab();
+    if ( ! currentTab || currentTab?.textContent.trim() !== 'img2img' ) {
+        return;
+    }
+
+    const altScriptName = 'img2img alternative test';
+    const scriptSelect = gradioApp().querySelector('#component-223 select');
+    const methodRadios = gradioApp().querySelectorAll('[name="radio-component-182"]');
+    scriptSelect.addEventListener( 'change', function() {
+        if( scriptSelect.value === altScriptName) {
+            prev_sampling_method = gradioApp().querySelector('[name="radio-component-182"]:checked');
+            methodRadios.forEach(radio => {
+                const isEuler = radio.value === 'Euler';
+                const label = radio.closest('label');
+                radio.disabled = !isEuler;
+                radio.checked = isEuler;
+                label.classList[isEuler ? 'remove' : 'add']('!cursor-not-allowed');
+                label.title = !isEuler ? `${altScriptName} only works with the Euler method` : '';
+            });
+        } else {
+            // reset to previous method
+            methodRadios.forEach(radio => {
+                const label = radio.closest('label');
+                radio.disabled = false;
+                radio.checked = radio === prev_sampling_method;
+                label.classList.remove('!cursor-not-allowed');
+                label.title = '';
+            });
+        }
+    });
+})

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -55,12 +55,6 @@ class Script:
     # your description as the value.
     def describe(self):
         return ""
-
-    # If your script is only compatible with a subset of samplers, return the sampler
-    # names here, an empty list indicates compatibility with all samplers, for a full
-    # listing of current sampler names import modules.sd_samplers.samplers
-    def compatible_samplers(self):
-        return []
     
 scripts_data = []
 
@@ -137,11 +131,7 @@ class ScriptRunner:
             for control in controls:
                 control.custom_script_source = os.path.basename(script.filename)
                 control.visible = False
-
-            concat_compatible_samplers = ",".join(script.compatible_samplers())
-            inputs += [gr.HTML(value='<span class="customScriptAttrs" data-supported-samplers="{}"></span>'.format(concat_compatible_samplers))]
-            inputs[-1].visible=False
-                
+            
             inputs += controls
             script.args_to = len(inputs)
 
@@ -189,7 +179,7 @@ class ScriptRunner:
         if script is None:
             return None
 
-        script_args = args[script.args_from+1:script.args_to]
+        script_args = args[script.args_from:script.args_to]
         processed = script.run(p, *script_args)
 
         shared.total_tqdm.clear()

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -56,7 +56,12 @@ class Script:
     def describe(self):
         return ""
 
-
+    # If your script is only compatible with a subset of samplers, return the sampler
+    # names here, an empty list indicates compatibility with all samplers, for a full
+    # listing of current sampler names import modules.sd_samplers.samplers
+    def compatible_samplers(self):
+        return []
+    
 scripts_data = []
 
 
@@ -133,6 +138,10 @@ class ScriptRunner:
                 control.custom_script_source = os.path.basename(script.filename)
                 control.visible = False
 
+            concat_compatible_samplers = ",".join(script.compatible_samplers())
+            inputs += [gr.HTML(value='<span class="customScriptAttrs" data-supported-samplers="{}"></span>'.format(concat_compatible_samplers))]
+            inputs[-1].visible=False
+                
             inputs += controls
             script.args_to = len(inputs)
 
@@ -180,7 +189,7 @@ class ScriptRunner:
         if script is None:
             return None
 
-        script_args = args[script.args_from:script.args_to]
+        script_args = args[script.args_from+1:script.args_to]
         processed = script.run(p, *script_args)
 
         shared.total_tqdm.clear()

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -409,7 +409,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
 
         with gr.Row().style(equal_height=False):
             with gr.Column(variant='panel'):
-                steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20)
+                steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20, elem_id="txt2img_steps")
                 sampler_index = gr.Radio(label='Sampling method', elem_id="txt2img_sampling", choices=[x.name for x in samplers], value=samplers[0].name, type="index")
 
                 with gr.Group():
@@ -588,8 +588,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
 
-                steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20)
-                sampler_index = gr.Radio(label='Sampling method', choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="index")
+                steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20, elem_id="img2img_steps")
+                sampler_index = gr.Radio(label='Sampling method', elem_id="img2img_sampling", choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="index")
 
                 with gr.Group():
                     width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)

--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -119,9 +119,6 @@ class Script(scripts.Script):
 
     def show(self, is_img2img):
         return is_img2img
-
-    def compatible_samplers(self):
-        return ['Euler']
     
     def ui(self, is_img2img):
         original_prompt = gr.Textbox(label="Original prompt", lines=1)

--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -120,6 +120,9 @@ class Script(scripts.Script):
     def show(self, is_img2img):
         return is_img2img
 
+    def compatible_samplers(self):
+        return ['Euler']
+    
     def ui(self, is_img2img):
         original_prompt = gr.Textbox(label="Original prompt", lines=1)
         original_negative_prompt = gr.Textbox(label="Original negative prompt", lines=1)

--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -129,6 +129,12 @@ class Script(scripts.Script):
         sigma_adjustment = gr.Checkbox(label="Sigma adjustment for finding noise for image", value=False)
         return [original_prompt, original_negative_prompt, cfg, st, randomness, sigma_adjustment]
 
+    def ui_restraints(self):
+        restraints = {
+            "methods": ["Euler"]
+        }
+        return restraints
+
     def run(self, p, original_prompt, original_negative_prompt, cfg, st, randomness, sigma_adjustment):
         p.batch_size = 1
         p.batch_count = 1

--- a/style.css
+++ b/style.css
@@ -222,6 +222,10 @@ input[type="range"]{
     margin: 0.5em 0 -0.3em 0;
 }
 
+.gr-input-label.disabled {
+    opacity: 0.48;
+}
+
 #txt2img_sampling label{
     padding-left: 0.6em;
     padding-right: 0.6em;


### PR DESCRIPTION
When the "img2img alternative test" script is selected, the UI will be locked to the Euler method, and return to the previous state when changing the script to something else. This should prevent confusion among users and hopefully reduce issues raised regarding the feature.