### PR TITLE
Add interpolation method and weight to merged model output filename

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -186,7 +186,7 @@ def run_modelmerger(modelname_0, modelname_1, interp_method, interp_amount):
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
 
-    output_modelname = 'models/' + modelname_0 + '-' + modelname_1 + '-merged.ckpt'
+    output_modelname = 'models/' + modelname_0 + '-' + modelname_1 + '-' + interp_method.replace(" ", "_") + '-' + str(interp_amount) + '-merged.ckpt'
     print(f"Saving to {output_modelname}...")
     torch.save(model_0, output_modelname)
 


### PR DESCRIPTION
The current file name created does not contain any reference to the interpolation method or amount used... and creating more than one merge of the same model with different interpolation and amount lead to overwrite of files and general confusion.

This PR address this by adding the interpolation method name and amount to the output file name.

eg: `sd-1-4-wd-v1-2-full-ema-pruned-Weighted_Sum-0.7-merged.ckpt`