### PR TITLE
Custom logging and write info to PNG on save click

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -1,9 +1,9 @@
 import re
 import gradio as gr
 
-re_param_code = r"\s*([\w ]+):\s*([^,]+)(?:,|$)"
+re_param_code = r"\s*([\w ]+):\s*([^\"]+(?=\")|[^,]+)(?:,|\",|$)"
 re_param = re.compile(re_param_code)
-re_params = re.compile(r"^(?:" + re_param_code + "){3,}$")
+re_params = re.compile(r"^\"?(?:" + re_param_code + "){3,}(?:Filename:[\w])?$")
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 type_of_gr_update = type(gr.update())
 
@@ -36,6 +36,12 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         if line.startswith("Negative prompt:"):
             done_with_prompt = True
             line = line[16:].strip()
+        elif line.startswith("\"Negative prompt:"):
+            line = line[17:].strip()
+        elif line.startswith("Prompt:"):
+            line = line[8:].strip()
+        elif line.startswith("\"Prompt:"):
+            line = line[9:].strip()
 
         if done_with_prompt:
             negative_prompt += ("" if negative_prompt == "" else "\n") + line

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -1,7 +1,7 @@
 import re
 import gradio as gr
 
-re_param_code = r"\s*([\w ]+):\s*([^\"]+(?=\")|[^,]+)(?:,|\",|$)"
+re_param_code = r"\s*\"?([\w ]+):\s*([^\"]+(?=\")|[^,]+)(?:,|\",|$)"
 re_param = re.compile(re_param_code)
 re_params = re.compile(r"^\"?(?:" + re_param_code + "){3,}(?:Filename:[\w])?$")
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")


### PR DESCRIPTION
Hey folks, this is a bit of a custom and hacky edit I made for myself that I hope you can find use for.  It enables reproducing images from the information saved when clicking the Save button in the UI, as I often have automatic save turned off and the current CSV logs do not store enough information (variations, seed resizing, etc) to reproduce the image.

It changes the CSV structure of the log file to be more like the generation info seen in the UI, and includes all of the information currently needed to reproduce the image directly from a copy and paste from the log into the prompt.  (It does not currently toggle checkboxes such as "tiling" or "extras", but neither does the UI info)

This requires and includes a small change to copypaste to support quotes around values if they contain commas, like:
`"Prompt: a blue circle, on a white background"`

This this info is also written to the PNG EXIF info on save, and works to reconstruct the image from the PNG info tab.

Caveats to be aware of:
- This isn't _really_ a CSV, so log.txt might be more appropriate.  Perhaps a second file to not break any workflows.
- Currently does not handle prompt quotes such as `A shirt that reads "I love coffee"`, should be a simple regex fix.

I'm probably not going to have a lot of time to fix these items, so I've marked this PR as draft.  But please feel free to use and modify any of this if it is helpful to you.