### PR TITLE
(feat): Rework Checkpoint Merger UI for better clarity and usability

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -186,7 +186,7 @@ def run_modelmerger(primary_model_name, secondary_model_name, interp_method, int
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
 
-    output_modelname = 'models/' + primary_model_name + '_' + str(interp_amount) + '-' + secondary_model_name + '_' + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
+    output_modelname = 'models/' + primary_model_name + '_' + str(round(interp_amount,2)) + '-' + secondary_model_name + '_' + str(round((float(1.0) - interp_amount),2)) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
     print(f"Saving to {output_modelname}...")
     torch.save(primary_model, output_modelname)
 

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -140,7 +140,7 @@ def run_pnginfo(image):
     return '', geninfo, info
 
 
-def run_modelmerger(modelname_0, modelname_1, interp_method, interp_amount):
+def run_modelmerger(from_model_name, to_model_name, interp_method, interp_amount):
     # Linear interpolation (https://en.wikipedia.org/wiki/Linear_interpolation)
     def weighted_sum(theta0, theta1, alpha):
         return ((1 - alpha) * theta0) + (alpha * theta1)
@@ -150,23 +150,23 @@ def run_modelmerger(modelname_0, modelname_1, interp_method, interp_amount):
         alpha = alpha * alpha * (3 - (2 * alpha))
         return theta0 + ((theta1 - theta0) * alpha)
 
-    if os.path.exists(modelname_0):
-        model0_filename = modelname_0
-        modelname_0 = os.path.splitext(os.path.basename(modelname_0))[0]
+    if os.path.exists(to_model_name):
+        to_model_filename = to_model_name
+        to_model_name = os.path.splitext(os.path.basename(to_model_name))[0]
     else:
-        model0_filename = 'models/' + modelname_0 + '.ckpt'
+        to_model_filename = 'models/' + to_model_name + '.ckpt'
 
-    if os.path.exists(modelname_1):
-        model1_filename = modelname_1
-        modelname_1 = os.path.splitext(os.path.basename(modelname_1))[0]
+    if os.path.exists(from_model_name):
+        from_model_filename = from_model_name
+        from_model_name = os.path.splitext(os.path.basename(from_model_name))[0]
     else:
-        model1_filename = 'models/' + modelname_1 + '.ckpt'
+        from_model_filename = 'models/' + from_model_name + '.ckpt'
 
-    print(f"Loading {model0_filename}...")
-    model_0 = torch.load(model0_filename, map_location='cpu')
+    print(f"Loading {to_model_filename}...")
+    model_0 = torch.load(to_model_filename, map_location='cpu')
 
-    print(f"Loading {model1_filename}...")
-    model_1 = torch.load(model1_filename, map_location='cpu')
+    print(f"Loading {from_model_filename}...")
+    model_1 = torch.load(from_model_filename, map_location='cpu')
     
     theta_0 = model_0['state_dict']
     theta_1 = model_1['state_dict']
@@ -186,7 +186,7 @@ def run_modelmerger(modelname_0, modelname_1, interp_method, interp_amount):
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
 
-    output_modelname = 'models/' + modelname_0 + '-' + modelname_1 + '-' + interp_method.replace(" ", "_") + '-' + str(interp_amount) + '-merged.ckpt'
+    output_modelname = 'models/' + from_model_name + str(interp_amount) + '-' + to_model_name + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-' + '-merged.ckpt'
     print(f"Saving to {output_modelname}...")
     torch.save(model_0, output_modelname)
 

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -140,7 +140,7 @@ def run_pnginfo(image):
     return '', geninfo, info
 
 
-def run_modelmerger(from_model_name, to_model_name, interp_method, interp_amount):
+def run_modelmerger(primary_model_name, secondary_model_name, interp_method, interp_amount):
     # Linear interpolation (https://en.wikipedia.org/wiki/Linear_interpolation)
     def weighted_sum(theta0, theta1, alpha):
         return ((1 - alpha) * theta0) + (alpha * theta1)
@@ -150,23 +150,23 @@ def run_modelmerger(from_model_name, to_model_name, interp_method, interp_amount
         alpha = alpha * alpha * (3 - (2 * alpha))
         return theta0 + ((theta1 - theta0) * alpha)
 
-    if os.path.exists(to_model_name):
-        to_model_filename = to_model_name
-        to_model_name = os.path.splitext(os.path.basename(to_model_name))[0]
+    if os.path.exists(secondary_model_name):
+        secondary_model_filename = secondary_model_name
+        secondary_model_name = os.path.splitext(os.path.basename(secondary_model_name))[0]
     else:
-        to_model_filename = 'models/' + to_model_name + '.ckpt'
+        secondary_model_filename = 'models/' + secondary_model_name + '.ckpt'
 
-    if os.path.exists(from_model_name):
-        from_model_filename = from_model_name
-        from_model_name = os.path.splitext(os.path.basename(from_model_name))[0]
+    if os.path.exists(primary_model_name):
+        primary_model_filename = primary_model_name
+        primary_model_name = os.path.splitext(os.path.basename(primary_model_name))[0]
     else:
-        from_model_filename = 'models/' + from_model_name + '.ckpt'
+        primary_model_filename = 'models/' + primary_model_name + '.ckpt'
 
-    print(f"Loading {to_model_filename}...")
-    model_0 = torch.load(to_model_filename, map_location='cpu')
+    print(f"Loading {secondary_model_filename}...")
+    model_0 = torch.load(secondary_model_filename, map_location='cpu')
 
-    print(f"Loading {from_model_filename}...")
-    model_1 = torch.load(from_model_filename, map_location='cpu')
+    print(f"Loading {primary_model_filename}...")
+    model_1 = torch.load(primary_model_filename, map_location='cpu')
     
     theta_0 = model_0['state_dict']
     theta_1 = model_1['state_dict']
@@ -186,7 +186,7 @@ def run_modelmerger(from_model_name, to_model_name, interp_method, interp_amount
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
 
-    output_modelname = 'models/' + from_model_name + '_' + str(interp_amount) + '-' + to_model_name + '_' + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
+    output_modelname = 'models/' + primary_model_name + '_' + str(interp_amount) + '-' + secondary_model_name + '_' + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
     print(f"Saving to {output_modelname}...")
     torch.save(model_0, output_modelname)
 

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -186,7 +186,7 @@ def run_modelmerger(from_model_name, to_model_name, interp_method, interp_amount
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
 
-    output_modelname = 'models/' + from_model_name + str(interp_amount) + '-' + to_model_name + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-' + '-merged.ckpt'
+    output_modelname = 'models/' + from_model_name + '_' + str(interp_amount) + '-' + to_model_name + '_' + str(float(1.0) - interp_amount) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
     print(f"Saving to {output_modelname}...")
     torch.save(model_0, output_modelname)
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -10,7 +10,7 @@ from ldm.util import instantiate_from_config
 
 from modules import shared
 
-CheckpointInfo = namedtuple("CheckpointInfo", ['filename', 'title', 'hash'])
+CheckpointInfo = namedtuple("CheckpointInfo", ['filename', 'title', 'hash', 'model_name'])
 checkpoints_list = {}
 
 try:
@@ -45,7 +45,8 @@ def list_models():
     if os.path.exists(cmd_ckpt):
         h = model_hash(cmd_ckpt)
         title = modeltitle(cmd_ckpt, h)
-        checkpoints_list[title] = CheckpointInfo(cmd_ckpt, title, h)
+        model_name = title.rsplit(".",1)[0] # remove extension if present
+        checkpoints_list[title] = CheckpointInfo(cmd_ckpt, title, h, model_name)
     elif cmd_ckpt is not None and cmd_ckpt != shared.default_sd_model_file:
         print(f"Checkpoint in --ckpt argument not found: {cmd_ckpt}", file=sys.stderr)
 
@@ -53,7 +54,8 @@ def list_models():
         for filename in glob.glob(model_dir + '/**/*.ckpt', recursive=True):
             h = model_hash(filename)
             title = modeltitle(filename, h)
-            checkpoints_list[title] = CheckpointInfo(filename, title, h)
+            model_name = title.rsplit(".",1)[0] # remove extension if present
+            checkpoints_list[title] = CheckpointInfo(filename, title, h, model_name)
 
 
 def model_hash(filename):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -860,7 +860,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
                 gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/models</b> directory.</p>")
                 
                 with gr.Row():
-                    ckpt_name_list = [x.model_name for x in modules.sd_models.checkpoints_list.values()]
+                    ckpt_name_list = sorted([x.model_name for x in modules.sd_models.checkpoints_list.values()])
                     primary_model_name   = gr.Dropdown(ckpt_name_list, elem_id="modelmerger_primary_model_name", label="Primary Model Name")
                     secondary_model_name = gr.Dropdown(ckpt_name_list, elem_id="modelmerger_secondary_model_name", label="Secondary Model Name")
                 interp_amount = gr.Slider(minimum=0.0, maximum=1.0, step=0.05, label='Interpolation Amount', value=0.3)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -859,10 +859,11 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
             with gr.Column(variant='panel'):
                 gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/models</b> directory.</p>")
                 
-                modelname_0 = gr.Textbox(elem_id="modelmerger_modelname_0", label="Model Name (to)")
-                modelname_1 = gr.Textbox(elem_id="modelmerger_modelname_1", label="Model Name (from)")
-                interp_method = gr.Radio(choices=["Weighted Sum", "Sigmoid"], value="Weighted Sum", label="Interpolation Method")
+                with gr.Row():
+                    from_model_name = gr.Textbox(elem_id="modelmerger_from_model_name", label="Model Name (from)")
+                    to_model_name = gr.Textbox(elem_id="modelmerger_to_model_name", label="Model Name (to)")
                 interp_amount = gr.Slider(minimum=0.0, maximum=1.0, step=0.05, label='Interpolation Amount', value=0.3)
+                interp_method = gr.Radio(choices=["Weighted Sum", "Sigmoid"], value="Weighted Sum", label="Interpolation Method")
                 submit = gr.Button(elem_id="modelmerger_merge", label="Merge", variant='primary')
             
             with gr.Column(variant='panel'):
@@ -871,8 +872,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
             submit.click(
                 fn=run_modelmerger,
                 inputs=[
-                    modelname_0,
-                    modelname_1,
+                    from_model_name,
+                    to_model_name,
                     interp_method,
                     interp_amount
                 ],

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -860,8 +860,9 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
                 gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/models</b> directory.</p>")
                 
                 with gr.Row():
-                    from_model_name = gr.Textbox(elem_id="modelmerger_from_model_name", label="Model Name (from)")
-                    to_model_name = gr.Textbox(elem_id="modelmerger_to_model_name", label="Model Name (to)")
+                    ckpt_name_list = [x.model_name for x in modules.sd_models.checkpoints_list.values()]
+                    primary_model_name   = gr.Dropdown(ckpt_name_list, elem_id="modelmerger_primary_model_name", label="Primary Model Name")
+                    secondary_model_name = gr.Dropdown(ckpt_name_list, elem_id="modelmerger_secondary_model_name", label="Secondary Model Name")
                 interp_amount = gr.Slider(minimum=0.0, maximum=1.0, step=0.05, label='Interpolation Amount', value=0.3)
                 interp_method = gr.Radio(choices=["Weighted Sum", "Sigmoid"], value="Weighted Sum", label="Interpolation Method")
                 submit = gr.Button(elem_id="modelmerger_merge", label="Merge", variant='primary')
@@ -872,8 +873,8 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
             submit.click(
                 fn=run_modelmerger,
                 inputs=[
-                    from_model_name,
-                    to_model_name,
+                    primary_model_name,
+                    secondary_model_name,
                     interp_method,
                     interp_amount
                 ],


### PR DESCRIPTION
- Rework UI to visually show impact of slider on model from -> model to weight distribution
- Rename variables to better align with UI field input
- Improve merged checkpoint output file name to include proportion of each model included in the merged output checkpoint

The screen capture below show how the slider is now positioned under the "side by side" model names. The slider position also provide visual feedback as to how much of each model will be transferred in the merged model output. In this case, 30% from sd-1-4 and 70% from wd-v1-2-full-ema-pruned:

![image](https://user-images.githubusercontent.com/7474674/192668846-d769c121-f606-47b9-8484-38a599ad7664.png)

The new resulting file name will carry this information and will result in:

`sd-1-4_0.3-wd-v1-2-full-ema-pruned_0.7-Sigmoid-merged.ckpt`