### PR TITLE
Add Eta parameter to K Ancestral samplers

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -79,7 +79,7 @@ class StableDiffusionProcessing:
         self.color_corrections = None
         self.denoising_strength: float = 0
         
-        self.ddim_eta = opts.ddim_eta
+        self.eta = opts.eta
         self.ddim_discretize = opts.ddim_discretize
         self.s_churn = opts.s_churn
         self.s_tmin = opts.s_tmin
@@ -124,7 +124,7 @@ class Processed:
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
 
-        self.ddim_eta = p.ddim_eta
+        self.eta = p.eta
         self.ddim_discretize = p.ddim_discretize
         self.s_churn = p.s_churn
         self.s_tmin = p.s_tmin

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -39,8 +39,10 @@ samplers_for_img2img = [x for x in samplers if x.name != 'PLMS']
 
 sampler_extra_params = {
     'sample_euler':['s_churn','s_tmin','s_tmax','s_noise'],
+    'sample_euler_ancestral':['eta'],
     'sample_heun' :['s_churn','s_tmin','s_tmax','s_noise'],
     'sample_dpm_2':['s_churn','s_tmin','s_tmax','s_noise'],
+    'sample_dpm_2_ancestral':['eta'],
 }
 
 def setup_img2img_steps(p, steps=None):
@@ -154,9 +156,9 @@ class VanillaStableDiffusionSampler:
 
         # existing code fails with cetin step counts, like 9
         try:
-            samples_ddim, _ = self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.ddim_eta)
+            samples_ddim, _ = self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.eta)
         except Exception:
-            samples_ddim, _ = self.sampler.sample(S=steps+1, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.ddim_eta)
+            samples_ddim, _ = self.sampler.sample(S=steps+1, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=p.eta)
 
         return samples_ddim
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -221,7 +221,7 @@ options_templates.update(options_section(('ui', "User interface"), {
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {
-  "ddim_eta": OptionInfo(0.0, "DDIM eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+  "eta": OptionInfo(0.0, "DDIM and K Ancestral eta", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
   "ddim_discretize": OptionInfo('uniform', "img2img DDIM discretize", gr.Radio, {"choices": ['uniform','quad']}),
   's_churn': OptionInfo(0.0, "sigma churn", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
   's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),


### PR DESCRIPTION
crowsonkb has recently added eta support for ancestral samplers in k-diffusion. https://github.com/crowsonkb/k-diffusion/commit/4b3f25436d3de5c9db07aea9488eef7371a8edc7

This PR unifies Eta options and passes them to ancestral samplers. This PR requires the newest version of k-diffusion, or it will error as the eta parameter doesn't exist in previous versions.