### PR TITLE
K-diffusion eta range fix - invert range for ancestral samplers.

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -133,9 +133,9 @@ class VanillaStableDiffusionSampler:
 
         # existing code fails with cetain step counts, like 9
         try:
-            self.sampler.make_schedule(ddim_num_steps=steps,  ddim_eta=p.ddim_eta, ddim_discretize=p.ddim_discretize, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps,  ddim_eta=p.eta, ddim_discretize=p.ddim_discretize, verbose=False)
         except Exception:
-            self.sampler.make_schedule(ddim_num_steps=steps+1,ddim_eta=p.ddim_eta, ddim_discretize=p.ddim_discretize, verbose=False)
+            self.sampler.make_schedule(ddim_num_steps=steps+1,ddim_eta=p.eta, ddim_discretize=p.ddim_discretize, verbose=False)
 
         x1 = self.sampler.stochastic_encode(x, torch.tensor([t_enc] * int(x.shape[0])).to(shared.device), noise=noise)
 

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -91,7 +91,7 @@ axis_options = [
     AxisOption("Sigma min",   float, apply_field("s_tmin"),   format_value_add_label),
     AxisOption("Sigma max",   float, apply_field("s_tmax"),   format_value_add_label),
     AxisOption("Sigma noise", float, apply_field("s_noise"),  format_value_add_label),
-    AxisOption("DDIM Eta",    float, apply_field("ddim_eta"), format_value_add_label),
+    AxisOption("Eta",    float, apply_field("eta"), format_value_add_label),
     AxisOptionImg2Img("Denoising", float, apply_field("denoising_strength"), format_value_add_label),#  as it is now all AxisOptionImg2Img items must go after AxisOption ones
 ]
 


### PR DESCRIPTION
The new samplers default to 1: 
https://github.com/crowsonkb/k-diffusion/blob/4b3f25436d3de5c9db07aea9488eef7371a8edc7/k_diffusion/sampling.py#L72

Whereas the old non ancestral ones default to zero:
https://github.com/CompVis/stable-diffusion/blob/69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc/ldm/models/diffusion/ddim.py#L25

Adds a optional mapping function to invert the values passed to those ancestral samplers into the correct default.