### PR TITLE
(feat): Switch active checkpoint selection to dropdown

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -190,7 +190,7 @@ options_templates.update(options_section(('system', "System"), {
 }))
 
 options_templates.update(options_section(('sd', "Stable Diffusion"), {
-    "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Radio, lambda: {"choices": [x.title for x in modules.sd_models.checkpoints_list.values()]}),
+    "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": sorted([x.title for x in modules.sd_models.checkpoints_list.values()])}),
     "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
     "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),    
     "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies (normally you'd do less with less denoising)."),


### PR DESCRIPTION
Replaces the button selection for the checkpoint selection to a nice and tidy dropdown, similar to the one used for the "Checkpoint Merger" tab.

- Provides a better user experience
- Better suited to variable list of choices
- Keep the UI "stable" as list contract or expand
- Provide consistent way of selecting checkpoint across various tabs

![image](https://user-images.githubusercontent.com/7474674/192764258-159900f7-4021-4e23-ae2b-ab6e06ea558c.png)
