### PR TITLE
Fix broken send to extras

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -1,26 +1,15 @@
 // various functions for interation with ui.py not large enough to warrant putting them in separate files
 
 function selected_gallery_index(){
-    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem .gallery-item')
-    var button = gradioApp().querySelector('[style="display: block;"].tabitem .gallery-item.\\!ring-2')
+    const buttons = gradioApp().querySelectorAll('.gallery-item')
+    const button = gradioApp().querySelector('.gallery-item.\\!ring-2')
+    const index = Array.apply(null, buttons).indexOf(button)
 
-    var result = -1
-    buttons.forEach(function(v, i){ if(v==button) { result = i } })
-
-    return result
+    return index
 }
 
 function extract_image_from_gallery(gallery){
-    if(gallery.length == 1){
-        return gallery[0]
-    }
-
-    index = selected_gallery_index()
-
-    if (index < 0 || index >= gallery.length){
-        return [null]
-    }
-
+    const index = selected_gallery_index()
     return gallery[index];
 }
 

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -1,8 +1,8 @@
 // various functions for interation with ui.py not large enough to warrant putting them in separate files
 
 function selected_gallery_index(){
-    const buttons = gradioApp().querySelectorAll('.gallery-item')
-    const button = gradioApp().querySelector('.gallery-item.\\!ring-2')
+    const buttons = gradioApp().querySelectorAll('button.gallery-item')
+    const button = gradioApp().querySelector('button.gallery-item.\\!ring-2')
     const index = Array.apply(null, buttons).indexOf(button)
 
     return index

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -69,12 +69,6 @@ def plaintext_to_html(text):
 
 
 def image_from_url_text(filedata):
-    if type(filedata) == list:
-        if len(filedata) == 0:
-            return None
-
-        filedata = filedata[0]
-
     if filedata.startswith("data:image/png;base64,"):
         filedata = filedata[len("data:image/png;base64,"):]
 


### PR DESCRIPTION
This patch fixes sending an image from a batch to extras.

Here's the error I was seeing in my terminal:

```
Traceback (most recent call last):
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/gradio/routes.py", line 273, in run_predict
    output = await app.blocks.process_api(
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/gradio/blocks.py", line 753, in process_api
    result = await self.call_function(fn_index, inputs, iterator)
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/gradio/blocks.py", line 630, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/home/noprompt/miniconda3/envs/automatic/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/home/noprompt/git/stable-diffusion-webui/modules/ui.py", line 1066, in <lambda>
    fn=lambda x: image_from_url_text(x),
  File "/home/noprompt/git/stable-diffusion-webui/modules/ui.py", line 78, in image_from_url_text
    if filedata.startswith("data:image/png;base64,"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

This was due to a `-1` return value computing the `index` for `select_gallery_index`. Should be fixed now, works for me. Kinda hard to prove it w/o automated tests though 🤷 

In addition it also simplifies `extract_image_from_gallery` , and `select_gallery_index`. BTW `extract_image_from_gallery` was assigning a global variable `index`.