### PR TITLE
Respect --ckpt-dir command-line argument when merging models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__
 /venv
 /tmp
 /model.ckpt
-/models/*.ckpt
+/models/**/*.ckpt
 /GFPGANv1.3.pth
 /gfpgan/weights/*.pth
 /ui-config.json

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -157,15 +157,9 @@ def run_modelmerger(primary_model_name, secondary_model_name, interp_method, int
         return theta0 + ((theta1 - theta0) * alpha)
 
     primary_model_filename = os.path.join(cmd_opts.ckpt_dir, primary_model_name + '.ckpt')
-    if not os.path.exists(primary_model_filename):
-        primary_model_filename = os.path.join('models/', primary_model_name + '.ckpt')
-        
     primary_model_name = os.path.splitext(os.path.basename(primary_model_filename))[0]
 
     secondary_model_filename = os.path.join(cmd_opts.ckpt_dir, secondary_model_name + '.ckpt')
-    if not os.path.exists(secondary_model_filename):
-        secondary_model_filename = os.path.join('models/', secondary_model_name + '.ckpt')
-        
     secondary_model_name = os.path.splitext(os.path.basename(secondary_model_filename))[0]
 
     print(f"Loading {primary_model_filename}...")

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 
 from modules import processing, shared, images, devices
-from modules.shared import opts
+from modules.shared import opts, cmd_opts
 import modules.gfpgan_model
 from modules.ui import plaintext_to_html
 import modules.codeformer_model
@@ -156,17 +156,17 @@ def run_modelmerger(primary_model_name, secondary_model_name, interp_method, int
         alpha = 0.5 - math.sin(math.asin(1.0 - 2.0 * alpha) / 3.0)
         return theta0 + ((theta1 - theta0) * alpha)
 
-    if os.path.exists(primary_model_name):
-        primary_model_filename = primary_model_name
-        primary_model_name = os.path.splitext(os.path.basename(primary_model_name))[0]
-    else:
-        primary_model_filename = 'models/' + primary_model_name + '.ckpt'
+    primary_model_filename = os.path.join(cmd_opts.ckpt_dir, primary_model_name + '.ckpt')
+    if not os.path.exists(primary_model_filename):
+        primary_model_filename = os.path.join('models/', primary_model_name + '.ckpt')
+        
+    primary_model_name = os.path.splitext(os.path.basename(primary_model_filename))[0]
 
-    if os.path.exists(secondary_model_name):
-        secondary_model_filename = secondary_model_name
-        secondary_model_name = os.path.splitext(os.path.basename(secondary_model_name))[0]
-    else:
-        secondary_model_filename = 'models/' + secondary_model_name + '.ckpt'
+    secondary_model_filename = os.path.join(cmd_opts.ckpt_dir, secondary_model_name + '.ckpt')
+    if not os.path.exists(secondary_model_filename):
+        secondary_model_filename = os.path.join('models/', secondary_model_name + '.ckpt')
+        
+    secondary_model_name = os.path.splitext(os.path.basename(secondary_model_filename))[0]
 
     print(f"Loading {primary_model_filename}...")
     primary_model = torch.load(primary_model_filename, map_location='cpu')
@@ -192,8 +192,16 @@ def run_modelmerger(primary_model_name, secondary_model_name, interp_method, int
     for key in theta_1.keys():
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
-
-    output_modelname = 'models/' + primary_model_name + '_' + str(round(interp_amount,2)) + '-' + secondary_model_name + '_' + str(round((float(1.0) - interp_amount),2)) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt'
+    
+    # Respect --ckpt-dir command-line argument
+    output_modelname = ''
+    if os.path.exists(cmd_opts.ckpt_dir):
+        output_modelname = cmd_opts.ckpt_dir
+    else:
+        output_modelname = 'models/'
+    
+    output_modelname = os.path.join(output_modelname, primary_model_name + '_' + str(round(interp_amount,2)) + '-' + secondary_model_name + '_' + str(round((float(1.0) - interp_amount),2)) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt')
+    
     print(f"Saving to {output_modelname}...")
     torch.save(primary_model, output_modelname)
 

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -193,14 +193,7 @@ def run_modelmerger(primary_model_name, secondary_model_name, interp_method, int
         if 'model' in key and key not in theta_0:
             theta_0[key] = theta_1[key]
     
-    # Respect --ckpt-dir command-line argument
-    output_modelname = ''
-    if os.path.exists(cmd_opts.ckpt_dir):
-        output_modelname = cmd_opts.ckpt_dir
-    else:
-        output_modelname = 'models/'
-    
-    output_modelname = os.path.join(output_modelname, primary_model_name + '_' + str(round(interp_amount,2)) + '-' + secondary_model_name + '_' + str(round((float(1.0) - interp_amount),2)) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt')
+    output_modelname = os.path.join(cmd_opts.ckpt_dir, primary_model_name + '_' + str(round(interp_amount,2)) + '-' + secondary_model_name + '_' + str(round((float(1.0) - interp_amount),2)) + '-' + interp_method.replace(" ", "_") + '-merged.ckpt')
     
     print(f"Saving to {output_modelname}...")
     torch.save(primary_model, output_modelname)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -869,7 +869,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
     with gr.Blocks() as modelmerger_interface:
         with gr.Row().style(equal_height=False):
             with gr.Column(variant='panel'):
-                gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/checkpoint</b> directory.</p>")
+                gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>checkpoint</b> directory.</p>")
                 
                 with gr.Row():
                     ckpt_name_list = sorted([x.model_name for x in modules.sd_models.checkpoints_list.values()])

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -869,7 +869,7 @@ def create_ui(txt2img, img2img, run_extras, run_pnginfo, run_modelmerger):
     with gr.Blocks() as modelmerger_interface:
         with gr.Row().style(equal_height=False):
             with gr.Column(variant='panel'):
-                gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/models</b> directory.</p>")
+                gr.HTML(value="<p>A merger of the two checkpoints will be generated in your <b>/checkpoint</b> directory.</p>")
                 
                 with gr.Row():
                     ckpt_name_list = sorted([x.model_name for x in modules.sd_models.checkpoints_list.values()])


### PR DESCRIPTION
`--ckpt-dir` is now respected by the checkpoint merging code, and subdirectories are supported. Fixes #1224.