### PR TITLE
Escaping attention tags

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -328,6 +328,7 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
                 multipliers = []
                 mult = 1.0
 
+                lastToken=None
                 i = 0
                 while i < len(tokens):
                     token = tokens[i]
@@ -361,7 +362,8 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
                         if not found:
                             remade_tokens.append(token)
                             multipliers.append(mult)
-
+                    
+                    lastToken = token
                     i += 1
 
                 if len(remade_tokens) > maxlen - 2:


### PR DESCRIPTION
Good news, there's only a handful of tokens that map to `\` and they map to only `\`, not in combination with anything else -- for now.

Bad news: 101 mappings for the various brackets, some of which are sequential `(((` so the escaped tokenized form isn't simply transformable to the non bracketed tokenization.

Good news: none of the current tokens for brackets include common alphanumeric or spaces!

So zeroing the multiplier and popping the last escape will work for the majority of inputs - with the current vocab it'll never pop out errant characters other than `\` but it can't handle repeating brackets in an expected way, where a user might expect to escape:

`(((` as `\(\(\(` the actual effective way would be `\(((` as `(((` is a single token, similarly `\)))`

`\((((` however, 3 being the max sequential bracket run that currently occurs, would leave a remaining attention multiplier containing token.

But the usual 99% use case of  `word \(word\) word (word) word` works perfectly,

We could attempt some very *fun* token re-writing or to make the escaping as generally expected in all cases but would that be too scary @AUTOMATIC1111 ?

Current list of bracket tokens for reference:

```
!!!)  !!)  !)  !),  !).  !:)  !]  "(  ")  "[  $)  %)  %),  ')  (  ("  (#  ($  (&  ('  ((  (((  (*  (+
(-  (.  (...  (:  (;  (@  (Â£  (Â©  (ðŁĵ·  (ðŁĵ·:  (ðŁĵ¸  (ðŁĵ¸:  )  )!  )!!  )"  )#  )'  ))  )))
))))  ),  )-  ).  )..  )...  )/  ):  );  )?  )@  )_/  )_/Â¯  )âĢ¦  *)  +)  ,)  -(  -)  .(  .)  ...(  ...)
.]  :")  :'(  :')  :(  :((  :)  :))  :)))  :))))  :).  :-(  :-)  :]  ;)  ;))  ;-)  =)  =))  ?)  [  [#  [...  [@ 
]  ]"  ],  ].  ]:  ^)  _(  _)  Â¯\_(  ðŁĺĤ)  
```