### PR TITLE
Fix selected_gallery_index selectors

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -1,8 +1,8 @@
 // various functions for interation with ui.py not large enough to warrant putting them in separate files
 
 function selected_gallery_index(){
-    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem .gallery-item')
-    var button = gradioApp().querySelector('[style="display: block;"].tabitem .gallery-item.\\!ring-2')
+    var buttons = gradioApp().querySelectorAll('.absolute .gallery-item')
+    var button = gradioApp().querySelector('.absolute .gallery-item.\\!ring-2')
 
     var result = -1
     buttons.forEach(function(v, i){ if(v==button) { result = i } })


### PR DESCRIPTION
querySelectorAll and querySelector weren't returning anything, which caused the Save button to always save all images instead of respecting the save_selected_only setting. The cause was probably a change in the HTML or styles on the page.