### PR TITLE
Fix scripts loading order

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -56,7 +56,6 @@ def load_scripts(basedir):
         return
 
     for filename in sorted(os.listdir(basedir)):
-        print(f"Loading script: {filename}")
         path = os.path.join(basedir, filename)
 
         if not os.path.isfile(path):

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -55,7 +55,8 @@ def load_scripts(basedir):
     if not os.path.exists(basedir):
         return
 
-    for filename in os.listdir(basedir):
+    for filename in sorted(os.listdir(basedir)):
+        print(f"Loading script: {filename}")
         path = os.path.join(basedir, filename)
 
         if not os.path.isfile(path):


### PR DESCRIPTION
The scripts are not loaded in the same order on Linux and on Windows, which causes the gradio API to be different.

This PR will ensure that the scripts are always added in alphabetical order, keeping the API consistent between operating systems.

This should help fix https://github.com/leszekhanusz/diffusion-ui/issues/40