### PR TITLE
Add new K samplers

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -19,7 +19,7 @@ gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "git+https://github.com/Tencen
 
 stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc")
 taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
-k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "9e3002b7cd64df7870e08527b7664eb2f2f5f3f5")
+k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "a7ec1974d4ccb394c2dca275f42cd97490618924")
 codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
 blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
 ldsr_commit_hash = os.environ.get('LDSR_COMMIT_HASH', "abf33e7002d59d9085081bce93ec798dcabd49af")


### PR DESCRIPTION
This PR adds new samplers from k-diffusion (dpm_fast and dpm_adaptive.)

A potential issue is some users may have an older version of k-diffusion installed as a package - which python will default to - meaning they won't have access to these samplers. By its own, an older k-diffusion will refrain from erroring with these new samplers, but my (terrible) way to remove these samplers from img2img will error.

Potential solutions are: Force use of cloned k-diffusion (perhaps by uninstalling) or find a more intelligent way to remove new samplers from img2img.

I intend to limit these samplers to txt2img as I couldn't get them working for img2img. I'm pretty sure DPM Adaptive is incompatible by default - it chooses its own steps.

DPM Adaptive will ignore specified step counts as it picks its own - that's why it's called adaptive. I'm not sure how best to communicate this to the user.

![xy_grid-0002-1](https://user-images.githubusercontent.com/36072735/192966875-47635659-7bc0-43e9-9f33-d910efa6bdd4.png)

Note that k_dpm_ad has the same - automatic - step count in all instances. 48, in this example.