### PR TITLE
scripts/xy_grid: Handle edge-case with non-empty axis values

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -159,6 +159,9 @@ class Script(scripts.Script):
         p.batch_size = 1
 
         def process_axis(opt, vals):
+            if opt.label == 'Nothing':
+                return [0]
+
             valslist = [x.strip() for x in vals.split(",")]
 
             if opt.type == int:


### PR DESCRIPTION
Fixes bug where if Type is Nothing and axis values are filled out (from ie. previously using another Type), it will still needlessly run it N times (with identical results).