### PR TITLE
force import of cloned k-diffusion

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -4,7 +4,8 @@ import torch
 import tqdm
 from PIL import Image
 import inspect
-
+from modules.paths import paths
+sys.path.insert(0, paths["k_diffusion"])
 import k_diffusion.sampling
 import ldm.models.diffusion.ddim
 import ldm.models.diffusion.plms


### PR DESCRIPTION
After new samplers have been added, people on legacy installs of k-diffusion have struggled to make use of it due to python defaulting to the older, site-packages version. This PR prepends the k-diffusion repo in sys_path, therefore fixing this issue.

This will also fix eta for the same people on legacy installs.

closes #1323 