### PR TITLE
Improve git clone in launch.py

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -73,20 +73,22 @@ def is_installed(package):
 
 
 def git_clone(url, dir, name, commithash=None):
-    # TODO clone into temporary dir and move if successful
-
     if os.path.exists(dir):
         return
 
-    if commithash is None:
-        run(f'"{git}" clone --depth 1 "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
-    else:
-        os.makedirs(dir)
-        git_prefix = f'"{git}" -C "{dir}"'
-        run(f'{git_prefix} init', None, f"Could not initialize git repository at {dir}")
-        run(f'{git_prefix} remote add origin {url}', None, f"Could not add {name}'s url: {url}")
-        run(f'{git_prefix} fetch --depth 1 origin {commithash}', f"Fetching {name}...", f"Couldn't fetch {name} from url {url} commit {commithash}")
-        run(f'{git_prefix} checkout {commithash}', None, f"Unable to checkout {name} commit {commithash}")
+    try:
+        if commithash is None:
+            run(f'"{git}" clone --depth 1 "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
+        else:
+            os.makedirs(dir)
+            git_prefix = f'"{git}" -C "{dir}"'
+            run(f'{git_prefix} init', None, f"Could not initialize git repository at {dir}")
+            run(f'{git_prefix} remote add origin {url}', None, f"Could not add {name}'s url: {url}")
+            run(f'{git_prefix} fetch --depth 1 origin {commithash}', f"Fetching {name}...", f"Couldn't fetch {name} from url {url} commit {commithash}")
+            run(f'{git_prefix} checkout {commithash}', None, f"Unable to checkout {name} commit {commithash}")
+    except Exception as e:
+        shutil.rmtree(dir, ignore_errors=True)
+        raise e
 
 
 try:

--- a/launch.py
+++ b/launch.py
@@ -78,10 +78,15 @@ def git_clone(url, dir, name, commithash=None):
     if os.path.exists(dir):
         return
 
-    run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
-
-    if commithash is not None:
-        run(f'"{git}" -C {dir} checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
+    if commithash is None:
+        run(f'"{git}" clone --depth 1 "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
+    else:
+        os.makedirs(dir)
+        git_prefix = f'"{git}" -C "{dir}"'
+        run(f'{git_prefix} init', None, f"Could not initialize git repository at {dir}")
+        run(f'{git_prefix} remote add origin {url}', None, f"Could not add {name}'s url: {url}")
+        run(f'{git_prefix} fetch --depth 1 origin {commithash}', f"Fetching {name}...", f"Couldn't fetch {name} from url {url} commit {commithash}")
+        run(f'{git_prefix} checkout {commithash}', None, f"Unable to checkout {name} commit {commithash}")
 
 
 try:


### PR DESCRIPTION
Performs a shallow clone instead of a full clone, which saves a few 100MB. Also completed the TODO by cloning it to a temporary directory and then moving that directory instead of cloning directly to the final directory.