### PR TITLE
Fix when eta = 0

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -125,7 +125,7 @@ class VanillaStableDiffusionSampler:
         return res
 
     def initialize(self, p):
-        self.eta = p.eta or opts.eta_ddim
+        self.eta = p.eta if p.eta is not None else opts.eta_ddim
 
         for fieldname in ['p_sample_ddim', 'p_sample_plms']:
             if hasattr(self.sampler, fieldname):


### PR DESCRIPTION
Unexpected behavior when using eta = 0 in something like XY and your default eta was set to something non-zero, which would use your default eta instead of 0.