### PR TITLE
fix load_models

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -30,6 +30,12 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
     try:
         places = []
 
+        # Normalizes path separators in command line options to match the OS
+        if command_path is not None:
+            command_path = os.path.normpath(command_path)
+        if model_path is not None:
+            model_path = os.path.normpath(model_path)
+
         if command_path is not None and command_path != model_path:
             pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
             if os.path.exists(pretrained_path):
@@ -43,7 +49,11 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
         for place in places:
             if os.path.exists(place):
                 for file in glob.iglob(place + '**/**', recursive=True):
-                    full_path = os.path.join(place, file)
+                    if file.startswith(place):
+                        full_path = file
+                    else:
+                        full_path = os.path.join(place, file)
+
                     if os.path.isdir(full_path):
                         continue
                     if len(ext_filter) != 0:


### PR DESCRIPTION
I encountered an issue where load_models doesn't handle command line argument paths well.

This PR fix it.
- `os.path.normpath` for command_path and model_path before glob.
- skip `os.path.join` if glob results contains parent path.
