### PR TITLE
prevents dirname returning empty subfolder patterns

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -374,7 +374,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
 
     if save_to_dirs:
-        dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, seed, prompt)
+        dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, seed, prompt).strip('\\')
         path = os.path.join(path, dirname)
 
     os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
If a folder naming pattern with multiple levels is defined, like `[pattern1]\[pattern2]`, an empty pattern will no longer make it save to nowhere.