### PR TITLE
Make save to dirs optional for imgs saved from ui

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -170,6 +170,7 @@ options_templates.update(options_section(('saving-to-dirs', "Saving to a directo
     "grid_save_to_dirs": OptionInfo(False, "Save grids to subdirectory"),
     "directories_filename_pattern": OptionInfo("", "Directory name pattern"),
     "directories_max_prompt_words": OptionInfo(8, "Max prompt words", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1}),
+    "use_save_to_dirs_for_ui": OptionInfo(False, "Use \"Save images to a subdirectory\" option for images saved from UI"),
 }))
 
 options_templates.update(options_section(('upscaling', "Upscaling"), {

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -111,7 +111,7 @@ def save_files(js_data, images, index):
 
     p = MyObject(data)
     path = opts.outdir_save
-    save_to_dirs = opts.save_to_dirs
+    save_to_dirs = opts.use_save_to_dirs_for_ui
 
     if save_to_dirs:
         dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, p.seed, p.prompt)


### PR DESCRIPTION
Personally, my workflow was relying on the directory for saving images using the UI save button having a flat folder structure. 
I used that folder as an auto-import folder for an image organization library which doesn't follow subdirectories, unfortunately. 

#1214 broke that workflow unfortunately. I implemented a quick fix by making the use of subdirectories optional for images saved from the UI.
I decided to have the option off by default to be consistent with past behaviour of the save button. I wouldn't have an issue with changing it to be enabled by default, though.

In my opinion it doesn't necessarily make sense to impose the same folder structure of the batch output onto a folder that is often used to selectively save individual images. But that may depend on a user's individual workflow and how they choose to use the save button in the UI. 
Either way, I think making the use of it optional is in most people's best interest. 