### PR TITLE
Convert folder icon surrogate pair to valid utf8 to fix /config path

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -15,7 +15,7 @@ titles = {
     "\u267b\ufe0f": "Reuse seed from last generation, mostly useful if it was randomed",
     "\u{1f3a8}": "Add a random artist to the prompt.",
     "\u2199\ufe0f": "Read generation parameters from prompt into user interface.",
-    "\uD83D\uDCC2": "Open images output directory",
+    "\u{1f4c2}": "Open images output directory",
 
     "Inpaint a part of image": "Draw a mask over an image, and the script will regenerate the masked area with content according to prompt",
     "SD upscale": "Upscale image normally, split result into tiles, improve each tile using img2img, merge whole image back",

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -69,7 +69,7 @@ random_symbol = '\U0001f3b2\ufe0f'  # 🎲️
 reuse_symbol = '\u267b\ufe0f'  # ♻️
 art_symbol = '\U0001f3a8'  # 🎨
 paste_symbol = '\u2199\ufe0f'  # ↙
-folder_symbol = '\uD83D\uDCC2'
+folder_symbol = '\U0001f4c2'  # 📂
 
 def plaintext_to_html(text):
     text = "<p>" + "<br>\n".join([f"{html.escape(x)}" for x in text.split('\n')]) + "</p>"


### PR DESCRIPTION
Fetching the `127.0.0.1:7860/config` path is currently broken and it was working a few days ago.

It will return an `Internal Server Error` and the following error appears in the console:

```
  File "/mnt/tera/git-repos/leszekhanusz/gradio/gradio/routes.py", line 52, in render
    return orjson.dumps(content, option=orjson.OPT_SERIALIZE_NUMPY)
TypeError: str is not valid UTF-8: surrogates not allowed
```

Using git bisect I was able to pinpoint the problem to this commit: f8acbb8f880815facb5037efcd676f2f0d2b5bf4
It's because the folder icon is not valid utf-8.

This PR will convert the surrogate pair to utf-8 (I used [this online calculator](http://russellcottrell.com/greek/utilities/SurrogatePairCalculator.htm))