### PR TITLE
#1484 fix empty styles pattern

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -315,7 +315,7 @@ def apply_filename_pattern(x, p, seed, prompt):
         #currently disabled if using the save button, will work otherwise 
         # if enabled it will cause a bug because styles is not included in the save_files data dictionary
         if hasattr(p, "styles"):
-            x = x.replace("[styles]", sanitize_filename_part(", ".join([x for x in p.styles if not x == "None"] or "None"), replace_spaces=False))
+            x = x.replace("[styles]", sanitize_filename_part(", ".join([x for x in p.styles if not x == "None"]) or "None", replace_spaces=False))
 
         x = x.replace("[sampler]", sanitize_filename_part(sd_samplers.samplers[p.sampler_index].name, replace_spaces=False))
 


### PR DESCRIPTION
moved ` or "None"` outside `.join()` closing bracket else it returns "N, o, n, e"