### PR TITLE
Update K-Diffusion and include noise scheduler script

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -19,7 +19,7 @@ clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLI
 
 stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc")
 taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
-k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "567e11f7062ba20ae32b5a8cd07fb0fc4b9410cf")
+k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "f4e99857772fc3a126ba886aadf795a332774878")
 codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
 blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
 

--- a/launch.py
+++ b/launch.py
@@ -19,7 +19,7 @@ clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLI
 
 stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc")
 taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
-k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "a7ec1974d4ccb394c2dca275f42cd97490618924")
+k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "567e11f7062ba20ae32b5a8cd07fb0fc4b9410cf")
 codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
 blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -26,6 +26,17 @@ samplers_k_diffusion = [
     ('DPM adaptive', 'sample_dpm_adaptive', ['k_dpm_ad']),
 ]
 
+if opts.show_karras_scheduler_variants:
+    k_diffusion.sampling.sample_dpm_2_ka = k_diffusion.sampling.sample_dpm_2
+    k_diffusion.sampling.sample_dpm_2_ancestral_ka = k_diffusion.sampling.sample_dpm_2_ancestral
+    k_diffusion.sampling.sample_lms_ka = k_diffusion.sampling.sample_lms
+    samplers_k_diffusion_ka = [
+        ('LMS K Scheduling', 'sample_lms_ka', ['k_lms_ka']),
+        ('DPM2 K Scheduling', 'sample_dpm_2_ka', ['k_dpm_2_ka']),
+        ('DPM2 a K Scheduling', 'sample_dpm_2_ancestral_ka', ['k_dpm_2_a_ka']),
+    ]
+    samplers_k_diffusion.extend(samplers_k_diffusion_ka)
+
 samplers_data_k_diffusion = [
     SamplerData(label, lambda model, funcname=funcname: KDiffusionSampler(funcname, model), aliases)
     for label, funcname, aliases in samplers_k_diffusion
@@ -315,6 +326,8 @@ class KDiffusionSampler:
 
         if p.sampler_noise_scheduler_override:
           sigmas = p.sampler_noise_scheduler_override(steps)
+        elif self.funcname.endswith('ka'):
+          sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.1, sigma_max=10, device=shared.device)
         else:
           sigmas = self.model_wrap.get_sigmas(steps)
         x = x * sigmas[0]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -228,6 +228,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "font": OptionInfo("", "Font for image grids that have text"),
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initialy_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
+    "show_karras_scheduler_variants": OptionInfo(True, "Show Karras scheduling variants for select samplers. Try these variants if your K sampled images suffer from excessive noise."),
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {

--- a/scripts/alternate_sampler_noise_schedules.py
+++ b/scripts/alternate_sampler_noise_schedules.py
@@ -1,0 +1,53 @@
+import inspect
+from modules.processing import Processed, process_images
+import gradio as gr
+import modules.scripts as scripts
+import k_diffusion.sampling
+import torch
+
+
+class Script(scripts.Script):
+
+    def title(self):
+        return "Alternate Sampler Noise Schedules"
+
+    def ui(self, is_img2img):
+      noise_scheduler = gr.Dropdown(label="Noise Scheduler", choices=['Default','Karras','Exponential', 'Variance Preserving'], value='Default', type="index")
+      sched_smin     = gr.Slider(value=0.1,   label="Sigma min",                  minimum=0.0,   maximum=100.0, step=0.5,)
+      sched_smax     = gr.Slider(value=10.0,  label="Sigma max",                  minimum=0.0,   maximum=100.0, step=0.5)
+      sched_rho      = gr.Slider(value=7.0,   label="Sigma rho (Karras only)",    minimum=7.0,   maximum=100.0, step=0.5)
+      sched_beta_d   = gr.Slider(value=19.9,  label="Beta distribution (VP only)",minimum=0.0,   maximum=40.0, step=0.5)
+      sched_beta_min = gr.Slider(value=0.1,   label="Beta min (VP only)",         minimum=0.0,   maximum=40.0, step=0.1)
+      sched_eps_s    = gr.Slider(value=0.001, label="Epsilon (VP only)",          minimum=0.001, maximum=1.0,   step=0.001)
+
+      return [noise_scheduler, sched_smin, sched_smax, sched_rho, sched_beta_d, sched_beta_min, sched_eps_s]
+
+    def run(self, p, noise_scheduler, sched_smin, sched_smax, sched_rho, sched_beta_d, sched_beta_min, sched_eps_s):
+
+      noise_scheduler_func_name = ['-','get_sigmas_karras','get_sigmas_exponential','get_sigmas_vp'][noise_scheduler]
+
+      base_params = {
+        "sigma_min":sched_smin, 
+        "sigma_max":sched_smax, 
+        "rho":sched_rho, 
+        "beta_d":sched_beta_d, 
+        "beta_min":sched_beta_min, 
+        "eps_s":sched_eps_s,
+        "device":"cuda" if torch.cuda.is_available() else "cpu"
+      }
+
+      if hasattr(k_diffusion.sampling,noise_scheduler_func_name):
+
+        sigma_func  = getattr(k_diffusion.sampling,noise_scheduler_func_name)
+        sigma_func_kwargs = {}
+
+        for k,v in base_params.items():
+          if k in inspect.signature(sigma_func).parameters:
+            sigma_func_kwargs[k] = v
+
+        def substitute_noise_scheduler(n):
+          return sigma_func(n,**sigma_func_kwargs)
+
+        p.sampler_noise_scheduler_override = substitute_noise_scheduler
+
+      return process_images(p)


### PR DESCRIPTION
This PR updates K-Diffusion to enable the newest improvements in DPM Adaptive (stochastic sampling and ancestral sampling for adaptive) and includes the noise scheduler script by @dfaker.

The reason I include the script can be seen here #1435 but the TLDR is DPM samplers will output a unpleasantly noisy/filtered image if using the default scheduler. Karras scheduling seems to be the intended way to use these samplers. I included the script instead of changing the default to preserve seed compatibility.

closes #1435

Default
![00016-2418091115](https://user-images.githubusercontent.com/36072735/193549520-4f9209e0-2daa-4add-8c1d-35edcf6dd1dd.png)

Karras scheduling
![00088-2418091115](https://user-images.githubusercontent.com/36072735/193549592-96d76ee9-d62f-4947-be85-6966d921c6d1.png)
