### PR TITLE
Allow nested structures inside schedules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ clean-fid
 resize-right
 torchdiffeq
 kornia
+lark

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -21,3 +21,4 @@ clean-fid==0.1.29
 resize-right==0.0.2
 torchdiffeq==0.2.3
 kornia==0.6.7
+lark==1.1.2


### PR DESCRIPTION
Allow nested constructs with colons such as `[A:B:0.5]` and `(C:1.5)` in prompt edits.
Only the schedule parsing function is changed.