### PR TITLE
XY plot Prompt order

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -38,15 +38,21 @@ def apply_order(p, x, xs):
 
     token_order.sort(key=lambda t: t[0])
 
-    search_from_pos = 0
-    for idx, (original_pos, old_token) in enumerate(token_order):
-        # Get position of the token again as it will likely change as tokens are being replaced
-        pos = search_from_pos + p.prompt[search_from_pos:].find(old_token)
-        if original_pos >= 0:
-            # Avoid trying to replace what was just replaced by searching later in the prompt string
-            p.prompt = p.prompt[0:search_from_pos] + p.prompt[search_from_pos:].replace(old_token, x[idx], 1)
+    prompt_parts = []
 
-        search_from_pos = pos + len(x[idx])
+    # Split the prompt up, taking out the tokens
+    for _, token in token_order:
+        n = p.prompt.find(token)
+        prompt_parts.append(p.prompt[0:n])
+        p.prompt = p.prompt[n + len(token):]
+
+    # Rebuild the prompt with the tokens in the order we want
+    prompt_tmp = ""
+    for idx, part in enumerate(prompt_parts):
+        prompt_tmp += part
+        prompt_tmp += x[idx]
+    p.prompt = prompt_tmp + p.prompt
+    
 
 samplers_dict = {}
 for i, sampler in enumerate(modules.sd_samplers.samplers):

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -32,24 +32,21 @@ def apply_prompt(p, x, xs):
 def apply_order(p, x, xs):
     token_order = []
 
-    # Initally grab the tokens from the prompt so they can be later be replaced in order of earliest seen in the prompt
+    # Initally grab the tokens from the prompt so they can be be replaced in order of earliest seen
     for token in x:
         token_order.append((p.prompt.find(token), token))
 
     token_order.sort(key=lambda t: t[0])
 
     search_from_pos = 0
-    for idx, token in enumerate(x):
-        original_pos, old_token = token_order[idx]
-
+    for idx, (original_pos, old_token) in enumerate(token_order):
         # Get position of the token again as it will likely change as tokens are being replaced
-        pos = p.prompt.find(old_token)
+        pos = search_from_pos + p.prompt[search_from_pos:].find(old_token)
         if original_pos >= 0:
             # Avoid trying to replace what was just replaced by searching later in the prompt string
-            p.prompt = p.prompt[0:search_from_pos] + p.prompt[search_from_pos:].replace(old_token, token, 1)
+            p.prompt = p.prompt[0:search_from_pos] + p.prompt[search_from_pos:].replace(old_token, x[idx], 1)
 
-        search_from_pos = pos + len(token)
-
+        search_from_pos = pos + len(x[idx])
 
 samplers_dict = {}
 for i, sampler in enumerate(modules.sd_samplers.samplers):


### PR DESCRIPTION
Add an option to X/Y plot script that allows user to compare different prompt orders.

It takes words from your prompt and replaces them using each permutation of the coma separated list you give under X/Y values in the interface. Those tokens are expected to be in the prompt string. This does grow factorially so obviously adding 10 tokens to reorder wont be pleasant, but this may be useful for seeing the difference the order of words in your prompt can make in the result.

![image](https://user-images.githubusercontent.com/87161919/193742434-2b5a92ce-8a0c-4614-9e14-103df1e9cbad.png)

Prompt: photorealistic, cute, a photograph, of a (large) cat, jumping, with small ears, (orange:0.6)
X values: (large), jumping, small
Y values: (orange:0.6), cute

For example in this prompt, along the X-axis the prompts will be:
photorealistic, (orange:0.6), a photograph, of a **(large)** cat, **jumping**, with **small** ears, cute
photorealistic, (orange:0.6), a photograph, of a **(large)** cat, **small**, with **jumping** ears, cute
photorealistic, (orange:0.6), a photograph, of a **jumping** cat, **(large)**, with **small** ears, cute
etc.

The next one down along the X-axis would be have the positions of `(orange:0.6)` and `cute` swapped.
photorealistic, **cute**, a photograph, of a (large) cat, jumping, with small ears, **(orange:0.6)**
etc.