### PR TITLE
Sanitize pathname

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -353,9 +353,6 @@ def apply_filename_pattern(x, p, seed, prompt):
                 words = ["empty"]
             x = x.replace("[prompt_words]", sanitize_filename_part(" ".join(words[0:max_prompt_words]), replace_spaces=False))
 
-    if cmd_opts.hide_ui_dir_config:
-        x = re.sub(r'^[\\/]+|\.{2,}[\\/]+|[\\/]+\.{2,}', '', x)
-
     x = sanitize_pathname(x)
 
     return x


### PR DESCRIPTION
Sanitize pathname after all patterns applied.

`os.path.normpath()` seems to work, but it doesn't give you finer control over parts of the path.

`invalid_filename_prefix` and `*_postfix` strip are done here, so I removed them from `sanitize_filename_part()`.