### PR TITLE
PNG Info also works with jpg - text updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check the [custom scripts](https://github.com/AUTOMATIC1111/stable-diffusion-web
 - Generation parameters
      - parameters you used to generate images are saved with that image
      - in PNG chunks for PNG, in EXIF for JPEG
-     - can drag the image to PNG info tab to restore generation parameters and automatically copy them into UI
+     - can drag the image to IMG info tab to restore generation parameters and automatically copy them into UI
      - can be disabled in settings
 - Settings page
 - Running arbitrary python code from UI (must run with --allow-code to enable)

--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -19,7 +19,7 @@ function dropReplaceImage( imgWrap, files ) {
     };
     
     if ( imgWrap.closest('#pnginfo_image') ) {
-        // special treatment for PNG Info tab, wait for fetch request to finish
+        // special treatment for IMG Info tab, wait for fetch request to finish
         const oldFetch = window.fetch;
         window.fetch = async (input, options) => {
             const response = await oldFetch(input, options);

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -147,7 +147,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "grid_only_if_multiple": OptionInfo(True, "Do not save grids consisting of one picture"),
     "n_rows": OptionInfo(-1, "Grid row count; use -1 for autodetect and 0 for it to be same as batch size", gr.Slider, {"minimum": -1, "maximum": 16, "step": 1}),
 
-    "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),
+    "enable_pnginfo": OptionInfo(True, "Save prompt and parameters in image metadata"),
     "save_txt": OptionInfo(False, "Create a text file next to every image with generation parameters."),
     "save_images_before_face_restoration": OptionInfo(False, "Save a copy of image before doing face restoration."),
     "jpeg_quality": OptionInfo(80, "Quality for saved jpeg images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -195,7 +195,7 @@ options_templates.update(options_section(('face-restoration', "Face restoration"
 options_templates.update(options_section(('system', "System"), {
     "memmon_poll_rate": OptionInfo(8, "VRAM usage polls per second during generation. Set to 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 40, "step": 1}),
     "samples_log_stdout": OptionInfo(False, "Always print all generation info to standard output"),
-    "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job. Broken in PyCharm console."),
+    "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job. In PyCharm select 'emulate terminal in console output'."),
 }))
 
 options_templates.update(options_section(('sd', "Stable Diffusion"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -195,7 +195,7 @@ options_templates.update(options_section(('face-restoration', "Face restoration"
 options_templates.update(options_section(('system', "System"), {
     "memmon_poll_rate": OptionInfo(8, "VRAM usage polls per second during generation. Set to 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 40, "step": 1}),
     "samples_log_stdout": OptionInfo(False, "Always print all generation info to standard output"),
-    "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job. In PyCharm select 'emulate terminal in console output'."),
+    "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job."),
 }))
 
 options_templates.update(options_section(('sd', "Stable Diffusion"), {
@@ -204,7 +204,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
     "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies (normally you'd do less with less denoising)."),
     "enable_quantization": OptionInfo(False, "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds. Requires restart to apply."),
-    "enable_emphasis": OptionInfo(True, "Eemphasis: use (text) to make model pay more attention to text and [text] to make it pay less attention"),
+    "enable_emphasis": OptionInfo(True, "Emphasis: use (text) to make model pay more attention to text and [text] to make it pay less attention"),
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
     "filter_nsfw": OptionInfo(False, "Filter NSFW content"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1213,7 +1213,7 @@ def create_ui(wrap_gradio_gpu_call):
         (txt2img_interface, "txt2img", "txt2img"),
         (img2img_interface, "img2img", "img2img"),
         (extras_interface, "Extras", "extras"),
-        (pnginfo_interface, "PNG Info", "pnginfo"),
+        (pnginfo_interface, "IMG Info", "pnginfo"),
         (modelmerger_interface, "Checkpoint Merger", "modelmerger"),
         (textual_inversion_interface, "Textual inversion", "ti"),
         (settings_interface, "Settings", "settings"),


### PR DESCRIPTION
Updating config to reflect that PNG Info also supports JPG.

### In navigation bar:
PNG Info -> IMG Info   (tried to keep it short to keep navbar area clean, could also be 'Image Info')

### In Settings
Save text information about generation parameters as chunks to png files -> Save prompt and parameters in image metadata

I think this could help people to use the feature and avoid confusion