### PR TITLE
Add  progress images size threshold

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -228,7 +228,7 @@ options_templates.update(options_section(('interrogate', "Interrogate Options"),
 options_templates.update(options_section(('ui', "User interface"), {
     "show_progressbar": OptionInfo(True, "Show progressbar"),
     "show_progress_every_n_steps": OptionInfo(0, "Show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
-    "progress_size_threshold": OptionInfo(0, "progress images will be resized to a given resolution if above. Set 0 to disable.", gr.Number, {"minimum": 0, "step": 4}),
+    "progress_size_threshold": OptionInfo(0, "Progress images will be throttled to N resolution. Set 0 to disable.", gr.Number, {"minimum": 0, "step": 4}),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),
     "add_model_hash_to_info": OptionInfo(True, "Add model hash to generation information"),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -227,7 +227,8 @@ options_templates.update(options_section(('interrogate', "Interrogate Options"),
 
 options_templates.update(options_section(('ui', "User interface"), {
     "show_progressbar": OptionInfo(True, "Show progressbar"),
-    "show_progress_every_n_steps": OptionInfo(0, "Show show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
+    "show_progress_every_n_steps": OptionInfo(0, "Show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
+    "progress_size_threshold": OptionInfo(0, "progress images will be resized to a given resolution if above. Set 0 to disable.", gr.Number, {"minimum": 0, "step": 4}),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),
     "add_model_hash_to_info": OptionInfo(True, "Add model hash to generation information"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -254,6 +254,13 @@ def check_progress_call(id_part):
         else:
             preview_visibility = gr_show(True)
 
+            if opts.progress_size_threshold > 0:
+                if (max(image.size) > opts.progress_size_threshold):
+                    res_desired_ratio = opts.progress_size_threshold/max(image.size)
+                    out_res = tuple([int(i*res_desired_ratio) for i in image.size])
+                    image = image.resize(out_res)
+
+
     if shared.state.textinfo is not None:
         textinfo_result = gr.HTML.update(value=shared.state.textinfo, visible=True)
     else:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -256,9 +256,9 @@ def check_progress_call(id_part):
 
             if opts.progress_size_threshold > 0:
                 if (max(image.size) > opts.progress_size_threshold):
-                    res_desired_ratio = opts.progress_size_threshold/max(image.size)
-                    out_res = tuple([int(i*res_desired_ratio) for i in image.size])
-                    image = image.resize(out_res)
+                    preview_res_ratio = opts.progress_size_threshold/max(image.size)
+                    preview_res = tuple([int(i*preview_res_ratio) for i in image.size]) # shrink resolution by ratio
+                    image = image.resize(preview_res)
 
 
     if shared.state.textinfo is not None:


### PR DESCRIPTION
This adds the option to resize the progress preview images  before being sent to the webui. This Improves UI performance, and saves a small amount of resources.

edit: clarity and spelling