### PR TITLE
Pass arguments from bash to python

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -33,7 +33,7 @@ goto :launch
 :skip_venv
 
 :launch
-%PYTHON% launch.py
+%PYTHON% launch.py %*
 pause
 exit /b
 

--- a/webui.sh
+++ b/webui.sh
@@ -138,4 +138,4 @@ fi
 printf "\n%s\n" "${delimiter}"
 printf "Launching launch.py..."
 printf "\n%s\n" "${delimiter}"
-"${python_cmd}" "${LAUNCH_SCRIPT}"
+"${python_cmd}" "${LAUNCH_SCRIPT}" "$@"


### PR DESCRIPTION
The bash script doesn't pass arguments into python, so things like --shared and --listen are ignored.