### PR TITLE
Added `grid_save_to_dirs_for_ui` option

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -353,7 +353,7 @@ def get_next_sequence_number(path, basename):
     return result + 1
 
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix=""):
+def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix="", save_to_dirs=None):
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
@@ -377,7 +377,8 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     else:
         pnginfo = None
 
-    save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
+    if save_to_dirs is None:
+        save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
 
     if save_to_dirs:
         dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, seed, prompt).strip('\\ /')
@@ -431,4 +432,4 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         with open(f"{fullfn_without_extension}.txt", "w", encoding="utf8") as file:
             file.write(info + "\n")
 
-
+    return fullfn

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -178,6 +178,7 @@ options_templates.update(options_section(('saving-to-dirs', "Saving to a directo
     "save_to_dirs": OptionInfo(False, "Save images to a subdirectory"),
     "grid_save_to_dirs": OptionInfo(False, "Save grids to a subdirectory"),
     "use_save_to_dirs_for_ui": OptionInfo(False, "When using \"Save\" button, save images to a subdirectory"),
+    "grid_save_to_dirs_for_ui": OptionInfo(False, "When using \"Save\" button, save grids to a subdirectory"),
     "directories_filename_pattern": OptionInfo("", "Directory name pattern"),
     "directories_max_prompt_words": OptionInfo(8, "Max prompt words for [prompt_words] pattern", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1}),
 }))

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -35,7 +35,7 @@ import modules.codeformer_model
 import modules.styles
 import modules.generation_parameters_copypaste
 from modules.prompt_parser import get_learned_conditioning_prompt_schedules
-from modules.images import apply_filename_pattern, get_next_sequence_number
+from modules.images import save_image
 import modules.textual_inversion.ui
 
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the bowser will not show any UI
@@ -114,20 +114,14 @@ def save_files(js_data, images, index):
     p = MyObject(data)
     path = opts.outdir_save
     save_to_dirs = opts.use_save_to_dirs_for_ui
-
-    if save_to_dirs:
-        dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, p.seed, p.prompt)
-        path = os.path.join(opts.outdir_save, dirname)
-
-    os.makedirs(path, exist_ok=True)
-  
+    grid_save_to_dirs: bool = opts.grid_save_to_dirs_for_ui
+    extension: str = opts.samples_format
+    start_index = 0
 
     if index > -1 and opts.save_selected_only and (index >= data["index_of_first_image"]):  # ensures we are looking at a specific non-grid picture, and we have save_selected_only
 
         images = [images[index]]
-        infotexts = [data["infotexts"][index]]
-    else:
-        infotexts = data["infotexts"]
+        start_index = index
 
     with open(os.path.join(opts.outdir_save, "log.csv"), "a", encoding="utf8", newline='') as file:
         at_start = file.tell() == 0
@@ -135,37 +129,19 @@ def save_files(js_data, images, index):
         if at_start:
             writer.writerow(["prompt", "seed", "width", "height", "sampler", "cfgs", "steps", "filename", "negative_prompt"])
 
-        file_decoration = opts.samples_filename_pattern or "[seed]-[prompt_spaces]"
-        if file_decoration != "":
-            file_decoration = "-" + file_decoration.lower()
-        file_decoration = apply_filename_pattern(file_decoration, p, p.seed, p.prompt)
-        truncated = (file_decoration[:240] + '..') if len(file_decoration) > 240 else file_decoration
-        filename_base = truncated
-        extension = opts.samples_format.lower()
-
-        basecount = get_next_sequence_number(path, "")
-        for i, filedata in enumerate(images):
-            file_number = f"{basecount+i:05}"
-            filename = file_number + filename_base + f".{extension}"
-            filepath = os.path.join(path, filename)
-
-
+        for image_index, filedata in enumerate(images, start_index):
             if filedata.startswith("data:image/png;base64,"):
                 filedata = filedata[len("data:image/png;base64,"):]
 
             image = Image.open(io.BytesIO(base64.decodebytes(filedata.encode('utf-8'))))
-            if opts.enable_pnginfo and extension == 'png':
-                pnginfo = PngImagePlugin.PngInfo()
-                pnginfo.add_text('parameters', infotexts[i])
-                image.save(filepath, pnginfo=pnginfo)
-            else:
-                image.save(filepath, quality=opts.jpeg_quality)
 
-            if opts.enable_pnginfo and extension in ("jpg", "jpeg", "webp"):
-                piexif.insert(piexif.dump({"Exif": {
-                    piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(infotexts[i], encoding="unicode")
-                }}), filepath)
+            is_grid = image_index < p.index_of_first_image
+            is_save_to_dirs = grid_save_to_dirs if is_grid else save_to_dirs
+            i = 0 if is_grid else (image_index - p.index_of_first_image)
 
+            fullfn = save_image(image, path, "", seed=p.all_seeds[i], prompt=p.all_prompts[i], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=is_save_to_dirs)
+
+            filename = os.path.relpath(fullfn, path)
             filenames.append(filename)
 
         writer.writerow([data["prompt"], data["seed"], data["width"], data["height"], data["sampler"], data["cfg_scale"], data["steps"], filenames[0], data["negative_prompt"]])


### PR DESCRIPTION
Currently `Saving to a directory` has the following options:
- Save images to a subdirectory
- Save grids to a subdirectory
- When using "Save" button, save images to a subdirectory

This PR added the following option:
- When using "Save" button, save grids to a subdirectory

## About the implementation

### `modules.ui.save_files()`
Removed duplicated code such as file name generation and embedding image information, and now uses `modules.images.save_image()`.

### `modules.images.save_image()`
Added new keyword argument `save_to_dirs=None`.
The default value of `None` does not change the previous behavior.
If a bool value is specified, it will override the default behavior.