### PR TITLE
Fix patterns when saving image from UI

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -292,12 +292,7 @@ def apply_filename_pattern(x, p, seed, prompt):
         x = x.replace("[cfg]", str(p.cfg_scale))
         x = x.replace("[width]", str(p.width))
         x = x.replace("[height]", str(p.height))
-
-        #currently disabled if using the save button, will work otherwise
-        # if enabled it will cause a bug because styles is not included in the save_files data dictionary
-        if hasattr(p, "styles"):
-            x = x.replace("[styles]", sanitize_filename_part(", ".join([x for x in p.styles if not x == "None"]) or "None", replace_spaces=False))
-
+        x = x.replace("[styles]", sanitize_filename_part(", ".join([x for x in p.styles if not x == "None"]) or "None", replace_spaces=False))
         x = x.replace("[sampler]", sanitize_filename_part(sd_samplers.samplers[p.sampler_index].name, replace_spaces=False))
 
     x = x.replace("[model_hash]", shared.sd_model.sd_model_hash)

--- a/modules/images.py
+++ b/modules/images.py
@@ -295,7 +295,7 @@ def apply_filename_pattern(x, p, seed, prompt):
         x = x.replace("[styles]", sanitize_filename_part(", ".join([x for x in p.styles if not x == "None"]) or "None", replace_spaces=False))
         x = x.replace("[sampler]", sanitize_filename_part(sd_samplers.samplers[p.sampler_index].name, replace_spaces=False))
 
-    x = x.replace("[model_hash]", shared.sd_model.sd_model_hash)
+    x = x.replace("[model_hash]", getattr(p, "sd_model_hash", shared.sd_model.sd_model_hash))
     x = x.replace("[date]", datetime.date.today().isoformat())
     x = x.replace("[datetime]", datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
     x = x.replace("[job_timestamp]", getattr(p, "job_timestamp", shared.state.job_timestamp))

--- a/modules/images.py
+++ b/modules/images.py
@@ -298,7 +298,7 @@ def apply_filename_pattern(x, p, seed, prompt):
     x = x.replace("[model_hash]", shared.sd_model.sd_model_hash)
     x = x.replace("[date]", datetime.date.today().isoformat())
     x = x.replace("[datetime]", datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
-    x = x.replace("[job_timestamp]", shared.state.job_timestamp)
+    x = x.replace("[job_timestamp]", getattr(p, "job_timestamp", shared.state.job_timestamp))
 
     # Apply [prompt] at last. Because it may contain any replacement word.^M
     if prompt is not None:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -122,6 +122,7 @@ class Processed:
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
         self.styles = p.styles
+        self.job_timestamp = state.job_timestamp
 
         self.eta = p.eta
         self.ddim_discretize = p.ddim_discretize
@@ -167,6 +168,7 @@ class Processed:
             "index_of_first_image": self.index_of_first_image,
             "infotexts": self.infotexts,
             "styles": self.styles,
+            "job_timestamp": self.job_timestamp,
         }
 
         return json.dumps(obj)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -121,6 +121,7 @@ class Processed:
         self.denoising_strength = getattr(p, 'denoising_strength', None)
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
+        self.styles = p.styles
 
         self.eta = p.eta
         self.ddim_discretize = p.ddim_discretize
@@ -165,6 +166,7 @@ class Processed:
             "extra_generation_params": self.extra_generation_params,
             "index_of_first_image": self.index_of_first_image,
             "infotexts": self.infotexts,
+            "styles": self.styles,
         }
 
         return json.dumps(obj)


### PR DESCRIPTION
Currently `[styles]` is not working from the save button.
So added `Processed.styles` attribute and use it.

Currently `[job_timestamp]` and `[model_hash]` shows the server-side state instead of the UI state.
So added `Processed.job_timestamp` attribute and use it.
It also uses `Processed.sd_model_hash` attribute that already exists.