### PR TITLE
fix import error

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -4,13 +4,13 @@ import torch
 import tqdm
 from PIL import Image
 import inspect
+from modules import prompt_parser
+from modules.shared import opts, cmd_opts, state
+import modules.shared as shared
 import k_diffusion.sampling
 import ldm.models.diffusion.ddim
 import ldm.models.diffusion.plms
-from modules import prompt_parser
 
-from modules.shared import opts, cmd_opts, state
-import modules.shared as shared
 
 
 SamplerData = namedtuple('SamplerData', ['name', 'constructor', 'aliases'])


### PR DESCRIPTION
The newest update to hide samplers changed import order and I suppose broke the import chain leading to paths.py while doing it, leading to errors #1785 

This PR simply moves the imports around to fix the issue.

closes #1785, closes #1792 