### PR TITLE
Fix for 'unable to find module'

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2,6 +2,7 @@ import os
 import threading
 import time
 import importlib
+import modules.paths
 from modules import devices, sd_samplers
 from modules.paths import script_path
 import signal
@@ -14,7 +15,6 @@ import modules.gfpgan_model as gfpgan
 import modules.img2img
 
 import modules.lowvram
-import modules.paths
 import modules.scripts
 import modules.sd_hijack
 import modules.sd_models


### PR DESCRIPTION
See issue
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/1785
After a commit
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/5f24b7bcf4a074fbdec757617fcd1bc82e76551b
Running webui.sh|bat became to produce error as it cannot reach sys.path, which is only correct after modules.paths import.