### PR TITLE
Preserve parameter chunk when saving in browser / using “Send to …”

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -42,7 +42,7 @@ def run_extras(extras_mode, image, image_folder, gfpgan_visibility, codeformer_v
     outputs = []
     for image, image_name in zip(imageArr, imageNameArr):
         if image is None:
-            return [pi.image for pi in outputs], "Please select an input image.", ''
+            return [pi.get_filename(outpath) for pi in outputs], "Please select an input image.", ''
         existing_pnginfo = image.info or {}
 
         image = image.convert("RGB")
@@ -103,7 +103,7 @@ def run_extras(extras_mode, image, image_folder, gfpgan_visibility, codeformer_v
 
     devices.torch_gc()
 
-    return [pi.image for pi in outputs], plaintext_to_html(info), ''
+    return [pi.get_filename(outpath) for pi in outputs], plaintext_to_html(info), ''
 
 
 def run_pnginfo(image):

--- a/modules/images.py
+++ b/modules/images.py
@@ -18,6 +18,8 @@ LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.L
 
 
 def image_grid(imgs, batch_size=1, rows=None):
+    from modules.processing import ProcessedImage
+
     if rows is None:
         if opts.n_rows > 0:
             rows = opts.n_rows
@@ -29,13 +31,14 @@ def image_grid(imgs, batch_size=1, rows=None):
 
     cols = math.ceil(len(imgs) / rows)
 
-    w, h = imgs[0].size
+    w, h = imgs[0].image.size
     grid = Image.new('RGB', size=(cols * w, rows * h), color='black')
 
     for i, img in enumerate(imgs):
-        grid.paste(img, box=(i % cols * w, i // cols * h))
+        grid.paste(img.image, box=(i % cols * w, i // cols * h))
 
-    return grid
+    # use the infotext of the first image as the infotext of the grid
+    return ProcessedImage(grid, imgs[0].infotext, is_grid=True)
 
 
 Grid = namedtuple("Grid", ["tiles", "tile_w", "tile_h", "image_w", "image_h", "overlap"])
@@ -115,7 +118,9 @@ class GridAnnotation:
         self.size = None
 
 
-def draw_grid_annotations(im, width, height, hor_texts, ver_texts):
+def draw_grid_annotations(grid, width, height, hor_texts, ver_texts):
+    from modules.processing import ProcessedImage
+
     def wrap(drawing, text, font, line_length):
         lines = ['']
         for word in text.split():
@@ -148,6 +153,7 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts):
 
     pad_left = 0 if sum([sum([len(line.text) for line in lines]) for lines in ver_texts]) == 0 else width * 3 // 4
 
+    im = grid.image
     cols = im.width // width
     rows = im.height // height
 
@@ -192,10 +198,10 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts):
 
         draw_texts(d, x, y, ver_texts[row])
 
-    return result
+    return ProcessedImage(result, grid.infotext, is_grid=True)
 
 
-def draw_prompt_matrix(im, width, height, all_prompts):
+def draw_prompt_matrix(grid, width, height, all_prompts):
     prompts = all_prompts[1:]
     boundary = math.ceil(len(prompts) / 2)
 
@@ -205,7 +211,7 @@ def draw_prompt_matrix(im, width, height, all_prompts):
     hor_texts = [[GridAnnotation(x, is_active=pos & (1 << i) != 0) for i, x in enumerate(prompts_horiz)] for pos in range(1 << len(prompts_horiz))]
     ver_texts = [[GridAnnotation(x, is_active=pos & (1 << i) != 0) for i, x in enumerate(prompts_vert)] for pos in range(1 << len(prompts_vert))]
 
-    return draw_grid_annotations(im, width, height, hor_texts, ver_texts)
+    return draw_grid_annotations(grid, width, height, hor_texts, ver_texts)
 
 
 def resize_image(resize_mode, im, width, height):
@@ -353,7 +359,7 @@ def get_next_sequence_number(path, basename):
     return result + 1
 
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix="", save_to_dirs=None):
+def save_image(pi, path, basename, seed=None, prompt=None, extension='png', short_filename=False, no_prompt=False, p=None, forced_filename=None, suffix="", save_to_dirs=None):
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
@@ -366,6 +372,13 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     file_decoration = apply_filename_pattern(file_decoration, p, seed, prompt) + suffix
 
+    try:
+        existing_info, info = pi.infotext
+        pnginfo_section_name = 'extras'
+    except ValueError:
+        existing_info, info = None, pi.infotext
+        pnginfo_section_name = 'parameters'
+
     if extension == 'png' and opts.enable_pnginfo and info is not None:
         pnginfo = PngImagePlugin.PngInfo()
 
@@ -377,6 +390,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     else:
         pnginfo = None
 
+    grid = pi.is_grid
     if save_to_dirs is None:
         save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
 
@@ -407,6 +421,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             },
         })
 
+    image = pi.image
     if extension.lower() in ("jpg", "jpeg", "webp"):
         image.save(fullfn, quality=opts.jpeg_quality)
         if opts.enable_pnginfo and info is not None:

--- a/modules/images.py
+++ b/modules/images.py
@@ -5,9 +5,7 @@ from collections import namedtuple
 import re
 
 import numpy as np
-import piexif
-import piexif.helper
-from PIL import Image, ImageFont, ImageDraw, PngImagePlugin
+from PIL import Image, ImageFont, ImageDraw
 from fonts.ttf import Roboto
 import string
 
@@ -372,24 +370,6 @@ def save_image(pi, path, basename, seed=None, prompt=None, extension='png', shor
 
     file_decoration = apply_filename_pattern(file_decoration, p, seed, prompt) + suffix
 
-    try:
-        existing_info, info = pi.infotext
-        pnginfo_section_name = 'extras'
-    except ValueError:
-        existing_info, info = None, pi.infotext
-        pnginfo_section_name = 'parameters'
-
-    if extension == 'png' and opts.enable_pnginfo and info is not None:
-        pnginfo = PngImagePlugin.PngInfo()
-
-        if existing_info is not None:
-            for k, v in existing_info.items():
-                pnginfo.add_text(k, str(v))
-
-        pnginfo.add_text(pnginfo_section_name, info)
-    else:
-        pnginfo = None
-
     grid = pi.is_grid
     if save_to_dirs is None:
         save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
@@ -414,21 +394,10 @@ def save_image(pi, path, basename, seed=None, prompt=None, extension='png', shor
         fullfn = os.path.join(path, f"{forced_filename}.{extension}")
         fullfn_without_extension = os.path.join(path, forced_filename)
 
-    def exif_bytes():
-        return piexif.dump({
-            "Exif": {
-                piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(info or "", encoding="unicode")
-            },
-        })
+    pi.save(fullfn)
+    pi.saved_fn = fullfn
 
     image = pi.image
-    if extension.lower() in ("jpg", "jpeg", "webp"):
-        image.save(fullfn, quality=opts.jpeg_quality)
-        if opts.enable_pnginfo and info is not None:
-            piexif.insert(exif_bytes(), fullfn)
-    else:
-        image.save(fullfn, quality=opts.jpeg_quality, pnginfo=pnginfo)
-
     target_side_length = 4000
     oversize = image.width > target_side_length or image.height > target_side_length
     if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > 4 * 1024 * 1024):
@@ -440,11 +409,10 @@ def save_image(pi, path, basename, seed=None, prompt=None, extension='png', shor
             image = image.resize((image.width * target_side_length // image.height, target_side_length), LANCZOS)
 
         image.save(fullfn_without_extension + ".jpg", quality=opts.jpeg_quality)
-        if opts.enable_pnginfo and info is not None:
-            piexif.insert(exif_bytes(), fullfn_without_extension + ".jpg")
+        if opts.enable_pnginfo:
+            pi.insert_exif(fullfn_without_extension + ".jpg")
 
-    if opts.save_txt and info is not None:
-        with open(f"{fullfn_without_extension}.txt", "w", encoding="utf8") as file:
-            file.write(info + "\n")
+    if opts.save_txt:
+        pi.save_txt(f"{fullfn_without_extension}.txt")
 
     return fullfn

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -74,10 +74,12 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
 
     assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
 
+    outdir_samples = opts.outdir_samples or opts.outdir_img2img_samples
+    outdir_grids = opts.outdir_grids or opts.outdir_img2img_grids
     p = StableDiffusionProcessingImg2Img(
         sd_model=shared.sd_model,
-        outpath_samples=opts.outdir_samples or opts.outdir_img2img_samples,
-        outpath_grids=opts.outdir_grids or opts.outdir_img2img_grids,
+        outpath_samples=outdir_samples,
+        outpath_grids=outdir_grids,
         prompt=prompt,
         negative_prompt=negative_prompt,
         styles=[prompt_style, prompt_style2],
@@ -132,4 +134,4 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
     if opts.do_not_show_images:
         processed.images = []
 
-    return [pi.image for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))
+    return [pi.get_filename(outdir_samples, outdir_grids) for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -51,7 +51,7 @@ def process_batch(p, input_dir, output_dir, args):
                 filename = f"{left}-{n}{right}"
 
             if not save_normally:
-                processed_image.save(os.path.join(output_dir, filename))
+                processed_image.image.save(os.path.join(output_dir, filename))
 
 
 def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
@@ -117,7 +117,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
 
         process_batch(p, img2img_batch_input_dir, img2img_batch_output_dir, args)
 
-        processed = Processed(p, [], p.seed, "")
+        processed = Processed(p, [], p.seed)
     else:
         processed = modules.scripts.scripts_img2img.run(p, *args)
         if processed is None:
@@ -132,4 +132,4 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
     if opts.do_not_show_images:
         processed.images = []
 
-    return processed.images, generation_info_js, plaintext_to_html(processed.info)
+    return [pi.image for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -97,15 +97,20 @@ class StableDiffusionProcessing:
         raise NotImplementedError()
 
 
+class ProcessedImage:
+    def __init__(self, image, infotext, is_grid=False):
+        self.image = image
+        self.infotext = infotext
+        self.is_grid = is_grid
+
 class Processed:
-    def __init__(self, p: StableDiffusionProcessing, images_list, seed=-1, info="", subseed=None, all_prompts=None, all_seeds=None, all_subseeds=None, index_of_first_image=0, infotexts=None):
+    def __init__(self, p: StableDiffusionProcessing, images_list, seed=-1, subseed=None, all_prompts=None, all_seeds=None, all_subseeds=None, index_of_first_image=0, comments=()):
         self.images = images_list
         self.prompt = p.prompt
         self.negative_prompt = p.negative_prompt
         self.seed = seed
         self.subseed = subseed
         self.subseed_strength = p.subseed_strength
-        self.info = info
         self.width = p.width
         self.height = p.height
         self.sampler_index = p.sampler_index
@@ -137,7 +142,7 @@ class Processed:
         self.all_prompts = all_prompts or [self.prompt]
         self.all_seeds = all_seeds or [self.seed]
         self.all_subseeds = all_subseeds or [self.subseed]
-        self.infotexts = infotexts or [info]
+        self.comments = comments
 
     def js(self):
         obj = {
@@ -164,13 +169,10 @@ class Processed:
             "denoising_strength": self.denoising_strength,
             "extra_generation_params": self.extra_generation_params,
             "index_of_first_image": self.index_of_first_image,
-            "infotexts": self.infotexts,
+            "infotexts": [pi.infotext for pi in self.images],
         }
 
         return json.dumps(obj)
-
-    def infotext(self,  p: StableDiffusionProcessing, index):
-        return create_infotext(p, self.all_prompts, self.all_seeds, self.all_subseeds, comments=[], position_in_batch=index % self.batch_size, iteration=index // self.batch_size)
 
 
 # from https://discuss.pytorch.org/t/help-regarding-slerp-function-for-generative-model-sampling/32475/3
@@ -334,7 +336,6 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     if os.path.exists(cmd_opts.embeddings_dir):
         model_hijack.embedding_db.load_textual_inversion_embeddings()
 
-    infotexts = []
     output_images = []
 
     with torch.no_grad():
@@ -399,7 +400,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
                 if p.restore_faces:
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_face_restoration:
-                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-face-restoration")
+                        pi = ProcessedImage(Image.fromarray(x_sample), infotext(n, i))
+                        images.save_image(pi, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, p=p, suffix="-before-face-restoration")
 
                     devices.torch_gc()
 
@@ -410,7 +412,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
                 if p.color_corrections is not None and i < len(p.color_corrections):
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
-                        images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
+                        pi = ProcessedImage(image, infotext(n, i))
+                        images.save_image(pi, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, p=p, suffix="-before-color-correction")
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.overlay_images is not None and i < len(p.overlay_images):
@@ -427,13 +430,12 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     image.alpha_composite(overlay)
                     image = image.convert('RGB')
 
-                if opts.samples_save and not p.do_not_save_samples:
-                    images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p)
+                pi = ProcessedImage(image, infotext(n, i))
 
-                text = infotext(n, i)
-                infotexts.append(text)
-                image.info["parameters"] = text
-                output_images.append(image)
+                if opts.samples_save and not p.do_not_save_samples:
+                    images.save_image(pi, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, p=p)
+
+                output_images.append(pi)
 
             del x_samples_ddim 
 
@@ -449,17 +451,14 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
             grid = images.image_grid(output_images, p.batch_size)
 
             if opts.return_grid:
-                text = infotext()
-                infotexts.insert(0, text)
-                grid.info["parameters"] = text
                 output_images.insert(0, grid)
                 index_of_first_image = 1
 
             if opts.grid_save:
-                images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], all_prompts[0], opts.grid_format, info=infotext(), short_filename=not opts.grid_extended_filename, p=p, grid=True)
+                images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], all_prompts[0], opts.grid_format, short_filename=not opts.grid_extended_filename, p=p)
 
     devices.torch_gc()
-    return Processed(p, output_images, all_seeds[0], infotext() + "".join(["\n\n" + x for x in comments]), subseed=all_subseeds[0], all_prompts=all_prompts, all_seeds=all_seeds, all_subseeds=all_subseeds, index_of_first_image=index_of_first_image, infotexts=infotexts)
+    return Processed(p, output_images, all_seeds[0], subseed=all_subseeds[0], all_prompts=all_prompts, all_seeds=all_seeds, all_subseeds=all_subseeds, index_of_first_image=index_of_first_image, comments=comments)
 
 
 class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -123,6 +123,7 @@ class ProcessedImage:
         os.close(fd)
         self.save(fn)
         self.unsaved_fn = fn
+        shared.unsaved_files_to_remove.append(fn)
         return fn
 
     def save(self, fn):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -357,3 +357,22 @@ total_tqdm = TotalTQDM()
 
 mem_mon = modules.memmon.MemUsageMonitor("MemMon", device, opts)
 mem_mon.start()
+
+
+unsaved_files_to_remove = []
+
+def remove_temporary_files():
+    for fn in unsaved_files_to_remove:
+        try:
+            os.unlink(fn)
+        except OSError:
+            pass
+        else:
+            print(f"removed '{fn}'")
+    for path in set(os.path.dirname(fn) for fn in unsaved_files_to_remove):
+        try:
+            os.rmdir(path)
+        except OSError:
+            pass
+        else:
+            print(f"removed directory '{path}'")

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -241,7 +241,7 @@ def train_embedding(embedding_name, learn_rate, data_root, log_directory, steps,
             )
 
             processed = processing.process_images(p)
-            image = processed.images[0]
+            image = processed.images[0].image
 
             shared.state.current_image = image
             image.save(last_saved_image)

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -7,10 +7,12 @@ from modules.ui import plaintext_to_html
 
 
 def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, scale_latent: bool, denoising_strength: float, *args):
+    outdir_samples = opts.outdir_samples or opts.outdir_txt2img_samples
+    outdir_grids = opts.outdir_grids or opts.outdir_txt2img_grids
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
-        outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
-        outpath_grids=opts.outdir_grids or opts.outdir_txt2img_grids,
+        outpath_samples=outdir_samples,
+        outpath_grids=outdir_grids,
         prompt=prompt,
         styles=[prompt_style, prompt_style2],
         negative_prompt=negative_prompt,
@@ -51,5 +53,5 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
     if opts.do_not_show_images:
         processed.images = []
 
-    return [pi.image for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))
+    return [pi.get_filename(outdir_samples, outdir_grids) for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -51,5 +51,5 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
     if opts.do_not_show_images:
         processed.images = []
 
-    return processed.images, generation_info_js, plaintext_to_html(processed.info)
+    return [pi.image for pi in processed.images], generation_info_js, plaintext_to_html(processed.images[0].infotext + "".join(["\n\n" + x for x in processed.comments]))
 

--- a/scripts/loopback.py
+++ b/scripts/loopback.py
@@ -59,9 +59,9 @@ class Script(scripts.Script):
 
                 if initial_seed is None:
                     initial_seed = processed.seed
-                    initial_info = processed.info
+                    initial_info = processed.images[0].infotext
 
-                init_img = processed.images[0]
+                init_img = processed.images[0].image
 
                 p.init_images = [init_img]
                 p.seed = processed.seed + 1
@@ -70,7 +70,7 @@ class Script(scripts.Script):
 
             grid = images.image_grid(history, rows=1)
             if opts.grid_save:
-                images.save_image(grid, p.outpath_grids, "grid", initial_seed, p.prompt, opts.grid_format, info=info, short_filename=not opts.grid_extended_filename, grid=True, p=p)
+                images.save_image(grid, p.outpath_grids, "grid", initial_seed, p.prompt, opts.grid_format, short_filename=not opts.grid_extended_filename, p=p)
 
             grids.append(grid)
             all_images += history
@@ -78,6 +78,6 @@ class Script(scripts.Script):
         if opts.return_grid:
             all_images = grids + all_images
 
-        processed = Processed(p, all_images, initial_seed, initial_info)
+        processed = Processed(p, all_images, initial_seed)
 
         return processed

--- a/scripts/outpainting_mk_2.py
+++ b/scripts/outpainting_mk_2.py
@@ -8,7 +8,7 @@ import gradio as gr
 from PIL import Image, ImageDraw
 
 from modules import images, processing, devices
-from modules.processing import Processed, process_images
+from modules.processing import Processed, ProcessedImage, process_images
 from modules.shared import opts, cmd_opts, state
 
 
@@ -232,11 +232,11 @@ class Script(scripts.Script):
             p.latent_mask = latent_mask
 
             proc = process_images(p)
-            proc_img = proc.images[0]
+            proc_img = proc.images[0].image
 
             if initial_seed_and_info[0] is None:
                 initial_seed_and_info[0] = proc.seed
-                initial_seed_and_info[1] = proc.info
+                initial_seed_and_info[1] = proc.images[0].infotext
 
             out.paste(proc_img, (0 if is_left else out.width - proc_img.width, 0 if is_top else out.height - proc_img.height))
             out = out.crop((0, 0, res_w, res_h))
@@ -253,10 +253,11 @@ class Script(scripts.Script):
         if down > 0:
             img = expand(img, down, is_bottom=True)
 
-        res = Processed(p, [img], initial_seed_and_info[0], initial_seed_and_info[1])
+        pi = ProcessedImage(img, initial_seed_and_info[1])
+        res = Processed(p, [pi], initial_seed_and_info[0])
 
         if opts.samples_save:
-            images.save_image(img, p.outpath_samples, "", res.seed, p.prompt, opts.grid_format, info=res.info, p=p)
+            images.save_image(pi, p.outpath_samples, "", res.seed, p.prompt, opts.grid_format, p=p)
 
         return res
 

--- a/scripts/poor_mans_outpainting.py
+++ b/scripts/poor_mans_outpainting.py
@@ -5,7 +5,7 @@ import gradio as gr
 from PIL import Image, ImageDraw
 
 from modules import images, processing, devices
-from modules.processing import Processed, process_images
+from modules.processing import Processed, ProcessedImage, process_images
 from modules.shared import opts, cmd_opts, state
 
 
@@ -119,10 +119,10 @@ class Script(scripts.Script):
 
             if initial_seed is None:
                 initial_seed = processed.seed
-                initial_info = processed.info
+                initial_info = processed.images[0].infotext
 
             p.seed = processed.seed + 1
-            work_results += processed.images
+            work_results += [pi.image for pi in processed.images]
 
 
         image_index = 0
@@ -137,11 +137,12 @@ class Script(scripts.Script):
                 image_index += 1
 
         combined_image = images.combine_grid(grid)
+        pi = ProcessedImage(combined_image, initial_info)
 
         if opts.samples_save:
-            images.save_image(combined_image, p.outpath_samples, "", initial_seed, p.prompt, opts.grid_format, info=initial_info, p=p)
+            images.save_image(pi, p.outpath_samples, "", initial_seed, p.prompt, opts.grid_format, p=p)
 
-        processed = Processed(p, [combined_image], initial_seed, initial_info)
+        processed = Processed(p, [pi], initial_seed)
 
         return processed
 

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -33,7 +33,7 @@ def draw_xy_grid(xs, ys, x_label, y_label, cell):
             res.append(processed.images[0])
 
     grid = images.image_grid(res, rows=len(ys))
-    grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
+    grid = images.draw_grid_annotations(grid, res[0].image.width, res[0].image.height, hor_texts, ver_texts)
 
     first_pocessed.images = [grid]
 
@@ -82,6 +82,6 @@ class Script(scripts.Script):
         processed.images.insert(0, grid)
 
         if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", prompt=original_prompt, seed=processed.seed, grid=True, p=p)
+            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", prompt=original_prompt, seed=processed.seed, p=p)
 
         return processed

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -52,4 +52,4 @@ class Script(scripts.Script):
             proc = process_images(p)
             images += proc.images
 
-        return Processed(p, images, p.seed, "")
+        return Processed(p, images, p.seed)

--- a/scripts/sd_upscale.py
+++ b/scripts/sd_upscale.py
@@ -75,10 +75,10 @@ class Script(scripts.Script):
                 processed = processing.process_images(p)
 
                 if initial_info is None:
-                    initial_info = processed.info
+                    initial_info = processed.images[0].infotext
 
                 p.seed = processed.seed + 1
-                work_results += processed.images
+                work_results += [pi.image for pi in processed.images]
 
             image_index = 0
             for y, h, row in grid.tiles:
@@ -87,11 +87,12 @@ class Script(scripts.Script):
                     image_index += 1
 
             combined_image = images.combine_grid(grid)
-            result_images.append(combined_image)
+            pi = ProcessedImage(combined_image, initial_info)
+            result_images.append(pi)
 
             if opts.samples_save:
-                images.save_image(combined_image, p.outpath_samples, "", start_seed, p.prompt, opts.samples_format, info=initial_info, p=p)
+                images.save_image(pi, p.outpath_samples, "", start_seed, p.prompt, opts.samples_format, p=p)
 
-        processed = Processed(p, result_images, seed, initial_info)
+        processed = Processed(p, result_images, seed)
 
         return processed

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -11,7 +11,7 @@ import modules.scripts as scripts
 import gradio as gr
 
 from modules import images
-from modules.processing import process_images, Processed
+from modules.processing import ProcessedImage, process_images
 from modules.shared import opts, cmd_opts, state
 import modules.shared as shared
 import modules.sd_samplers
@@ -152,11 +152,11 @@ def draw_xy_grid(p, xs, ys, x_labels, y_labels, cell, draw_legend):
             try:
               res.append(processed.images[0])
             except:
-              res.append(Image.new(res[0].mode, res[0].size))
+              res.append(ProcessedImage(Image.new(res[0].image.mode, res[0].image.size), ''))
 
     grid = images.image_grid(res, rows=len(ys))
     if draw_legend:
-        grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
+        grid = images.draw_grid_annotations(grid, res[0].image.width, res[0].image.height, hor_texts, ver_texts)
 
     first_pocessed.images = [grid]
 
@@ -295,7 +295,7 @@ class Script(scripts.Script):
         )
 
         if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "xy_grid", prompt=p.prompt, seed=processed.seed, grid=True, p=p)
+            images.save_image(processed.images[0], p.outpath_grids, "xy_grid", prompt=p.prompt, seed=processed.seed, p=p)
 
         # restore checkpoint in case it was changed by axes
         modules.sd_models.reload_model_weights(shared.sd_model)

--- a/webui.py
+++ b/webui.py
@@ -84,6 +84,7 @@ def webui():
     # make the program just exit at ctrl+c without waiting for anything
     def sigint_handler(sig, frame):
         print(f'Interrupted with signal {sig} in {frame}')
+        shared.remove_temporary_files()
         os._exit(0)
 
     signal.signal(signal.SIGINT, sigint_handler)


### PR DESCRIPTION
When an image is saved from the browser via “Save Image As...”, the resulting image file is missing the generation parameters.  This is because the UI returns processed images to Gradio as PIL image objects which don't contain the parameters rather than as actual image files which do.

In order to fix this, the image has to be written to a temporary file on disk, and the filename needs to be passed to Gradio.  This has Gradio send the file to the browser as-is, including PNG/Exif metadata.

Currently, the parameters associated with an image aren't always passed to the same places the image is passed.  Since it would be cumbersome to add an “infotext” parameter everywhere, and since there also needs to be some place to store the image filename, this pull request introduces a class “ProcessedImage” that bundles a PIL image with its associated infotext.  This can be thought of as the “per-image” component of a Processed instance.

Returning the image filename then becomes a matter of replacing `ProcessedImage.image` with a call to `ProcessedImage.get_filename()`.

This fixes issue #1053.