### PR TITLE
Removed duplicate image saving codes

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -353,7 +353,7 @@ def get_next_sequence_number(path, basename):
     return result + 1
 
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix=""):
+def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix="", save_to_dirs=None):
     if short_filename or prompt is None or seed is None:
         file_decoration = ""
     elif opts.save_to_dirs:
@@ -377,7 +377,8 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     else:
         pnginfo = None
 
-    save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
+    if save_to_dirs is None:
+        save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
 
     if save_to_dirs:
         dirname = apply_filename_pattern(opts.directories_filename_pattern or "[prompt_words]", p, seed, prompt).strip('\\ /')
@@ -431,4 +432,4 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         with open(f"{fullfn_without_extension}.txt", "w", encoding="utf8") as file:
             file.write(info + "\n")
 
-
+    return fullfn


### PR DESCRIPTION
Use `modules.images.save_image()` instead.

## Tested

Self (manually) tested.

- Saving single image: OK
- Saving grid image: OK
- Saving multiple images: OK
  - Each file has correct seed, prompt and information: OK
- Filename prefix (sequence number): OK
- Filename patterns: OK
- Save to dirs (`use_save_to_dirs_for_ui` options): OK

## Changed behavior

- Old: Each files has the same base-name. (e.g. If the pattern has `[seed]`, all filenames will be the first image's seed.)
  New: A file name is generated for each file with its own information.
- Old: `opts.export_for_4chan` and `opts.save_txt` doesn't work when saving image.
  New: They are enabled when saving image.