### PR TITLE
Don't crash on editor swap files

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -338,6 +338,9 @@ def get_next_sequence_number(path, basename):
 
     prefix_length = len(basename)
     for p in os.listdir(path):
+        # ignore hidden files unless basename itself is hidden
+        if p.startswith('.') and not basename.startswith('.'):
+            continue
         if p.startswith(basename):
             l = os.path.splitext(p[prefix_length:])[0].split('-')  # splits the filename (removing the basename first if one is defined, so the sequence number is always the first element)
             try:

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -19,7 +19,7 @@ import modules.scripts
 def process_batch(p, input_dir, output_dir, args):
     processing.fix_seed(p)
 
-    images = [file for file in [os.path.join(input_dir, x) for x in os.listdir(input_dir)] if os.path.isfile(file)]
+    images = [file for file in [os.path.join(input_dir, x) for x in os.listdir(input_dir) if not x.startswith('.')] if os.path.isfile(file)]
 
     print(f"Will process {len(images)} images, creating {p.n_iter * p.batch_size} new images for each.")
 

--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -34,6 +34,8 @@ class InterrogateModels:
 
         if os.path.exists(content_dir):
             for filename in os.listdir(content_dir):
+                if filename.startswith('.'):
+                    continue
                 m = re_topn.search(filename)
                 topn = 1 if m is None else int(m.group(1))
 

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -102,6 +102,8 @@ def move_files(src_path: str, dest_path: str, ext_filter: str = None):
             os.makedirs(dest_path)
         if os.path.exists(src_path):
             for file in os.listdir(src_path):
+                if file.startswith('.'):
+                    continue
                 fullpath = os.path.join(src_path, file)
                 if os.path.isfile(fullpath):
                     if ext_filter is not None:
@@ -125,7 +127,7 @@ def load_upscalers():
     # so we'll try to import any _model.py files before looking in __subclasses__
     modules_dir = os.path.join(sd, "modules")
     for file in os.listdir(modules_dir):
-        if "_model.py" in file:
+        if not file.startswith(".") and "_model.py" in file:
             model_name = file.replace("_model.py", "")
             full_model = f"modules.{model_name}_model"
             try:

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -56,6 +56,8 @@ def load_scripts(basedir):
         return
 
     for filename in sorted(os.listdir(basedir)):
+        if filename.startswith('.'):
+            continue
         path = os.path.join(basedir, filename)
 
         if not os.path.isfile(path):

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -33,7 +33,7 @@ class PersonalizedBase(Dataset):
 
         assert data_root, 'dataset directory not specified'
 
-        self.image_paths = [os.path.join(data_root, file_path) for file_path in os.listdir(data_root)]
+        self.image_paths = [os.path.join(data_root, file_path) for file_path in os.listdir(data_root) if not file_path.startswith('.')]
         print("Preparing dataset...")
         for path in tqdm.tqdm(self.image_paths):
             image = Image.open(path)

--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -16,7 +16,7 @@ def preprocess(process_src, process_dst, process_flip, process_split, process_ca
 
     os.makedirs(dst, exist_ok=True)
 
-    files = os.listdir(src)
+    files = [fn for fn in os.listdir(src) if not fn.startswith('.')]
 
     shared.state.textinfo = "Preprocessing..."
     shared.state.job_count = len(files)

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -107,6 +107,8 @@ class EmbeddingDatabase:
             self.register_embedding(embedding, shared.sd_model)
 
         for fn in os.listdir(self.embeddings_dir):
+            if fn.startswith('.'):
+                continue
             try:
                 fullfn = os.path.join(self.embeddings_dir, fn)
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1399,6 +1399,8 @@ with open(os.path.join(script_path, "script.js"), "r", encoding="utf8") as jsfil
 
 jsdir = os.path.join(script_path, "javascript")
 for filename in sorted(os.listdir(jsdir)):
+    if filename.startswith('.'):
+        continue
     with open(os.path.join(jsdir, filename), "r", encoding="utf8") as jsfile:
         javascript += f"\n<script>{jsfile.read()}</script>"
 


### PR DESCRIPTION
Some editors create hidden swap files in the directory of an edited file.  When the UI tries to decode such a swap file, it crashes.  The simplest way to avoid this is to ignore hidden files; this avoids problems with `.gitignore` files, as well.