### PR TITLE
Removed duplicate definition Upscaler.model_path

### DIFF
--- a/modules/bsrgan_model.py
+++ b/modules/bsrgan_model.py
@@ -10,13 +10,11 @@ from basicsr.utils.download_util import load_file_from_url
 import modules.upscaler
 from modules import devices, modelloader
 from modules.bsrgan_model_arch import RRDBNet
-from modules.paths import models_path
 
 
 class UpscalerBSRGAN(modules.upscaler.Upscaler):
     def __init__(self, dirname):
         self.name = "BSRGAN"
-        self.model_path = os.path.join(models_path, self.name)
         self.model_name = "BSRGAN 4x"
         self.model_url = "https://github.com/cszn/KAIR/releases/download/v1.0/BSRGAN.pth"
         self.user_path = dirname

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -7,7 +7,6 @@ from basicsr.utils.download_util import load_file_from_url
 
 import modules.esrgam_model_arch as arch
 from modules import shared, modelloader, images, devices
-from modules.paths import models_path
 from modules.upscaler import Upscaler, UpscalerData
 from modules.shared import opts
 
@@ -76,7 +75,6 @@ class UpscalerESRGAN(Upscaler):
         self.model_name = "ESRGAN_4x"
         self.scalers = []
         self.user_path = dirname
-        self.model_path = os.path.join(models_path, self.name)
         super().__init__()
         model_paths = self.find_models(ext_filter=[".pt", ".pth"])
         scalers = []

--- a/modules/ldsr_model.py
+++ b/modules/ldsr_model.py
@@ -7,13 +7,11 @@ from basicsr.utils.download_util import load_file_from_url
 from modules.upscaler import Upscaler, UpscalerData
 from modules.ldsr_model_arch import LDSR
 from modules import shared
-from modules.paths import models_path
 
 
 class UpscalerLDSR(Upscaler):
     def __init__(self, user_path):
         self.name = "LDSR"
-        self.model_path = os.path.join(models_path, self.name)
         self.user_path = user_path
         self.model_url = "https://heibox.uni-heidelberg.de/f/578df07c8fc04ffbadf3/?dl=1"
         self.yaml_url = "https://heibox.uni-heidelberg.de/f/31a76b13ea27482981b4/?dl=1"

--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -8,14 +8,12 @@ from basicsr.utils.download_util import load_file_from_url
 from realesrgan import RealESRGANer
 
 from modules.upscaler import Upscaler, UpscalerData
-from modules.paths import models_path
 from modules.shared import cmd_opts, opts
 
 
 class UpscalerRealESRGAN(Upscaler):
     def __init__(self, path):
         self.name = "RealESRGAN"
-        self.model_path = os.path.join(models_path, self.name)
         self.user_path = path
         super().__init__()
         try:

--- a/modules/scunet_model.py
+++ b/modules/scunet_model.py
@@ -9,14 +9,12 @@ from basicsr.utils.download_util import load_file_from_url
 
 import modules.upscaler
 from modules import devices, modelloader
-from modules.paths import models_path
 from modules.scunet_model_arch import SCUNet as net
 
 
 class UpscalerScuNET(modules.upscaler.Upscaler):
     def __init__(self, dirname):
         self.name = "ScuNET"
-        self.model_path = os.path.join(models_path, self.name)
         self.model_name = "ScuNET GAN"
         self.model_name2 = "ScuNET PSNR"
         self.model_url = "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_gan.pth"

--- a/modules/swinir_model.py
+++ b/modules/swinir_model.py
@@ -8,7 +8,6 @@ from basicsr.utils.download_util import load_file_from_url
 from tqdm import tqdm
 
 from modules import modelloader
-from modules.paths import models_path
 from modules.shared import cmd_opts, opts, device
 from modules.swinir_model_arch import SwinIR as net
 from modules.upscaler import Upscaler, UpscalerData
@@ -25,7 +24,6 @@ class UpscalerSwinIR(Upscaler):
                          "/003_realSR_BSRGAN_DFOWMFC_s64w8_SwinIR" \
                          "-L_x4_GAN.pth "
         self.model_name = "SwinIR 4x"
-        self.model_path = os.path.join(models_path, self.name)
         self.user_path = dirname
         super().__init__()
         scalers = []

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -36,10 +36,11 @@ class Upscaler:
         self.half = not modules.shared.cmd_opts.no_half
         self.pre_pad = 0
         self.mod_scale = None
-        if self.name is not None and create_dirs:
+
+        if self.model_path is not None and self.name:
             self.model_path = os.path.join(models_path, self.name)
-            if not os.path.exists(self.model_path):
-                os.makedirs(self.model_path)
+        if self.model_path and create_dirs:
+            os.makedirs(self.model_path, exist_ok=True)
 
         try:
             import cv2


### PR DESCRIPTION
`Upscaler.model_path` is defined multiple places.

Fixed it as follow:
- Generate `model_path` in `Upscaler.__init__()` if not before defined.
- Remove definitions from any `Upscaler*` class.

### Question

In `Upscaler.__init__()`, There is no place where `create_dirs` is assigned True. It will never be `True`.
Do you think this implementation should be kept?
