### PR TITLE
[X/Y Plot] Don't change the seed initially if "Keep -1 for seeds" is checked

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -190,7 +190,9 @@ class Script(scripts.Script):
         return [x_type, x_values, y_type, y_values, draw_legend, no_fixed_seeds]
 
     def run(self, p, x_type, x_values, y_type, y_values, draw_legend, no_fixed_seeds):
-        modules.processing.fix_seed(p)
+        if not no_fixed_seeds:
+            modules.processing.fix_seed(p)
+
         p.batch_size = 1
 
         def process_axis(opt, vals):


### PR DESCRIPTION
This fixes #1049, and should not interfere with the original (limited) intent because if they picked Seed as an option, `fix_axis_seeds` still does what it needs to do, anyway.