### PR TITLE
xformers attention

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -129,7 +129,7 @@ if not is_installed("clip"):
 if not is_installed("xformers") and xformers:
     if platform.system() == "Windows":
         run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
-    elif:
+    elif platform.system() == "Linux":
         run_pip("install xformers", "xformers")
 
 os.makedirs(dir_repos, exist_ok=True)

--- a/launch.py
+++ b/launch.py
@@ -124,6 +124,9 @@ if not is_installed("gfpgan"):
 if not is_installed("clip"):
     run_pip(f"install {clip_package}", "clip")
 
+if not is_installed("xformers"):
+    run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+
 os.makedirs(dir_repos, exist_ok=True)
 
 git_clone("https://github.com/CompVis/stable-diffusion.git", repo_dir('stable-diffusion'), "Stable Diffusion", stable_diffusion_commit_hash)

--- a/launch.py
+++ b/launch.py
@@ -4,6 +4,7 @@ import os
 import sys
 import importlib.util
 import shlex
+import platform
 
 dir_repos = "repositories"
 dir_tmp = "tmp"
@@ -31,6 +32,7 @@ def extract_arg(args, name):
 
 
 args, skip_torch_cuda_test = extract_arg(args, '--skip-torch-cuda-test')
+args, xformers = extract_arg(args, '--xformers')
 
 
 def repo_dir(name):
@@ -124,8 +126,11 @@ if not is_installed("gfpgan"):
 if not is_installed("clip"):
     run_pip(f"install {clip_package}", "clip")
 
-if not is_installed("xformers"):
-    run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+if not is_installed("xformers") and xformers:
+    if platform.system() == "Windows":
+        run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+    elif:
+        run_pip("install xformers", "xformers")
 
 os.makedirs(dir_repos, exist_ok=True)
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -21,7 +21,7 @@ diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.At
 
 def apply_optimizations():
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip or shared.xformers_available):
+    if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip) and shared.xformers_available:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -21,12 +21,12 @@ diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.At
 
 def apply_optimizations():
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip):
+    if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip or shared.xformers_available):
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
-    elif cmd_opts.opt_split_attention:
+    elif cmd_opts.opt_split_attention or torch.cuda.is_available():
         ldm.modules.attention_CrossAttention_forward = sd_hijack_optimizations.split_cross_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -23,7 +23,7 @@ def apply_optimizations():
     ldm.modules.diffusionmodules.model.nonlinearity = silu
     if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip):
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     elif cmd_opts.opt_split_attention:

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -26,7 +26,7 @@ def apply_optimizations():
     elif cmd_opts.opt_split_attention:
         ldm.modules.attention_CrossAttention_forward = sd_hijack_optimizations.split_cross_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
-    elif not cmd_opts.disable_opt_xformers_attention and not cmd_opts.opt_split_attention:
+    elif not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip):
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.attention.CrossAttention._maybe_init = sd_hijack_optimizations._maybe_init
         ldm.modules.attention.CrossAttention.attention_op = None

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -23,10 +23,10 @@ def apply_optimizations():
     ldm.modules.diffusionmodules.model.nonlinearity = silu
     if cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
-    if cmd_opts.opt_split_attention:
+    elif cmd_opts.opt_split_attention:
         ldm.modules.attention_CrossAttention_forward = sd_hijack_optimizations.split_cross_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
-    elif not cmd_opts.disable_opt_xformers_attention:
+    elif not cmd_opts.disable_opt_xformers_attention and not cmd_opts.opt_split_attention:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.attention.CrossAttention._maybe_init = sd_hijack_optimizations._maybe_init
         ldm.modules.attention.CrossAttention.attention_op = None

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -20,17 +20,16 @@ diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.At
 
 
 def apply_optimizations():
+    ldm.modules.diffusionmodules.model.nonlinearity = silu
     if cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     if cmd_opts.opt_split_attention:
         ldm.modules.attention_CrossAttention_forward = sd_hijack_optimizations.split_cross_attention_forward
-        ldm.modules.diffusionmodules.model.nonlinearity = sd_hijack_optimizations.nonlinearity_hijack
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
     elif not cmd_opts.disable_opt_xformers_attention:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.attention.CrossAttention._maybe_init = sd_hijack_optimizations._maybe_init
         ldm.modules.attention.CrossAttention.attention_op = None
-        ldm.modules.diffusionmodules.model.nonlinearity = sd_hijack_optimizations.nonlinearity_hijack
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
 
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -21,15 +21,13 @@ diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.At
 
 def apply_optimizations():
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if cmd_opts.opt_split_attention_v1:
+    if not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip):
+        ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
+    elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     elif cmd_opts.opt_split_attention:
         ldm.modules.attention_CrossAttention_forward = sd_hijack_optimizations.split_cross_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
-    elif not cmd_opts.disable_opt_xformers_attention and not (cmd_opts.opt_split_attention or torch.version.hip):
-        ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.attention.CrossAttention._maybe_init = sd_hijack_optimizations._maybe_init
-        ldm.modules.attention.CrossAttention.attention_op = None
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
 
 

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -98,8 +98,14 @@ def xformers_attention_forward(self, x, context=None, mask=None):
     h = self.heads
     q_in = self.to_q(x)
     context = default(context, x)
-    k_in = self.to_k(context)
-    v_in = self.to_v(context)
+    hypernetwork = shared.selected_hypernetwork()
+    hypernetwork_layers = (hypernetwork.layers if hypernetwork is not None else {}).get(context.shape[2], None)
+    if hypernetwork_layers is not None:
+        k_in = self.to_k(hypernetwork_layers[0](context))
+        v_in = self.to_v(hypernetwork_layers[1](context))
+    else:
+        k_in = self.to_k(context)
+        v_in = self.to_v(context)
     q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b n h d', h=h), (q_in, k_in, v_in))
     del q_in, k_in, v_in
     out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None)
@@ -169,3 +175,13 @@ def cross_attention_attnblock_forward(self, x):
         h3 += x
 
         return h3
+    
+    def xformers_attnblock_forward(self, x):
+        h_ = x
+        h_ = self.norm(h_)
+        q1 = self.q(h_).contiguous()
+        k1 = self.k(h_).contiguous()
+        v = self.v(h_).contiguous()
+        out = xformers.ops.memory_efficient_attention(q1, k1, v)
+        out = self.proj_out(out)
+        return x+out

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -94,39 +94,17 @@ def split_cross_attention_forward(self, x, context=None, mask=None):
 
     return self.to_out(r2)
 
-def _maybe_init(self, x):
-    """
-    Initialize the attention operator, if required We expect the head dimension to be exposed here, meaning that x
-    : B, Head, Length
-    """
-    if self.attention_op is not None:
-        return
-    _, M, K = x.shape
-    try:
-        self.attention_op = xformers.ops.AttentionOpDispatch(
-            dtype=x.dtype,
-            device=x.device,
-            k=K,
-            attn_bias_type=type(None),
-            has_dropout=False,
-            kv_len=M,
-            q_len=M,
-        ).op
-    except NotImplementedError as err:
-        raise NotImplementedError(f"Please install xformers with the flash attention / cutlass components.\n{err}")
-
 def xformers_attention_forward(self, x, context=None, mask=None):
     h = self.heads
     q_in = self.to_q(x)
     context = default(context, x)
     k_in = self.to_k(context)
     v_in = self.to_v(context)
-    q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
+    q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b n h d', h=h), (q_in, k_in, v_in))
     del q_in, k_in, v_in
-    self._maybe_init(q)
-    out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None, op=self.attention_op)
+    out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None)
 
-    out = rearrange(out, '(b h) n d -> b n (h d)', h=h)
+    out = rearrange(out, 'b n h d -> b n (h d)', h=h)
     return self.to_out(out)
 
 def cross_attention_attnblock_forward(self, x):

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -1,9 +1,14 @@
 import math
 import torch
 from torch import einsum
-import xformers.ops
-import functorch
-xformers._is_functorch_available=True
+try:
+    import xformers.ops
+    import functorch
+    xformers._is_functorch_available = True
+    shared.xformers_available = True
+except:
+    print('Cannot find xformers, defaulting to split attention. Try setting --xformers in your webui-user file if you wish to install it.')
+    continue
 from ldm.util import default
 from einops import rearrange
 

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -176,7 +176,7 @@ def cross_attention_attnblock_forward(self, x):
 
         return h3
     
-    def xformers_attnblock_forward(self, x):
+def xformers_attnblock_forward(self, x):
         h_ = x
         h_ = self.norm(h_)
         q1 = self.q(h_).contiguous()

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -74,7 +74,7 @@ device = devices.device
 
 batch_cond_uncond = cmd_opts.always_batch_cond_uncond or not (cmd_opts.lowvram or cmd_opts.medvram)
 parallel_processing_allowed = not cmd_opts.lowvram and not cmd_opts.medvram
-
+xformers_available = False
 config_filename = cmd_opts.ui_settings_file
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -43,6 +43,7 @@ parser.add_argument("--realesrgan-models-path", type=str, help="Path to director
 parser.add_argument("--scunet-models-path", type=str, help="Path to directory with ScuNET model file(s).", default=os.path.join(models_path, 'ScuNET'))
 parser.add_argument("--swinir-models-path", type=str, help="Path to directory with SwinIR model file(s).", default=os.path.join(models_path, 'SwinIR'))
 parser.add_argument("--ldsr-models-path", type=str, help="Path to directory with LDSR model file(s).", default=os.path.join(models_path, 'LDSR'))
+parser.add_argument("--disable-opt-xformers-attention", action='store_true', help="force-disables xformers attention optimization")
 parser.add_argument("--opt-split-attention", action='store_true', help="force-enables cross-attention layer optimization. By default, it's on for torch.cuda and off for other torch devices.")
 parser.add_argument("--disable-opt-split-attention", action='store_true', help="force-disables cross-attention layer optimization")
 parser.add_argument("--opt-split-attention-v1", action='store_true', help="enable older version of split attention optimization that does not consume all the VRAM it can find")

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,3 @@ torchdiffeq
 kornia
 lark
 functorch
-#xformers?

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ resize-right
 torchdiffeq
 kornia
 lark
+functorch
+#xformers?

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -22,3 +22,4 @@ resize-right==0.0.2
 torchdiffeq==0.2.3
 kornia==0.6.7
 lark==1.1.2
+functorch==0.2.1


### PR DESCRIPTION
This PR adds xformer optimized cross-attention, a flag to disable it and use split instead, _maybe_init function that - for some reason - seems to be necessary for xformers to work in this instance and enables functorch in xformers, which further increased performance on my machine.

We still need a way for easy distribution of xformers. Otherwise, this PR is good to go (barring bugs I've not been able to perceive)
cc. @Doggettx @Thomas-MMJ @ArrowM @consciencia

PS. Much thanks to @fmassa @danthe3rd @yocabon and many others for their generous efforts to bring xformers to Windows.

I've seen a %15 improvement with batch size 1, 100 steps, 512x512 and euler_a. xFormers allows me to output 2048x2048 whereas I would previously OOM.

closes #576 