### PR TITLE
Added a flag to run as root if needed

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -3,6 +3,7 @@
 # Please do not make any changes to this file,  #
 # change the variables in webui-user.sh instead #
 #################################################
+
 # Read variables from webui-user.sh
 # shellcheck source=/dev/null
 if [[ -f webui-user.sh ]]
@@ -46,6 +47,17 @@ then
     LAUNCH_SCRIPT="launch.py"
 fi
 
+# this script cannot be run as root by default
+can_run_as_root=0
+
+# read any command line flags to the webui.sh script
+while getopts "f" flag
+do
+    case ${flag} in
+        f) can_run_as_root=1;;
+    esac
+done
+
 # Disable sentry logging
 export ERROR_REPORTING=FALSE
 
@@ -61,7 +73,7 @@ printf "\e[1m\e[34mTested on Debian 11 (Bullseye)\e[0m"
 printf "\n%s\n" "${delimiter}"
 
 # Do not run as root
-if [[ $(id -u) -eq 0 ]]
+if [[ $(id -u) -eq 0 && can_run_as_root -eq 0 ]]
 then
     printf "\n%s\n" "${delimiter}"
     printf "\e[1m\e[31mERROR: This script must not be launched as root, aborting...\e[0m"


### PR DESCRIPTION
Lets you run it as root. I ran into this issue while installing on Vast.ai, their default image starts u as root. It was easier to disable this than to setup new users, etc. The default behavior is left unchanged: it will complain and quit if you are root.

```bash
./webui.sh -f  # skip root check and run anyway
```