### PR TITLE
Add GZipMiddleware to root demo instance

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -5,6 +5,8 @@ import importlib
 import signal
 import threading
 
+from fastapi.middleware.gzip import GZipMiddleware
+
 from modules.paths import script_path
 
 from modules import devices, sd_samplers
@@ -92,7 +94,7 @@ def webui():
 
         demo = modules.ui.create_ui(wrap_gradio_gpu_call=wrap_gradio_gpu_call)
         
-        demo.launch(
+        app,local_url,share_url = demo.launch(
             share=cmd_opts.share,
             server_name="0.0.0.0" if cmd_opts.listen else None,
             server_port=cmd_opts.port,
@@ -101,6 +103,8 @@ def webui():
             inbrowser=cmd_opts.autolaunch,
             prevent_thread_lock=True
         )
+        
+        app.add_middleware(GZipMiddleware,minimum_size=1000)
 
         while 1:
             time.sleep(0.5)


### PR DESCRIPTION
Adding GZipMiddleware middleware for all requests over 1000 bytes represents a 23%+ saving in bytes transferred for large images with little speed change, tests with image response from 1 step at 1024x2048 purely for image size:

Gzip Off:

| Bytes | Time    |
|-------|---------|
|4.2 MB | 14.75 s |	
|4.2 MB	| 13.79 s |	
|4.2 MB	| 14.12 s | 	
|4.2 MB	| 14.04 s |
|4.2 MB	| 14.07 s |	

Gzip On:
| Bytes | Time    |
|-------|---------|
| 3.2 MB |	14.36 s |	
| 3.2 MB |	14.44 s |	
| 3.2 MB |	14.26 s |
| 3.2 MB |	14.14 s |
| 3.2 MB |	14.53 s |	