### PR TITLE
Fix for Prompts_from_file showing extra textbox.

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -143,6 +143,8 @@ class ScriptRunner:
                 args_to = script.args_to
                 script_args = args[args_from:args_to]
                 on_show_updates = wrap_call(script.on_show, script.filename, "on_show", *script_args)
+                if (len(on_show_updates) != (args_to - args_from)):
+                    print("Error in custom script (" + script.filename + "): on_show() method should return the same number of arguments as ui().", file=sys.stderr)
             else:
                 args_from = 0
                 args_to = 0
@@ -150,12 +152,13 @@ class ScriptRunner:
             ret = [ ui.gr_show(True)] # always show the dropdown
             for i in range(1, len(inputs)):
                 if (args_from <= i < args_to):
-                    ret.append( on_show_updates[i - args_from] )
+                    if (i - args_from) < len(on_show_updates):
+                        ret.append( on_show_updates[i - args_from] )
+                    else:
+                        ret.append(ui.gr_show(True))
                 else:
                     ret.append(ui.gr_show(False))
             return ret
-
-            # return [ui.gr_show(True if (i == 0) else on_show_updates[i - args_from] if args_from <= i < args_to else False) for i in range(len(inputs))]
 
         dropdown.change(
             fn=select_script,

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -1,5 +1,4 @@
 import os
-from pydoc import visiblename
 import sys
 import traceback
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -1,4 +1,5 @@
 import os
+from pydoc import visiblename
 import sys
 import traceback
 
@@ -30,6 +31,15 @@ class Script:
     # Thus, return is_img2img to only show the script on the img2img tab.
     def show(self, is_img2img):
         return True
+
+
+    # Called when the ui for this script has been shown.
+    # Useful for hiding some controls, since the scripts module sets visibility to
+    # everything to true. The parameters will be the parameters returned by the ui method
+    # The return value should be gradio updates, similar to what you would return
+    # from a Gradio event handler.
+    def on_show(self, *args):
+        return [ui.gr_show(True)] * len(args)
 
     # This is where the additional processing is implemented. The parameters include
     # self, the model object "p" (a StableDiffusionProcessing class, see
@@ -125,20 +135,32 @@ class ScriptRunner:
             inputs += controls
             script.args_to = len(inputs)
 
-        def select_script(script_index):
+        def select_script(*args):
+            script_index = args[0]
+            on_show_updates = []
             if 0 < script_index <= len(self.scripts):
                 script = self.scripts[script_index-1]
                 args_from = script.args_from
                 args_to = script.args_to
+                script_args = args[args_from:args_to]
+                on_show_updates = wrap_call(script.on_show, script.filename, "on_show", *script_args)
             else:
                 args_from = 0
                 args_to = 0
 
-            return [ui.gr_show(True if i == 0 else args_from <= i < args_to) for i in range(len(inputs))]
+            ret = [ ui.gr_show(True)] # always show the dropdown
+            for i in range(1, len(inputs)):
+                if (args_from <= i < args_to):
+                    ret.append( on_show_updates[i - args_from] )
+                else:
+                    ret.append(ui.gr_show(False))
+            return ret
+
+            # return [ui.gr_show(True if (i == 0) else on_show_updates[i - args_from] if args_from <= i < args_to else False) for i in range(len(inputs))]
 
         dropdown.change(
             fn=select_script,
-            inputs=[dropdown],
+            inputs=inputs,
             outputs=inputs
         )
 

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -10,8 +10,6 @@ from modules.processing import Processed, process_images
 from PIL import Image
 from modules.shared import opts, cmd_opts, state
 
-g_txt_mode = False
-
 class Script(scripts.Script):
     def title(self):
         return "Prompts from file or textbox"

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -10,6 +10,7 @@ from modules.processing import Processed, process_images
 from PIL import Image
 from modules.shared import opts, cmd_opts, state
 
+g_txt_mode = False
 
 class Script(scripts.Script):
     def title(self):
@@ -28,6 +29,9 @@ class Script(scripts.Script):
         prompt_txt = gr.TextArea(label="Prompts")
         checkbox_txt.change(fn=lambda x: [gr.File.update(visible = not x), gr.TextArea.update(visible = x)], inputs=[checkbox_txt], outputs=[file, prompt_txt])
         return [checkbox_txt, file, prompt_txt]
+
+    def on_show(self, checkbox_txt, file, prompt_txt):
+        return [ gr.Checkbox.update(visible = True), gr.File.update(visible = not checkbox_txt), gr.TextArea.update(visible = checkbox_txt) ]
 
     def run(self, p, checkbox_txt, data: bytes, prompt_txt: str):
         if (checkbox_txt):


### PR DESCRIPTION
The Prompts_from_file custom script shows the textbox when you load it, even though the "use textbox" checkbox is unchecked..  I added an additional optional on_show method to scripts which gives scripts a chance to update visibility of their own controls when the script is loaded, and made use of it to fix this bug.  Might be useful for others who want to have conditionally visible UI, since the current script runner always shows all controls.