### PR TITLE
xy_grid: Confirm that options are valid before starting

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -143,7 +143,7 @@ def draw_xy_grid(p, xs, ys, x_labels, y_labels, cell, draw_legend):
     ver_texts = [[images.GridAnnotation(y)] for y in y_labels]
     hor_texts = [[images.GridAnnotation(x)] for x in x_labels]
 
-    first_pocessed = None
+    first_processed = None
 
     state.job_count = len(xs) * len(ys) * p.n_iter
 
@@ -152,8 +152,8 @@ def draw_xy_grid(p, xs, ys, x_labels, y_labels, cell, draw_legend):
             state.job = f"{ix + iy * len(xs) + 1} out of {len(xs) * len(ys)}"
 
             processed = cell(x, y)
-            if first_pocessed is None:
-                first_pocessed = processed
+            if first_processed is None:
+                first_processed = processed
 
             try:
               res.append(processed.images[0])
@@ -164,9 +164,9 @@ def draw_xy_grid(p, xs, ys, x_labels, y_labels, cell, draw_legend):
     if draw_legend:
         grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
 
-    first_pocessed.images = [grid]
+    first_processed.images = [grid]
 
-    return first_pocessed
+    return first_processed
 
 
 re_range = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*")
@@ -214,7 +214,6 @@ class Script(scripts.Script):
                     m = re_range.fullmatch(val)
                     mc = re_range_count.fullmatch(val)
                     if m is not None:
-
                         start = int(m.group(1))
                         end = int(m.group(2))+1
                         step = int(m.group(3)) if m.group(3) is not None else 1
@@ -256,6 +255,16 @@ class Script(scripts.Script):
                 valslist = list(permutations(valslist))
 
             valslist = [opt.type(x) for x in valslist]
+            
+            # Confirm options are valid before starting
+            if opt.label == "Sampler":
+                for sampler_val in valslist:
+                    if sampler_val.lower() not in samplers_dict.keys():
+                        raise RuntimeError(f"Unknown sampler: {sampler_val}")
+            elif opt.label == "Checkpoint name":
+                for ckpt_val in valslist:
+                    if modules.sd_models.get_closet_checkpoint_match(ckpt_val) is None:
+                        raise RuntimeError(f"Checkpoint for {ckpt_val} not found")
 
             return valslist
 


### PR DESCRIPTION
Added checks to confirm that all provided names for 'Samplers' and 'Checkpoints' options are valid before generating any images, failing immediately if not.
Currently, if one of these names has a typo, an error will only be thrown once the `draw_xy_grid` loop reaches that name, wasting a lot of time starting over if there's an typo at the end of a long list.

(Also fixing typo in variable name in `draw_xy_grid`.)

---

The tests I added are basically the same as in `apply_sampler` and `apply_checkpoint`, which probably makes those redundant now, but I left them in to be safe. I'm happy to remove them and resubmit if preferred.