### PR TITLE
Remove duplicate event listeners in the gallery

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -86,6 +86,9 @@ function showGalleryImage(){
         
         if(fullImg_preview != null){
             fullImg_preview.forEach(function function_name(e) {
+                if (e.dataset.modded)
+                    return;
+                e.dataset.modded = true;
                 if(e && e.parentElement.tagName == 'DIV'){
 
                     e.style.cursor='pointer'


### PR DESCRIPTION
Whenever you click on the bottom row preview of the gallery, the same event listener is added to the main image. When this is done enough times, responsiveness is killed.

![image](https://user-images.githubusercontent.com/24762404/194697028-841361da-293b-4854-90dd-40e6a19f0cd6.png)

This PR makes sure the listener is added only once.