### PR TITLE
Limit xformers to python 3.10 and Ampere

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -126,7 +126,7 @@ if not is_installed("gfpgan"):
 if not is_installed("clip"):
     run_pip(f"install {clip_package}", "clip")
 
-if not is_installed("xformers") and xformers:
+if not is_installed("xformers") and xformers and platform.python_version().startswith("3.10"):
     if platform.system() == "Windows":
         run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
     elif platform.system() == "Linux":

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -22,9 +22,10 @@ def apply_optimizations():
     undo_optimizations()
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if cmd_opts.xformers and shared.xformers_available and not torch.version.hip:
-        ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
+    if cmd_opts.xformers and shared.xformers_available and torch.version.cuda:
+        if torch.cuda.get_device_capability(shared.device) == (8, 6):
+            ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
+            ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     elif not cmd_opts.disable_opt_split_attention and (cmd_opts.opt_split_attention or torch.cuda.is_available()):

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -22,10 +22,9 @@ def apply_optimizations():
     undo_optimizations()
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if cmd_opts.xformers and shared.xformers_available and torch.version.cuda:
-        if torch.cuda.get_device_capability(shared.device) == (8, 6):
-            ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-            ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
+    if cmd_opts.xformers and shared.xformers_available and torch.version.cuda and torch.cuda.get_device_capability(shared.device) == (8, 6):
+        ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     elif not cmd_opts.disable_opt_split_attention and (cmd_opts.opt_split_attention or torch.cuda.is_available()):


### PR DESCRIPTION
It appears I was wrong about the xformers build and it doesn't work for older GPUs. My build also depends on Python 3.10.

This PR checks for both, python in launch.py, Ampere in sd_hijack.py