### PR TITLE
unleash xformers on linux and unbreak hires fix

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -3,6 +3,7 @@ import os
 import sys
 import traceback
 import torch
+import platform
 import numpy as np
 from torch import einsum
 from torch.nn.functional import silu
@@ -22,9 +23,9 @@ def apply_optimizations():
     undo_optimizations()
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
-    if cmd_opts.xformers and shared.xformers_available and torch.version.cuda and torch.cuda.get_device_capability(shared.device) == (8, 6):
+    if cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (torch.cuda.get_device_capability(shared.device) == (8, 6) or platform.system() == 'Linux'):
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1
     elif not cmd_opts.disable_opt_split_attention and (cmd_opts.opt_split_attention or torch.cuda.is_available()):


### PR DESCRIPTION
Hires is broken in select resolution pairs due to xformers_attnblock_forward. This PR reverts to split forward. It's a bit slower this way but solves the issue.

This PR also ignores the SM check on Linux.

closes #1975 