### PR TITLE
Added ability to ignore last n layers in FrozenCLIPEmbedder

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -281,8 +281,15 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
 
         remade_batch_tokens_of_same_length = [x + [self.wrapped.tokenizer.eos_token_id] * (target_token_count - len(x)) for x in remade_batch_tokens]
         tokens = torch.asarray(remade_batch_tokens_of_same_length).to(device)
-        outputs = self.wrapped.transformer(input_ids=tokens, position_ids=position_ids)
-        z = outputs.last_hidden_state
+
+        tmp = -opts.CLIP_ignore_last_layers
+        if (opts.CLIP_ignore_last_layers == 0):
+            outputs = self.wrapped.transformer(input_ids=tokens, position_ids=position_ids)
+            z = outputs.last_hidden_state
+        else:
+            outputs = self.wrapped.transformer(input_ids=tokens, position_ids=position_ids, output_hidden_states=tmp)
+            z = outputs.hidden_states[tmp]
+            z = self.wrapped.transformer.text_model.final_layer_norm(z)
 
         # restoring original mean is likely not correct, but it seems to work well to prevent artifacts that happen otherwise
         batch_multipliers_of_same_length = [x + [1.0] * (target_token_count - len(x)) for x in batch_multipliers]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -225,6 +225,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
     "filter_nsfw": OptionInfo(False, "Filter NSFW content"),
+    'CLIP_ignore_last_layers': OptionInfo(0, "Ignore last layers of CLIP model", gr.Slider, {"minimum": 0, "maximum": 5, "step": 1}),
     "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),
 }))
 


### PR DESCRIPTION
For certain models, it can produce better results when ignoring the last n layers of the CLIP transform model. I have set n to be adjustable via the GUI

This is with ignoring the last 2 layers
![image](https://user-images.githubusercontent.com/31809330/194722384-1ab3dd27-2dc5-4c27-a45e-480c6b3bf1f2.png)

This is with ignoring no layers
![image](https://user-images.githubusercontent.com/31809330/194722414-f719363b-e5fe-4217-b9e7-35af80525449.png)
