### PR TITLE
Shielded launch enviroment creation stuff from multiprocessing

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -6,38 +6,9 @@ import importlib.util
 import shlex
 import platform
 
-dir_repos = "repositories"
-dir_tmp = "tmp"
-
-python = sys.executable
-git = os.environ.get('GIT', "git")
-torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
-requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
-commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
-
-gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "git+https://github.com/TencentARC/GFPGAN.git@8d2447a2d918f8eba5a4a01463fd48e45126a379")
-clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1")
-
-stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc")
-taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
-k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "f4e99857772fc3a126ba886aadf795a332774878")
-codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
-blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
-
-args = shlex.split(commandline_args)
-
 
 def extract_arg(args, name):
     return [x for x in args if x != name], name in args
-
-
-args, skip_torch_cuda_test = extract_arg(args, '--skip-torch-cuda-test')
-xformers = '--xformers' in args
-deepdanbooru = '--deepdanbooru' in args
-
-
-def repo_dir(name):
-    return os.path.join(dir_repos, name)
 
 
 def run(command, desc=None, errdesc=None):
@@ -59,21 +30,9 @@ stderr: {result.stderr.decode(encoding="utf8", errors="ignore") if len(result.st
     return result.stdout.decode(encoding="utf8", errors="ignore")
 
 
-def run_python(code, desc=None, errdesc=None):
-    return run(f'"{python}" -c "{code}"', desc, errdesc)
-
-
-def run_pip(args, desc=None):
-    return run(f'"{python}" -m pip {args} --prefer-binary', desc=f"Installing {desc}", errdesc=f"Couldn't install {desc}")
-
-
 def check_run(command):
     result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     return result.returncode == 0
-
-
-def check_run_python(code):
-    return check_run(f'"{python}" -c "{code}"')
 
 
 def is_installed(package):
@@ -85,80 +44,117 @@ def is_installed(package):
     return spec is not None
 
 
-def git_clone(url, dir, name, commithash=None):
-    # TODO clone into temporary dir and move if successful
+def prepare_enviroment():
+    dir_repos = "repositories"
 
-    if os.path.exists(dir):
-        if commithash is None:
+    python = sys.executable
+    git = os.environ.get('GIT', "git")
+    torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
+    requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
+    commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
+
+    gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "git+https://github.com/TencentARC/GFPGAN.git@8d2447a2d918f8eba5a4a01463fd48e45126a379")
+    clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1")
+
+    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc")
+    taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
+    k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "f4e99857772fc3a126ba886aadf795a332774878")
+    codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
+    blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
+
+    args = shlex.split(commandline_args)
+
+    args, skip_torch_cuda_test = extract_arg(args, '--skip-torch-cuda-test')
+    xformers = '--xformers' in args
+    deepdanbooru = '--deepdanbooru' in args
+
+    def repo_dir(name):
+        return os.path.join(dir_repos, name)
+
+    def run_python(code, desc=None, errdesc=None):
+        return run(f'"{python}" -c "{code}"', desc, errdesc)
+
+    def run_pip(args, desc=None):
+        return run(f'"{python}" -m pip {args} --prefer-binary', desc=f"Installing {desc}", errdesc=f"Couldn't install {desc}")
+
+    def check_run_python(code):
+        return check_run(f'"{python}" -c "{code}"')
+
+    def git_clone(url, dir, name, commithash=None):
+        # TODO clone into temporary dir and move if successful
+
+        if os.path.exists(dir):
+            if commithash is None:
+                return
+
+            current_hash = run(f'"{git}" -C {dir} rev-parse HEAD', None, f"Couldn't determine {name}'s hash: {commithash}").strip()
+            if current_hash == commithash:
+                return
+
+            run(f'"{git}" -C {dir} fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
+            run(f'"{git}" -C {dir} checkout {commithash}', f"Checking out commint for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
             return
 
-        current_hash = run(f'"{git}" -C {dir} rev-parse HEAD', None, f"Couldn't determine {name}'s hash: {commithash}").strip()
-        if current_hash == commithash:
-            return
+        run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
 
-        run(f'"{git}" -C {dir} fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
-        run(f'"{git}" -C {dir} checkout {commithash}', f"Checking out commint for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
-        return
+        if commithash is not None:
+            run(f'"{git}" -C {dir} checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
 
-    run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
+    try:
+        commit = run(f"{git} rev-parse HEAD").strip()
+    except Exception:
+        commit = "<none>"
 
-    if commithash is not None:
-        run(f'"{git}" -C {dir} checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
+    print(f"Python {sys.version}")
+    print(f"Commit hash: {commit}")
 
+    if not is_installed("torch") or not is_installed("torchvision"):
+        run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch")
 
-try:
-    commit = run(f"{git} rev-parse HEAD").strip()
-except Exception:
-    commit = "<none>"
+    if not skip_torch_cuda_test:
+        run_python("import torch; assert torch.cuda.is_available(), 'Torch is not able to use GPU; add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'")
 
-print(f"Python {sys.version}")
-print(f"Commit hash: {commit}")
+    if not is_installed("gfpgan"):
+        run_pip(f"install {gfpgan_package}", "gfpgan")
 
+    if not is_installed("clip"):
+        run_pip(f"install {clip_package}", "clip")
 
-if not is_installed("torch") or not is_installed("torchvision"):
-    run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch")
+    if not is_installed("xformers") and xformers and platform.python_version().startswith("3.10"):
+        if platform.system() == "Windows":
+            run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+        elif platform.system() == "Linux":
+            run_pip("install xformers", "xformers")
 
-if not skip_torch_cuda_test:
-    run_python("import torch; assert torch.cuda.is_available(), 'Torch is not able to use GPU; add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'")
+    if not is_installed("deepdanbooru") and deepdanbooru:
+        run_pip("install git+https://github.com/KichangKim/DeepDanbooru.git@edf73df4cdaeea2cf00e9ac08bd8a9026b7a7b26#egg=deepdanbooru[tensorflow] tensorflow==2.10.0 tensorflow-io==0.27.0", "deepdanbooru")
 
-if not is_installed("gfpgan"):
-    run_pip(f"install {gfpgan_package}", "gfpgan")
+    os.makedirs(dir_repos, exist_ok=True)
 
-if not is_installed("clip"):
-    run_pip(f"install {clip_package}", "clip")
+    git_clone("https://github.com/CompVis/stable-diffusion.git", repo_dir('stable-diffusion'), "Stable Diffusion", stable_diffusion_commit_hash)
+    git_clone("https://github.com/CompVis/taming-transformers.git", repo_dir('taming-transformers'), "Taming Transformers", taming_transformers_commit_hash)
+    git_clone("https://github.com/crowsonkb/k-diffusion.git", repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
+    git_clone("https://github.com/sczhou/CodeFormer.git", repo_dir('CodeFormer'), "CodeFormer", codeformer_commit_hash)
+    git_clone("https://github.com/salesforce/BLIP.git", repo_dir('BLIP'), "BLIP", blip_commit_hash)
 
-if not is_installed("xformers") and xformers and platform.python_version().startswith("3.10"):
-    if platform.system() == "Windows":
-        run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
-    elif platform.system() == "Linux":
-        run_pip("install xformers", "xformers")
+    if not is_installed("lpips"):
+        run_pip(f"install -r {os.path.join(repo_dir('CodeFormer'), 'requirements.txt')}", "requirements for CodeFormer")
 
-if not is_installed("deepdanbooru") and deepdanbooru:
-    run_pip("install git+https://github.com/KichangKim/DeepDanbooru.git@edf73df4cdaeea2cf00e9ac08bd8a9026b7a7b26#egg=deepdanbooru[tensorflow] tensorflow==2.10.0 tensorflow-io==0.27.0", "deepdanbooru")
+    run_pip(f"install -r {requirements_file}", "requirements for Web UI")
 
-os.makedirs(dir_repos, exist_ok=True)
+    sys.argv += args
 
-git_clone("https://github.com/CompVis/stable-diffusion.git", repo_dir('stable-diffusion'), "Stable Diffusion", stable_diffusion_commit_hash)
-git_clone("https://github.com/CompVis/taming-transformers.git", repo_dir('taming-transformers'), "Taming Transformers", taming_transformers_commit_hash)
-git_clone("https://github.com/crowsonkb/k-diffusion.git", repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
-git_clone("https://github.com/sczhou/CodeFormer.git", repo_dir('CodeFormer'), "CodeFormer", codeformer_commit_hash)
-git_clone("https://github.com/salesforce/BLIP.git", repo_dir('BLIP'), "BLIP", blip_commit_hash)
+    if "--exit" in args:
+        print("Exiting because of --exit argument")
+        exit(0)
 
-if not is_installed("lpips"):
-    run_pip(f"install -r {os.path.join(repo_dir('CodeFormer'), 'requirements.txt')}", "requirements for CodeFormer")
-
-run_pip(f"install -r {requirements_file}", "requirements for Web UI")
-
-sys.argv += args
-
-if "--exit" in args:
-    print("Exiting because of --exit argument")
-    exit(0)
 
 def start_webui():
     print(f"Launching Web UI with arguments: {' '.join(sys.argv[1:])}")
     import webui
     webui.webui()
 
+
 if __name__ == "__main__":
+    prepare_enviroment()
     start_webui()


### PR DESCRIPTION
Due how python multiprocessing works, spawned processes basically reimport the main script. launch.py has a lot of unshielded environment initialization which slows down multiprocessing start.

Tried to shield it, but I'm not sure if any global variables are used anywhere, doesn't seem so, as nothing imports launch.py.
Any functions which can be global scope - stay global scope, some require variables, so I left them in local scope.

This is a follow up to discussion of https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/1752