### PR TITLE
Fix `edit-attention` not updating Gradio textbox's internal state when using arrow keys

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -38,4 +38,7 @@ addEventListener('keydown', (event) => {
 		target.selectionStart = selectionStart;
 		target.selectionEnd = selectionEnd;
 	}
+	// Since we've modified a Gradio Textbox component manually, we need to simulate an `input` DOM event to ensure its
+	// internal Svelte data binding remains in sync.
+	target.dispatchEvent(new Event("input", { bubbles: true }));
 });


### PR DESCRIPTION
When using the arrow keys to increase or decrease the attention of the highlighted text, the raw `value` of the textarea is modified but no event is dispatched, so the controlled Svelte component doesn't know about it.  This means that if you submit the prompt without making any other changes, it will be submitted with whatever the textarea's value was before using the arrow keys.

This PR modifies `edit-attention` to trigger an input event, simulating the user having modified the textarea's contents and causing the usual set of event listeners to run.

Fixes #2114.

Tested on:
- Windows 11 build 22000
- Firefox
- RTX 3080