### PR TITLE
Add Pascal and Turing supported xformers wheels

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -127,7 +127,7 @@ def prepare_enviroment():
 
     if not is_installed("xformers") and xformers and platform.python_version().startswith("3.10"):
         if platform.system() == "Windows":
-            run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/a/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+            run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/c/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
         elif platform.system() == "Linux":
             run_pip("install xformers", "xformers")
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -23,7 +23,7 @@ def apply_optimizations():
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
-    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and torch.cuda.get_device_capability(shared.device) == (8, 6)):
+    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (8, 6)):
         print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -13,8 +13,6 @@ from modules import shared
 if shared.cmd_opts.xformers or shared.cmd_opts.force_enable_xformers:
     try:
         import xformers.ops
-        import functorch
-        xformers._is_functorch_available = True
         shared.xformers_available = True
     except Exception:
         print("Cannot import xformers", file=sys.stderr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ resize-right
 torchdiffeq
 kornia
 lark
-functorch

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -22,4 +22,3 @@ resize-right==0.0.2
 torchdiffeq==0.2.3
 kornia==0.6.7
 lark==1.1.2
-functorch==0.2.1


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I've built xformers Windows wheels that support Pascal, Turing and Ampere. This PR allows these architectures by default and updates my wheel in launch.py to the newest version.

The support ends at Ampere because we need a new PyTorch release for Lovelace and Hopper support.

I've removed functorch as it'll soon be deprecated anyways due to PyTorch planning to merge TorchDynamo into PyTorch.

I've also built a linux wheel - but that's not manylinux, so I've refrained from including it lest I break everybodys setup.

**Additional notes and description of your changes**

We *need* a way to update xformers for people on my older wheels as this PR, without a way to update them, will break their setup.

**Environment this was tested in**

 - OS: Windows
 - Browser: Chromium
 - Graphics card: 3080 12GB, 1070, 1060
