### PR TITLE
Always show previous mask when sending to inpaint, send fix for extras -> inpaint.

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -961,7 +961,7 @@ def create_ui(wrap_gradio_gpu_call):
         
         extras_send_to_inpaint.click(
             fn=lambda x: image_from_url_text(x),
-            _js="extract_image_from_gallery_img2img",
+            _js="extract_image_from_gallery_inpaint",
             inputs=[result_images],
             outputs=[init_img_with_mask],
         )

--- a/style.css
+++ b/style.css
@@ -467,3 +467,10 @@ input[type="range"]{
     max-width: 32em;
     padding: 0;
 }
+
+canvas[key="mask"] {
+    z-index: 12 !important;
+    filter: invert();
+    mix-blend-mode: multiply;
+    pointer-events: none;
+}


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Problem with invisible leftover mask is described in detail #1331 #1455  #1186  #1802
Now if size of a newly sent image remains the same, mask will be visible as well as used in the inpainting process. 

Second small issue fixed: upon sending (extras -> inpaint) target image resulted in img2img tab due to an invalid function call.

**Additional notes and description of your changes**

First problem solved with CSS solution provided in #1331 by @Lerc . Indeed i think it's more of a Gradio issue since we cant explicitly state how we want to treat mask in sketch edit mode when we update target image. But this works for now.
z-index for the old canvas now equal to the one we're drawing at the time. (12) Since they keep mask inverted and completely colored in black and white, we use invert filter and mix-blend-mode:multiply to draw the actual mask. pointer-event:none is required to prevent underlying interface from overlapping with mask. Obviously, if default gradio.image css layout or logic will change, this solution will stop working probably. Its a temporary workaround for a really annoying bug.

Second problem was a quick copying error i presume.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card NVIDIA GTX 1060 6gb