### PR TITLE
Add ctrl+enter as a shortcut to quickly start a generation.

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,6 +41,22 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 /**
+ * Add a ctrl+enter as a shortcut to start a generation
+ */
+ document.addEventListener('keydown', function(e) {
+    var handled = false;
+    if (e.key !== undefined) {
+        if((e.key == "Enter" && (e.metaKey || e.ctrlKey))) handled = true;
+    } else if (e.keyCode !== undefined) {
+        if((e.keyCode == 13 && (e.metaKey || e.ctrlKey))) handled = true;
+    }
+    if (handled) { 
+        gradioApp().querySelector("#txt2img_generate").click(); 
+        e.preventDefault();
+    }
+})
+
+/**
  * checks that a UI element is not in another hidden element or tab content
  */
 function uiElementIsVisible(el) {


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
Add `ctrl+enter` as a shortcut to start a generation. Should work anywhere on the page, but most importantly it works inside the prompt textbox. 

**Environment this was tested in**
- Vivalid 5.5.2805.35
- Firefox 105.0.3 
- Chrome 106.0.5249.103
- Edge 106.0.1370.37




