### PR TITLE
Comma backtrack padding

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -23,7 +23,7 @@ def apply_optimizations():
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
-    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and torch.cuda.get_device_capability(shared.device) == (8, 6)):
+    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (8, 6)):
         print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -138,6 +138,7 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
         fixes = []
         remade_tokens = []
         multipliers = []
+        last_comma = -1
 
         for tokens, (text, weight) in zip(tokenized, parsed):
             i = 0
@@ -146,24 +147,20 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
 
                 embedding, embedding_length_in_tokens = self.hijack.embedding_db.find_embedding_at_position(tokens, i)
 
-                if opts.comma_padding_backtrack != 0 and max(len(remade_tokens), 1) % 75 == 0 and token != self.comma_token:
-                    j = len(remade_tokens)
-                    found = False
-                    while not found and j != -1:
-                        j -= 1
-                        found = remade_tokens[j] == self.comma_token and i - j <= opts.comma_padding_backtrack
-                    if found:
-                        j += 1
-                        reloc_tokens = remade_tokens[j:]
-                        reloc_mults = multipliers[j:]
+                if token == self.comma_token:
+                    last_comma = len(remade_tokens)
+                elif opts.comma_padding_backtrack != 0 and max(len(remade_tokens), 1) % 75 == 0 and last_comma != -1 and len(remade_tokens) - last_comma <= opts.comma_padding_backtrack:
+                    last_comma += 1
+                    reloc_tokens = remade_tokens[last_comma:]
+                    reloc_mults = multipliers[last_comma:]
 
-                        remade_tokens = remade_tokens[:j]
-                        length = len(remade_tokens)
-                        rem = (length // 75 + 1) * 75 - length
-
-                        remade_tokens += [id_end] * rem + reloc_tokens
-                        multipliers = multipliers[:j] + [1.0] * rem + reloc_mults
-
+                    remade_tokens = remade_tokens[:last_comma]
+                    length = len(remade_tokens)
+                    
+                    rem = (length // 75 + 1) * 75 - length
+                    remade_tokens += [id_end] * rem + reloc_tokens
+                    multipliers = multipliers[:last_comma] + [1.0] * rem + reloc_mults
+                
                 if embedding is None:
                     remade_tokens.append(token)
                     multipliers.append(weight)

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -157,7 +157,7 @@ class FrozenCLIPEmbedderWithCustomWords(torch.nn.Module):
                     remade_tokens = remade_tokens[:last_comma]
                     length = len(remade_tokens)
                     
-                    rem = (length // 75 + 1) * 75 - length
+                    rem = int(math.ceil(length / 75)) * 75 - length
                     remade_tokens += [id_end] * rem + reloc_tokens
                     multipliers = multipliers[:last_comma] + [1.0] * rem + reloc_mults
                 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -226,6 +226,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "enable_emphasis": OptionInfo(True, "Emphasis: use (text) to make model pay more attention to text and [text] to make it pay less attention"),
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
+    "comma_padding_backtrack": OptionInfo(20, "Increase coherency by padding from the last comma within n tokens when using more than 75 tokens", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1 }),
     "filter_nsfw": OptionInfo(False, "Filter NSFW content"),
     'CLIP_stop_at_last_layers': OptionInfo(1, "Stop At last layers of CLIP model", gr.Slider, {"minimum": 1, "maximum": 12, "step": 1}),
     "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),


### PR DESCRIPTION
Help improve coherency when having words that overlap token set bondaries.

When a token is at a boundary of 75 and it is not a comma, the last n tokens (n which can be spec. in config) are checked to see if any are a comma. If one is, tokens are padded starting from that comma to the next mult. of 75, and the tokens that were there before get moved into the next token set.

ex: {[74]=comma,[75]=orange},{[76]=hair} -> {[74]=comma,[75]=padding},{[76]=orange, [77]=hair}

Before:
![without](https://user-images.githubusercontent.com/112723046/194930779-a10b5c4a-69a7-47aa-8c6c-2d790ab26df8.png)
After:
![with](https://user-images.githubusercontent.com/112723046/194930798-692ce135-63c9-4180-a938-d69930fd6d71.png)

```
masterpiece, 1girl, cute, , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , orange hair
Negative prompt: lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name
Steps: 20, Sampler: Euler, CFG scale: 11, Seed: 2347389309, Size: 512x640, Model hash: 925997e9, Eta: 0.67
```

Edit: if being merged, please squash merge. I fucked up on some buttons and have the default commit messages