### PR TITLE
Check if prompt missing S/R token to prevent accidental mis-gens.

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -27,8 +27,15 @@ def apply_field(field):
 
 
 def apply_prompt(p, x, xs):
+
+    orig_prompt = p.prompt
+    orig_negative_prompt = p.negative_prompt
+
     p.prompt = p.prompt.replace(xs[0], x)
     p.negative_prompt = p.negative_prompt.replace(xs[0], x)
+
+    if p.prompt == orig_prompt and p.negative_prompt == orig_negative_prompt:
+        raise RuntimeError(f"Prompt S/R did not find {xs[0]} in prompt or negative prompt. Did you forget to add the token?")
 
 
 def apply_order(p, x, xs):


### PR DESCRIPTION
This PR adds a check to the X/Y grid prompt s/r (string replace) functionality to see if the token to be replaced is actually in the prompt. If it isn't it raises an error alerting the user to check their prompt.

The motivation is that when doing rapid prompt iterating for grid comparisons, I've occasionally found that I missed putting the token to be replaced and end up with a grid of the same picture instead. For example, lets say I'm working on this prompt:

![Screenshot_20221010_164233](https://user-images.githubusercontent.com/18688190/194951855-dc5aa974-8241-470f-9d93-f446904bffca.png)
![Screenshot_20221010_164309](https://user-images.githubusercontent.com/18688190/194951883-37eee561-708b-49f4-b69a-8df8d0299ac2.png)

This works as expected:

![1664458111530-1234-A spaceship in deep-space](https://user-images.githubusercontent.com/18688190/194952982-b812ebc0-a2e9-4600-a867-3f043847e2e3.jpg)

--- 

Now after some time exploring finding a new prompt I'm interested in I start again:

![Screenshot_20221010_164330](https://user-images.githubusercontent.com/18688190/194953131-9af9fd59-779c-4f08-8a03-d360fa452cf4.png)

![Screenshot_20221010_164309](https://user-images.githubusercontent.com/18688190/194953194-9cf9dbab-0ef8-4b1e-acc9-5405877a0197.png)

![1664458111531-1234-A spaceship in hyper-space](https://user-images.githubusercontent.com/18688190/194953287-8e1cd1bb-d8f3-4c43-9fb0-a9b6626edd7f.jpg)


Oops, I forgot to change the start word, and have just spent several (or many) minutes generating the same picture over and over. This PR will alert me quickly to the mistake I made.

I don't know of any use-case where one would want to use Prompt S/R without the word being present, so I think throwing an error is ok. If anyone knows of such a usecase, please let me know.

