### PR TITLE
Fix init img in loopback 

### DIFF
--- a/scripts/loopback.py
+++ b/scripts/loopback.py
@@ -38,12 +38,16 @@ class Script(scripts.Script):
 
         grids = []
         all_images = []
+        original_init_image = p.init_images
         state.job_count = loops * batch_count
 
         initial_color_corrections = [processing.setup_color_correction(p.init_images[0])]
 
         for n in range(batch_count):
             history = []
+
+            # Reset to original init image at the start of each batch
+            p.init_images = original_init_image
 
             for i in range(loops):
                 p.n_iter = 1


### PR DESCRIPTION
Before a new batch would use the last image from the previous batch. Now each batch will use the original image for the init image at the start of the batch.

Fixes the issue I reported in the [bug report](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/1963) I submitted:

**Setup**
I've got an image which I want to run img2img loopback on. I choose the loopback option in img2img and set the loops count to three and the batch count to five.

**Expected result:**
Get five distinct batches all using the original image as the input image.

**Actual result:**
The second batch uses the last image from the first batch as the input image, the third batch uses the last image from the second batch as the input image, etc. Five batches with a loop count of three is the the equivalent of doing one batch with 15 loops.

**Solution**
Change the img2img behavior so that for each batch it uses the original input image ignoring the changes in the other batches.