### PR TITLE
Deepbooru score threshold slider

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -239,6 +239,7 @@ options_templates.update(options_section(('interrogate', "Interrogate Options"),
     "interrogate_clip_min_length": OptionInfo(24, "Interrogate: minimum description length (excluding artists, etc..)", gr.Slider, {"minimum": 1, "maximum": 128, "step": 1}),
     "interrogate_clip_max_length": OptionInfo(48, "Interrogate: maximum description length", gr.Slider, {"minimum": 1, "maximum": 256, "step": 1}),
     "interrogate_clip_dict_limit": OptionInfo(1500, "Interrogate: maximum number of lines in text file (0 = No limit)"),
+    "interrogate_deepbooru_score_threshold": OptionInfo(0.5, "Interrogate: deepbooru score threshold", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}),
 }))
 
 options_templates.update(options_section(('ui', "User interface"), {

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -311,7 +311,7 @@ def interrogate(image):
 
 
 def interrogate_deepbooru(image):
-    prompt = get_deepbooru_tags(image)
+    prompt = get_deepbooru_tags(image, opts.interrogate_deepbooru_score_threshold)
     return gr_show(True) if prompt is None else prompt
 
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
Deepbooru score threshold parameter that controls how many tags it returns was hard coded at 0.5. This change adds a slider to the settings page where it can be set to between 0 and 1

**Environment this was tested in**
Windows 10, Firefox 105.0.3

Example images:
Threshold set to 0.5
![image](https://user-images.githubusercontent.com/115507730/194967060-49500691-34db-4a20-a6eb-9d5d1683e657.png)
Threshold set to 0.9
![image](https://user-images.githubusercontent.com/115507730/194967080-19d3ac0c-dc2c-46f0-9047-4c996fb37575.png)