### PR TITLE
Dpm fast and adaptive enable for img2img

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -366,7 +366,6 @@ class KDiffusionSampler:
             sigmas = self.model_wrap.get_sigmas(steps)
 
         sigma_sched = sigmas[steps - t_enc - 1:]
-        print('check values same', sigmas[steps - t_enc - 1] , sigma_sched[0], sigmas[steps - t_enc - 1] - sigma_sched[0])
         xi = x + noise * sigma_sched[0]
         
         extra_params_kwargs = self.initialize(p)

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -57,7 +57,7 @@ def set_samplers():
     global samplers, samplers_for_img2img
 
     hidden = set(opts.hide_samplers)
-    hidden_img2img = set(opts.hide_samplers + ['PLMS', 'DPM fast', 'DPM adaptive'])
+    hidden_img2img = set(opts.hide_samplers + ['PLMS'])
 
     samplers = [x for x in all_samplers if x.name not in hidden]
     samplers_for_img2img = [x for x in all_samplers if x.name not in hidden_img2img]
@@ -365,16 +365,27 @@ class KDiffusionSampler:
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 
-        noise = noise * sigmas[steps - t_enc - 1]
-        xi = x + noise
-
-        extra_params_kwargs = self.initialize(p)
-
         sigma_sched = sigmas[steps - t_enc - 1:]
+        print('check values same', sigmas[steps - t_enc - 1] , sigma_sched[0], sigmas[steps - t_enc - 1] - sigma_sched[0])
+        xi = x + noise * sigma_sched[0]
+        
+        extra_params_kwargs = self.initialize(p)
+        if 'sigma_min' in inspect.signature(self.func).parameters:
+            ## last sigma is zero which is allowed by DPM Fast & Adaptive so taking value before last
+            extra_params_kwargs['sigma_min'] = sigma_sched[-2]
+        if 'sigma_max' in inspect.signature(self.func).parameters:
+            extra_params_kwargs['sigma_max'] = sigma_sched[0]
+        if 'n' in inspect.signature(self.func).parameters:
+            extra_params_kwargs['n'] = len(sigma_sched) - 1
+        if 'sigma_sched' in inspect.signature(self.func).parameters:
+            extra_params_kwargs['sigma_sched'] = sigma_sched
+        if 'sigmas' in inspect.signature(self.func).parameters:
+            extra_params_kwargs['sigmas'] = sigma_sched
 
         self.model_wrap_cfg.init_latent = x
 
-        return self.func(self.model_wrap_cfg, xi, sigma_sched, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs)
+        return self.func(self.model_wrap_cfg, xi, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs)
+
 
     def sample(self, p, x, conditioning, unconditional_conditioning, steps=None):
         steps = steps or p.steps

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -370,7 +370,7 @@ class KDiffusionSampler:
         
         extra_params_kwargs = self.initialize(p)
         if 'sigma_min' in inspect.signature(self.func).parameters:
-            ## last sigma is zero which is allowed by DPM Fast & Adaptive so taking value before last
+            ## last sigma is zero which isn't allowed by DPM Fast & Adaptive so taking value before last
             extra_params_kwargs['sigma_min'] = sigma_sched[-2]
         if 'sigma_max' in inspect.signature(self.func).parameters:
             extra_params_kwargs['sigma_max'] = sigma_sched[0]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Change sample_img2img to handle the different function signatures for DPM Fast & DPM Adaptive, so that they can be used in img2img and txt2img with Highres fix enabled.

**Additional notes and description of your changes**

Added sigma_min, sigma_max, n, sigma_sched, sigmas to extra_params_kwargs
Removed sigma_sched from default call parameters as this conflicts with the DPM Fast & Adaptive required parameters

Really sigma_sched and sigma should be aligned in the sampler functions parameter names but that wouldn't add any functionality so isn't part of this pull request.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090 24GB,

**Screenshots or videos of your changes**
Setting used "With img2img, do exactly the amount of steps the slider specifies (normally you'd do less with less denoising). " set to True
Prompt: A forest with a storm cloud in the background
Steps: 50
CFG Scale: 7
Seed: 3791266193


512x512 Sampling Highres. fix: OFF Method: DPM Fast  
![00041-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194966587-629242f5-24e6-4eb5-a53c-c39ed19aa6ca.jpg)

1024x1024 Highres. fix: ON Denoising strength: 0.1 Method: DPM Fast  
![00042-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194966595-3f3b6ccc-cb79-4f3d-adb6-ec9a45735ad4.jpg)

2048x2048 Highres. fix: ON Denoising strength: 0.1 Method: DPM Fast  
![00043-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194966605-87fa2f27-f162-4ebf-972d-1f32725e3e2f.jpg)

1024x1024 Highres. fix: ON Denoising strength: 0.25 Method: DPM Fast  
![00044-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194966614-a14057eb-1d8f-4b10-b073-00a34a6f87d2.jpg)

512x512 Sampling Highres. fix: OFF Method: LMS
![00046-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194967327-90b1c310-31a6-44ce-881a-d17719c1c7c4.jpg)

1024x1024 Highres. fix: ON Denoising strength: 0.25 Method: LMS 
![00045-3791266193-A forest with a storm cloud in the background](https://user-images.githubusercontent.com/4314538/194967341-6de43ca0-4354-4403-b949-09f63028e368.jpg)
