### PR TITLE
Refresh list of models/ckpts upon hitting restart gradio in the setti…

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -39,6 +39,7 @@ import modules.generation_parameters_copypaste
 from modules import prompt_parser
 from modules.images import save_image
 import modules.textual_inversion.ui
+from modules.sd_models import list_models
 
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
@@ -1289,6 +1290,9 @@ Requested path was: {f}
         def request_restart():
             shared.state.interrupt()
             settings_interface.gradio_ref.do_restart = True
+
+            # refresh models so that new models/.ckpt's show up on reload
+            list_models()
 
         restart_gradio.click(
             fn=request_restart,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -39,7 +39,6 @@ import modules.generation_parameters_copypaste
 from modules import prompt_parser
 from modules.images import save_image
 import modules.textual_inversion.ui
-from modules.sd_models import list_models
 
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
@@ -1291,8 +1290,6 @@ Requested path was: {f}
             shared.state.interrupt()
             settings_interface.gradio_ref.do_restart = True
 
-            # refresh models so that new models/.ckpt's show up on reload
-            list_models()
 
         restart_gradio.click(
             fn=request_restart,

--- a/webui.py
+++ b/webui.py
@@ -124,6 +124,8 @@ def webui():
         modules.scripts.reload_scripts(os.path.join(script_path, "scripts"))
         print('Reloading modules: modules.ui')
         importlib.reload(modules.ui)
+        print('Refreshing Model List')
+        modules.sd_models.list_models()
         print('Restarting Gradio')
 
 


### PR DESCRIPTION
Refreshes the list of models able to be selected upon hitting the orange reset gradio button in the settings pane of the UI. It may be that a refresh button should be added next to the models drop down in the UI but this should at least help for now with those that need to be able to refresh without completely restarting #2186.