### PR TITLE
Make the ctrl+enter shortcut use the generate button on the current tab

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1331,7 +1331,7 @@ Requested path was: {f}
         
         with gr.Tabs() as tabs:
             for interface, label, ifid in interfaces:
-                with gr.TabItem(label, id=ifid):
+                with gr.TabItem(label, id=ifid, elem_id='tab_' + ifid):
                     interface.render()
         
         if os.path.exists(os.path.join(script_path, "notification.mp3")):

--- a/script.js
+++ b/script.js
@@ -6,6 +6,10 @@ function get_uiCurrentTab() {
     return gradioApp().querySelector('.tabs button:not(.border-transparent)')
 }
 
+function get_uiCurrentTabContent() {
+    return gradioApp().querySelector('.tabitem[id^=tab_]:not([style*="display: none"])')
+}
+
 uiUpdateCallbacks = []
 uiTabChangeCallbacks = []
 let uiCurrentTab = null
@@ -50,8 +54,11 @@ document.addEventListener("DOMContentLoaded", function() {
     } else if (e.keyCode !== undefined) {
         if((e.keyCode == 13 && (e.metaKey || e.ctrlKey))) handled = true;
     }
-    if (handled) { 
-        gradioApp().querySelector("#txt2img_generate").click(); 
+    if (handled) {
+        button = get_uiCurrentTabContent().querySelector('button[id$=_generate]');
+        if (button) {
+            button.click();
+        }
         e.preventDefault();
     }
 })


### PR DESCRIPTION
The current code is clicking on the txt2img generate button even if it is not the current tab.

This PR makes the shortcut use the generate button on the current tab, it works on the txt2img, img2img and extras tabs.