### PR TITLE
edit attention key handler: return early when weight parse returns NaN

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -25,6 +25,7 @@ addEventListener('keydown', (event) => {
 	} else {
 		end = target.value.slice(selectionEnd + 1).indexOf(")") + 1;
 		weight = parseFloat(target.value.slice(selectionEnd + 1, selectionEnd + 1 + end));
+		if (isNaN(weight)) return;
 		if (event.key == minus) weight -= 0.1;
 		if (event.key == plus) weight += 0.1;
 


### PR DESCRIPTION
for the situation where you make an overlapping selection with the same start:

**make a selection, press up, and then press shift+backwards, press up again.**

Slicing out the float fails with a nan, presumably because it's reading the colon as a float, which overwrites the weight.