### PR TITLE
update environment-wsl2.yaml

### DIFF
--- a/environment-wsl2.yaml
+++ b/environment-wsl2.yaml
@@ -3,9 +3,9 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - python=3.8.5
-  - pip=20.3
+  - python=3.10
+  - pip=22.2.2
   - cudatoolkit=11.3
-  - pytorch=1.11.0
-  - torchvision=0.12.0
-  - numpy=1.19.2
+  - pytorch=1.12.1
+  - torchvision=0.13.1
+  - numpy=1.23.1


### PR DESCRIPTION
This file was not updated and contained older versions of python and pytorch which would cause conflicts with the currently required packages, leading to broken environment when subsequently running launch.py in an environment initialized with environment-wsl2.yaml.