### PR TITLE
Restore last generation params rebased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 /webui.settings.bat
 /embeddings
 /styles.csv
+/params.txt
 /styles.csv.bak
 /webui-user.bat
 /webui-user.sh

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -14,7 +14,7 @@ titles = {
     "\u{1f3b2}\ufe0f": "Set seed to -1, which will cause a new random number to be used every time",
     "\u267b\ufe0f": "Reuse seed from last generation, mostly useful if it was randomed",
     "\u{1f3a8}": "Add a random artist to the prompt.",
-    "\u2199\ufe0f": "Read generation parameters from prompt into user interface.",
+    "\u2199\ufe0f": "Read generation parameters from prompt or last generation if prompt is empty into user interface.",
     "\u{1f4c2}": "Open images output directory",
 
     "Inpaint a part of image": "Draw a mask over an image, and the script will regenerate the masked area with content according to prompt",

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -1,5 +1,7 @@
+import os
 import re
 import gradio as gr
+from modules.shared import script_path
 
 re_param_code = r"\s*([\w ]+):\s*([^,]+)(?:,|$)"
 re_param = re.compile(re_param_code)
@@ -61,6 +63,12 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
 def connect_paste(button, paste_fields, input_comp, js=None):
     def paste_func(prompt):
+        if not prompt:
+            filename = os.path.join(script_path, "params.txt")
+            if os.path.exists(filename):
+                with open(filename, "r", encoding="utf8") as file:
+                    prompt = file.read()
+
         params = parse_generation_parameters(prompt)
         res = []
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -324,6 +324,10 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     else:
         assert p.prompt is not None
 
+    with open(os.path.join(shared.script_path, "params.txt"), "w", encoding="utf8") as file:
+        processed = Processed(p, [], p.seed, "")
+        file.write(processed.infotext(p, 0))
+
     devices.torch_gc()
 
     seed = get_fixed_seed(p.seed)


### PR DESCRIPTION
Rebased to latest code

Implements https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/842

Uses the current read generation from prompt button to load from file if prompt is empty

Not sure if this is ideal when using --shared, since you could load someone else's last generation