### PR TITLE
Ensure the opts.outdir_save directory exists before opening log.csv

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -131,6 +131,8 @@ def save_files(js_data, images, do_make_zip, index):
         images = [images[index]]
         start_index = index
 
+    os.makedirs(opts.outdir_save, exist_ok=True)
+
     with open(os.path.join(opts.outdir_save, "log.csv"), "a", encoding="utf8", newline='') as file:
         at_start = file.tell() == 0
         writer = csv.writer(file)


### PR DESCRIPTION
If the directory for saving images using the Save button doesn't yet exist, pressing the Save button will fail to save the image and instead print information about the image followed by:
```
Traceback (most recent call last):
  File "/Users/brkirch/Documents/GitHub/stable-diffusion-webui/modules/ui.py", line 182, in f
    res = list(func(*args, **kwargs))
  File "/Users/brkirch/Documents/GitHub/stable-diffusion-webui/modules/ui.py", line 134, in save_files
    with open(os.path.join(opts.outdir_save, "log.csv"), "a", encoding="utf8", newline='') as file:
FileNotFoundError: [Errno 2] No such file or directory: 'log/images/log.csv'

Traceback (most recent call last):
  File "/Users/brkirch/miniconda/envs/web-ui/lib/python3.10/site-packages/gradio/routes.py", line 275, in run_predict
    output = await app.blocks.process_api(
  File "/Users/brkirch/miniconda/envs/web-ui/lib/python3.10/site-packages/gradio/blocks.py", line 789, in process_api
    predictions = self.postprocess_data(fn_index, result["prediction"], state)
  File "/Users/brkirch/miniconda/envs/web-ui/lib/python3.10/site-packages/gradio/blocks.py", line 740, in postprocess_data
    if predictions[i] is components._Keywords.FINISHED_ITERATING:
IndexError: tuple index out of range
```
This PR creates the directory before attempting to open log.csv, preventing these errors from occurring. Fixes #2225.