### PR TITLE
[img2imgalt] Fix seed & Allow batch

### DIFF
--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -129,8 +129,6 @@ class Script(scripts.Script):
         return [original_prompt, original_negative_prompt, cfg, st, randomness, sigma_adjustment]
 
     def run(self, p, original_prompt, original_negative_prompt, cfg, st, randomness, sigma_adjustment):
-        p.batch_size = 1
-        p.batch_count = 1
 
 
         def sample_extra(conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength):
@@ -154,7 +152,7 @@ class Script(scripts.Script):
                     rec_noise = find_noise_for_image(p, cond, uncond, cfg, st)
                 self.cache = Cached(rec_noise, cfg, st, lat, original_prompt, original_negative_prompt, sigma_adjustment)
 
-            rand_noise = processing.create_random_tensors(p.init_latent.shape[1:], [p.seed + x + 1 for x in range(p.init_latent.shape[0])])
+            rand_noise = processing.create_random_tensors(p.init_latent.shape[1:], seeds=seeds, subseeds=subseeds, subseed_strength=p.subseed_strength, seed_resize_from_h=p.seed_resize_from_h, seed_resize_from_w=p.seed_resize_from_w, p=p)
             
             combined_noise = ((1 - randomness) * rec_noise + randomness * rand_noise) / ((randomness**2 + (1-randomness)**2) ** 0.5)
             


### PR DESCRIPTION
# Problems
## 1. Randomness for img2imgalt not work
`Randomness` use `p.seed` as its seed. 
But in `processing.process_images`, `p.seed` is not set:

``` python
    seed = get_fixed_seed(p.seed)
    subseed = get_fixed_seed(p.subseed)
```

As a result, `rand_noise` in `sample_extra` is always generated by the seed 0.

My solution is to use the parameter `seeds` as seeds, since this modifies the code changes very little(only 1 line).

## 2. Batch for img2imgalt's is not allowed
I know, without randomness, the batch for img2imgalt is meaningless.
However, since randomness is supported now, batch should be allowed.

I just delete two lines code.