### PR TITLE
Use filename as is when replacing it in [filewords] prompt TI template

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -231,6 +231,7 @@ options_templates.update(options_section(('system', "System"), {
 
 options_templates.update(options_section(('training', "Training"), {
     "unload_models_when_training": OptionInfo(False, "Unload VAE and CLIP from VRAM when training"),
+    "filewords_join_character": OptionInfo(" ", "Override character used to join tags in [filewords] prompt template. (default: ' ')")
 }))
 
 options_templates.update(options_section(('sd', "Stable Diffusion"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -231,7 +231,6 @@ options_templates.update(options_section(('system', "System"), {
 
 options_templates.update(options_section(('training', "Training"), {
     "unload_models_when_training": OptionInfo(False, "Unload VAE and CLIP from VRAM when training"),
-    "filewords_join_character": OptionInfo(" ", "Override character used to join tags in [filewords] prompt template. (default: ' ')")
 }))
 
 options_templates.update(options_section(('sd', "Stable Diffusion"), {

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -11,8 +11,7 @@ import tqdm
 from modules import devices, shared
 import re
 
-re_tag = re.compile(r"[a-zA-Z][_\w\d()]+")
-
+re_tag = re.compile(r"[a-zA-Z][_\s\w\d()]+")
 
 class PersonalizedBase(Dataset):
     def __init__(self, data_root, width, height, repeats, flip_p=0.5, placeholder_token="*", model=None, device=None, template_file=None, include_cond=False):
@@ -45,6 +44,7 @@ class PersonalizedBase(Dataset):
             filename = os.path.basename(path)
             filename_tokens = os.path.splitext(filename)[0]
             filename_tokens = re_tag.findall(filename_tokens)
+            filename_tokens = [tag.strip() for tag in filename_tokens]
 
             npimage = np.array(image).astype(np.uint8)
             npimage = (npimage / 127.5 - 1.0).astype(np.float32)
@@ -73,9 +73,10 @@ class PersonalizedBase(Dataset):
         self.indexes = self.initial_indexes[torch.randperm(self.initial_indexes.shape[0])]
 
     def create_text(self, filename_tokens):
+        filewords_join_character = shared.opts.filewords_join_character.strip().ljust(1)[0] # force 1 char and at least to be a space
         text = random.choice(self.lines)
         text = text.replace("[name]", self.placeholder_token)
-        text = text.replace("[filewords]", ' '.join(filename_tokens))
+        text = text.replace("[filewords]", filewords_join_character.join(filename_tokens))
         return text
 
     def __len__(self):

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -44,7 +44,6 @@ class PersonalizedBase(Dataset):
             filename = os.path.basename(path)
             filename_tokens = os.path.splitext(filename)[0]
             filename_tokens = re_tag.findall(filename_tokens)
-            filename_tokens = [tag.strip() for tag in filename_tokens]
 
             npimage = np.array(image).astype(np.uint8)
             npimage = (npimage / 127.5 - 1.0).astype(np.float32)


### PR DESCRIPTION
From #2338 and #1552 
This allows to change the default separator when generating the prompt from the template and replacing [filewords] with filename tags. By default tags were joined by a space, but this allows to change the join character.

I also needed to change the TI regex when getting and splitting the tags from filename, because the spaces between words would separate them. 
Before:
![image](https://user-images.githubusercontent.com/11600634/195357119-67e67354-11c8-4055-9bdc-996a459415d3.png)
After:
![image](https://user-images.githubusercontent.com/11600634/195357173-88053c02-7523-4834-83ec-14339eead590.png)

