### PR TITLE
Add `--lowram` param for low RAM machine like Colab

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -134,7 +134,12 @@ def load_model_weights(model, checkpoint_info):
 
     print(f"Loading weights [{sd_model_hash}] from {checkpoint_file}")
 
-    pl_sd = torch.load(checkpoint_file, map_location="cpu")
+    if shared.cmd_opts.lowram:
+        print("Load to VRAM if GPU is available (low RAM)")
+        pl_sd = torch.load(checkpoint_file)
+    else:
+        pl_sd = torch.load(checkpoint_file, map_location="cpu")
+
     if "global_step" in pl_sd:
         print(f"Global Step: {pl_sd['global_step']}")
 
@@ -158,7 +163,13 @@ def load_model_weights(model, checkpoint_info):
 
     if os.path.exists(vae_file):
         print(f"Loading VAE weights from: {vae_file}")
-        vae_ckpt = torch.load(vae_file, map_location="cpu")
+
+        if shared.cmd_opts.lowram:
+            print("Load to VRAM if GPU is available (low RAM)")
+            vae_ckpt = torch.load(vae_file)
+        else:
+            vae_ckpt = torch.load(vae_file, map_location="cpu")
+
         vae_dict = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss"}
 
         model.first_stage_model.load_state_dict(vae_dict)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -34,6 +34,7 @@ parser.add_argument("--hypernetwork-dir", type=str, default=os.path.join(models_
 parser.add_argument("--allow-code", action='store_true', help="allow custom script execution from webui")
 parser.add_argument("--medvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a little speed for low VRM usage")
 parser.add_argument("--lowvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a lot of speed for very low VRM usage")
+parser.add_argument("--lowram", action='store_true', help="load models to VRM instead of RAM (for machines which have bigger VRM than RAM such as free Google Colab server)")
 parser.add_argument("--always-batch-cond-uncond", action='store_true', help="disables cond/uncond batching that is enabled to save memory with --medvram or --lowvram")
 parser.add_argument("--unload-gfpgan", action='store_true', help="does not do anything.")
 parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast")


### PR DESCRIPTION
#2366
Servers like Google Colab (free edition), have low RAM (12.56 GB), it will force exit by Colab and crash when loading large model (for example, 7GB). However it has large VRAM (16GB) that will not run out of.

*Google Colab output*
```
/content/stable-diffusion-webui
Python 3.7.14 (default, Sep  8 2022, 00:06:44) 
[GCC 7.5.0]
Commit hash: 80f3cf2bb2ce3f00d801cae2c3a8c20a8d4167d8
Installing requirements for Web UI
Launching Web UI with arguments: --share --gradio-debug --gradio-auth ljzd:114514
LatentDiffusion: Running in eps-prediction mode
DiffusionWrapper has 859.52 M params.
making attention of type 'vanilla' with 512 in_channels
Working with z of shape (1, 4, 32, 32) = 4096 dimensions.
making attention of type 'vanilla' with 512 in_channels
Loading weights [06c50424] from /content/stable-diffusion-webui/models/Stable-diffusion/model.ckpt
^C
```

*Screenshot - without `--lowram`*

<img width="1215" alt="截屏2022-10-13 02 21 09" src="https://user-images.githubusercontent.com/63289359/195419251-ef2a896f-32ec-497e-899e-a5c79821aa0e.png">
<img width="319" alt="截屏2022-10-13 02 25 46" src="https://user-images.githubusercontent.com/63289359/195419734-c012a901-5572-4316-a452-4086bfb07c62.png">

*Screenshot when using `--lowram`*

<img width="1231" alt="截屏2022-10-13 02 18 07" src="https://user-images.githubusercontent.com/63289359/195419076-48edb034-4bf8-451b-a4c4-e7f8b7f9a7b6.png">
