### PR TITLE
Fixed issue with Hypernetwork Training with VAE loaded

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -160,8 +160,9 @@ def load_model_weights(model, checkpoint_info):
         print(f"Loading VAE weights from: {vae_file}")
         vae_ckpt = torch.load(vae_file, map_location="cpu")
         vae_dict = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss"}
+        vae_dict = {"first_stage_model." + k: v for k, v in vae_dict.items()}
 
-        model.first_stage_model.load_state_dict(vae_dict)
+        model.first_stage_model.load_state_dict(vae_dict, strict=False)
 
     model.first_stage_model.to(devices.dtype_vae)
 


### PR DESCRIPTION
Several issues (#2205 #2294) have reported that Hypernet Training with a VAE loaded would mess up the training results.
The VAE weights in the model ckpt file have a key like "first_stage_model.encoder.down.1.block.0.norm2.bias", but the VAE weights in the VAE pt file are "encoder.down.1.block.0.norm2.bias", so I modified the key to the same expression and now Hypernetwork Training works fine with VAE loaded.
Not sure why.
Referenced: https://github.com/CompVis/stable-diffusion/blob/69ae4b35e0a0f6ee1af8bb9a5d0016ccb27e36dc/ldm/models/autoencoder.py#L313
