### PR TITLE
Added script to interpolate between 2 prompts, and create a gif

### DIFF
--- a/scripts/prompt_interpolation.py
+++ b/scripts/prompt_interpolation.py
@@ -41,14 +41,14 @@ class Script(scripts.Script):
 
 
     def show(self, is_img2img):
-        return not is_img2img
+        return True
 
 
     def ui(self, is_img2img):
         prompt2 = gr.TextArea(label="Interpolation prompt")
         n_images = gr.Slider(minimum=1, maximum=128, step=1, value=1, label="Number of images")
         make_a_gif = gr.Checkbox(label="Make a gif", value=True)
-        duration = gr.Slider(minimum=1, maximum=1000, step=1, value=100, label="Duration of images (ms)", visible=False)
+        duration = gr.Slider(minimum=1, maximum=1000, step=1, value=100, label="Duration of images (ms)", visible=True)
         make_a_gif.change(fn=lambda x: gr.update(visible=x), inputs=[make_a_gif], outputs=[duration])
         return [prompt2, n_images, make_a_gif, duration]
 

--- a/scripts/prompt_interpolation.py
+++ b/scripts/prompt_interpolation.py
@@ -1,0 +1,89 @@
+import modules.scripts as scripts
+import gradio as gr
+import random
+import os
+from PIL import Image
+
+from modules import images
+from modules.processing import process_images
+from modules.processing import Processed
+from modules.shared import opts, cmd_opts, state
+
+
+def process(p, prompt1, prompt2, n_images):
+    first_processed = None
+    processed_images = []
+
+    for i in range(p.batch_size * p.n_iter):
+        processed_images.append([])
+    
+    state.job_count = n_images * p.n_iter
+
+    for i in range(n_images):
+        state.job = f"interpolation: {i + 1} out of {n_images}"
+        interpolation = 0.5 if n_images == 1 else i / (n_images - 1)
+        p.prompt = f"{prompt1} :{1 - interpolation} AND {prompt2} :{interpolation}"
+        processed = process_images(p)
+        
+        if first_processed is None:
+            first_processed = processed
+
+        for i, img in enumerate(processed.images):
+            processed_images[i].append(img)
+
+    return first_processed, processed_images
+
+
+class Script(scripts.Script):
+
+    def title(self):
+        return "Prompts interpolation"
+
+
+    def show(self, is_img2img):
+        return not is_img2img
+
+
+    def ui(self, is_img2img):
+        prompt2 = gr.TextArea(label="Interpolation prompt")
+        n_images = gr.Slider(minimum=1, maximum=128, step=1, value=1, label="Number of images")
+        make_a_gif = gr.Checkbox(label="Make a gif", value=True)
+        duration = gr.Slider(minimum=1, maximum=1000, step=1, value=100, label="Duration of images (ms)", visible=False)
+        make_a_gif.change(fn=lambda x: gr.update(visible=x), inputs=[make_a_gif], outputs=[duration])
+        return [prompt2, n_images, make_a_gif, duration]
+
+
+    def run(self, p, prompt2, n_images, make_a_gif, duration):
+        if p.seed == -1:
+            p.seed = int(random.randrange(4294967294))
+        
+        p.do_not_save_grid = True
+        prompt1 = p.prompt
+        
+        processed, processed_images = process(p, prompt1, prompt2, n_images)
+
+        p.prompt_for_display = processed.prompt = f"{prompt1} AND {prompt2}"
+        processed_images_flattened = []
+        
+        for row in processed_images:
+            processed_images_flattened += row
+        
+        if len(processed_images_flattened) == 1:
+            processed.images = processed_images_flattened
+        else:
+            processed.images = [images.image_grid(processed_images_flattened, rows=p.batch_size * p.n_iter)] \
+                + processed_images_flattened
+        
+        if make_a_gif or opts.grid_save:
+            (fullfn, _) = images.save_image(processed.images[0], p.outpath_grids, "grid",
+                prompt=p.prompt_for_display, seed=processed.seed, grid=True, p=p)
+        
+        if make_a_gif:
+            for i, row in enumerate(processed_images):
+                fullfn = fullfn[:fullfn.rfind(".")] + "_" + str(i) + ".gif"
+                # since there is no option for saving gif images in images.save_image(), I had to
+                # do it from scratch, maybe it can be improved in the future
+                processed_images[i][0].save(fullfn, save_all=True,
+                    append_images=processed_images[i][1:], optimize=False, duration=duration, loop=0)
+        
+        return processed


### PR DESCRIPTION
Sorry for my poor english, I am french.

With this script, you can interpolate between two prompts (using the "AND" keyword), generate as many images as you want.
You can also generate a gif with the result.

Example:

The first prompt is `asuna sword art online, french braid, best quality, solo, portrait`
The second prompt is `princess zelda, super smash bros ultimate, best quality, solo, portrait`
The negative prompt is `lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, male focus, solo male, poorly drawn, deformed, poorly drawn face, (extra leg:1.3), (extra fingers:1.2), out of frame`
![image](https://user-images.githubusercontent.com/24735555/195443859-19507821-63f5-4381-873a-52b5aa37f45c.png)

If I set the number of images to 128, and choose 50 sampling steps, and enable the "make a gif" option, here is the result (in outputs/txt2img-grids):
![grid-0428-2781198134-asuna sword art online, french braid, best quality, solo, portrait AND princess zelda, super smash bros ultimate, best quality,_0](https://user-images.githubusercontent.com/24735555/195446660-21ef5285-4c95-4294-adce-b680a97817bc.gif)
This gif is not the real one, it is compressed because otherwise it would be too big for github.

