### PR TITLE
Fix images generated count in browser notifications

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -36,7 +36,7 @@ onUiUpdate(function(){
     const notification = new Notification(
         'Stable Diffusion',
         {
-            body: `Generated ${imgs.size > 1 ? imgs.size - 1 : 1} image${imgs.size > 1 ? 's' : ''}`,
+            body: `Generated ${imgs.size > 1 ? imgs.size - opts.return_grid : 1} image${imgs.size > 1 ? 's' : ''}`,
             icon: headImg,
             image: headImg,
         }


### PR DESCRIPTION
Display correct count of images generated in browser notification regardless of "Show grid in results for web" setting.
Old way would count 1 less generated image if you had turned off grid result.