### PR TITLE
Fixed 'str type doesn't have encoding, do you mean decode()' error

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -26,12 +26,12 @@ def run(command, desc=None, errdesc=None):
         message = f"""{errdesc or 'Error running command'}.
 Command: {command}
 Error code: {result.returncode}
-stdout: {result.stdout.decode(encoding="utf8", errors="ignore") if len(result.stdout)>0 else '<empty>'}
-stderr: {result.stderr.decode(encoding="utf8", errors="ignore") if len(result.stderr)>0 else '<empty>'}
+stdout: {result.stdout.encode().decode(encoding="utf8", errors="ignore") if len(result.stdout)>0 else '<empty>'}
+stderr: {result.stderr.encode().decode(encoding="utf8", errors="ignore") if len(result.stderr)>0 else '<empty>'}
 """
         raise RuntimeError(message)
 
-    return result.stdout.decode(encoding="utf8", errors="ignore")
+    return result.stdout.encode().decode(encoding="utf8", errors="ignore")
 
 
 def check_run(command):
@@ -86,7 +86,7 @@ def git_clone(url, dir, name, commithash=None):
 
 
 def prepare_enviroment():
-    torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
+    torch_command = os.environ.get('TORCH_COMMAND', "pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
     commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
 


### PR DESCRIPTION
While I run launch.py，got 'str type doesn't have encoding, do you mean decode()' ，It means result.stdout and result.stderr were recognized as str type... so I added 'encode()' : result.stdout.encode().decode(encoding="utf8", errors="ignore") and result.stderr.encode().decode(encoding="utf8", errors="ignore"), and then it worked. May I open a pull request?