### PR TITLE
[Fix & Improve] Add `token counter` for `negative prompt` & Allow `alt+enter` in negative prompt

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -194,9 +194,20 @@ onUiUpdate(function(){
 		img2img_textarea?.addEventListener("input", () => update_token_counter("img2img_token_button"));
         img2img_textarea?.addEventListener("keyup", (event) => submit_prompt(event, "img2img_generate"));
 	}
+	if (!txt2img_neg_textarea) {
+        txt2img_neg_textarea = gradioApp().querySelector("#txt2img_neg_prompt > label > textarea");
+        txt2img_neg_textarea?.addEventListener("input", () => update_token_counter("txt2img_neg_token_button"));
+        txt2img_neg_textarea?.addEventListener("keyup", (event) => submit_prompt(event, "txt2img_generate"));
+	}
+	if (!img2img_neg_textarea) {
+        img2img_neg_textarea = gradioApp().querySelector("#img2img_neg_prompt > label > textarea");
+        img2img_neg_textarea?.addEventListener("input", () => update_token_counter("img2img_neg_token_button"));
+        img2img_neg_textarea?.addEventListener("keyup", (event) => submit_prompt(event, "img2img_generate"));
+	}
 })
 
 let txt2img_textarea, img2img_textarea = undefined;
+let txt2img_neg_textarea, img2img_neg_textarea = undefined;
 let wait_time = 800
 let token_timeout;
 

--- a/style.css
+++ b/style.css
@@ -109,6 +109,12 @@
     height: 100%;
 }
 
+#token_counter_col{
+    min-width: unset !important;
+    flex-grow: 0 !important;
+    padding: 0.4em 0;
+}
+
 #roll_col{
     min-width: unset !important;
     flex-grow: 0 !important;
@@ -167,10 +173,10 @@ button{
     align-self: stretch !important;
 }
 
-#prompt, #negative_prompt{
+#txt2img_prompt textarea, #img2img_prompt textarea{
     border: none !important;
 }
-#prompt textarea, #negative_prompt textarea{
+#txt2img_neg_prompt textarea, #img2img_neg_prompt textarea{
     border: none !important;
 }
 
@@ -275,9 +281,6 @@ input[type="range"]{
   display: block;
   margin-top: -0.75em;
   margin-bottom: -0.75em;
-}
-
-#txt2img_negative_prompt, #img2img_negative_prompt{
 }
 
 #txt2img_progressbar, #img2img_progressbar, #ti_progressbar{


### PR DESCRIPTION
# Problem
## 1. `Negative prompt` has token limits, but no `token counter` show it
If I don't understand wrong, `negative prompt` and `prompt` are handled the same way, except that the latter allows `AND`.
So it seems a token counter for negative prompt can be helpful.

## 2. The shortcut `alt+enter` not works for negative prompt
Obviously, this shortcut should work.

## misc
* Fix `prompt`'s css error. Now the css setting of no border for `prompt` works.
* Add `alt+enter` hint in the placeholder.

# Preview
When nothing input:
![image](https://user-images.githubusercontent.com/82883326/195766379-42e1bfb5-67b2-442c-9362-b6fd320274da.png)

After inputing something:
![image](https://user-images.githubusercontent.com/82883326/195766322-7e344b09-a5a4-4b23-ae21-f1a472e98d2f.png)

Also tested for img2img:
![image](https://user-images.githubusercontent.com/82883326/195766507-a2113722-00c1-4422-a362-a340780bcd70.png)

**I have noticed that the negative prompt does not support AND, so I have made a distinction in token counter. (as shown in the test for img2img)**


