### PR TITLE
preview image settings for training hypernetworks/embeddings

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -180,7 +180,7 @@ def attention_CrossAttention_forward(self, x, context=None, mask=None):
     return self.to_out(out)
 
 
-def train_hypernetwork(hypernetwork_name, learn_rate, data_root, log_directory, steps, create_image_every, save_hypernetwork_every, template_file, preview_image_prompt):
+def train_hypernetwork(hypernetwork_name, learn_rate, data_root, log_directory, steps, create_image_every, save_hypernetwork_every, template_file, preview_image_prompt, preview_image_steps, preview_image_width, preview_image_height, preview_image_negative_prompt, preview_image_cfg_scale, preview_image_sampler_index):
     assert hypernetwork_name, 'hypernetwork not selected'
 
     path = shared.hypernetworks.get(hypernetwork_name, None)
@@ -274,7 +274,12 @@ def train_hypernetwork(hypernetwork_name, learn_rate, data_root, log_directory, 
             p = processing.StableDiffusionProcessingTxt2Img(
                 sd_model=shared.sd_model,
                 prompt=preview_text,
-                steps=20,
+                steps=preview_image_steps,
+                width=preview_image_width,
+                height=preview_image_height,
+                negative_prompt=preview_image_negative_prompt,
+                cfg_scale=preview_image_cfg_scale,
+                sampler_index=preview_image_sampler_index,
                 do_not_save_grid=True,
                 do_not_save_samples=True,
             )

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -172,7 +172,7 @@ def create_embedding(name, num_vectors_per_token, init_text='*'):
     return fn
 
 
-def train_embedding(embedding_name, learn_rate, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_image_prompt):
+def train_embedding(embedding_name, learn_rate, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_image_prompt, preview_image_steps, preview_image_width, preview_image_height, preview_image_negative_prompt, preview_image_cfg_scale, preview_image_sampler_index):
     assert embedding_name, 'embedding not selected'
 
     shared.state.textinfo = "Initializing textual inversion training..."
@@ -264,9 +264,12 @@ def train_embedding(embedding_name, learn_rate, data_root, log_directory, traini
             p = processing.StableDiffusionProcessingTxt2Img(
                 sd_model=shared.sd_model,
                 prompt=preview_text,
-                steps=20,
-                height=training_height,
-                width=training_width,
+                steps=preview_image_steps,
+                negative_prompt=preview_image_negative_prompt,
+                cfg_scale=preview_image_cfg_scale,
+                sampler_index=preview_image_sampler_index,
+                width=preview_image_width,
+                height=preview_image_height,
                 do_not_save_grid=True,
                 do_not_save_samples=True,
             )

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1101,6 +1101,12 @@ def create_ui(wrap_gradio_gpu_call):
                     save_embedding_every = gr.Number(label='Save a copy of embedding to log directory every N steps, 0 to disable', value=500, precision=0)
                     save_image_with_stored_embedding = gr.Checkbox(label='Save images with embedding in PNG chunks', value=True)
                     preview_image_prompt = gr.Textbox(label='Preview prompt', value="")
+                    preview_image_negative_prompt = gr.Textbox(label='Preview negative prompt', value="")
+                    preview_image_steps = gr.Slider(minimum=1, maximum=150, step=1, label="Preview sampling steps", value=20)
+                    preview_image_sampler_index = gr.Radio(label='Preview sampling method', elem_id="txt2img_sampling", choices=[x.name for x in samplers], value=samplers[0].name, type="index")
+                    preview_image_width = gr.Slider(minimum=64, maximum=2048, step=64, label="Preview width", value=512)
+                    preview_image_height = gr.Slider(minimum=64, maximum=2048, step=64, label="Preview weight", value=512)
+                    preview_image_cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Preview CFG scale', value=7.0)
 
                     with gr.Row():
                         interrupt_training = gr.Button(value="Interrupt")
@@ -1179,6 +1185,12 @@ def create_ui(wrap_gradio_gpu_call):
                 template_file,
                 save_image_with_stored_embedding,
                 preview_image_prompt,
+                preview_image_steps,
+                preview_image_width,
+                preview_image_height,
+                preview_image_negative_prompt,
+                preview_image_cfg_scale,
+                preview_image_sampler_index
             ],
             outputs=[
                 ti_output,
@@ -1199,6 +1211,12 @@ def create_ui(wrap_gradio_gpu_call):
                 save_embedding_every,
                 template_file,
                 preview_image_prompt,
+                preview_image_steps,
+                preview_image_width,
+                preview_image_height,
+                preview_image_negative_prompt,
+                preview_image_cfg_scale,
+                preview_image_sampler_index
             ],
             outputs=[
                 ti_output,


### PR DESCRIPTION
Hi so according to the hypernetworks tutorial [here](https://rentry.org/hypernetwork4dumdums#step-5-training-and-testing) you need to edit `hypernetworks.py` to change image preview settings

I wanted to make it easier to fiddle around with so I added some new options to the training ui

Thanks for all your hard work and good luck weathering the coming singularity