### PR TITLE
Change grid row count autodetect to prevent empty spots

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -23,10 +23,13 @@ def image_grid(imgs, batch_size=1, rows=None):
             rows = opts.n_rows
         elif opts.n_rows == 0:
             rows = batch_size
-        else:
+        elif opts.grid_prevent_empty_spots:
             rows = math.floor(math.sqrt(len(imgs)))
             while len(imgs) % rows != 0:
                 rows -= 1
+        else:
+            rows = math.sqrt(len(imgs))
+            rows = round(rows)
 
     cols = math.ceil(len(imgs) / rows)
 

--- a/modules/images.py
+++ b/modules/images.py
@@ -24,8 +24,9 @@ def image_grid(imgs, batch_size=1, rows=None):
         elif opts.n_rows == 0:
             rows = batch_size
         else:
-            rows = math.sqrt(len(imgs))
-            rows = round(rows)
+            rows = math.floor(math.sqrt(len(imgs)))
+            while len(imgs) % rows != 0:
+                rows -= 1
 
     cols = math.ceil(len(imgs) / rows)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -175,6 +175,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "grid_format": OptionInfo('png', 'File format for grids'),
     "grid_extended_filename": OptionInfo(False, "Add extended info (seed, prompt) to filename when saving grid"),
     "grid_only_if_multiple": OptionInfo(True, "Do not save grids consisting of one picture"),
+    "grid_prevent_empty_spots": OptionInfo(False, "Prevent empty spots in grid (when set to autodetect)"),
     "n_rows": OptionInfo(-1, "Grid row count; use -1 for autodetect and 0 for it to be same as batch size", gr.Slider, {"minimum": -1, "maximum": 16, "step": 1}),
 
     "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),


### PR DESCRIPTION
Instead of just rounding (sometimes resulting in grids with "empty" spots), find a divisor.
For example: 8 images will now result in a 4x2 grid instead of a 3x3 with one empty spot.

_(Much better for 8, 10, 15, 18, etc. but probably worse for large prime numbers.)_