### PR TITLE
Disable compiling deepbooru model

### DIFF
--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -102,7 +102,7 @@ def get_deepbooru_tags_model():
 
     tags = dd.project.load_tags_from_project(model_path)
     model = dd.project.load_model_from_project(
-        model_path, compile_model=True
+        model_path, compile_model=False
     )
     return model, tags
 


### PR DESCRIPTION
Compiling model produces following warning when using **Interrogate DeepBooru**.

```
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
```

Compiling is only necessary when you have to train, so I've just disabled compiling.

Ref: https://stackoverflow.com/a/57054106/12818768