### PR TITLE
Auto re-open selected image in gallery when re-generation

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -67,12 +67,13 @@ function check_gallery(id_gallery){
         if(galleryObservers[id_gallery]){
             galleryObservers[id_gallery].disconnect();
         }
+        let prevSelectedIndex = selected_gallery_index();
         galleryObservers[id_gallery] = new MutationObserver(function (){
             let galleryButtons = gradioApp().querySelectorAll('#'+id_gallery+' .gallery-item')
             let galleryBtnSelected = gradioApp().querySelector('#'+id_gallery+' .gallery-item.\\!ring-2')
-            if (galleryButtons.length === 1 && !galleryBtnSelected) {
-                //automatically open when there is only 1 gallery btn, and was previously selected
-                galleryButtons[0].click();
+            if (prevSelectedIndex !== -1 && galleryButtons.length>prevSelectedIndex && !galleryBtnSelected) {
+                //automatically re-open previously selected index (if exists)
+                galleryButtons[prevSelectedIndex].click();
             }
         })
         galleryObservers[id_gallery].observe( gallery, { childList:true, subtree:false })

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -74,9 +74,7 @@ function check_gallery(id_gallery){
             if (prevSelectedIndex !== -1 && galleryButtons.length>prevSelectedIndex && !galleryBtnSelected) {
                 //automatically re-open previously selected index (if exists)
                 galleryButtons[prevSelectedIndex].click();
-		setTimeout(function (){
-                    showGalleryImage()
-                },100)
+		showGalleryImage();
             }
         })
         galleryObservers[id_gallery].observe( gallery, { childList:true, subtree:false })

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -74,6 +74,9 @@ function check_gallery(id_gallery){
             if (prevSelectedIndex !== -1 && galleryButtons.length>prevSelectedIndex && !galleryBtnSelected) {
                 //automatically re-open previously selected index (if exists)
                 galleryButtons[prevSelectedIndex].click();
+		setTimeout(function (){
+                    showGalleryImage()
+                },100)
             }
         })
         galleryObservers[id_gallery].observe( gallery, { childList:true, subtree:false })

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -71,7 +71,6 @@ function check_gallery(id_gallery){
             if (galleryButtons.length === 1 && !galleryBtnSelected) {
                 //automatically open when there is only 1 gallery btn, and was previously selected
                 galleryButtons[0].click();
-                console.log('clicked');
             }
         })
         galleryObservers[id_gallery].observe( gallery, { childList:true, subtree:false })

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -42,13 +42,15 @@ function check_progressbar(id_part, id_progressbar, id_progressbar_span, id_skip
                         skip.style.display = "none"
                     }
                     interrupt.style.display = "none"
+			
+                    //disconnect observer once generation finished, so user can close selected image if they want
+                    if (galleryObservers[id_gallery]) {
+                        galleryObservers[id_gallery].disconnect();
+                        galleries[id_gallery] = null;
+                    }    
                 }
 
-				//disconnect observer once generation finished, so user can close selected image if they want
-				if (galleryObservers[id_gallery]) {
-					galleryObservers[id_gallery].disconnect();
-					galleries[id_gallery] = null;
-				}    
+
             }
 
             window.setTimeout(function() { requestMoreProgress(id_part, id_progressbar_span, id_skip, id_interrupt) }, 500)


### PR DESCRIPTION
Fix #2326 #2398 #2445

As above tickets reported, after bump version to gradio 3.4.1(https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/d7474a5185df2af84a93a12bc7e140d24e0fc516), selected image no longer stays selected when you re-generate an image. Every thing is reset to small thumbnail mode in gallery, making re-touch image multiple times a pain.

It is not clear to me if it's a gradio bug or intended.  A  javascript walkaround on webui might be best approach for now.

## How it works

This PR attaches an observer to gallery when generation in progress

- if there was an image selected in gallery and gradio closes the image after re-generation, auto re-open new result at the previous index after generation.
- If no image is selected, nothing happens.

This matches behavior of prior to Gradio 3.4.1 version bump. Because it's done with observer, user should not notice the preview window ever being closed.

single image:

![chrome_2022-10-14_17-14-06](https://user-images.githubusercontent.com/873853/195960146-4709592b-3411-4fd4-a6bd-a089d627747e.gif)

multiple images:
![chrome_2022-10-14_17-14-43](https://user-images.githubusercontent.com/873853/195960122-bb800ce6-6f4b-4cca-924b-54dd3360202f.gif)


