### PR TITLE
Raise an assertion error if no training images have been found.

### DIFF
--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -81,7 +81,8 @@ class PersonalizedBase(Dataset):
                 entry.cond = cond_model([entry.cond_text]).to(devices.cpu)
 
             self.dataset.append(entry)
-
+        
+        assert len(self.dataset) > 1, "No images have been found in the dataset."
         self.length = len(self.dataset) * repeats
 
         self.initial_indexes = np.arange(self.length) % len(self.dataset)


### PR DESCRIPTION
If you accidently set a folder that contains no images, the call to `__getitem__` will fail with an division by zero Instead, now we simply raise an assertion error to tell the user we did not find any images.