### PR TITLE
Fix directory for image history feature

### DIFF
--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -97,7 +97,9 @@ def delete_image(delete_num, tabname, dir_name, name, page_index, filenames, ima
 
 
 def show_images_history(gr, opts, tabname, run_pnginfo, switch_dict):
-    if tabname == "txt2img":
+    if opts.outdir_samples != "":
+        dir_name = opts.outdir_samples
+    elif tabname == "txt2img":
         dir_name = opts.outdir_txt2img_samples
     elif tabname == "img2img":
         dir_name = opts.outdir_img2img_samples

--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -104,7 +104,7 @@ def show_images_history(gr, opts, tabname, run_pnginfo, switch_dict):
     elif tabname == "extras":
         dir_name = opts.outdir_extras_samples
     d = dir_name.split("/")
-    dir_name = d[0]
+    dir_name = "/" if dir_name.startswith("/") else d[0]
     for p in d[1:]:
         dir_name = os.path.join(dir_name, p)
     with gr.Row():


### PR DESCRIPTION
Fixed two issues.
- In images_history.py, the output directory was treated as a relative path even though it is an absolute path in the configuration.
- "outdir_samples" directory is not used even though it is specified.