### PR TITLE
added refresh button to embedding and hypernetwork dropdowns in Train…

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -538,6 +538,24 @@ def create_ui(wrap_gradio_gpu_call):
     import modules.img2img
     import modules.txt2img
 
+    def create_refresh_button(refresh_component, refresh_method, refreshed_args, elem_id):
+        def refresh():
+            refresh_method()
+            args = refreshed_args() if callable(refreshed_args) else refreshed_args
+
+            for k, v in args.items():
+                setattr(refresh_component, k, v)
+
+            return gr.update(**(args or {}))
+
+        refresh_button = gr.Button(value=refresh_symbol, elem_id=elem_id)
+        refresh_button.click(
+            fn = refresh,
+            inputs = [],
+            outputs = [refresh_component]
+        )
+        return refresh_button
+
     with gr.Blocks(analytics_enabled=False) as txt2img_interface:
         txt2img_prompt, roll, txt2img_prompt_style, txt2img_negative_prompt, txt2img_prompt_style2, submit, _, _, txt2img_prompt_style_apply, txt2img_save_style, txt2img_paste, token_counter, token_button = create_toprow(is_img2img=False)
         dummy_component = gr.Label(visible=False)
@@ -1163,8 +1181,12 @@ def create_ui(wrap_gradio_gpu_call):
 
                 with gr.Tab(label="Train"):
                     gr.HTML(value="<p style='margin-bottom: 0.7em'>Train an embedding; must specify a directory with a set of 1:1 ratio images</p>")
-                    train_embedding_name = gr.Dropdown(label='Embedding', choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys()))
-                    train_hypernetwork_name = gr.Dropdown(label='Hypernetwork', choices=[x for x in shared.hypernetworks.keys()])
+                    with gr.Row():
+                        train_embedding_name = gr.Dropdown(label='Embedding', choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys()))
+                        create_refresh_button(train_embedding_name, sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings, lambda: {"choices": sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys())}, "refresh_train_embedding_name")
+                    with gr.Row():
+                        train_hypernetwork_name = gr.Dropdown(label='Hypernetwork', choices=[x for x in shared.hypernetworks.keys()])
+                        create_refresh_button(train_hypernetwork_name, shared.reload_hypernetworks, lambda: {"choices": sorted([x for x in shared.hypernetworks.keys()])}, "refresh_train_hypernetwork_name")
                     learn_rate = gr.Textbox(label='Learning rate', placeholder="Learning rate", value="0.005")
                     dataset_directory = gr.Textbox(label='Dataset directory', placeholder="Path to directory with input images")
                     log_directory = gr.Textbox(label='Log directory', placeholder="Path to directory where to write outputs", value="textual_inversion")
@@ -1312,26 +1334,11 @@ def create_ui(wrap_gradio_gpu_call):
         if info.refresh is not None:
             if is_quicksettings:
                 res = comp(label=info.label, value=fun, **(args or {}))
-                refresh_button = gr.Button(value=refresh_symbol, elem_id="refresh_"+key)
+                refresh_button = create_refresh_button(res, info.refresh, info.component_args, "refresh_" + key)
             else:
                 with gr.Row(variant="compact"):
                     res = comp(label=info.label, value=fun, **(args or {}))
-                    refresh_button = gr.Button(value=refresh_symbol, elem_id="refresh_" + key)
-
-            def refresh():
-                info.refresh()
-                refreshed_args = info.component_args() if callable(info.component_args) else info.component_args
-
-                for k, v in refreshed_args.items():
-                    setattr(res, k, v)
-
-                return gr.update(**(refreshed_args or {}))
-
-            refresh_button.click(
-                fn=refresh,
-                inputs=[],
-                outputs=[res],
-            )
+                    refresh_button = create_refresh_button(res, info.refresh, info.component_args, "refresh_" + key)
         else:
             res = comp(label=info.label, value=fun, **(args or {}))
 

--- a/style.css
+++ b/style.css
@@ -491,7 +491,7 @@ input[type="range"]{
     padding: 0;
 }
 
-#refresh_sd_model_checkpoint, #refresh_sd_hypernetwork{
+#refresh_sd_model_checkpoint, #refresh_sd_hypernetwork, #refresh_train_hypernetwork_name, #refresh_train_embedding_name{
     max-width: 2.5em;
     min-width: 2.5em;
     height: 2.4em;


### PR DESCRIPTION
## Problem
everytime I modified pt files in `embedding_dir` or `hypernetwork_dir`, I
need to restart webui to have the new files shown in the dropdown of
Train Tab

## Solution
refactored `create_refresh_button` out of `create_setting_component` so we
can use this method to create button next to `gr.Dropdown`s of embedding
name and hypernetworks

## Extra Modification
hypernetwork pt are now sorted in alphabetic order

## Test Video
https://drive.google.com/file/d/1N4Jw4vek8WwMmS8czPvI0bv8bLXTTbSX/view?usp=sharing