### PR TITLE
Add actions/stale workflow to automatically close issues stale for 14 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '31 4 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 14
+        days-before-pr-stale: 365
+        days-before-close: 3
+        exempt-all-assignees: True
+        stale-issue-message: 'As there has been no activity in this issue for 14 days, this issue is now marked as stale. It will be closed in 3 days if it remains stale.'
+        stale-pr-message: 'As there has been no activity in this PR for 365 days, this PR is now marked as stale. It will be closed in 3 days if it remains stale.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        close-issue-message: 'Closed stale issue.'
+        close-pr-message: 'Closed stale PR.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,6 +25,7 @@ jobs:
         days-before-pr-stale: 365
         days-before-close: 3
         exempt-all-assignees: True
+        exempt-issue-labels: 'bug, enhancement, dreams'
         stale-issue-message: 'As there has been no activity in this issue for 14 days, this issue is now marked as stale. It will be closed in 3 days if it remains stale.'
         stale-pr-message: 'As there has been no activity in this PR for 365 days, this PR is now marked as stale. It will be closed in 3 days if it remains stale.'
         stale-issue-label: 'stale'


### PR DESCRIPTION
This PR adds stale.yml which marks issues in which there is no activity for 14 days and PRs inactive for a year as "stale".

If these issues/PRs remain stale for 3 days, they will be automatically closed.