### PR TITLE
Fix download section layout

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -594,7 +594,7 @@ def create_ui(wrap_gradio_gpu_call):
                     txt2img_preview = gr.Image(elem_id='txt2img_preview', visible=False)
                     txt2img_gallery = gr.Gallery(label='Output', show_label=False, elem_id='txt2img_gallery').style(grid=4)
 
-                with gr.Group():
+                with gr.Column():
                     with gr.Row():
                         save = gr.Button('Save')
                         send_to_img2img = gr.Button('Send to img2img')
@@ -809,7 +809,7 @@ def create_ui(wrap_gradio_gpu_call):
                     img2img_preview = gr.Image(elem_id='img2img_preview', visible=False)
                     img2img_gallery = gr.Gallery(label='Output', show_label=False, elem_id='img2img_gallery').style(grid=4)
 
-                with gr.Group():
+                with gr.Column():
                     with gr.Row():
                         save = gr.Button('Save')
                         img2img_send_to_img2img = gr.Button('Send to img2img')

--- a/style.css
+++ b/style.css
@@ -241,13 +241,6 @@ fieldset span.text-gray-500, .gr-block.gr-box span.text-gray-500,  label.block s
     margin: 0;
 }
 
-.gr-panel div.flex-col div.justify-between div{
-  position: absolute;
-  top: -0.1em;
-  right: 1em;
-  padding: 0 0.5em;
-}
-
 #settings .gr-panel div.flex-col div.justify-between div{
     position: relative;
     z-index: 200;


### PR DESCRIPTION
Before: 
![chrome_2022-10-15_00-36-45](https://user-images.githubusercontent.com/873853/195978374-c5a03991-3717-42ab-a8a6-b806febc82b1.png)

After:
![chrome_2022-10-15_01-21-11](https://user-images.githubusercontent.com/873853/195978378-7d110e0e-1107-44ac-8d35-62b48edda961.png)

## What changed
- `gr.Group()` probably won't meant to be used here, it has 0 gaps/margins.  Changed to `gr.Column()` which has a 1rem gap between rows.   
- the texts for file downloads are stacked together because of custom css override, the selector`.gr-panel div.flex-col div.justify-between div` was meant to control range input label position. After gradio 3.4.1 bump, the element has been changed to `input`, which has a different selector `.gr-box > div > div > input.gr-text-input` in css file. The old selector is no longer needed.

before: 
![chrome_2022-10-15_02-14-12](https://user-images.githubusercontent.com/873853/195978969-1b923572-e5b3-4b0c-b431-9649bc4d5ca3.png)

after gradio 3.4.1:
![chrome_2022-10-15_02-15-34](https://user-images.githubusercontent.com/873853/195978973-3b52800b-0f20-4e1e-9848-e5671f656c81.png)
