### PR TITLE
Prevent modal content from being selected

### DIFF
--- a/style.css
+++ b/style.css
@@ -316,6 +316,8 @@ input[type="range"]{
   height: 100%;
   overflow: auto;
   background-color: rgba(20, 20, 20, 0.95);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .modalControls {


### PR DESCRIPTION
When the gallery is clicked in quick succession, sometimes the image in the full screen modal is selected and highlighted, which can be annoying.
This PR prevents that from happening.