### PR TITLE
Add xformers for Lovelace and Hopper

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -104,7 +104,7 @@ def prepare_enviroment():
     args = shlex.split(commandline_args)
 
     args, skip_torch_cuda_test = extract_arg(args, '--skip-torch-cuda-test')
-    args, reinstall_xformers = extract_argg(args, '--reinstall-xformers')
+    args, reinstall_xformers = extract_arg(args, '--reinstall-xformers')
     xformers = '--xformers' in args
     deepdanbooru = '--deepdanbooru' in args
     ngrok = '--ngrok' in args

--- a/launch.py
+++ b/launch.py
@@ -107,6 +107,7 @@ def prepare_enviroment():
     xformers = '--xformers' in args
     deepdanbooru = '--deepdanbooru' in args
     ngrok = '--ngrok' in args
+    reinstall_xformers = '--reinstall-xformers' in args
 
     try:
         commit = run(f"{git} rev-parse HEAD").strip()
@@ -128,9 +129,9 @@ def prepare_enviroment():
     if not is_installed("clip"):
         run_pip(f"install {clip_package}", "clip")
 
-    if not is_installed("xformers") and xformers and platform.python_version().startswith("3.10"):
+    if (not is_installed("xformers") or reinstall_xformers) and xformers and platform.python_version().startswith("3.10"):
         if platform.system() == "Windows":
-            run_pip("install https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/c/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
+            run_pip("install -U -I --no-deps https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/f/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl", "xformers")
         elif platform.system() == "Linux":
             run_pip("install xformers", "xformers")
 

--- a/launch.py
+++ b/launch.py
@@ -104,10 +104,10 @@ def prepare_enviroment():
     args = shlex.split(commandline_args)
 
     args, skip_torch_cuda_test = extract_arg(args, '--skip-torch-cuda-test')
+    args, reinstall_xformers = extract_argg(args, '--reinstall-xformers')
     xformers = '--xformers' in args
     deepdanbooru = '--deepdanbooru' in args
     ngrok = '--ngrok' in args
-    reinstall_xformers = '--reinstall-xformers' in args
 
     try:
         commit = run(f"{git} rev-parse HEAD").strip()

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -24,7 +24,7 @@ def apply_optimizations():
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
 
-    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (8, 6)):
+    if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)):
         print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward


### PR DESCRIPTION
This PR updates the prebuilt wheel with my new one that supports Pascal to Hopper, and adds a `--reinstall-xformers` argument to force reinstall xformers as large amounts of users struggled to perform this operation manually.