### PR TITLE
Add styles to UI Config

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -508,9 +508,11 @@ def create_toprow(is_img2img):
             with gr.Row():
                 with gr.Column(scale=1, elem_id="style_pos_col"):
                     prompt_style = gr.Dropdown(label="Style 1", elem_id=f"{id_part}_style_index", choices=[k for k, v in shared.prompt_styles.styles.items()], value=next(iter(shared.prompt_styles.styles.keys())))
+                    prompt_style.save_to_config = True
 
                 with gr.Column(scale=1, elem_id="style_neg_col"):
                     prompt_style2 = gr.Dropdown(label="Style 2", elem_id=f"{id_part}_style2_index", choices=[k for k, v in shared.prompt_styles.styles.items()], value=next(iter(shared.prompt_styles.styles.keys())))
+                    prompt_style2.save_to_config = True
 
     return prompt, roll, prompt_style, negative_prompt, prompt_style2, submit, button_interrogate, button_deepbooru, prompt_style_apply, save_style, paste, token_counter, token_button
 
@@ -1725,6 +1727,11 @@ Requested path was: {f}
             apply_field(x, 'value')
 
         if type(x) == gr.Number:
+            apply_field(x, 'value')
+
+        # Since there are many dropdowns that shouldn't be saved,
+        # we only mark dropdowns that should be saved.
+        if type(x) == gr.Dropdown and getattr(x, 'save_to_config', False):
             apply_field(x, 'value')
 
     visit(txt2img_interface, loadsave, "txt2img")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1732,7 +1732,7 @@ Requested path was: {f}
         # Since there are many dropdowns that shouldn't be saved,
         # we only mark dropdowns that should be saved.
         if type(x) == gr.Dropdown and getattr(x, 'save_to_config', False):
-            apply_field(x, 'value')
+            apply_field(x, 'value', lambda val: val in x.choices)
 
     visit(txt2img_interface, loadsave, "txt2img")
     visit(img2img_interface, loadsave, "img2img")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1705,7 +1705,9 @@ Requested path was: {f}
             saved_value = ui_settings.get(key, None)
             if saved_value is None:
                 ui_settings[key] = getattr(obj, field)
-            elif condition is None or condition(saved_value):
+            elif condition and not condition(saved_value):
+                print(f'Warning: Bad ui setting value: {key}: {saved_value}; Default value "{getattr(obj, field)}" will be used instead.')
+            else:
                 setattr(obj, field, saved_value)
 
         if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number] and x.visible:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28638469/196005866-44712114-0a5a-479d-87a4-31cf538c268d.png)

Now user can set Styles from `ui-config.json`.

To set styles other than None at the start of the program, set style's name at the `ui-config.json`.  
ex: `"txt2img/Style 1/value": "my_style"`

If user uses bad UI setting, (ex: use style name that doesn't exists) program warns it and uses default UI setting.  
(Previous behaviour was to quietly use default UI setting, without warning.)