### PR TITLE
Clean Layout Toprow + Artists and Embeddings-Insertor near styles

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -496,9 +496,7 @@ def create_toprow(is_img2img):
 
         button_interrogate = None
         button_deepbooru = None
-        if is_img2img:
-            with gr.Column(scale=1, elem_id="interrogate_col"):
-                button_interrogate = gr.Button('Interrogate\nCLIP', elem_id="interrogate")
+        
 
         with gr.Column(variant='panel'): #big right
             with gr.Row():
@@ -514,6 +512,12 @@ def create_toprow(is_img2img):
                             with gr.Row(elem_id="pasteRollButtonRow"):
                                 paste = gr.Button(value=paste_symbol + " Apply prompt", elem_id="paste")
                                 roll = gr.Button(value=art_symbol+" Random artist", elem_id="roll", visible=len(shared.artist_db.artists) > 0)
+   
+                                if is_img2img:
+                                    with gr.Row(scale=1):
+                                        button_interrogate = gr.Button('Interrogate\nCLIP', elem_id="interrogate")
+                                        if cmd_opts.deepdanbooru:
+                                            button_deepbooru = gr.Button('Interrogate\nDeepBooru', elem_id="deepbooru")
         
                 with gr.Column(scale=1):
                     artistsDD = gr.Dropdown(allowedArtists, Interactive=True, label="Artists", show_label=True, elem_id="artistsDD", visible=len(allowedArtists) > 0)
@@ -522,7 +526,8 @@ def create_toprow(is_img2img):
                         skip = gr.Button('Skip', elem_id=f"{id_part}_skip")
                         interrupt = gr.Button('Interrupt', elem_id=f"{id_part}_interrupt")
                         submit = gr.Button('Generate', elem_id=f"{id_part}_generate", variant='primary')
-  
+
+ 
                 skip.click(
                     fn=lambda: shared.state.skip(),
                     inputs=[],
@@ -535,18 +540,8 @@ def create_toprow(is_img2img):
                     outputs=[],
                 )
 
-            with gr.Row(scale=1):
-                if is_img2img:
-                    interrogate = gr.Button('Interrogate\nCLIP', elem_id="interrogate")
-                    if cmd_opts.deepdanbooru:
-                        deepbooru = gr.Button('Interrogate\nDeepBooru', elem_id="deepbooru")
-                    else:
-                        deepbooru = None
-                else:
-                    interrogate = None
-                    deepbooru = None
 
-    return prompt, roll, prompt_style, negative_prompt, prompt_style2, submit, interrogate, deepbooru, prompt_style_apply, save_style, paste, token_counter, token_button, embStyleDD, artistsDD
+    return prompt, roll, prompt_style, negative_prompt, prompt_style2, submit, button_interrogate, button_deepbooru, prompt_style_apply, save_style, paste, token_counter, token_button, embStyleDD, artistsDD
 
 
 def setup_progressbar(progressbar, preview, id_part, textinfo=None):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -487,9 +487,9 @@ def create_toprow(is_img2img):
 
             with gr.Column(scale=3, elem_id="promptsCol"):
                 with gr.Row(elem_id="promptRow"):
-                    prompt = gr.Textbox( lines=2,elem_id=f"{id_part}_prompt", show_label=False, placeholder="Prompt")
+                    prompt = gr.Textbox( lines=2,elem_id=f"{id_part}_prompt", show_label=False, placeholder="Prompt (press Ctrl+Enter or Alt+Enter to generate)")
                 with gr.Row(elem_id="negPromptRow"):
-                    negative_prompt = gr.Textbox(lines=2,elem_id="negative_prompt", show_label=False, placeholder="Negative prompt")
+                    negative_prompt = gr.Textbox(lines=2,elem_id="negative_prompt", show_label=False, placeholder="Negative prompt (press Ctrl+Enter or Alt+Enter to generate)")
                 with gr.Row(elem_id="tokenRow"):
                     token_counter = gr.HTML(value="<span></span>", elem_id=f"{id_part}_token_counter", visible = True)
                     token_button = gr.Button(visible=False, elem_id=f"{id_part}_token_button")

--- a/style.css
+++ b/style.css
@@ -53,7 +53,6 @@
     flex:1; 
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    margin-top: 0.75rem;
 }
 
 @media screen and (min-width: 2500px) {
@@ -138,24 +137,23 @@
     margin: 0.1em 0;
 }
 
-#pasteRollButtonRow, #zipRow {
+#zipRow {
     margin-top: 0.5rem;
 }
 
 #stylesButtonRow, #pasteRollButtonRow {
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    margin-top: 0.75rem;
-    gap: 0.5rem!important;
 }
 #interrogate_col{
 /*    min-width: 0 !important; */
-    max-width: 8em !important;
+/*    max-width: 8em !important; */
 }
+
 #interrogate, #deepbooru, #roll, #paste{
 /*    margin: 0em 0.25em 0.9em 0.25em; */
     min-width: 8em;
-    max-width: 8em;
+/*    max-width: 8em;  use row/flex instead of hard coded max width"
 }
 
 #toprow_button_col {

--- a/style.css
+++ b/style.css
@@ -50,6 +50,10 @@
 
 #txt2img_generate, #img2img_generate {
     min-height: 4.5em;
+    flex:1; 
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    margin-top: 0.75rem;
 }
 
 @media screen and (min-width: 2500px) {
@@ -115,7 +119,15 @@
     padding: 0.4em 0;
 }
 
-#roll, #paste, #style_create, #style_apply{
+/*
+#embStyle>label>select {
+    background-image: none;
+    background-size: 0;
+    padding-right: 0;
+}
+*/
+
+#embStyleButton{
     min-width: 2em;
     min-height: 2em;
     max-width: 2em;
@@ -126,21 +138,36 @@
     margin: 0.1em 0;
 }
 
+#pasteRollButtonRow, #zipRow {
+    margin-top: 0.5rem;
+}
+
+#stylesButtonRow, #pasteRollButtonRow {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    margin-top: 0.75rem;
+    gap: 0.5rem!important;
+}
 #interrogate_col{
-    min-width: 0 !important;
+/*    min-width: 0 !important; */
     max-width: 8em !important;
 }
-#interrogate, #deepbooru{
-    margin: 0em 0.25em 0.9em 0.25em;
+#interrogate, #deepbooru, #roll, #paste{
+/*    margin: 0em 0.25em 0.9em 0.25em; */
     min-width: 8em;
     max-width: 8em;
+}
+
+#toprow_button_col {
+    min-width: 2em !important;
+    max-width: 2em !important;
 }
 
 #style_pos_col, #style_neg_col{
     min-width: 8em !important;
 }
 
-#txt2img_style_index, #txt2img_style2_index, #img2img_style_index, #img2img_style2_index{
+#txt2img_style_index, #txt2img_style2_index, #img2img_style_index, #img2img_style2_index, #embStyle, #artistsDD{
     margin-top: 1em;
 }
 
@@ -155,8 +182,9 @@
 
 #toprow div{
     border: none;
-    gap: 0;
-    background: transparent;
+    gap: 0.25rem;
+    /*align-items: center;*/
+    /*background: transparent;*/
 }
 
 #resize_mode{
@@ -167,6 +195,25 @@ button{
     align-self: stretch !important;
 }
 
+#prompt, #negative_prompt{
+    border: none !important;
+    flex: 1;
+}
+
+
+#tokenRow {
+    /* upper prompts win, take rest */
+    flex:0
+}
+
+#txt2img_prompt {
+    flex:1;
+}
+
+#img2maskimg .h-60{
+    height: 30rem;
+}
+
 .overflow-hidden, .gr-panel{
     overflow: visible !important;
 }
@@ -174,6 +221,19 @@ button{
 #x_type, #y_type{
     max-width: 10em;
 }
+
+textarea {
+    resize: none;
+    border: none !important;
+    height: 100% !important;
+    flex:1;
+}
+
+/* very brutfore because gradio create label around textarea*/
+ label {
+    height: 100%; 
+}
+
 
 #txt2img_preview, #img2img_preview, #ti_preview{
     position: absolute;
@@ -256,9 +316,6 @@ input[type="range"]{
   display: block;
   margin-top: -0.75em;
   margin-bottom: -0.75em;
-}
-
-#txt2img_negative_prompt, #img2img_negative_prompt{
 }
 
 #txt2img_progressbar, #img2img_progressbar, #ti_progressbar{
@@ -410,7 +467,7 @@ input[type="range"]{
 #txt2img_interrupt, #img2img_interrupt{
   position: absolute;
   width: 50%;
-  height: 72px;
+  height: -webkit-fill-available;
   background: #b4c0cc;
   border-radius: 0px;
   display: none;
@@ -420,10 +477,14 @@ input[type="range"]{
   position: absolute;
   width: 50%;
   right: 0px;
-  height: 72px;
+  height: -webkit-fill-available;
   background: #b4c0cc;
   border-radius: 0px;
   display: none;
+}
+
+#generateRow {
+    flex: 1;
 }
 
 .red {
@@ -461,6 +522,21 @@ input[type="range"]{
     background: #a55000;
 }
 
+#promptsCol {
+    flex:1;
+}
+
+#promptRow {
+    flex: 2;
+}
+#negPromptRow {
+    flex: 1;
+}
+
+.dark .dark\:bg-gray-700 {
+    --tw-bg-opacity: 0!important;
+    background-color: rgb(55 65 81 / var(--tw-bg-opacity));
+}
 #quicksettings {
     gap: 0.4em;
 }


### PR DESCRIPTION
Hi Automatic1111,
second attempt, now without EOL changes and complete file diffs...

* This PR adds the Artists and Embeddings-Insertor near Style, where the complete TOPROW is revisited. (txt2img/img2img)
* Clear layout, more responsive prompt/style/generate sections.
* How it works: Select an artist or existing embedding from the dropdown and it will be added to the promp section, like the "roll artist" button

Reason: People start start to add many embeddings (not hypernetwork) and to handle the keywords behind each embedding, I mean the dropdown is quite helpful if not mandatory. 

Check the selected embedding in the screenshot, who will mnemorize such terms?
![image](https://user-images.githubusercontent.com/7210708/196015921-795c5a61-caae-49f4-adf1-2f6f5090c36f.png)

Artists list, know them all :-) (next: add category and maybe small example image)
![image](https://user-images.githubusercontent.com/7210708/196015955-b2375d72-bccb-4ecd-988d-1c8954a04faa.png)

img2img
![image](https://user-images.githubusercontent.com/7210708/196015981-be5166f8-3064-4877-bac0-d7e68705afa4.png)
