### PR TITLE
add update warning to launch.py

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -5,6 +5,7 @@ import sys
 import importlib.util
 import shlex
 import platform
+import requests
 
 dir_repos = "repositories"
 python = sys.executable
@@ -126,6 +127,16 @@ def prepare_enviroment():
     print(f"Python {sys.version}")
     print(f"Commit hash: {commit}")
 
+    try:
+        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
+        if commit != "<none>" and commits['commit']['sha'] != commit:
+            print("--------------------------------------------------------")
+            print("| You are not up to date with the most recent release. |")
+            print("| Consider running `git pull` to update.               |")
+            print("--------------------------------------------------------")
+    except Exception as e:
+        pass
+    
     if not is_installed("torch") or not is_installed("torchvision"):
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch")
 

--- a/launch.py
+++ b/launch.py
@@ -86,7 +86,24 @@ def git_clone(url, dir, name, commithash=None):
     if commithash is not None:
         run(f'"{git}" -C {dir} checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
 
+        
+def version_check(commit):
+    try:
+        import requests
+        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
+        if commit != "<none>" and commits['commit']['sha'] != commit:
+            print("--------------------------------------------------------")
+            print("| You are not up to date with the most recent release. |")
+            print("| Consider running `git pull` to update.               |")
+            print("--------------------------------------------------------")
+        elif commits['commit']['sha'] == commit:
+            print("You are up to date with the most recent release.")
+        else:
+            print("Not a git clone, can't perform version check.")
+    except Exception as e:
+        print("versipm check failed",e)
 
+        
 def prepare_enviroment():
     torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
@@ -165,16 +182,8 @@ def prepare_enviroment():
 
     sys.argv += args
 
-    try:
-        import requests
-        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
-        if commit != "<none>" and commits['commit']['sha'] != commit:
-            print("--------------------------------------------------------")
-            print("| You are not up to date with the most recent release. |")
-            print("| Consider running `git pull` to update.               |")
-            print("--------------------------------------------------------")
-    except Exception as e:
-        pass
+    if '--update-check' in args:
+        version_check(commit)
     
     if "--exit" in args:
         print("Exiting because of --exit argument")

--- a/launch.py
+++ b/launch.py
@@ -5,7 +5,6 @@ import sys
 import importlib.util
 import shlex
 import platform
-import requests
 
 dir_repos = "repositories"
 python = sys.executable
@@ -126,16 +125,6 @@ def prepare_enviroment():
 
     print(f"Python {sys.version}")
     print(f"Commit hash: {commit}")
-
-    try:
-        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
-        if commit != "<none>" and commits['commit']['sha'] != commit:
-            print("--------------------------------------------------------")
-            print("| You are not up to date with the most recent release. |")
-            print("| Consider running `git pull` to update.               |")
-            print("--------------------------------------------------------")
-    except Exception as e:
-        pass
     
     if not is_installed("torch") or not is_installed("torchvision"):
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch")
@@ -176,6 +165,17 @@ def prepare_enviroment():
 
     sys.argv += args
 
+    try:
+        import requests
+        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
+        if commit != "<none>" and commits['commit']['sha'] != commit:
+            print("--------------------------------------------------------")
+            print("| You are not up to date with the most recent release. |")
+            print("| Consider running `git pull` to update.               |")
+            print("--------------------------------------------------------")
+    except Exception as e:
+        pass
+    
     if "--exit" in args:
         print("Exiting because of --exit argument")
         exit(0)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -74,6 +74,7 @@ parser.add_argument("--disable-console-progressbars", action='store_true', help=
 parser.add_argument("--enable-console-prompts", action='store_true', help="print prompts to console when generating with txt2img and img2img", default=False)
 parser.add_argument('--vae-path', type=str, help='Path to Variational Autoencoders model', default=None)
 parser.add_argument("--disable-safe-unpickle", action='store_true', help="disable checking pytorch models for malicious code", default=False)
+parser.add_argument("--update-check", action='store_true', help="enable http check to confirm that the currently running version is the most recent release.", default=False)
 
 
 cmd_opts = parser.parse_args()


### PR DESCRIPTION
Add an update warning to launch.py that compares https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master to the current commit hash.

very notiable 80s hacker message is shown

```ASM
--------------------------------------------------------
| You are not up to date with the most recent release. |
| Consider running `git pull` to update.               |
--------------------------------------------------------
```

(Colours are sadly not accurate.)

alternatively using `{git} rev-parse origin/master` may be another option.