### PR TITLE
Make output folder only when output is created

### DIFF
--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-
+import sys
 
 def traverse_all_files(output_dir, image_list, curr_dir=None):
     curr_path = output_dir if curr_dir is None else os.path.join(output_dir, curr_dir)
@@ -24,10 +24,14 @@ def traverse_all_files(output_dir, image_list, curr_dir=None):
 
 def get_recent_images(dir_name, page_index, step, image_index, tabname):
     page_index = int(page_index)
-    f_list = os.listdir(dir_name)
     image_list = []
-    image_list = traverse_all_files(dir_name, image_list)
-    image_list = sorted(image_list, key=lambda file: -os.path.getctime(os.path.join(dir_name, file)))
+    if not os.path.exists(dir_name):
+        pass
+    elif os.path.isdir(dir_name):
+        image_list = traverse_all_files(dir_name, image_list)
+        image_list = sorted(image_list, key=lambda file: -os.path.getctime(os.path.join(dir_name, file)))
+    else:
+        print(f"ERROR: {dir_name} is not a directory. Check the path in the settings.", file=sys.stderr)
     num = 48 if tabname != "extras" else 12
     max_page_index = len(image_list) // num + 1
     page_index = max_page_index if page_index == -1 else page_index + step

--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -31,7 +31,7 @@ def get_recent_images(dir_name, page_index, step, image_index, tabname):
         image_list = traverse_all_files(dir_name, image_list)
         image_list = sorted(image_list, key=lambda file: -os.path.getctime(os.path.join(dir_name, file)))
     else:
-        print(f"ERROR: {dir_name} is not a directory. Check the path in the settings.", file=sys.stderr)
+        print(f'ERROR: "{dir_name}" is not a directory. Check the path in the settings.', file=sys.stderr)
     num = 48 if tabname != "extras" else 12
     max_page_index = len(image_list) // num + 1
     page_index = max_page_index if page_index == -1 else page_index + step

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -334,12 +334,6 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     seed = get_fixed_seed(p.seed)
     subseed = get_fixed_seed(p.subseed)
 
-    if p.outpath_samples is not None:
-        os.makedirs(p.outpath_samples, exist_ok=True)
-
-    if p.outpath_grids is not None:
-        os.makedirs(p.outpath_grids, exist_ok=True)
-
     modules.sd_hijack.model_hijack.apply_circular(p.tiling)
     modules.sd_hijack.model_hijack.clear_comments()
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1395,7 +1395,7 @@ def create_ui(wrap_gradio_gpu_call):
 
     def open_folder(f):
         if not os.path.exists(f):
-            print(f"{f} doesn't exist. After you create an image, the folder will be created.")
+            print(f'Folder "{f}" does not exist. After you create an image, the folder will be created.')
             return
         elif not os.path.isdir(f):
             print(f"""

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1394,7 +1394,10 @@ def create_ui(wrap_gradio_gpu_call):
     component_dict = {}
 
     def open_folder(f):
-        if not os.path.isdir(f):
+        if not os.path.exists(f):
+            print(f"{f} doesn't exist. After you create an image, the folder will be created.")
+            return
+        elif not os.path.isdir(f):
             print(f"""
 WARNING
 An open_folder request was made with an argument that is not a folder.


### PR DESCRIPTION
Current behaviour always creates txt2img and img2img output folder at the startup.

This makes a weird behaviour when user disabled "Always save all generated images" and "Always save all generated image grids" settings.  
User won't get any output saved, but output folder will still created.

Since `images.save_image` creates output folder by itself, we don't have to make output folder at the startup.


This PR will make output folder when user generates images,  
but it won't make output folder at all when user disabled saving images in settings.