### PR TITLE
fix: add null check when start running project the currentButton is null

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -31,7 +31,7 @@ function updateOnBackgroundChange() {
             }
         })
 
-        if (modalImage.src != currentButton.children[0].src) {
+        if (currentButton?.children?.length > 0 && modalImage.src != currentButton.children[0].src) {
             modalImage.src = currentButton.children[0].src;
             if (modalImage.style.display === 'none') {
                 modal.style.setProperty('background-image', `url(${modalImage.src})`)


### PR DESCRIPTION
`updateOnBackgroundChange()` will be called when project starts, but currentButton is null, add a null check to avoid this error.

![console error](https://user-images.githubusercontent.com/64416955/196048522-67ac0399-ee79-41eb-ac85-01ab889e5e3c.png)
