### PR TITLE
Print list of embeddings on embedding reload

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -137,6 +137,7 @@ class EmbeddingDatabase:
                 continue
 
         print(f"Loaded a total of {len(self.word_embeddings)} textual inversion embeddings.")
+        print("Embeddings:", ', '.join(self.word_embeddings.keys()))
 
     def find_embedding_at_position(self, tokens, offset):
         token = tokens[offset]


### PR DESCRIPTION
Prints in the format:

```
Loaded a total of 5 textual inversion embeddings.
Embeddings: dr-strange, victorian-lace, ricar, indiana
Running on local URL:  http://127.0.0.1:7860
```