### PR TITLE
Fix CLIP Interrogator and disable ranks for it

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -157,9 +157,9 @@ class InterrogateModels:
                     matches = self.rank(image_features, items, top_count=topn)
                     for match, score in matches:
                         if include_ranks:
-                            res += ", " + match
-                        else:
                             res += f", ({match}:{score})"
+                        else:
+                            res += ", " + match
 
         except Exception:
             print(f"Error interrogating", file=sys.stderr)


### PR DESCRIPTION
Sorry if something is wrong, it's my first pull request ever made...

This PR fixes strange interrogator behavior when it includes ranks to CLIP Interrogator described here https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2641
Besides that it also adds a crazy prompt weights to words (12-18 per word)
I looked into interrogate.py file, found an if statement which is IMO really wrong and changed it, now it works as intended

Example of wrong interrogation:

![image](https://user-images.githubusercontent.com/38957619/196061026-f862b310-e9aa-4361-885e-404b9cf12642.png)

Example of right interrogation: 

![image](https://user-images.githubusercontent.com/38957619/196061350-01a39eca-a801-4563-870c-9a70092c994f.png)