### PR TITLE
Fix #2750

### DIFF
--- a/javascript/imageMaskFix.js
+++ b/javascript/imageMaskFix.js
@@ -31,8 +31,8 @@ function imageMaskResize() {
 
     wrapper.style.width = `${wW}px`;
     wrapper.style.height = `${wH}px`;
-    wrapper.style.left = `${(w-wW)/2}px`;
-    wrapper.style.top = `${(h-wH)/2}px`;
+    wrapper.style.left = `0px`;
+    wrapper.style.top = `0px`;
 
     canvases.forEach( c => {
         c.style.width = c.style.height = '';


### PR DESCRIPTION
Left / top alignment of the inpainting image mask was necessary with gradio 3.4.1. In gradio 3.5 the parent div of the image mask is centered, so the left / top alignment put the mask in the wrong place as described in #2750 #2795 #2805. This fix was tested on Windows 10 / Chrome.