### PR TITLE
default to generating gradio auth

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -65,6 +65,7 @@ parser.add_argument("--hide-ui-dir-config", action='store_true', help="hide dire
 parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui settings", default=os.path.join(script_path, 'config.json'))
 parser.add_argument("--gradio-debug",  action='store_true', help="launch gradio with --debug option")
 parser.add_argument("--gradio-auth", type=str, help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
+parser.add_argument("--no-gradio-auth", action='store_true', help='Disable authentication for gradio. Not recommended due to concerns of RCE exploits')
 parser.add_argument("--gradio-img2img-tool", type=str, help='gradio image uploader tool: can be either editor for ctopping, or color-sketch for drawing', choices=["color-sketch", "editor"], default="editor")
 parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
 parser.add_argument("--styles-file", type=str, help="filename to use for styles", default=os.path.join(script_path, 'styles.csv'))


### PR DESCRIPTION
Right now, the `share=True` option defaults to no gradio auth. There have been RCE exploits for web ui currently and in the past, and new commits are not being audited for security.

This commit aims to fix this by automatically generating a temporary gradio login which will be output to the console when using the share=True option. This can be disabled by specifying your own auth with the `--gradio-auth` argument, or with a new argument named `--no-gradio-auth`.

People who use the `share=True` option probably don't realize they are opening up an attack vector that allows remote code execution, so I believe that this is a good solution to that problem.