### PR TITLE
Styles.csv encoding utf-8-sig, webui-user.bat change to script directory

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -45,7 +45,7 @@ class StyleDatabase:
         if not os.path.exists(path):
             return
 
-        with open(path, "r", encoding="utf8", newline='') as file:
+        with open(path, "r", encoding="utf-8-sig", newline='') as file:
             reader = csv.DictReader(file)
             for row in reader:
                 # Support loading old CSV format with "name, text"-columns
@@ -79,7 +79,7 @@ class StyleDatabase:
     def save_styles(self, path: str) -> None:
         # Write to temporary file first, so we don't nuke the file if something goes wrong
         fd, temp_path = tempfile.mkstemp(".csv")
-        with os.fdopen(fd, "w", encoding="utf8", newline='') as file:
+        with os.fdopen(fd, "w", encoding="utf-8-sig", newline='') as file:
             # _fields is actually part of the public API: typing.NamedTuple is a replacement for collections.NamedTuple,
             # and collections.NamedTuple has explicit documentation for accessing _fields. Same goes for _asdict()
             writer = csv.DictWriter(file, fieldnames=PromptStyle._fields)

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -1,4 +1,5 @@
 @echo off
+cd /d "%~dp0"
 
 set PYTHON=
 set GIT=


### PR DESCRIPTION
### change `styles.csv` encoding from utf8 to utf-8-sig
this allows for better compatibility for some programs such as Excel
**reason provided in next comment**

### changing work directory to script directory for `webui-user.bat`

so that the script can be executed via terminal without changing the work directory first

otherwise when the script tries to `call webui.bat` it may not find the file

this should be safe to merge
as the current has a built-in auto update system will stash the changes then restore it after pull
so this change should not overwriting existing `webui-user.bat`

this should only affect new downloads

OS: Windows
Browser chrome
Graphics card NVIDIA GTX 1650 4GB