### PR TITLE
prevent highlighting/selecting image

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -116,6 +116,7 @@ function showGalleryImage() {
                 e.dataset.modded = true;
                 if(e && e.parentElement.tagName == 'DIV'){
                     e.style.cursor='pointer'
+                    e.style.userSelect='none'
                     e.addEventListener('click', function (evt) {
                         if(!opts.js_modal_lightbox) return;
                         modalZoomSet(gradioApp().getElementById('modalImage'), opts.js_modal_lightbox_initially_zoomed)


### PR DESCRIPTION
Occasionally when clicking on an image just right, it causes the image to become selected. This small styling change prevents it from being selected.

before 
<img width="686" alt="image" src="https://user-images.githubusercontent.com/362590/196154488-88f5a609-0aab-4ba6-aacb-7c238f76dcf7.png">
after
<img width="669" alt="image" src="https://user-images.githubusercontent.com/362590/196154570-2a7794fd-ebcf-44ed-bacd-7fbdb4bcf78e.png">
