### PR TITLE
Disable weights auto swap with config option

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -264,6 +264,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "enable_emphasis": OptionInfo(True, "Emphasis: use (text) to make model pay more attention to text and [text] to make it pay less attention"),
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
+    "disable_weights_auto_swap": OptionInfo(False, "Disable auto swapping weights to match model hash in prompts"),
     "comma_padding_backtrack": OptionInfo(20, "Increase coherency by padding from the last comma within n tokens when using more than 75 tokens", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1 }),
     "filter_nsfw": OptionInfo(False, "Filter NSFW content"),
     'CLIP_stop_at_last_layers': OptionInfo(1, "Stop At last layers of CLIP model", gr.Slider, {"minimum": 1, "maximum": 12, "step": 1}),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -542,6 +542,10 @@ def apply_setting(key, value):
     if value is None:
         return gr.update()
 
+    # dont allow model to be swapped when model hash exists in prompt
+    if key == "sd_model_checkpoint" and opts.disable_weights_auto_swap:
+        return gr.update()
+
     if key == "sd_model_checkpoint":
         ckpt_info = sd_models.get_closet_checkpoint_match(value)
 


### PR DESCRIPTION
This config option will disable the model weights from being automatically changed from the prompt's `model hash` key.

I often find when iterating over new dreambooth models that I want to test old prompts with new models.  But when you use PNGInfo to load old prompts, it auto swaps back to my old dreambooth model, and I have to manually change back to the new one.  This ends up happening a lot and I got tired of it.

Tested working with, and without, the config option selected.

This should also address https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2831