### PR TITLE
Fix xformers attnblock

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -27,7 +27,7 @@ def apply_optimizations():
     if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)):
         print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         print("Applying v1 cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -27,7 +27,7 @@ def apply_optimizations():
     if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)):
         print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.cross_attention_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
     elif cmd_opts.opt_split_attention_v1:
         print("Applying v1 cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.split_cross_attention_forward_v1

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -292,15 +292,3 @@ def cross_attention_attnblock_forward(self, x):
 
         return h3
     
-def xformers_attnblock_forward(self, x):
-    try:
-        h_ = x
-        h_ = self.norm(h_)
-        q1 = self.q(h_).contiguous()
-        k1 = self.k(h_).contiguous()
-        v = self.v(h_).contiguous()
-        out = xformers.ops.memory_efficient_attention(q1, k1, v)
-        out = self.proj_out(out)
-        return x + out
-    except NotImplementedError:
-        return cross_attention_attnblock_forward(self, x)

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -301,6 +301,9 @@ def xformers_attnblock_forward(self, x):
         v = self.v(h_)
         b, c, h, w = q.shape
         q, k, v = map(lambda t: rearrange(t, 'b c h w -> b (h w) c'), (q, k, v))
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
         out = xformers.ops.memory_efficient_attention(q, k, v)
         out = rearrange(out, 'b (h w) c -> b c h w', h=h)
         out = self.proj_out(out)


### PR DESCRIPTION
In various threads, there's been reports of xformers degrading quality. After some debugging, I narrowed it down to xformers_attnblock_forward.

I failed at fixing this and believe it's probably impossible to fix. I think it's some issue related to the strides of `q, k ,v`. The CompVis code to rearrange tensors for this function leads to uneven stride sizes and that makes it incompatible with `memory_efficient_attention`.

Using legacy attnblock_forward fixes the quality loss issue. %5 slower on my 4090.

cc. @danthe3rd
Do you have any ideas about how we could properly implement xformers for this function?