### PR TITLE
Small updates that make the API more usable

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -2,14 +2,12 @@ from modules.api.processing import StableDiffusionProcessingAPI
 from modules.processing import StableDiffusionProcessingTxt2Img, process_images
 import modules.shared as shared
 import uvicorn
-from fastapi import FastAPI, Body, APIRouter
+from fastapi import Body, APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, Json
 import json
 import io
 import base64
-
-app = FastAPI()
 
 class TextToImageResponse(BaseModel):
     images: list[str] = Field(default=None, title="Image", description="The generated image in base64 format.")
@@ -18,7 +16,7 @@ class TextToImageResponse(BaseModel):
 
 
 class Api:
-    def __init__(self):
+    def __init__(self, app):
         self.router = APIRouter()
         app.add_api_route("/v1/txt2img", self.text2imgapi, methods=["POST"])
 

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -18,7 +18,7 @@ class TextToImageResponse(BaseModel):
 class Api:
     def __init__(self, app):
         self.router = APIRouter()
-        app.add_api_route("/v1/txt2img", self.text2imgapi, methods=["POST"])
+        app.add_api_route("/sdapi/v1/txt2img", self.text2imgapi, methods=["POST"])
 
     def text2imgapi(self, txt2imgreq: StableDiffusionProcessingAPI ):
         p = StableDiffusionProcessingTxt2Img(**vars(txt2imgreq))

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -74,7 +74,8 @@ parser.add_argument("--disable-console-progressbars", action='store_true', help=
 parser.add_argument("--enable-console-prompts", action='store_true', help="print prompts to console when generating with txt2img and img2img", default=False)
 parser.add_argument('--vae-path', type=str, help='Path to Variational Autoencoders model', default=None)
 parser.add_argument("--disable-safe-unpickle", action='store_true', help="disable checking pytorch models for malicious code", default=False)
-parser.add_argument("--api", action='store_true', help="use api=True to launch the api instead of the webui")
+parser.add_argument("--api", action='store_true', help="use api=True to launch the api with the webui")
+parser.add_argument("--nowebui", action='store_true', help="use api=True to launch the api instead of the webui")
 
 cmd_opts = parser.parse_args()
 restricted_opts = [

--- a/webui.py
+++ b/webui.py
@@ -96,14 +96,11 @@ def initialize():
 
 
 def api():
-    initialize()
-
     from modules.api.api import Api
-    api = Api()
-    api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
+    api = Api(app)
 
 
-def webui():
+def webui(launch_api=False):
     initialize()
 
     while 1:
@@ -121,6 +118,9 @@ def webui():
         )
 
         app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+        if (launch_api):
+            api(app)
 
         while 1:
             time.sleep(0.5)
@@ -143,6 +143,6 @@ def webui():
 
 if __name__ == "__main__":
     if cmd_opts.api:
-        api()
+        webui(True)
     else:
-        webui()
+        webui(False)


### PR DESCRIPTION
This brings in some of the discussion and comments I made in #765 about combining an API and the WebUI at the same time.  It also adds a --nowebui that disables the webui and forces the api to start up instead.  It's untested at the moment so it's more of an example.  I'll try to do some actual tests to it later tonight to see that the start up and both options work properly.  

I did also move the API endpoints into /sdapi/v1/ so that there's less chance of conflicts between the gradio api and the one provided here.