### PR TITLE
Don't eat colons in booru tags

### DIFF
--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -157,6 +157,7 @@ def get_deepbooru_tags_from_model(model, tags, pil_image, threshold, deepbooru_o
     # sort by reverse by likelihood and normal for alpha, and format tag text as requested
     unsorted_tags_in_theshold.sort(key=lambda y: y[sort_ndx], reverse=(not alpha_sort))
     for weight, tag in unsorted_tags_in_theshold:
+        tag_outformat = tag
         if use_spaces:
             tag_outformat = tag_outformat.replace('_', ' ')
         if use_escape:

--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -157,8 +157,6 @@ def get_deepbooru_tags_from_model(model, tags, pil_image, threshold, deepbooru_o
     # sort by reverse by likelihood and normal for alpha, and format tag text as requested
     unsorted_tags_in_theshold.sort(key=lambda y: y[sort_ndx], reverse=(not alpha_sort))
     for weight, tag in unsorted_tags_in_theshold:
-        # note: tag_outformat will still have a colon if include_ranks is True
-        tag_outformat = tag.replace(':', ' ')
         if use_spaces:
             tag_outformat = tag_outformat.replace('_', ' ')
         if use_escape:


### PR DESCRIPTION
Prevent colons in deepbooru output from being replaced by spaces, `:D` -> `D` for example.
I don't know why this line was added. Perhaps the author was not sure if `(:D:1.5)` works? But it does.