### PR TITLE
Display estimated time remaining, in progress bar

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -268,7 +268,7 @@ def calc_time_left(progress, threshold, label, force_display):
         time_since_start = time.time() - shared.state.time_start
         eta = (time_since_start/progress)
         eta_relative = eta-time_since_start
-        if eta_relative > threshold or force_display:              
+        if (eta_relative > threshold and progress > 0.02) or force_display:           
             return label + time.strftime('%H:%M:%S', time.gmtime(eta_relative))        
         else:
             return ""

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -261,6 +261,15 @@ def wrap_gradio_call(func, extra_outputs=None):
     return f
 
 
+def calc_time_left(progress):
+    if progress == 0:
+        return "N/A"
+    else:
+        time_since_start = time.time() - shared.state.time_start
+        eta = (time_since_start/progress)
+        return time.strftime('%H:%M:%S', time.gmtime(eta-time_since_start))        
+
+
 def check_progress_call(id_part):
     if shared.state.job_count == 0:
         return "", gr_show(False), gr_show(False), gr_show(False)
@@ -272,11 +281,13 @@ def check_progress_call(id_part):
     if shared.state.sampling_steps > 0:
         progress += 1 / shared.state.job_count * shared.state.sampling_step / shared.state.sampling_steps
 
+    time_left = calc_time_left( progress )
+
     progress = min(progress, 1)
 
     progressbar = ""
     if opts.show_progressbar:
-        progressbar = f"""<div class='progressDiv'><div class='progress' style="width:{progress * 100}%">{str(int(progress*100))+"%" if progress > 0.01 else ""}</div></div>"""
+        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:hidden;width:{progress * 100}%">{str(int(progress*100))+"% ETA:"+time_left if progress > 0.01 else ""}</div></div>"""
 
     image = gr_show(False)
     preview_visibility = gr_show(False)
@@ -308,6 +319,7 @@ def check_progress_call_initial(id_part):
     shared.state.current_latent = None
     shared.state.current_image = None
     shared.state.textinfo = None
+    shared.state.time_start = time.time()
 
     return check_progress_call(id_part)
 


### PR DESCRIPTION
This fixes the Issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/1412 that I'm facing too. It displays estimated time left for job to finish - right in the progress bar, next to percentage. Works for batches and works on mobile.

There's no way to see how much time it's left for rendering to finish in the UI. It's essential for long batch jobs and makes UI more friendly and predictable.

This is my first and only contribution to this repo so please pardon any mistakes I made. Seems to work fine on my end. Also css works on mobile (added "hidden" style).