### PR TITLE
Auto select attention block for editing

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -9,9 +9,38 @@ addEventListener('keydown', (event) => {
 	let minus = "ArrowDown"
 	if (event.key != plus && event.key != minus) return;
 
-	selectionStart = target.selectionStart;
-	selectionEnd = target.selectionEnd;
-	if(selectionStart == selectionEnd) return;
+	let selectionStart = target.selectionStart;
+	let selectionEnd = target.selectionEnd;
+	// If the user hasn't selected anything, let's select their current parenthesis block
+	if (selectionStart === selectionEnd) {
+		// Find opening parenthesis around current cursor
+		const before = target.value.substring(0, selectionStart);
+		let beforeParen = before.lastIndexOf("(");
+		if (beforeParen == -1) return;
+		let beforeParenClose = before.lastIndexOf(")");
+		while (beforeParenClose !== -1 && beforeParenClose > beforeParen) {
+			beforeParen = before.lastIndexOf("(", beforeParen - 1);
+			beforeParenClose = before.lastIndexOf(")", beforeParenClose - 1);
+		}
+
+		// Find closing parenthesis around current cursor
+		const after = target.value.substring(selectionStart);
+		let afterParen = after.indexOf(")");
+		if (afterParen == -1) return;
+		let afterParenOpen = after.indexOf("(");
+		while (afterParenOpen !== -1 && afterParen > afterParenOpen) {
+			afterParen = after.indexOf(")", afterParen + 1);
+			afterParenOpen = after.indexOf("(", afterParenOpen + 1);
+		}
+		if (beforeParen === -1 || afterParen === -1) return;
+
+		// Set the selection to the text between the parenthesis
+		const parenContent = target.value.substring(beforeParen + 1, selectionStart + afterParen);
+		const lastColon = parenContent.lastIndexOf(":");
+		selectionStart = beforeParen + 1;
+		selectionEnd = selectionStart + lastColon;
+		target.setSelectionRange(selectionStart, selectionEnd);
+	}
 
 	event.preventDefault();
 


### PR DESCRIPTION
This is a very minor enhancement to the prompt editing UI. It improves the edit attention script by automatically selecting a wrapping parenthesis block if you don't have text selected. This makes editing weights of existing weighted blocks much easier.

![Example image](https://user-images.githubusercontent.com/607609/196301204-320cc007-f6fb-419c-ab13-aad6b419b610.png)

**[Demo video](https://dl.dropboxusercontent.com/s/oinvo1ovjj2ucy9/2022-10-17%2017-17.mp4?dl=0)**