### PR TITLE
Image correctly being sent from History tab to img2img

### DIFF
--- a/javascript/images_history.js
+++ b/javascript/images_history.js
@@ -25,6 +25,16 @@ var images_history_click_tab = function(){
     }                
 }
 
+function switch_to_hustory(){
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[4].click();
+    return args_to_array(arguments);
+}
+
+function extract_image_from_history(gallery) {
+    switch_to_img2img_img2img()
+    return extract_image_from_gallery(gallery);
+}
+
 function images_history_disabled_del(){
     gradioApp().querySelectorAll(".images_history_del_button").forEach(function(btn){
         btn.setAttribute('disabled','disabled');

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -45,6 +45,11 @@ function switch_to_img2img_img2img(){
     return args_to_array(arguments);
 }
 
+function switch_to_pnginfo(){
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[3].click();
+    return args_to_array(arguments);
+}
+
 function switch_to_img2img_inpaint(){
     gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
     gradioApp().getElementById('mode_img2img').querySelectorAll('button')[1].click();
@@ -66,6 +71,11 @@ function extract_image_from_gallery_txt2img(gallery){
 function extract_image_from_gallery_img2img(gallery){
     switch_to_img2img_img2img()
     return extract_image_from_gallery(gallery);
+}
+
+function extract_image_from_pnginfo(gallery){
+    switch_to_pnginfo()
+    return gallery;
 }
 
 function extract_image_from_gallery_inpaint(gallery){

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -45,11 +45,6 @@ function switch_to_img2img_img2img(){
     return args_to_array(arguments);
 }
 
-function switch_to_pnginfo(){
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[3].click();
-    return args_to_array(arguments);
-}
-
 function switch_to_img2img_inpaint(){
     gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
     gradioApp().getElementById('mode_img2img').querySelectorAll('button')[1].click();
@@ -71,11 +66,6 @@ function extract_image_from_gallery_txt2img(gallery){
 function extract_image_from_gallery_img2img(gallery){
     switch_to_img2img_img2img()
     return extract_image_from_gallery(gallery);
-}
-
-function extract_image_from_pnginfo(gallery){
-    switch_to_pnginfo()
-    return gallery;
 }
 
 function extract_image_from_gallery_inpaint(gallery){

--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -1,11 +1,6 @@
 import os
 import shutil
 import sys
-import base64
-from PIL import Image, PngImagePlugin
-import html
-import io
-import tempfile
 
 def traverse_all_files(output_dir, image_list, curr_dir=None):
     curr_path = output_dir if curr_dir is None else os.path.join(output_dir, curr_dir)

--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -27,29 +27,6 @@ def traverse_all_files(output_dir, image_list, curr_dir=None):
     return image_list
 
 
-def image_from_url_text(filedata):
-    if type(filedata) == dict and filedata["is_file"]:
-        filename = filedata["name"]
-        tempdir = os.path.normpath(tempfile.gettempdir())
-        normfn = os.path.normpath(filename)
-        assert normfn.startswith(tempdir), 'trying to open image file not in temporary directory'
-
-        return Image.open(filename)
-
-    if type(filedata) == list:
-        if len(filedata) == 0:
-            return None
-
-        filedata = filedata[0]
-
-    if filedata.startswith("data:image/png;base64,"):
-        filedata = filedata[len("data:image/png;base64,"):]
-
-    filedata = base64.decodebytes(filedata.encode('utf-8'))
-    image = Image.open(io.BytesIO(filedata))
-    return image
-
-
 def get_recent_images(dir_name, page_index, step, image_index, tabname):
     page_index = int(page_index)
     image_list = []
@@ -128,7 +105,7 @@ def delete_image(delete_num, tabname, dir_name, name, page_index, filenames, ima
     return new_file_list, 1
 
 
-def show_images_history(gr, opts, tabname, run_pnginfo, switch_dict, init_img):
+def show_images_history(gr, opts, tabname, run_pnginfo, switch_dict, init_img, image_from_url_text):
     if opts.outdir_samples != "":
         dir_name = opts.outdir_samples
     elif tabname == "txt2img":
@@ -208,11 +185,11 @@ def create_history_tabs(gr, opts, run_pnginfo, switch_dict, init_img):
         with gr.Tabs() as tabs:
             with gr.Tab("txt2img history"):
                 with gr.Blocks(analytics_enabled=False) as images_history_txt2img:
-                    show_images_history(gr, opts, "txt2img", run_pnginfo, switch_dict, init_img)
+                    show_images_history(gr, opts, "txt2img", run_pnginfo, switch_dict, init_img, switch_dict["ifu"])
             with gr.Tab("img2img history"):
                 with gr.Blocks(analytics_enabled=False) as images_history_img2img:
-                    show_images_history(gr, opts, "img2img", run_pnginfo, switch_dict, init_img)
+                    show_images_history(gr, opts, "img2img", run_pnginfo, switch_dict, init_img, switch_dict["ifu"])
             with gr.Tab("extras history"):
                 with gr.Blocks(analytics_enabled=False) as images_history_img2img:
-                    show_images_history(gr, opts, "extras", run_pnginfo, switch_dict, init_img)
+                    show_images_history(gr, opts, "extras", run_pnginfo, switch_dict, init_img, switch_dict["ifu"])
     return images_history

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1150,7 +1150,7 @@ def create_ui(wrap_gradio_gpu_call):
         "i2i":img2img_paste_fields
     }
 
-    images_history = img_his.create_history_tabs(gr, opts, wrap_gradio_call(modules.extras.run_pnginfo), images_history_switch_dict)
+    images_history = img_his.create_history_tabs(gr, opts, wrap_gradio_call(modules.extras.run_pnginfo), images_history_switch_dict, init_img)
 
     with gr.Blocks() as modelmerger_interface:
         with gr.Row().style(equal_height=False):
@@ -1717,6 +1717,13 @@ Requested path was: {f}
 
         modules.generation_parameters_copypaste.connect_paste(pnginfo_send_to_txt2img, txt2img_paste_fields + settings_paste_fields, generation_info, 'switch_to_txt2img')
         modules.generation_parameters_copypaste.connect_paste(pnginfo_send_to_img2img, img2img_paste_fields + settings_paste_fields, generation_info, 'switch_to_img2img_img2img')
+
+        pnginfo_send_to_img2img.click(
+            fn=lambda x: x,
+            _js="extract_image_from_pnginfo",
+            inputs=[image],
+            outputs=[init_img],
+        )
 
     ui_config_file = cmd_opts.ui_config_file
     ui_settings = {}

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1147,7 +1147,8 @@ def create_ui(wrap_gradio_gpu_call):
     images_history_switch_dict = {
         "fn":modules.generation_parameters_copypaste.connect_paste,
         "t2i":txt2img_paste_fields,
-        "i2i":img2img_paste_fields
+        "i2i":img2img_paste_fields,
+        "ifu":image_from_url_text
     }
 
     images_history = img_his.create_history_tabs(gr, opts, wrap_gradio_call(modules.extras.run_pnginfo), images_history_switch_dict, init_img)
@@ -1717,13 +1718,6 @@ Requested path was: {f}
 
         modules.generation_parameters_copypaste.connect_paste(pnginfo_send_to_txt2img, txt2img_paste_fields + settings_paste_fields, generation_info, 'switch_to_txt2img')
         modules.generation_parameters_copypaste.connect_paste(pnginfo_send_to_img2img, img2img_paste_fields + settings_paste_fields, generation_info, 'switch_to_img2img_img2img')
-
-        pnginfo_send_to_img2img.click(
-            fn=lambda x: x,
-            _js="extract_image_from_pnginfo",
-            inputs=[image],
-            outputs=[init_img],
-        )
 
     ui_config_file = cmd_opts.ui_config_file
     ui_settings = {}


### PR DESCRIPTION
A proposal to fix issues https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2941, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2892, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2783, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/3272

It correctly sends images from History and PNG Info tabs to img2img (for inpainting, outpainting etc). Right now it's not working, only parameters are transferred. So img2img does not work after clicking "send to img2img".