### PR TITLE
Fix the border overlap in the most janky way

### DIFF
--- a/style.css
+++ b/style.css
@@ -516,3 +516,7 @@ img2maskimg, #img2maskimg > .h-60, #img2maskimg > .h-60 > div, #img2maskimg > .h
     max-height: 480px !important;
     min-height: 480px !important;
 }
+
+.gr-form > .gr-block {
+	border-radius: 7px;
+}


### PR DESCRIPTION
This was really bugging me for a while

Before:
![](https://us-east-1.tixte.net/uploads/cdn.blueskye.dev/firefox_i3mMQinQBq.png)
After
![](https://us-east-1.tixte.net/uploads/cdn.blueskye.dev/firefox_mvJIer1sLm.png)