### PR TITLE
Add Colab notebook by ddPn08

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Make sure the required [dependencies](https://github.com/AUTOMATIC1111/stable-di
 
 Alternatively, use Google Colab:
 
+- [Colab, maintained by ddPn08](https://github.com/ddPn08/automatic1111-colab)
 - [Colab, maintained by Akaibu](https://colab.research.google.com/drive/1kw3egmSn-KgWsikYvOMjJkVDsPLjEMzl)
 - [Colab, original by me, outdated](https://colab.research.google.com/drive/1Iy-xW9t1-OQWhb0hNxueGij8phCyluOh).
 


### PR DESCRIPTION
Add links to Colab notebooks created by ddPn08 maintained in [this repository](https://github.com/ddPn08/automatic1111-colab)
This Colab notebook is easy to use and updated frequently.