### PR TITLE
change styles.csv encoding from utf8 to utf-8-sig

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -45,7 +45,7 @@ class StyleDatabase:
         if not os.path.exists(path):
             return
 
-        with open(path, "r", encoding="utf8", newline='') as file:
+        with open(path, "r", encoding="utf-8-sig", newline='') as file:
             reader = csv.DictReader(file)
             for row in reader:
                 # Support loading old CSV format with "name, text"-columns
@@ -79,7 +79,7 @@ class StyleDatabase:
     def save_styles(self, path: str) -> None:
         # Write to temporary file first, so we don't nuke the file if something goes wrong
         fd, temp_path = tempfile.mkstemp(".csv")
-        with os.fdopen(fd, "w", encoding="utf8", newline='') as file:
+        with os.fdopen(fd, "w", encoding="utf-8-sig", newline='') as file:
             # _fields is actually part of the public API: typing.NamedTuple is a replacement for collections.NamedTuple,
             # and collections.NamedTuple has explicit documentation for accessing _fields. Same goes for _asdict()
             writer = csv.DictWriter(file, fieldnames=PromptStyle._fields)


### PR DESCRIPTION
### change `styles.csv` encoding from utf8 to utf-8-sig
open a new pull request on another branch due to
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/2930#issuecomment-1281822756
> webui-user.bat is not to be edited

### Reason for using utf-8-sig over utf8 for `styles.csv`
this allows for better compatibility for some programs such as Excel

Currently the web UI allows users to save Styles and Styles_Name to `styles.csv`,
and it allows the use of non-english characters, such as Chinese Japanese
**this is working without issue**

but if the user were to open the `styles.csv` in an external software such as Excel
the text will be displayed as **garbled**
> screenshot below

this can be fixed by adding the BOM to the `styles.csv`


### Backwards compatibility with existing `styles.csv`
**No issue**

`utf-8-sig` **allows** the read and writing of BOM **and non-BOM** files

conversely `utf8` can only read non-BOM files
trying to read a file with file with BOM will result in an error

No issue with writing existing non-BOM `styles.csv`
with`utf-8-sig`, when writing to a existing non-BOM files, the file will be **automatically converted** to BOM

| | read utf8 | read utf-8-sig | write utf8 | write utf-8-sig | Excel
| --- | --- | --- |  --- | --- | --- |
| utf-8 file | works | works | works | convert file to utf-8-bom | error
| utf-8-bom file | error | works | untested | works | works

### example with Excel opening a non-BOM and BOM csv file
![image](https://user-images.githubusercontent.com/40751091/196209418-01634dde-f828-4731-a79f-2eec3b911ffb.png)
opening same file but one, left non-bom (error), right bom (correct)


OS: Windows
Browser chrome
Graphics card NVIDIA GTX 1650 4GB