### PR TITLE
Fixed "Torch active/reserverd~" style

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,9 +34,6 @@
 .performance {
     font-size: 0.85em;
     color: #444;
-    display: flex;
-    justify-content: space-between;
-    white-space: nowrap;
 }
 
 .performance .time {
@@ -44,8 +41,6 @@
 }
 
 .performance .vram {
-    margin-left: 0;
-    text-align: right;
 }
 
 #txt2img_generate, #img2img_generate {


### PR DESCRIPTION
In Safari, the style of "Torch active/reserverd~" breaks down when accessed from narrow devices such as iPhone.
I was able to fix the style mess by removing the style below.

Before correction
<img width="409" alt="スクリーンショット 2022-10-19 5 03 45" src="https://user-images.githubusercontent.com/60560430/196532960-b04f722f-10f5-40db-8f76-398afd6accd8.png">

After correction
<img width="385" alt="スクリーンショット 2022-10-19 5 04 15" src="https://user-images.githubusercontent.com/60560430/196532981-ca458443-d130-4a34-887f-1ec6fe542790.png">
