### PR TITLE
Option to use a CSV file as source for prompts when training hypernetworks or embeddings.

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -196,7 +196,7 @@ def stack_conds(conds):
 
     return torch.stack(conds)
 
-def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log_directory, steps, create_image_every, save_hypernetwork_every, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
+def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log_directory, steps, create_image_every, save_hypernetwork_every, use_prompts_csv, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
     assert hypernetwork_name, 'hypernetwork not selected'
 
     path = shared.hypernetworks.get(hypernetwork_name, None)
@@ -225,7 +225,7 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
 
     shared.state.textinfo = f"Preparing dataset from {html.escape(data_root)}..."
     with torch.autocast("cuda"):
-        ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=512, height=512, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=hypernetwork_name, model=shared.sd_model, device=devices.device, template_file=template_file, include_cond=True, batch_size=batch_size)
+        ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=512, height=512, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=hypernetwork_name, model=shared.sd_model, device=devices.device, use_prompts_csv=use_prompts_csv, template_file=template_file, include_cond=True, batch_size=batch_size)
 
     if unload:
         shared.sd_model.cond_stage_model.to(devices.cpu)

--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -4,6 +4,7 @@ import platform
 import sys
 import tqdm
 import time
+import shutil
 
 from modules import shared, images
 from modules.shared import opts, cmd_opts
@@ -77,6 +78,9 @@ def preprocess_work(process_src, process_dst, process_width, process_height, pro
 
         if process_flip:
             save_pic_with_caption(ImageOps.mirror(image), index)
+
+    if os.path.exists(os.path.join(src, "prompts.csv")):
+        shutil.copyfile(os.path.join(src, "prompts.csv"), os.path.join(dst, "prompts.csv"))
 
     for index, imagefile in enumerate(tqdm.tqdm(files)):
         subindex = [0]

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -200,7 +200,7 @@ def write_loss(log_directory, filename, step, epoch_len, values):
         })
 
 
-def train_embedding(embedding_name, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
+def train_embedding(embedding_name, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, use_prompts_csv, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
     assert embedding_name, 'embedding not selected'
 
     shared.state.textinfo = "Initializing textual inversion training..."
@@ -232,7 +232,7 @@ def train_embedding(embedding_name, learn_rate, batch_size, data_root, log_direc
 
     shared.state.textinfo = f"Preparing dataset from {html.escape(data_root)}..."
     with torch.autocast("cuda"):
-        ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=embedding_name, model=shared.sd_model, device=devices.device, template_file=template_file, batch_size=batch_size)
+        ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=embedding_name, model=shared.sd_model, device=devices.device, use_prompts_csv=use_prompts_csv, template_file=template_file, batch_size=batch_size)
 
     hijack = sd_hijack.model_hijack
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1233,6 +1233,7 @@ def create_ui(wrap_gradio_gpu_call):
                     batch_size = gr.Number(label='Batch size', value=1, precision=0)
                     dataset_directory = gr.Textbox(label='Dataset directory', placeholder="Path to directory with input images")
                     log_directory = gr.Textbox(label='Log directory', placeholder="Path to directory where to write outputs", value="textual_inversion")
+                    use_prompts_csv = gr.Checkbox(label="Use prompts.csv from dataset directory", value=False)
                     template_file = gr.Textbox(label='Prompt template file', value=os.path.join(script_path, "textual_inversion_templates", "style_filewords.txt"))
                     training_width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512)
                     training_height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512)
@@ -1317,6 +1318,7 @@ def create_ui(wrap_gradio_gpu_call):
                 steps,
                 create_image_every,
                 save_embedding_every,
+                use_prompts_csv,
                 template_file,
                 save_image_with_stored_embedding,
                 preview_from_txt2img,
@@ -1340,6 +1342,7 @@ def create_ui(wrap_gradio_gpu_call):
                 steps,
                 create_image_every,
                 save_embedding_every,
+                use_prompts_csv,
                 template_file,
                 preview_from_txt2img,
                 *txt2img_preview_params,


### PR DESCRIPTION
Since there are a few issues regarding the template files, like special characters and filename length limitations,
I have added the possibility to use a CSV file as source for prompts for the dataset.

The CSV file is called "prompts.csv" and is located in the dataset source folder.
![csv file](https://user-images.githubusercontent.com/24941186/196540405-34927d3f-11b3-43b2-9bf9-a58f8fd388b6.PNG)

The csv file uses the standard "dialect" of python (csv.excel).

It might be more desirable to just supply the name of the CSV, i found the checkbox to be simpler though.