### PR TITLE
Generate image grid for progress preview.

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -291,6 +291,7 @@ options_templates.update(options_section(('interrogate', "Interrogate Options"),
 options_templates.update(options_section(('ui', "User interface"), {
     "show_progressbar": OptionInfo(True, "Show progressbar"),
     "show_progress_every_n_steps": OptionInfo(0, "Show image creation progress every N sampling steps. Set 0 to disable.", gr.Slider, {"minimum": 0, "maximum": 32, "step": 1}),
+    "progress_decode_combined": OptionInfo(False, "Decode all progress images at once. (Slighty speeds up progress generation but consumes significantly more VRAM with large batches.)"),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),
     "add_model_hash_to_info": OptionInfo(True, "Add model hash to generation information"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -302,7 +302,10 @@ def check_progress_call(id_part):
         if shared.parallel_processing_allowed:
 
             if shared.state.sampling_step - shared.state.current_image_sampling_step >= opts.show_progress_every_n_steps and shared.state.current_latent is not None:
-                shared.state.current_image = modules.sd_samplers.sample_to_image(shared.state.current_latent)
+                if opts.progress_decode_combined:
+                    shared.state.current_image = modules.sd_samplers.samples_to_image_grid_combined(shared.state.current_latent)
+                else:
+                    shared.state.current_image = modules.sd_samplers.samples_to_image_grid(shared.state.current_latent)
                 shared.state.current_image_sampling_step = shared.state.sampling_step
 
         image = shared.state.current_image


### PR DESCRIPTION
# Pull Request Summary
This PR makes the image creation progress display a grid of all images within the current batch instead of just the first.

There are two functions implemented:
- The first (`samples_to_image_grid`) decodes the samples one at a time, converting them to an image, appending them to a list and then finally passing it to `images.image_grid`.
- The second (`samples_to_image_grid_combined`) decodes the samples simultaneously. This is slightly faster than the previous function, but uses significantly more VRAM when using large batch sizes.

I've added a setting to allow a user to switch decoding methods, **it defaults to individual decoding.**

**Note:** This is my first time diving into PyTorch/Stable Diffusion, and it's been a while since I've written Python, so it's mostly just me trying to join already existing things together.
While a relatively small PR, if something is incorrect/needs adjusting, please explain it clearly so I can try to understand better.

# Benchmarks
These are some benchmarks I did locally, they should be considered approximate.
**All times taken with process time NOT wall time.**

## Setup
### Hardware
CPU: i5-4690K @4.5GHz
GPU: GTX1080 (8GB VRAM)
RAM: 24GB DDR3 @1866MHz
### Settings
Arguments: `--opt-split-attention --xformers`
Steps: 65
Size: 512x512
Batch size: 4
Image progress steps: 10

## Data
### Individual Decoding (`samples_to_image_grid`)
#### First generation:
| Step | Process Time |
| --- |:---:|
| 10 | 2.640625s |
| 20 | 2.78125s |
| 30 | 2.78125s |
| 40 | 2.671875s |
| 50 | 3.75s |
| 60 | 2.859375s |

Total: 17.484375
Mean: 2.914062
Median: 2.78125
Maximum VRAM during generation (including previews): 4.9GB

#### Second generation:
| Step | Process Time |
| --- |:---:|
| 10 | 2.78125s |
| 20 | 3.234375s |
| 30 | 3.25s |
| 40 | 2.90625s |
| 50 | 2.9375s |
| 60 | 3.15625s |

Total: 18.265625
Mean: 3.044270
Median: 3.046875
Maximum VRAM during generation (including previews): 4.7GB 

### Combined Decoding (`samples_to_image_grid_combined`)
#### First generation:
| Step | Process Time |
| --- |:---:|
| 10 | 2.546875s |
| 20 | 2.015625s |
| 30 | 2.59375s |
| 40 | 2.1875s |
| 50 | 2.234375s |
| 60 | 2.65625s |

Total: 14.234375
Mean: 2.372395
Median: 2.390625
Maximum VRAM during generation (including previews): 7.8GB

#### Second generation:
| Step | Process Time |
| --- |:---:|
| 10 | 2.515625s |
| 20 | 2.3125s |
| 30 | 2.953125s |
| 40 | 2.28125s |
| 50 | 2.46875s |
| 60 | 2.765625s |

Total: 15.296875
Mean: 2.549479
Median: 2.492187
Maximum VRAM during generation (including previews): 7.9GB