### PR TITLE
Download BLIP checkpoint and save it for later use, as opposed to loading it from internet every time

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -43,9 +43,17 @@ class InterrogateModels:
                 self.categories.append(Category(name=filename, topn=topn, items=lines))
 
     def load_blip_model(self):
+        this_folder = os.path.dirname(__file__)
+        blip_model_dir = os.path.abspath(os.path.join(this_folder, '..', 'models', 'BLIP'))
+        pretrained_path = os.path.join(blip_model_dir, 'model_base_caption_capfilt_large.pth')
+        # download BLIP checkpoint if not exist
+        if not os.path.exists(pretrained_path):
+            from basicsr.utils.download_util import load_file_from_url
+            load_file_from_url(url=blip_model_url, model_dir=blip_model_dir, progress=True)
+                
         import models.blip
 
-        blip_model = models.blip.blip_decoder(pretrained=blip_model_url, image_size=blip_image_eval_size, vit='base', med_config=os.path.join(paths.paths["BLIP"], "configs", "med_config.json"))
+        blip_model = models.blip.blip_decoder(pretrained=pretrained_path, image_size=blip_image_eval_size, vit='base', med_config=os.path.join(paths.paths["BLIP"], "configs", "med_config.json"))
         blip_model.eval()
 
         return blip_model


### PR DESCRIPTION
before the BLIP model is loaded directly from internet and not saved locally
this means if UI is relaunched, it will have to be downloaded again
this seems quite wasteful, and inconsistent with other downloaded assets like `deepbooru`

I made it so that the checkpoint is download to `models/BLIP/model_base_caption_capfilt_large.pth` for later use
so it doesn't have to be downloaded again on next UI launch
similar procedure to `deepbooru`

I don't know if there was a reason behind loading it for internet every time
maybe the checkpoint is updated frequently?

the checkpoint is 854MB
and it can take a while to download depends on your internet speed


**Tested and working**
I basically reuse the code form other (`deepbooru.py`) download procedures

Environment
Win 10
Python 3.10.6
Chrome