### PR TITLE
Log more specific hypernet name to infotext.

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -304,7 +304,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
         "Size": f"{p.width}x{p.height}",
         "Model hash": getattr(p, 'sd_model_hash', None if not opts.add_model_hash_to_info or not shared.sd_model.sd_model_hash else shared.sd_model.sd_model_hash),
         "Model": (None if not opts.add_model_name_to_info or not shared.sd_model.sd_checkpoint_info.model_name else shared.sd_model.sd_checkpoint_info.model_name.replace(',', '').replace(':', '')),
-        "Hypernet": (None if shared.loaded_hypernetwork is None else shared.loaded_hypernetwork.name.replace(',', '').replace(':', '')),
+        "Hypernet": (None if shared.loaded_hypernetwork is None else shared.loaded_hypernetwork.filename.split('\\')[-1].split('.')[0]),
         "Batch size": (None if p.batch_size < 2 else p.batch_size),
         "Batch pos": (None if p.batch_size < 2 else position_in_batch),
         "Variation seed": (None if p.subseed_strength == 0 else all_subseeds[index]),


### PR DESCRIPTION
Previously, generating first one image with Hypernetwork set to `johndoe-10000.pt` then another with it set to `johndoe.pt` would create infotext listing "Hypernet: johndoe" for both cases. This is wrong, because the _former_ image's PNG info would point to the _latter_ one's checkpoint.

Instead, let's list `Hypernet: johndoe-10000` for the former case, and `Hypernet: johndoe` for the latter. In general, we list `shared.loaded_hypernetwork.filename` split from its final backslash to the period before its file extension, noninclusive.