### PR TITLE
Better estimated time in progress bar

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -268,8 +268,13 @@ def calc_time_left(progress, threshold, label, force_display):
         time_since_start = time.time() - shared.state.time_start
         eta = (time_since_start/progress)
         eta_relative = eta-time_since_start
-        if (eta_relative > threshold and progress > 0.02) or force_display:           
-            return label + time.strftime('%H:%M:%S', time.gmtime(eta_relative))        
+        if (eta_relative > threshold and progress > 0.02) or force_display:
+            if eta_relative > 3600:
+                return label + time.strftime('%H:%M:%S', time.gmtime(eta_relative))
+            elif eta_relative > 60:
+                return label + time.strftime('%M:%S',  time.gmtime(eta_relative))
+            else:
+                return label + time.strftime('%Ss',  time.gmtime(eta_relative))
         else:
             return ""
 
@@ -285,7 +290,7 @@ def check_progress_call(id_part):
     if shared.state.sampling_steps > 0:
         progress += 1 / shared.state.job_count * shared.state.sampling_step / shared.state.sampling_steps
 
-    time_left = calc_time_left( progress, 60, " ETA:", shared.state.time_left_force_display )
+    time_left = calc_time_left( progress, 1, " ETA: ", shared.state.time_left_force_display )
     if time_left != "":
         shared.state.time_left_force_display = True
 
@@ -293,7 +298,7 @@ def check_progress_call(id_part):
 
     progressbar = ""
     if opts.show_progressbar:
-        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:hidden;width:{progress * 100}%">{str(int(progress*100))+"%"+time_left if progress > 0.01 else ""}</div></div>"""
+        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:visible;width:{progress * 100}%;white-space:nowrap;">{str(int(progress*100))+"%"+time_left if progress > 0.01 else ""}</div></div>"""
 
     image = gr_show(False)
     preview_visibility = gr_show(False)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -298,7 +298,7 @@ def check_progress_call(id_part):
 
     progressbar = ""
     if opts.show_progressbar:
-        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:visible;width:{progress * 100}%;white-space:nowrap;">{str(int(progress*100))+"%"+time_left if progress > 0.01 else ""}</div></div>"""
+        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:visible;width:{progress * 100}%;white-space:nowrap;">{"&nbsp;" * 2 + str(int(progress*100))+"%" + time_left if progress > 0.01 else ""}</div></div>"""
 
     image = gr_show(False)
     preview_visibility = gr_show(False)


### PR DESCRIPTION
Added different formatting for smaller times (no need for hours and minutes when only seconds are left). Made it so estimated time showed even when no space is available (overflow is shown for better readability).

![image](https://user-images.githubusercontent.com/58919185/196755561-b7c0e69f-307c-4451-ad36-2709c9e2ec69.png)
(edited this image to add the new padding)

![image](https://user-images.githubusercontent.com/58919185/196750950-4249198a-5d47-400f-8f90-b9081cb55cc7.png)

![image](https://user-images.githubusercontent.com/58919185/196751268-10e6b19f-8088-4be7-a173-5cd15eec9292.png)

![image](https://user-images.githubusercontent.com/58919185/196751318-347b3119-1f09-47a0-b849-fa75d5cfd23e.png)
