### PR TITLE
Send empty prompts as valid generation parameters

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -45,10 +45,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         else:
             prompt += ("" if prompt == "" else "\n") + line
 
-    if len(prompt) > 0:
         res["Prompt"] = prompt
-
-    if len(negative_prompt) > 0:
         res["Negative prompt"] = negative_prompt
 
     for k, v in re_param.findall(lastline):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Whenever generation parameters from PNG info or from prompt textbox are being copied, both empty prompts should be used. They were previously ignored which resulted in following issue: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/3103 , now it is resolved.
 
**Additional notes and description of your changes**

As i understand it, there was an attempt to keep as much information as possible (i.e. if the prompt to send is empty, let's keep old prompt in place). But it's not really expected behavior. 
Plus i sincerely hope those conditions only were there to prevent sending empty prompts and not to guard some edge cases of the parser?

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser Chrome
 - Graphics card NVIDIA GTX 1060 6GB

**Screenshots or videos of your changes**
![GIF 19 10 2022 19-35-38](https://user-images.githubusercontent.com/32306715/196751630-d8fed907-a319-4bc6-b584-dc8a77017a2b.gif)
