### PR TITLE
Reordered the buttons for the history tab and gave them a better label

### DIFF
--- a/modules/images_history.py
+++ b/modules/images_history.py
@@ -112,12 +112,12 @@ def show_images_history(gr, opts, tabname, run_pnginfo, switch_dict):
     else:
         return
     with gr.Row():
-        renew_page = gr.Button('Renew Page', elem_id=tabname + "_images_history_renew_page")
-        first_page = gr.Button('First Page')
-        prev_page = gr.Button('Prev Page')
+        renew_page = gr.Button('Refresh', elem_id=tabname + "_images_history_renew_page")
+        prev_page = gr.Button('<<')
+        next_page = gr.Button('>>')
         page_index = gr.Number(value=1, label="Page Index")
-        next_page = gr.Button('Next Page')
-        end_page = gr.Button('End Page')
+        first_page = gr.Button('First Page')
+        end_page = gr.Button('Last Page')
     with gr.Row(elem_id=tabname + "_images_history"):
         with gr.Row():
             with gr.Column(scale=2):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
Noticed that the buttons for the history tab were a bit counterintuitive, so I move them around to make a bit more sense. The buttons for prev and page are now above the gallery itself, while the buttons for last and first page have been moved next to the gallery. 

the label for `prev page` and `next page`  have been changed to `<< >>` respectively, `End page` is changed to `Last Page` and `renew page` is now simply called  `refresh`

![vivaldi_yMabH5Yh48](https://user-images.githubusercontent.com/12272837/196783418-129173a6-bcf3-4de0-8ae3-c53204a34a0d.png)
