### PR TITLE
Fixed ignore batch count when outpainting_mk2 is selected

### DIFF
--- a/scripts/outpainting_mk_2.py
+++ b/scripts/outpainting_mk_2.py
@@ -150,6 +150,7 @@ class Script(scripts.Script):
         p.inpainting_fill = 1
         p.do_not_save_samples = True
         p.do_not_save_grid = True
+        p.n_iter = 1
 
         left = pixels if "left" in direction else 0
         right = pixels if "right" in direction else 0


### PR DESCRIPTION
My first pull request.

Fixed [issues/3177](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/3177)
ignore batch count when outpainting_mk2 is selected