### PR TITLE
fix img2img color correction only applying to the first image of a batch

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -440,10 +440,10 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
                 image = Image.fromarray(x_sample)
 
-                if p.color_corrections is not None and i < len(p.color_corrections):
+                if p.color_corrections is not None and i // p.batch_size < len(p.color_corrections):
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
                         images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
-                    image = apply_color_correction(p.color_corrections[i], image)
+                    image = apply_color_correction(p.color_corrections[i // p.batch_size], image)
 
                 if p.overlay_images is not None and i < len(p.overlay_images):
                     overlay = p.overlay_images[i]


### PR DESCRIPTION
fix img2img color correction only applying to the first image of a batch
when batch size > 1

this should fix issue #1441

I have test with the 3 modes that uses color correction `img2img` `Inpaint` `Batch img2img`
and my fix seems to be working as intended

Win 10
Chrome
Python 3.10.6