### PR TITLE
Fix the browser console errors when restart the gradio app.

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -226,6 +226,6 @@ function update_token_counter(button_id) {
 }
 
 function restart_reload(){
-    document.body.innerHTML='<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>';
+    gradioApp().innerHTML = '<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>';
     setTimeout(function(){location.reload()},2000)
 }

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1840,6 +1840,8 @@ def load_javascript(raw_response):
 
     javascript += f"\n<script>{localization.localization_js(shared.opts.localization)}</script>"
 
+    raw_response = vars(raw_response).get("raw_response", raw_response)
+
     def template_response(*args, **kwargs):
         res = raw_response(*args, **kwargs)
         res.body = res.body.replace(
@@ -1847,6 +1849,7 @@ def load_javascript(raw_response):
         res.init_headers()
         return res
 
+    template_response.raw_response = raw_response
     gradio.routes.templates.TemplateResponse = template_response
 
 


### PR DESCRIPTION
### [Error 1](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/2835#issuecomment-1283830771).
In last PR, I removed the `gradio_routes_templates_response` variable in `globals()`:
![image](https://user-images.githubusercontent.com/12682063/196986763-640fa973-ea90-4ee7-bff7-7d3605fc0dd0.png)
When the gradioApp restarted, the `ui.py` model would be reloaded, so the code of load javascript files has append to the `gradio.routes.templates.TemplateResponse` repeatedly.
Now, i fixed the problem by add the `raw_response` into the dict of the `template_response` method, and check is it already exist when the `reload_javascript` method executed. I think to some extent that it will be more reliable than use the `globals()` scope.

### Error 2
![image](https://user-images.githubusercontent.com/12682063/196989670-7f96315b-299d-4399-a6ab-0ef011fa84e7.png)

It caused by the follow code in the `ui.js`:
![image](https://user-images.githubusercontent.com/12682063/196989415-86ac907a-af9d-4b13-8685-6368d2787cac.png)
It will clear the whole body of the document, thus the `gradioApp()` method would throw the error when it was called by the `contextMenu.js`.

