### PR TITLE
Fix skip and interrupt buttons for Highres. fix option enabled

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -587,7 +587,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         x = None
         devices.torch_gc()
 
-        return self.sampler.sample_img2img(self, samples, noise, conditioning, unconditional_conditioning, steps=self.steps) or samples
+        samples = self.sampler.sample_img2img(self, samples, noise, conditioning, unconditional_conditioning, steps=self.steps)
+
+        return samples
 
 
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -587,9 +587,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         x = None
         devices.torch_gc()
 
-        samples = self.sampler.sample_img2img(self, samples, noise, conditioning, unconditional_conditioning, steps=self.steps)
-
-        return samples
+        return self.sampler.sample_img2img(self, samples, noise, conditioning, unconditional_conditioning, steps=self.steps) or samples
 
 
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -196,6 +196,7 @@ class VanillaStableDiffusionSampler:
         x1 = self.sampler.stochastic_encode(x, torch.tensor([t_enc] * int(x.shape[0])).to(shared.device), noise=noise)
 
         self.init_latent = x
+        self.last_latent = x
         self.step = 0
 
         samples = self.launch_sampling(steps, lambda: self.sampler.decode(x1, conditioning, t_enc, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning))
@@ -206,6 +207,7 @@ class VanillaStableDiffusionSampler:
         self.initialize(p)
 
         self.init_latent = None
+        self.last_latent = x
         self.step = 0
 
         steps = steps or p.steps
@@ -388,6 +390,7 @@ class KDiffusionSampler:
             extra_params_kwargs['sigmas'] = sigma_sched
 
         self.model_wrap_cfg.init_latent = x
+        self.last_latent = x
 
         samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, xi, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs))
 
@@ -414,6 +417,7 @@ class KDiffusionSampler:
         else:
             extra_params_kwargs['sigmas'] = sigmas
 
+        self.last_latent = x
         samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': p.cfg_scale}, disable=False, callback=self.callback_state, **extra_params_kwargs))
 
         return samples


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Whenever Highres. fix is enabled skip/interrupt will not work as intended in txt2img tab. Related issues: #3181 #3087

**Additional notes and description of your changes**

Two sampler instances are used in the process (sample -> sample_img2img), whenever interruption or skip happened on the first one, it returned last_latent, as intended. Second time it gets through sample_img2img without any action, so default value of last_latent is None, that was the problem. If interruption occurred while the second sampler was running, it was fine. Hence the dependency in the title of #3087

Initially i just returned the first result if the second is None, but then i noticed it is still possible to replicate the problem if interruption happened before sampler makes one iteration even without highres option. So instead i changed the initial value of the last_latent. This should cover both scenarios.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB