### PR TITLE
[enhance] increase maximum batch count on WebUI

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -648,7 +648,7 @@ def create_ui(wrap_gradio_gpu_call):
                     denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7)
 
                 with gr.Row(equal_height=True):
-                    batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1)
+                    batch_count = gr.Slider(minimum=1, maximum=999, step=1, label='Batch counts', value=1)
                     batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1)
 
                 cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0)
@@ -861,7 +861,7 @@ def create_ui(wrap_gradio_gpu_call):
                     tiling = gr.Checkbox(label='Tiling', value=False)
 
                 with gr.Row():
-                    batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1)
+                    batch_count = gr.Slider(minimum=1, maximum=999, step=1, label='Batch counts', value=1)
                     batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1)
 
                 with gr.Group():


### PR DESCRIPTION
Hi, 

I was trying to increase the batch count so I can let my PC work overnight.

But seems there is a weird bug on "gradio" that the layout won't change by just adding maximum=999 and restarting the WebUI.
![image](https://user-images.githubusercontent.com/6138806/197101702-6593c826-1a7e-4bb5-81ff-82bac27b7a1b.png)

Anyway, I found out that I also need to change the label and restart the WebUI to let the UI re-cache.
![image](https://user-images.githubusercontent.com/6138806/197101754-95b72080-921e-41fb-94ff-036b29e7275a.png)
