### PR TITLE
Change option description of unload_models_when_training

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -249,7 +249,7 @@ options_templates.update(options_section(('system', "System"), {
 }))
 
 options_templates.update(options_section(('training', "Training"), {
-    "unload_models_when_training": OptionInfo(False, "Unload VAE and CLIP from VRAM when training"),
+    "unload_models_when_training": OptionInfo(False, "Move VAE and CLIP to RAM when training hypernetwork. Saves VRAM."),
     "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
     "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
     "training_image_repeats_per_epoch": OptionInfo(1, "Number of repeats for a single input image per epoch; used only for displaying epoch number", gr.Number, {"precision": 0}),


### PR DESCRIPTION
Background: Some users report when using VAE weights when training a embedding will cause low quality results.
This prevents people from confusing this option with completely unloading VAE weights (by completely I mean having the same result as not having a .vae.pt file in models folder when webui starts).

Preferably I'd like to add another option which does completely unload VAE when doing TI training, but I can't figure out how to do it.