### PR TITLE
allow loading new vaes from stabilityai

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -186,7 +186,7 @@ def load_model_weights(model, checkpoint_info):
         if os.path.exists(vae_file):
             print(f"Loading VAE weights from: {vae_file}")
             vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
-            vae_dict = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss"}
+            vae_dict = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] not in ["loss", "mode"]}
             model.first_stage_model.load_state_dict(vae_dict)
 
         model.first_stage_model.to(devices.dtype_vae)


### PR DESCRIPTION
https://huggingface.co/stabilityai/sd-vae-ft-mse-original

This PR expands the existing state dict key check to include new keys from these VAEs that would block loading.

With vae-ft-ema
![00008-1078979861](https://user-images.githubusercontent.com/36072735/197145433-fb45993a-c7af-419f-bd66-d969f0e36e4d.png)
Default
![00009-1078979861](https://user-images.githubusercontent.com/36072735/197145491-0b6fad90-7f17-4861-b290-a31d985a8423.png)

Extremely marginal improvement IMO.