### PR TITLE
Removing blank issues and tell people to ask questions in Discussions instead

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: WebUI Community Support
+    url: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This is intended to prevent people for asking about the meaning of life in the **Issues** tab

**Additional notes and description of your changes**

It disables "open a blank issue" and creates a third button that leads to the **Discussions** tab

**Environment this was tested in**

Github web

OS: W11
Browser Brave

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/20817233/197157611-d49b9e8e-8106-46af-809c-e6484a470199.png)


Maybe we could also link to the [community support discord](https://discord.gg/xU8y74HG4d) I have created for this very purpose ?