### PR TITLE
Address bug #3327

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -521,20 +521,16 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 scale = math.sqrt(desired_pixel_count / actual_pixel_count)
                 self.firstphase_width = math.ceil(scale * self.width / 64) * 64
                 self.firstphase_height = math.ceil(scale * self.height / 64) * 64
-                firstphase_width_truncated = int(scale * self.width)
-                firstphase_height_truncated = int(scale * self.height)
 
+            width_ratio = self.width / self.firstphase_width
+            height_ratio = self.height / self.firstphase_height
+
+            if width_ratio > height_ratio:
+                firstphase_width_truncated = self.firstphase_width
+                firstphase_height_truncated = self.firstphase_width * self.height / self.width
             else:
-
-                width_ratio = self.width / self.firstphase_width
-                height_ratio = self.height / self.firstphase_height
-
-                if width_ratio > height_ratio:
-                    firstphase_width_truncated = self.firstphase_width
-                    firstphase_height_truncated = self.firstphase_width * self.height / self.width
-                else:
-                    firstphase_width_truncated = self.firstphase_height * self.width / self.height
-                    firstphase_height_truncated = self.firstphase_height
+                firstphase_width_truncated = self.firstphase_height * self.width / self.height
+                firstphase_height_truncated = self.firstphase_height
 
             self.extra_generation_params["First pass size"] = f"{self.firstphase_width}x{self.firstphase_height}"
             self.truncate_x = int(self.firstphase_width - firstphase_width_truncated) // opt_f


### PR DESCRIPTION
Adjust code so that both 0x0 and manual input of firstpass dimension crop the same way.