### PR TITLE
fix bug of progress bar when running img2img and highres fix (#3093, #3145)

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -219,7 +219,7 @@ class VanillaStableDiffusionSampler:
             unconditional_conditioning = {"c_concat": [image_conditioning], "c_crossattn": [unconditional_conditioning]}
             
             
-        samples = self.launch_sampling(steps, lambda: self.sampler.decode(x1, conditioning, t_enc, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning))
+        samples = self.launch_sampling(t_enc + 1, lambda: self.sampler.decode(x1, conditioning, t_enc, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning))
 
         return samples
 
@@ -420,7 +420,7 @@ class KDiffusionSampler:
         self.model_wrap_cfg.init_latent = x
         self.last_latent = x
 
-        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, xi, extra_args={
+        samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args={
             'cond': conditioning, 
             'image_cond': image_conditioning, 
             'uncond': unconditional_conditioning, 


### PR DESCRIPTION
Fixed bugs #3093 and #3145 so some progress bars are handled correctly.

- The total number of steps for img2img is `t_enc + 1`, not `steps`.
- I checked `KDiffusionSampler` to check for this bug, but `VanillaStableDiffusionSampler` may also need to be fixed (haven't check yet).