### PR TITLE
add unixtime support on filename

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -62,8 +62,8 @@ titles = {
 
     "Interrogate": "Reconstruct prompt from existing image and put it into the prompt field.",
 
-    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [datetime], [job_timestamp]; leave empty for default.",
-    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [datetime], [job_timestamp]; leave empty for default.",
+    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [datetime], [job_timestamp], [unixtime], [job_unixtime]; leave empty for default.",
+    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [prompt_words], [date], [datetime], [unixtime], [job_timestamp], [job_unixtime]; leave empty for default.",
     "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
 
     "Loopback": "Process an image, use it as an input, repeat.",

--- a/modules/images.py
+++ b/modules/images.py
@@ -301,9 +301,17 @@ def apply_filename_pattern(x, p, seed, prompt):
         x = x.replace("[sampler]", sanitize_filename_part(sd_samplers.samplers[p.sampler_index].name, replace_spaces=False))
 
     x = x.replace("[model_hash]", getattr(p, "sd_model_hash", shared.sd_model.sd_model_hash))
-    x = x.replace("[date]", datetime.date.today().isoformat())
-    x = x.replace("[datetime]", datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
+
+    # provide consistent current time request to smallest details
+    ctime = datetime.datetime.now()
+    cdate = ctime.date()
+
+    x = x.replace("[date]", cdate.isoformat())
+    x = x.replace("[datetime]", ctime.strftime("%Y%m%d%H%M%S"))
     x = x.replace("[job_timestamp]", getattr(p, "job_timestamp", shared.state.job_timestamp))
+
+    x = x.replace("[unixtime]", str(int(ctime.timestamp())))
+    x = x.replace("[job_unixtime]", str(int(getattr(p, "job_unixtime", shared.state.job_unixtime))))
 
     # Apply [prompt] at last. Because it may contain any replacement word.^M
     if prompt is not None:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -137,6 +137,7 @@ class Processed:
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
         self.styles = p.styles
+        self.job_unixtime = state.job_unixtime
         self.job_timestamp = state.job_timestamp
         self.clip_skip = opts.CLIP_stop_at_last_layers
 
@@ -185,6 +186,7 @@ class Processed:
             "infotexts": self.infotexts,
             "styles": self.styles,
             "job_timestamp": self.job_timestamp,
+            "job_unixtime": self.job_unixtime,
             "clip_skip": self.clip_skip,
         }
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -136,7 +136,7 @@ class State:
     job = ""
     job_no = 0
     job_count = 0
-    job_timestamp = '0'
+    job_time = datetime.datetime.now()
     sampling_step = 0
     sampling_steps = 0
     current_latent = None
@@ -155,8 +155,13 @@ class State:
         self.sampling_step = 0
         self.current_image_sampling_step = 0
 
-    def get_job_timestamp(self):
-        return datetime.datetime.now().strftime("%Y%m%d%H%M%S")  # shouldn't this return job_timestamp?
+    @property
+    def job_timestamp(self):
+        return self.job_time.strftime("%Y%m%d%H%M%S")
+
+    @property
+    def job_unixtime(self):
+        return self.job_time.timestamp()
 
 
 state = State()

--- a/webui.py
+++ b/webui.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import datetime
 import time
 import importlib
 import signal
@@ -51,7 +52,7 @@ def wrap_gradio_gpu_call(func, extra_outputs=None):
         shared.state.sampling_step = 0
         shared.state.job_count = -1
         shared.state.job_no = 0
-        shared.state.job_timestamp = shared.state.get_job_timestamp()
+        shared.state.job_time = datetime.datetime.now()
         shared.state.current_latent = None
         shared.state.current_image = None
         shared.state.current_image_sampling_step = 0


### PR DESCRIPTION
Adds `[unixtime]` and `[job_unixtime]` on filename patterns for saving files.

This allows people that seeking straight raw date values (without TZ taking effects) can easily format the filename.