### PR TITLE
Fixed deepdanbooru on linux after overhaul

### DIFF
--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -55,7 +55,7 @@ def create_deepbooru_process(threshold, deepbooru_opts):
     shared.deepbooru_process_queue = shared.deepbooru_process_manager.Queue()
     shared.deepbooru_process_return = shared.deepbooru_process_manager.dict()
     shared.deepbooru_process_return["value"] = -1
-    shared.deepbooru_process = multiprocessing.Process(target=deepbooru_process, args=(shared.deepbooru_process_queue, shared.deepbooru_process_return, threshold, deepbooru_opts))
+    shared.deepbooru_process = context.Process(target=deepbooru_process, args=(shared.deepbooru_process_queue, shared.deepbooru_process_return, threshold, deepbooru_opts))
     shared.deepbooru_process.start()
 
 

--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -50,7 +50,8 @@ def create_deepbooru_process(threshold, deepbooru_opts):
     the tags.
     """
     from modules import shared  # prevents circular reference
-    shared.deepbooru_process_manager = multiprocessing.Manager()
+    context = multiprocessing.get_context("spawn")
+    shared.deepbooru_process_manager = context.Manager()
     shared.deepbooru_process_queue = shared.deepbooru_process_manager.Queue()
     shared.deepbooru_process_return = shared.deepbooru_process_manager.dict()
     shared.deepbooru_process_return["value"] = -1


### PR DESCRIPTION
After deepdanbooru overhaul you've broke it's linux support by removing "spawn" method of multiprocessing, which is explicitely required for torch and tensorflow not to block each other.