### PR TITLE
remove `notificationButton` from global scope

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -2,7 +2,7 @@
 
 let lastHeadImg = null;
 
-notificationButton = null
+let notificationButton = null;
 
 onUiUpdate(function(){
     if(notificationButton == null){


### PR DESCRIPTION
I'm assuming assigning `notificationButton` to the global scope was not the desired behavior as I can't see any other references to it in the javascript files or python files. Sorry if this is an incorrect assumption. Thanks for the hard work. 