### PR TITLE
after initial launch, disable --autolaunch for subsequent restarts

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -135,6 +135,8 @@ def webui():
             inbrowser=cmd_opts.autolaunch,
             prevent_thread_lock=True
         )
+        # after initial launch, disable --autolaunch for subsequent restarts
+        cmd_opts.autolaunch = False
 
         app.add_middleware(GZipMiddleware, minimum_size=1000)
 


### PR DESCRIPTION
currently if one is to click the `Restart Gradio and Refresh components (Custom Scripts, ui.py, js and css only)` under settings the web ui will be restarted
![image](https://user-images.githubusercontent.com/40751091/197380676-a07a28da-9a8f-4971-a985-1181f0174789.png)

but if the `--autolaunch` option is used it will open a second web UI page
causing multiple web ui page to be opened in the browser

I believe this is undesirable Behavior

this change fixes this behavior
make it and only apply to the initial launch

> [--autolaunch](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Command-Line-Arguments-and-Settings)
open the webui URL in the system's default browser upon launch
