### PR TITLE
update deepdanbooru version

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -111,7 +111,7 @@ def prepare_enviroment():
 
     gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "git+https://github.com/TencentARC/GFPGAN.git@8d2447a2d918f8eba5a4a01463fd48e45126a379")
     clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1")
-    deepdanbooru_package = os.environ.get('DEEPDANBOORU_PACKAGE', "git+https://github.com/KichangKim/DeepDanbooru.git@edf73df4cdaeea2cf00e9ac08bd8a9026b7a7b26")
+    deepdanbooru_package = os.environ.get('DEEPDANBOORU_PACKAGE', "git+https://github.com/KichangKim/DeepDanbooru.git@d91a2963bf87c6a770d74894667e9ffa9f6de7ff")
 
     xformers_windows_package = os.environ.get('XFORMERS_WINDOWS_PACKAGE', 'https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/f/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl')
 


### PR DESCRIPTION
fix #2404 

`Ubuntu 20.04.4 LTS, NVIDIA GeForce RTX 3080,   NVIDIA-SMI 515.76       Driver Version: 515.76       CUDA Version: 11.7`

first `pip uninstall deepdanbooru`  , and restart with `--deepdanbooru`

no error:

![image](https://user-images.githubusercontent.com/2416816/197392756-146b4d07-02a5-4fb9-aeae-27a65b9a3a67.png)
