### PR TITLE
Adds -ip command line options. 

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -61,6 +61,7 @@ parser.add_argument("--disable-opt-split-attention", action='store_true', help="
 parser.add_argument("--use-cpu", nargs='+',choices=['all', 'sd', 'interrogate', 'gfpgan', 'bsrgan', 'esrgan', 'scunet', 'codeformer'], help="use CPU as torch device for specified modules", default=[], type=str.lower)
 parser.add_argument("--listen", action='store_true', help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests")
 parser.add_argument("--port", type=int, help="launch gradio with given server port, you need root/admin rights for ports < 1024, defaults to 7860 if available", default=None)
+parser.add_argument("--ip", type=str, help="launch gradio with given custom server ip, defaults to 0.0.0.0", default="0.0.0.0")
 parser.add_argument("--show-negative-prompt", action='store_true', help="does not do anything", default=False)
 parser.add_argument("--ui-config-file", type=str, help="filename to use for ui configuration", default=os.path.join(script_path, 'ui-config.json'))
 parser.add_argument("--hide-ui-dir-config", action='store_true', help="hide directory configuration from webui", default=False)

--- a/webui.py
+++ b/webui.py
@@ -116,7 +116,7 @@ def api_only():
     app.add_middleware(GZipMiddleware, minimum_size=1000)
     api = create_api(app)
 
-    api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
+    api.launch(server_name=cmd_opts.ip if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
 
 
 def webui():
@@ -128,7 +128,7 @@ def webui():
 
         app, local_url, share_url = demo.launch(
             share=cmd_opts.share,
-            server_name="0.0.0.0" if cmd_opts.listen else None,
+            server_name=cmd_opts.ip if cmd_opts.listen else None,
             server_port=cmd_opts.port,
             debug=cmd_opts.gradio_debug,
             auth=[tuple(cred.split(':')) for cred in cmd_opts.gradio_auth.strip('"').split(',')] if cmd_opts.gradio_auth else None,


### PR DESCRIPTION
Some machines with multiple adapters can't use 0.0.0.0 reliably and you need to set an explicit interface to listen on.
This adds a --ip command line optoins, which allows you to set an explicit listening IP. 
Default is 0.0.0.0, so everything behaves exactly as before.
Only nerds like me with too much hardware connected to their computer needs this :P but it's useful if it is there.