### PR TITLE
Save properly processed images with option "save_images_before_color_correction"

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -460,7 +460,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     devices.torch_gc()
 
                 image = Image.fromarray(x_sample)
-                
+
                 if p.color_corrections is not None and i < len(p.color_corrections):
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
                         image_without_cc = apply_overlay(p.overlay_images is not None and i < len(p.overlay_images), p.overlay_images[i], p.paste_to, image)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -46,6 +46,20 @@ def apply_color_correction(correction, image):
 
     return image
 
+def apply_overlay(overlay_exists, overlay, paste_loc, image):
+    if overlay_exists:
+        if paste_loc is not None:
+            x, y, w, h = paste_loc
+            base_image = Image.new('RGBA', (overlay.width, overlay.height))
+            image = images.resize_image(1, image, w, h)
+            base_image.paste(image, (x, y))
+            image = base_image
+
+        image = image.convert('RGBA')
+        image.alpha_composite(overlay)
+        image = image.convert('RGB')
+
+    return image
 
 def get_correct_sampler(p):
     if isinstance(p, modules.processing.StableDiffusionProcessingTxt2Img):
@@ -446,25 +460,14 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     devices.torch_gc()
 
                 image = Image.fromarray(x_sample)
-
+                
                 if p.color_corrections is not None and i < len(p.color_corrections):
                     if opts.save and not p.do_not_save_samples and opts.save_images_before_color_correction:
-                        images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
+                        image_without_cc = apply_overlay(p.overlay_images is not None and i < len(p.overlay_images), p.overlay_images[i], p.paste_to, image)
+                        images.save_image(image_without_cc, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-before-color-correction")
                     image = apply_color_correction(p.color_corrections[i], image)
 
-                if p.overlay_images is not None and i < len(p.overlay_images):
-                    overlay = p.overlay_images[i]
-
-                    if p.paste_to is not None:
-                        x, y, w, h = p.paste_to
-                        base_image = Image.new('RGBA', (overlay.width, overlay.height))
-                        image = images.resize_image(1, image, w, h)
-                        base_image.paste(image, (x, y))
-                        image = base_image
-
-                    image = image.convert('RGBA')
-                    image.alpha_composite(overlay)
-                    image = image.convert('RGB')
+                image = apply_overlay(p.overlay_images is not None and i < len(p.overlay_images), p.overlay_images[i], p.paste_to, image)
 
                 if opts.samples_save and not p.do_not_save_samples:
                     images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

When using inpainting with color correction, the user can save the pre-cc version, but it was saved before the unmodified part of the original image was applied to it.

**Additional notes and description of your changes**

There's a similar issue with distorted image being shown in previews essentialy for the same reason. Would it be much of an overhead to fix it there too? Should be minor compared to decoding it every n steps.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB

**Screenshots or videos of your changes**

Color corrected images are on the left.

Before:

![197073034-af5b0d02-0e4a-4611-ab44-8088e4144314](https://user-images.githubusercontent.com/32306715/197415516-6e3a024d-b0ba-4e7e-8b7b-c13cb4e3fc29.png)
![197073316-9989e551-150b-4f6c-a542-4c7ec75ecf1b](https://user-images.githubusercontent.com/32306715/197415520-c944b961-80b0-4fe1-97f7-cb55601e3fa0.png)


After:

![image](https://user-images.githubusercontent.com/32306715/197415553-ea19f9fa-5a5f-44e0-978e-fffa25e87ea1.png)
![image](https://user-images.githubusercontent.com/32306715/197415580-3cc9de1d-131a-4066-aeae-5f6aa3c55a0d.png)