### PR TITLE
Fix breaking change, default filename pattern

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -477,8 +477,10 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     if forced_filename is None:
         if short_filename or seed is None:
             file_decoration = ""
-        else:
+        elif opts.save_to_dirs:
             file_decoration = opts.samples_filename_pattern or "[seed]"
+        else:
+            file_decoration = opts.samples_filename_pattern or "[seed]-[prompt_spaces]"
 
         add_number = opts.save_images_add_number or file_decoration == ''
 


### PR DESCRIPTION
@AUTOMATIC1111 
you've accidentally make a breaking change

the current default (when blank) filename patten is `[seed]`
before it was `[seed]-[prompt_spaces]`

current
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/df0a1f83815c771246a7b1bca85d63feaefad8d1/modules/images.py#L481
before
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/eb007e5884c23fbc38d7e9d1dd3669625270ca27/modules/images.py#L474

I'm currently writing the wiki and found this during testing

I think this needs to be fixed quickly so I ping you