### PR TITLE
[Bugfix][API] - Fix API response for colab users

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -42,9 +42,6 @@ class Api:
         # convert base64 to PIL image
         return Image.open(io.BytesIO(imgdata))
 
-    def __processed_info_to_json(self, processed):
-        return json.dumps(processed.info)
-
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):
         sampler_index = sampler_to_index(txt2imgreq.sampler_index)
         
@@ -116,7 +113,6 @@ class Api:
             b64images.append(base64.b64encode(buffer.getvalue()))
 
         if (not img2imgreq.include_init_images):
-            # remove img2imgreq.init_images and img2imgreq.mask
             img2imgreq.init_images = None
             img2imgreq.mask = None
 

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -31,6 +31,7 @@ class ModelDef(BaseModel):
     field_alias: str
     field_type: Any
     field_value: Any
+    field_exclude: bool = False
 
 
 class PydanticModelGenerator:
@@ -68,7 +69,7 @@ class PydanticModelGenerator:
                 field=underscore(k),
                 field_alias=k,
                 field_type=field_type_generator(k, v),
-                field_value=v.default
+                field_value=v.default,
             )
             for (k,v) in self._class_data.items() if k not in API_NOT_ALLOWED
         ]
@@ -78,7 +79,8 @@ class PydanticModelGenerator:
                 field=underscore(fields["key"]), 
                 field_alias=fields["key"], 
                 field_type=fields["type"],
-                field_value=fields["default"]))
+                field_value=fields["default"],
+                field_exclude=fields["exclude"] if "exclude" in fields else False))
 
     def generate_model(self):
         """
@@ -86,7 +88,7 @@ class PydanticModelGenerator:
         from the json and overrides provided at initialization
         """
         fields = {
-            d.field: (d.field_type, Field(default=d.field_value, alias=d.field_alias)) for d in self._model_def
+            d.field: (d.field_type, Field(default=d.field_value, alias=d.field_alias, exclude=d.field_exclude)) for d in self._model_def
         }
         DynamicModel = create_model(self._model_name, **fields)
         DynamicModel.__config__.allow_population_by_field_name = True
@@ -102,5 +104,5 @@ StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingImg2Img", 
     StableDiffusionProcessingImg2Img,
-    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}]
+    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}]
 ).generate_model()

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -69,7 +69,7 @@ class PydanticModelGenerator:
                 field=underscore(k),
                 field_alias=k,
                 field_type=field_type_generator(k, v),
-                field_value=v.default,
+                field_value=v.default
             )
             for (k,v) in self._class_data.items() if k not in API_NOT_ALLOWED
         ]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes the api response type for[ python 3.7 users (people on Colab)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3381#issuecomment-1288857851). Also sends the `info` field back as actual json (rather than a string), and adds an optional `include_init_images` to decrease response size

**Additional notes and description of your changes**
`include_init_images` is false by default (so the mask and `init_image` won't be returned). This decreases the response size by ~50%, but might be confusing for users who want to see that. Might be worth flipping if we allow users to send in a URL as @ArcticFaded [suggested here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3381#issuecomment-1287968584)


**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Linux
 - Browser: REST client
 - Graphics card: nvidia a100 (using lambda labs)

**Screenshots or videos of your changes**
<img width="708" alt="Screen Shot 2022-10-24 at 12 16 34 PM" src="https://user-images.githubusercontent.com/3484403/197575127-b962908f-0200-4010-836b-85e582283397.png">
