### PR TITLE
images: allow nested bracket in filename pattern

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -277,7 +277,7 @@ invalid_filename_chars = '<>:"/\\|?*\n'
 invalid_filename_prefix = ' '
 invalid_filename_postfix = ' .'
 re_nonletters = re.compile(r'[\s' + string.punctuation + ']+')
-re_pattern = re.compile(r"([^\[\]]+|\[([^]]+)]|[\[\]]*)")
+re_pattern = re.compile(r"(.*?)(?:\[([^\[\]]+)\]|$)")
 re_pattern_arg = re.compile(r"(.*)<([^>]*)>$")
 max_filename_part_length = 128
 
@@ -362,9 +362,9 @@ class FilenameGenerator:
 
         for m in re_pattern.finditer(x):
             text, pattern = m.groups()
+            res += text
 
             if pattern is None:
-                res += text
                 continue
 
             pattern_args = []
@@ -385,12 +385,9 @@ class FilenameGenerator:
                     print(f"Error adding [{pattern}] to filename", file=sys.stderr)
                     print(traceback.format_exc(), file=sys.stderr)
 
-                if replacement is None:
-                    res += f'[{pattern}]'
-                else:
+                if replacement is not None:
                     res += str(replacement)
-
-                continue
+                    continue
 
             res += f'[{pattern}]'
 


### PR DESCRIPTION
The new `FilenameGenerator` class cannot handle nested brackets correctly.
Fixed it.

It can handle patterns like `[[datetime]]` to `[20221025030405]`.