### PR TITLE
Force hypernet training previews to ignore subdirectory option (prevents folderspam).

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -458,7 +458,7 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
 
             if image is not None:
                 shared.state.current_image = image
-                last_saved_image, last_text_info = images.save_image(image, images_dir, "", p.seed, p.prompt, shared.opts.samples_format, processed.infotexts[0], p=p, forced_filename=forced_filename)
+                last_saved_image, last_text_info = images.save_image(image, images_dir, "", p.seed, p.prompt, shared.opts.samples_format, processed.infotexts[0], p=p, forced_filename=forced_filename, save_to_dirs=False)
                 last_saved_image += f", prompt: {preview_text}"
 
         shared.state.job_no = hypernetwork.step


### PR DESCRIPTION
This fixes the bug described by @SeverianVoid both in [a comment on 5245c7a](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/5245c7a4935f67b677da0f5a1fc2b74c074aa0e2#commitcomment-87547378) and in [a comment on issue 2921](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2921#issuecomment-1287523905). 