### PR TITLE
use default_time_format if format is blank

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -343,7 +343,7 @@ class FilenameGenerator:
     def datetime(self, *args):
         time_datetime = datetime.datetime.now()
 
-        time_format = args[0] if len(args) > 0 else self.default_time_format
+        time_format = args[0] if len(args) > 0 and args[0] != "" else self.default_time_format
         try:
             time_zone = pytz.timezone(args[1]) if len(args) > 1 else None
         except pytz.exceptions.UnknownTimeZoneError as _:


### PR DESCRIPTION
`[datetime<Format><Time Zone>]`
currently if the Format is blank

a patten like so
`[datetime<><Time Zone>]`

since `""` (blank) is a valid format, it will not trigger the exception and so it will not use the default
adn will result in output `""`

also #3595 allow nested bracket
this PR is compatible with the fix PR #3595

I tested with lots combinations of nested brackets and blank parameters that I think it's practical to test

hopefully my test is for enough and this will be the last of bugs concerning this topic