### PR TITLE
Added a way to generate CLIP/Deepbooru prompts for an entire directory of images [PoC?]

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -234,9 +234,10 @@ class InterrogateModels:
 
         self.unload()
 
-        response = f"Processed {len(table)} images, saving csv to {output_dir}/clip.csv..."
+        actual_output = output_dir if output_dir else input_dir
+        response = f"Processed {len(table)} images, saving csv to {actual_output}/batch_prompts.csv..."
         print(response)
-        file = open(os.path.join(output_dir if output_dir else input_dir, 'clip.csv'), 'w+', newline ='')
+        file = open(os.path.join(actual_output, 'batch_prompts.csv'), 'w+', newline ='')
         with file:
             write = csv.writer(file)
             write.writerows(table)

--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -204,8 +204,6 @@ class InterrogateModels:
 
                 caption = self.generate_caption(image)
 
-                if shared.cmd_opts.lowvram or shared.cmd_opts.medvram:
-                    self.send_blip_to_ram() # sending blip to ram for every image sounds slow but not too sure
                 devices.torch_gc()
 
                 cur_prompt = caption

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -32,7 +32,7 @@ from modules.paths import script_path
 from modules.shared import opts, cmd_opts, restricted_opts
 
 if cmd_opts.deepdanbooru:
-    from modules.deepbooru import get_deepbooru_tags
+    from modules.deepbooru import get_deepbooru_tags, batch_get_deepbooru_tags
 
 import modules.codeformer_model
 import modules.generation_parameters_copypaste
@@ -397,6 +397,9 @@ def interrogate_deepbooru(image):
     prompt = get_deepbooru_tags(image)
     return gr_show(True) if prompt is None else prompt
 
+def batch_interrogate_deepbooru(input_dir, output_dir):
+    response = batch_get_deepbooru_tags(input_dir, output_dir)
+    return gr_show(True) if response is None else response
 
 def create_seed_inputs():
     with gr.Row():
@@ -869,7 +872,10 @@ def create_ui(wrap_gradio_gpu_call):
                         gr.HTML(f"<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.<br>Use an empty output directory to save pictures normally instead of writing to the output directory.{hidden}</p>")
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs)
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
-                        img2img_batch_clip = gr.Button('Interrogate with CLIP', elem_id="img2img_batch_interrogate")
+                        with gr.Row():
+                            img2img_batch_clip = gr.Button('Interrogate input dir. with CLIP', elem_id="img2img_batch_interrogate")
+                            if cmd_opts.deepdanbooru:
+                                img2img_batch_deepbooru = gr.Button('Interrogate input dir. with Deepbooru', elem_id="img2img_batch_interrogate_booru")
 
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
@@ -1014,6 +1020,11 @@ def create_ui(wrap_gradio_gpu_call):
                     fn=interrogate_deepbooru,
                     inputs=[init_img],
                     outputs=[img2img_prompt],
+                )
+                img2img_batch_deepbooru.click(
+                    fn=batch_interrogate_deepbooru,
+                    inputs=[img2img_batch_input_dir, img2img_batch_output_dir],
+                    outputs=[]
                 )
 
             save.click(

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -388,6 +388,10 @@ def interrogate(image):
 
     return gr_show(True) if prompt is None else prompt
 
+def batch_interrogate_clip(input_dir, output_dir):
+    response = shared.interrogator.batch_interrogate(input_dir, output_dir)
+
+    return gr_show(True) if response is None else response
 
 def interrogate_deepbooru(image):
     prompt = get_deepbooru_tags(image)
@@ -865,6 +869,7 @@ def create_ui(wrap_gradio_gpu_call):
                         gr.HTML(f"<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.<br>Use an empty output directory to save pictures normally instead of writing to the output directory.{hidden}</p>")
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs)
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
+                        img2img_batch_clip = gr.Button('Interrogate with CLIP', elem_id="img2img_batch_interrogate")
 
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
@@ -996,6 +1001,12 @@ def create_ui(wrap_gradio_gpu_call):
                 fn=interrogate,
                 inputs=[init_img],
                 outputs=[img2img_prompt],
+            )
+
+            img2img_batch_clip.click(
+                fn=batch_interrogate_clip,
+                inputs=[img2img_batch_input_dir, img2img_batch_output_dir],
+                outputs=[]
             )
 
             if cmd_opts.deepdanbooru:


### PR DESCRIPTION
Initial commit, added a button under batch img2img, and a function under interrogate.py to process a directory of images

Personally, I'm not too familiar with Python, PyTorch or Gradio, but I added a new button that loops through a directory and generates CLIP prompts for each image, and saves it all in a CSV in the output (or input) directory.

Just wanted to get this PR out there, but I think this can still be improved by adding a progress bar of some sort (to both the console and Gradio UI hopefully), and maybe reducing the amount of duplicated code as currently it's basically just the `interrogate()` function contents with some of the loads/unloads rearranged and a loop.

Intention of this is that it's a precursor to another addition I was looking into, a way of reading prompts from a file when doing a batched img2img.

I'm only able to test this on a Linux + AMD setup, but it worked for me on a test batch of 10 PNGs.

Screenshots below:
![Screenshot_20221025_211149](https://user-images.githubusercontent.com/93455333/197878069-ebbd2514-c349-417e-b9eb-d9f455adfd52.png)

![Screenshot_20221025_211340](https://user-images.githubusercontent.com/93455333/197878092-4b07089b-8a52-4fc5-be7b-ec6a77e14e4e.png)

