### PR TITLE
Regional outpainting prototype.

### DIFF
--- a/javascript/aspectRatioOverlay.js
+++ b/javascript/aspectRatioOverlay.js
@@ -25,6 +25,8 @@ function dimensionChange(e, is_width, is_height){
 		targetElement = gradioApp().querySelector('div[data-testid=image] img');
 	} else if(tabIndex == 1){
 		targetElement = gradioApp().querySelector('#img2maskimg div[data-testid=image] img');
+	} else if(tabIndex == 3){
+		targetElement = gradioApp().querySelector('#img2img_outpaint div[data-testid=image] img');
 	}
 
 	if(targetElement){

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -59,6 +59,13 @@ function switch_to_img2img_inpaint(){
     return args_to_array(arguments);
 }
 
+function switch_to_img2img_outpaint(){
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
+    gradioApp().getElementById('mode_img2img').querySelectorAll('button')[3].click();
+
+    return args_to_array(arguments);
+}
+
 function switch_to_extras(){
     gradioApp().querySelector('#tabs').querySelectorAll('button')[2].click();
 
@@ -77,6 +84,11 @@ function extract_image_from_gallery_img2img(gallery){
 
 function extract_image_from_gallery_inpaint(gallery){
     switch_to_img2img_inpaint()
+    return extract_image_from_gallery(gallery);
+}
+
+function extract_image_from_gallery_outpaint(gallery){
+    switch_to_img2img_outpaint()
     return extract_image_from_gallery(gallery);
 }
 
@@ -140,7 +152,7 @@ function submit_img2img(){
     var objc = null
     var objw = null
     
-    img1 = document.body.children[0].shadowRoot.getElementById('img2img_image')
+    img1 = document.body.children[0].shadowRoot.getElementById('img2img_outpaint')
     if(typeof(img1) != 'undefined' && img1 != null)
     {
         objc = img1.getElementsByClassName('cropper-crop-box')

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -136,12 +136,44 @@ function submit(){
 }
 
 function submit_img2img(){
+    var img1 = null
+    var objc = null
+    var objw = null
+    
+    img1 = document.body.children[0].shadowRoot.getElementById('img2img_image')
+    if(typeof(img1) != 'undefined' && img1 != null)
+    {
+        objc = img1.getElementsByClassName('cropper-crop-box')
+        if(typeof(objc) != 'undefined' && objc != null && objc.length > 0)
+        {
+            objc = objc[0]
+            objw = objc.getElementsByTagName('img')[0]
+        }
+        else
+        {
+            objc = null
+            objw = null
+        }
+    }
     requestProgress('img2img')
 
     res = create_submit_args(arguments)
 
     res[0] = get_tab_index('mode_img2img')
 
+    if(typeof(objw) != 'undefined' && objw != null)
+    {
+        res[1] = objw.src
+        res[2] = objw.style['transform']
+        res[3] = objw.style['width']
+        res[4] = objw.style['height']
+    }
+    if(typeof(objc) != 'undefined' && objc != null)
+    {
+        res[5] = objc.style['transform']
+        res[6] = objc.style['width']
+        res[7] = objc.style['height']
+    }
     return res
 }
 

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -64,7 +64,7 @@ def img2img(mode: int,
             srcimg,vwt,vww,vwh,vct,vcw,vch,
             prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str,
             init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint,
-            indopaint, vthresh, vloch, vlocw, outpainting_fill,
+            init_img_outpaint, vthresh, vloch, vlocw, outpainting_fill,
             mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int,
             restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float,
             denoising_strength: float, seed: int, subseed: int, subseed_strength: float,
@@ -76,6 +76,7 @@ def img2img(mode: int,
     outparms = None
     is_inpaint = mode == 1
     is_batch = mode == 2
+    is_outpaint = mode == 3
 
     if is_inpaint:
         if mask_mode == 0:
@@ -87,68 +88,70 @@ def img2img(mode: int,
         else:
             image = init_img_inpaint
             mask = init_mask_inpaint
+    elif is_outpaint:
+        image = init_img_outpaint
+        mask = None
+        locmx = np.array(image).max(axis = 2)
+        mx = ndimage.grey_dilation(locmx,size = (vloch,vlocw))
+        mregion = (mx < vthresh)
+        expreg = ndimage.grey_dilation(mregion,size = (vloch,vlocw))
+        mask = np.logical_and(expreg,locmx < vthresh)
+        mask = Image.fromarray(mask)
+        
+        inpainting_fill = outpainting_fill
+        if srcimg is None:
+            print("Cannot overlay outpaint, did not receive source image.")
+        else:
+            # if srcimg.startswith("data:image/png;base64,"): # Nope.
+            #     srcimg = srcimg[len("data:image/png;base64,"):]
+            # srcimg_b = base64.decodebytes(srcimg.encode('utf-8'))
+            srcimg_b = base64.b64decode(srcimg.split(",")[-1])
+            srcimg_pil = Image.open(io.BytesIO(srcimg_b))
+            if "translateX" in vwt:
+                fparst = vwt.find("(")
+                fpared = vwt.find(")")
+                vwx = vwt[fparst + 1:fpared]
+            else:
+                fparst = -1
+                fpared = -1
+                vwx = "0px"
+            if "translateY" in vwt:
+                fparst = vwt.find("(",fparst + 1)
+                fpared = vwt.find(")",fpared + 1)
+                vwy = vwt[fparst + 1:fpared]
+            else:
+                fparst = -1
+                fpared = -1
+                vwy = "0px"
+            if "translateX" in vct:    
+                fparst = vct.find("(")
+                fpared = vct.find(")")
+                vcx = vct[fparst + 1:fpared]
+            else:
+                fparst = -1
+                fpared = -1
+                vcx = "0px"
+            if "translateY" in vct:
+                fparst = vct.find("(",fparst + 1)
+                fpared = vct.find(")",fpared + 1)
+                vcy = vct[fparst + 1:fpared]
+            else:
+                fparst = -1
+                fpared = -1
+                vcy = "0px"
+            fpx = lambda x: float(x.replace("px","")) 
+            vwx = fpx(vwx) 
+            vwy = fpx(vwy)
+            vww = fpx(vww)
+            vwh = fpx(vwh)
+            vcx = fpx(vcx)
+            vcy = fpx(vcy)
+            vcw = fpx(vcw)
+            vch = fpx(vch)
+            outparms = (srcimg_pil,vwx,vwy,vww,vwh,vcx,vcy,vcw,vch)
     else:
         image = init_img
         mask = None
-        if indopaint:
-            locmx = np.array(image).max(axis = 2)
-            mx = ndimage.grey_dilation(locmx,size = (vloch,vlocw))
-            mregion = (mx < vthresh)
-            expreg = ndimage.grey_dilation(mregion,size = (vloch,vlocw))
-            mask = np.logical_and(expreg,locmx < vthresh)
-            mask = Image.fromarray(mask)
-            
-            inpainting_fill = outpainting_fill
-            if srcimg is None:
-                print("Cannot overlay outpaint, did not receive source image.")
-            else:
-                # if srcimg.startswith("data:image/png;base64,"): # Nope.
-                #     srcimg = srcimg[len("data:image/png;base64,"):]
-                # srcimg_b = base64.decodebytes(srcimg.encode('utf-8'))
-                srcimg_b = base64.b64decode(srcimg.split(",")[-1])
-                srcimg_pil = Image.open(io.BytesIO(srcimg_b))
-                if "translateX" in vwt:
-                    fparst = vwt.find("(")
-                    fpared = vwt.find(")")
-                    vwx = vwt[fparst + 1:fpared]
-                else:
-                    fparst = -1
-                    fpared = -1
-                    vwx = "0px"
-                if "translateY" in vwt:
-                    fparst = vwt.find("(",fparst + 1)
-                    fpared = vwt.find(")",fpared + 1)
-                    vwy = vwt[fparst + 1:fpared]
-                else:
-                    fparst = -1
-                    fpared = -1
-                    vwy = "0px"
-                if "translateX" in vct:    
-                    fparst = vct.find("(")
-                    fpared = vct.find(")")
-                    vcx = vct[fparst + 1:fpared]
-                else:
-                    fparst = -1
-                    fpared = -1
-                    vcx = "0px"
-                if "translateY" in vct:
-                    fparst = vct.find("(",fparst + 1)
-                    fpared = vct.find(")",fpared + 1)
-                    vcy = vct[fparst + 1:fpared]
-                else:
-                    fparst = -1
-                    fpared = -1
-                    vcy = "0px"
-                fpx = lambda x: float(x.replace("px","")) 
-                vwx = fpx(vwx) 
-                vwy = fpx(vwy)
-                vww = fpx(vww)
-                vwh = fpx(vwh)
-                vcx = fpx(vcx)
-                vcy = fpx(vcy)
-                vcw = fpx(vcw)
-                vch = fpx(vch)
-                outparms = (srcimg_pil,vwx,vwy,vww,vwh,vcx,vcy,vcw,vch)
 
     assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
 

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -6,6 +6,10 @@ import traceback
 import numpy as np
 from PIL import Image, ImageOps, ImageChops
 
+from scipy import ndimage
+import base64
+import io
+
 from modules import devices
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 from modules.shared import opts, state
@@ -56,7 +60,20 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int,
+            srcimg,vwt,vww,vwh,vct,vcw,vch,
+            prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str,
+            init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint,
+            indopaint, vthresh, vloch, vlocw, outpainting_fill,
+            mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int,
+            restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float,
+            denoising_strength: float, seed: int, subseed: int, subseed_strength: float,
+            seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool,
+            height: int, width: int, resize_mode: int, inpaint_full_res: bool,
+            inpaint_full_res_padding: int, inpainting_mask_invert: int,
+            img2img_batch_input_dir: str, img2img_batch_output_dir: str,*args):
+    
+    outparms = None
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -73,6 +90,64 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
     else:
         image = init_img
         mask = None
+        if indopaint:
+            locmx = np.array(image).max(axis = 2)
+            mx = ndimage.grey_dilation(locmx,size = (vloch,vlocw))
+            mregion = (mx < vthresh)
+            expreg = ndimage.grey_dilation(mregion,size = (vloch,vlocw))
+            mask = np.logical_and(expreg,locmx < vthresh)
+            mask = Image.fromarray(mask)
+            
+            inpainting_fill = outpainting_fill
+            if srcimg is None:
+                print("Cannot overlay outpaint, did not receive source image.")
+            else:
+                if srcimg.startswith("data:image/png;base64,"):
+                    srcimg = srcimg[len("data:image/png;base64,"):]
+                srcimg_b = base64.decodebytes(srcimg.encode('utf-8'))
+                srcimg_pil = Image.open(io.BytesIO(srcimg_b))
+                if "translateX" in vwt:
+                    fparst = vwt.find("(")
+                    fpared = vwt.find(")")
+                    vwx = vwt[fparst + 1:fpared]
+                else:
+                    fparst = -1
+                    fpared = -1
+                    vwx = "0px"
+                if "translateY" in vwt:
+                    fparst = vwt.find("(",fparst + 1)
+                    fpared = vwt.find(")",fpared + 1)
+                    vwy = vwt[fparst + 1:fpared]
+                else:
+                    fparst = -1
+                    fpared = -1
+                    vwy = "0px"
+                if "translateX" in vct:    
+                    fparst = vct.find("(")
+                    fpared = vct.find(")")
+                    vcx = vct[fparst + 1:fpared]
+                else:
+                    fparst = -1
+                    fpared = -1
+                    vcx = "0px"
+                if "translateY" in vct:
+                    fparst = vct.find("(",fparst + 1)
+                    fpared = vct.find(")",fpared + 1)
+                    vcy = vct[fparst + 1:fpared]
+                else:
+                    fparst = -1
+                    fpared = -1
+                    vcy = "0px"
+                fpx = lambda x: float(x.replace("px","")) 
+                vwx = fpx(vwx) 
+                vwy = fpx(vwy)
+                vww = fpx(vww)
+                vwh = fpx(vwh)
+                vcx = fpx(vcx)
+                vcy = fpx(vcy)
+                vcw = fpx(vcw)
+                vch = fpx(vch)
+                outparms = (srcimg_pil,vwx,vwy,vww,vwh,vcx,vcy,vcw,vch)
 
     assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
 
@@ -107,6 +182,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         inpaint_full_res=inpaint_full_res,
         inpaint_full_res_padding=inpaint_full_res_padding,
         inpainting_mask_invert=inpainting_mask_invert,
+        outparms = outparms,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -102,9 +102,10 @@ def img2img(mode: int,
             if srcimg is None:
                 print("Cannot overlay outpaint, did not receive source image.")
             else:
-                if srcimg.startswith("data:image/png;base64,"):
-                    srcimg = srcimg[len("data:image/png;base64,"):]
-                srcimg_b = base64.decodebytes(srcimg.encode('utf-8'))
+                # if srcimg.startswith("data:image/png;base64,"): # Nope.
+                #     srcimg = srcimg[len("data:image/png;base64,"):]
+                # srcimg_b = base64.decodebytes(srcimg.encode('utf-8'))
+                srcimg_b = base64.b64decode(srcimg.split(",")[-1])
                 srcimg_pil = Image.open(io.BytesIO(srcimg_b))
                 if "translateX" in vwt:
                     fparst = vwt.find("(")

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -66,6 +66,28 @@ def apply_overlay(image, paste_loc, index, overlays):
 
     return image
 
+def outpaint_overlay(imgdiff,imgsrc,wx,wy,ww,wh,cx,cy,cw,ch):
+    """Overlay source image with diffusion over region, given location parms."""
+    wx = wx * -1
+    wy = wy * -1
+    wrel = cw / ww 
+    hrel = ch / wh
+    lrel = wx / ww
+    trel = wy / wh
+    xexp = (max(-1 * wx,0) + max(cw + wx - ww,0) + ww) / ww
+    yexp = (max(-1 * wy,0) + max(ch + wy - wh,0) + wh) / wh
+    psrcx = min(wx,0) * -1 / ww
+    psrcy = min(wy,0) * -1 / wh
+    pcrpx = max(wx,0) / ww
+    pcrpy = max(wy,0) / wh
+     
+    (srcw,srch) = imgsrc.size 
+    imgdiff_rsz = imgdiff.resize((int(srcw * wrel),int(srch * hrel)))
+    imgpst = Image.new("RGB",(int(srcw * xexp),int(srch * yexp)),0)
+    imgpst.paste(imgsrc,(int(srcw * psrcx),int(srch * psrcy)))
+    imgpst.paste(imgdiff_rsz,(int(srcw * pcrpx),int(srch * pcrpy)))
+    return imgpst
+
 def get_correct_sampler(p):
     if isinstance(p, modules.processing.StableDiffusionProcessingTxt2Img):
         return sd_samplers.samplers
@@ -473,6 +495,9 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
+                if hasattr(p,"outparms"):
+                    if p.outparms is not None:
+                        image = outpaint_overlay(image,*p.outparms)
 
                 if opts.samples_save and not p.do_not_save_samples:
                     images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p)
@@ -632,6 +657,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     sampler = None
 
     def __init__(self, init_images: list=None, resize_mode: int=0, denoising_strength: float=0.75, mask: Any=None, mask_blur: int=4, inpainting_fill: int=0, inpaint_full_res: bool=True, inpaint_full_res_padding: int=0, inpainting_mask_invert: int=0, **kwargs):
+        self.outparms = kwargs.pop("outparms",None)
+        
         super().__init__(**kwargs)
 
         self.init_images = init_images

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -841,7 +841,11 @@ def create_ui(wrap_gradio_gpu_call):
                 with gr.Tabs(elem_id="mode_img2img") as tabs_img2img_mode:
                     with gr.TabItem('img2img', id='img2img'):
                         init_img = gr.Image(label="Image for img2img", elem_id="img2img_image", show_label=False, source="upload", interactive=True, type="pil", tool=cmd_opts.gradio_img2img_tool).style(height=480)
-
+                        indopaint = gr.Checkbox(label='Outpainting for img2img',value = False)
+                        vthresh = gr.Slider(label='Masking threshold', minimum=1, maximum=255, step=1, value=1)
+                        vloch = gr.Slider(label='Mask region height', minimum=1, maximum=99, step=1, value=30)
+                        vlocw = gr.Slider(label='Mask region width', minimum=1, maximum=99, step=1, value=30)
+                        outpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing'], value='original', type="index")
                     with gr.TabItem('Inpaint', id='inpaint'):
                         init_img_with_mask = gr.Image(label="Image for inpainting with mask",  show_label=False, elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool="sketch", image_mode="RGBA").style(height=480)
 
@@ -951,6 +955,14 @@ def create_ui(wrap_gradio_gpu_call):
                 _js="submit_img2img",
                 inputs=[
                     dummy_component,
+                    # Parms: srcimg,vwt,vww,vwh,vct,vcw,vch.
+                    dummy_component,
+                    dummy_component,
+                    dummy_component,
+                    dummy_component,
+                    dummy_component,
+                    dummy_component,
+                    dummy_component,
                     img2img_prompt,
                     img2img_negative_prompt,
                     img2img_prompt_style,
@@ -959,6 +971,11 @@ def create_ui(wrap_gradio_gpu_call):
                     init_img_with_mask,
                     init_img_inpaint,
                     init_mask_inpaint,
+                    indopaint,
+                    vthresh,
+                    vloch,
+                    vlocw,
+                    outpainting_fill,
                     mask_mode,
                     steps,
                     sampler_index,

--- a/style.css
+++ b/style.css
@@ -516,6 +516,13 @@ img2maskimg, #img2maskimg > .h-60, #img2maskimg > .h-60 > div, #img2maskimg > .h
     min-height: 480px !important;
 }
 
+#img2img_outpaint, #img2img_outpaint > .h-60, #img2img_outpaint > .h-60 > div, #img2img_outpaint > .h-60 > div > img
+{
+    height: 720px !important;
+    max-height: 720px !important;
+    min-height: 720px !important;
+}
+
 /* The following handles localization for right-to-left (RTL) languages like Arabic.
 The rtl media type will only be activated by the logic in javascript/localization.js.
 If you change anything above, you need to make sure it is RTL compliant by just running


### PR DESCRIPTION
Process outlined and demonstrated in #3507 .
Uses gradio's selection tool to get the region from img2img, it is a bit clunky but gets the job done.
The additional components required were hastily thrown onto the tab, not sure where exactly they should be (leaning towards a separate tab but haven't really looked into it).
Note that I tested it on a slightly modified local version (all requirements and repo version checks disabled, installed and cloned the latest versions manually), so YMMV.