### PR TITLE
Prevent people from just saying I've got the latest version in the bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     id: commit
     attributes:
       label: Commit where the problem happens
-      description: Which commit are you running ? (copy the **Commit hash** shown in the cmd/terminal when you launch the UI)
+      description: Which commit are you running ? (Do not write *Latest version/repo/commit*, as this means nothing and will have changed by the time we read your issue. Rather, copy the **Commit hash** shown in the cmd/terminal when you launch the UI)
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
As the title says, sorry for the title error earlier.

This adds "Do not write *Latest version/repo/commit*, as this means nothing and will have changed by the time we read your issue" to the description of the commit field in the bug report form.