### PR TITLE
Fix typo in launch.py

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -101,7 +101,7 @@ def version_check(commit):
         else:
             print("Not a git clone, can't perform version check.")
     except Exception as e:
-        print("versipm check failed",e)
+        print("version check failed",e)
 
         
 def prepare_enviroment():


### PR DESCRIPTION
Typo on line 104, "verspm" changed to "version"