### PR TITLE
Add missing support for linear activation in hypernetwork

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -25,6 +25,7 @@ from statistics import stdev, mean
 class HypernetworkModule(torch.nn.Module):
     multiplier = 1.0
     activation_dict = {
+        "linear": torch.nn.Identity,
         "relu": torch.nn.ReLU,
         "leakyrelu": torch.nn.LeakyReLU,
         "elu": torch.nn.ELU,


### PR DESCRIPTION
In hypernetwork, the linear activation_func that the old implementation used is missing from ui.

Add the linear activation in hypernetwork back to ui.