### PR TITLE
Swap around text and ETA in document.title, making the ETA in the tab name more visible

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -10,7 +10,7 @@ function check_progressbar(id_part, id_progressbar, id_progressbar_span, id_skip
     
     if(opts.show_progress_in_title && progressbar && progressbar.offsetParent){
         if(progressbar.innerText){
-            let newtitle = 'Stable Diffusion - ' + progressbar.innerText
+            let newtitle = progressbar.innerText + ' - Stable Diffusion';
             if(document.title != newtitle){
                 document.title =  newtitle;          
             }


### PR DESCRIPTION
Very minor tweak, swapped text and ETA the document.title, making it more visible for those who switch tabs when genning.

![Screenshot_20221026_210729](https://user-images.githubusercontent.com/93455333/198126920-b7366b80-7507-49f9-896c-1f3b31bf83aa.png)
