### PR TITLE
Fix xformers expected query.dim() == 3 and wrong type

### DIFF
--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -222,11 +222,14 @@ def xformers_attention_forward(self, x, context=None, mask=None):
     k_in = self.to_k(context_k)
     v_in = self.to_v(context_v)
 
-    q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b n h d', h=h), (q_in, k_in, v_in))
+    q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
     del q_in, k_in, v_in
-    out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None)
+    if shared.cmd_opts.no_half:
+        out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None).float()
+    else:
+        out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None).half()
 
-    out = rearrange(out, 'b n h d -> b n (h d)', h=h)
+    out = rearrange(out, '(b h) n d -> b n (h d)', h=h)
     return self.to_out(out)
 
 def cross_attention_attnblock_forward(self, x):
@@ -304,7 +307,10 @@ def xformers_attnblock_forward(self, x):
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
-        out = xformers.ops.memory_efficient_attention(q, k, v)
+        if shared.cmd_opts.no_half:
+          out = xformers.ops.memory_efficient_attention(q, k, v).float()
+        else:
+          out = xformers.ops.memory_efficient_attention(q, k, v).half()
         out = rearrange(out, 'b (h w) c -> b c h w', h=h)
         out = self.proj_out(out)
         return x + out


### PR DESCRIPTION
Now xformers  working with coIab T4 and I need more testers, please test with this test 🦆 prompt
#
duck
Steps: 50, Sampler: Euler a, CFG scale: 7, Seed: 1886223165, Size: 512x512, Model hash: 7460a6fa

#
sd-v1-4.ckpt

#
PC 1070
with --no-half - with xformers 2.12it/s
without --no-half - with xformers 1.66it/s
with --no-half - without xformers - with doggettx 1.87it/s
without --no-half without xformers - with doggettx 1.67it/s

Colab T4
with --no-half - with xformers 2.00it/s
without --no-half - with xformers 5.73it/s
with --no-half - without xformers - with doggettx 1.99it/s
without --no-half without xformers - with doggettx 4.96it/s