### PR TITLE
Disable unavailable or duplicate options for Activation functions

### DIFF
--- a/modules/hypernetworks/ui.py
+++ b/modules/hypernetworks/ui.py
@@ -9,7 +9,7 @@ from modules import devices, sd_hijack, shared
 from modules.hypernetworks import hypernetwork
 
 not_available = ["hardswish", "multiheadattention"]
-keys = list(x for x in hypernetwork.HypernetworkModule.activation_dict.keys() if x not in not_available)
+keys = ["linear"] + list(x for x in hypernetwork.HypernetworkModule.activation_dict.keys() if x not in not_available)
 
 def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None, activation_func=None, weight_init=None, add_layer_norm=False, use_dropout=False):
     # Remove illegal characters from name.

--- a/modules/hypernetworks/ui.py
+++ b/modules/hypernetworks/ui.py
@@ -8,7 +8,8 @@ import modules.textual_inversion.textual_inversion
 from modules import devices, sd_hijack, shared
 from modules.hypernetworks import hypernetwork
 
-keys = list(hypernetwork.HypernetworkModule.activation_dict.keys())
+not_available = ["hardswish", "multiheadattention"]
+keys = list(x for x in hypernetwork.HypernetworkModule.activation_dict.keys() if x not in not_available)
 
 def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None, activation_func=None, weight_init=None, add_layer_norm=False, use_dropout=False):
     # Remove illegal characters from name.


### PR DESCRIPTION
### Task list

**Pending tasks**
- [x] https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3698 and fixes Dropout




**Done tasks**
- [x] Disable unavailable or duplicate options.https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/462e6ba6675bd14c0f82e465423a0eedfff82372 This
    MultiHeadAttention is not an standard activation function.
    Swish is duplicate key of hardswish. But for supporting generated HNs, dict itself won't be mutated.

**Future jobs:** 

- [ ] **Fix Hypernetwork multiplier value while training**
As far as I read the code, **hyperparameter multiplier can be changed while training**

- [x] **Save and load optimizer state dict**
People complained about optimizer not resuming properly, it was because we don't save optimizer state dict. 

- [x] **Generalized way to save / load optimizers**
This is for generalizing optimizer resuming process. It does not necessarily mean it will offer more optimizer options immediately.

- [x] **Also offer an option to nuke optimizer state dict**
Sometimes you want to nuke optimizer state dict, which will very likely change its training direction.

- [ ] **Add an option for specify standard deviation + scale multiplier for initialization + nonzero bias initialization**
related - https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2740
Analyzed data : [**Colab**](https://colab.research.google.com/drive/1Zxe53p8ICEQ6YelpTA1YI5rr0wkgyqY5#scrollTo=POj6n9PZzRqC)
Shortly, Xavier and Kaiming have too big standard deviation in weight initialization compared to normal. 
But rather than using magic numbers, the std should be parameterized, and we can use xavier normally, if we scale it. (its called gain in pytorch parameter)

- [ ] Add an option to fix weight initialization seeds. 
This is for reproducing results.

- [x] Add an option to specify dropout structure.
[Few ](https://arca.live/b/hypernetworks/61560939?p=1) [examples](https://arca.live/b/hypernetworks/61556844?p=1) have shown that 1, 2, 2[Dropout], 1 structure is promising. This is actually bug-generated networks, which won't be able to struct same structure with fix.
Instead of totally removing the functionality, we need to offer detailed way to specify dropouts.
Example : [0, 0.1, 0.15, 0] -> applies dropout at second, third layer. The sequence should follow the layer structure, First and last value should never use value other than 0.

**Optional**
- [ ] Quick-start in page / Offering references of previously trained HNs

- [ ] **Emphasize the importance of dataset quality**

- [ ] Grouping activations by type

- [ ] Generalized ways to evaluate HNs properly

- [ ] Hyperparameter tuning pipeline

- [x] Add ways to use multiple hypernetworks sequentially or in parallel