### PR TITLE
Added "Comment" function to negative prompt

### DIFF
--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -5,9 +5,18 @@ from modules.shared import opts, cmd_opts
 import modules.shared as shared
 import modules.processing as processing
 from modules.ui import plaintext_to_html
+import re
 
 
-def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, *args):
+def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, *args): 
+    
+    # 1. remove all commented "#"
+    negative_prompt = re.sub(r"\\#+", "", negative_prompt, re.MULTILINE)
+    # 2. remove all of the prompt after "##"
+    negative_prompt = re.sub(r"##.*", "", negative_prompt, re.MULTILINE)
+    # 3. remove all prompts with "#" until the next ","
+    negative_prompt = re.sub(r"#.*?,", "", negative_prompt, re.MULTILINE)
+    
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,


### PR DESCRIPTION
This adds following functions (to the negative prompt only):
1. You can use "#" before one or several words and it will delete those until the next comma (f.e.: "#blue, round, cubic" --> "round, cubic")
2. You can use "##" to everything behind those characters (f.e.: "blue, ##round, cubic" --> "blue")
3. You can use "\#" or "\##" to simply undo the comment function (f.e.: "\#blue, \##round, cubic" --> "blue, round, cubic" ) This might not be useful to everyone but it can save a lot of time when messing with the negative prompt because you don't have to crop your prompt to somewhere only to paste it back later. It's also useful to add a "standard" negative prompt in the config which can be uncommented at any time when needed.