### PR TITLE
Allow batch img2img to read prompts from a CSV file located in the input folder

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -865,15 +865,8 @@ def create_ui(wrap_gradio_gpu_call):
                         gr.HTML(f"<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.<br>Use an empty output directory to save pictures normally instead of writing to the output directory.{hidden}</p>")
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs)
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
-<<<<<<< HEAD
-=======
                         with gr.Row():
                             img2img_batch_read_prompts_from_csv = gr.Checkbox(label="Read prompts from 'batch_prompts.csv' in the input directory?", value=False)
-                        with gr.Row():
-                            img2img_batch_clip = gr.Button('Interrogate input dir. with CLIP', elem_id="img2img_batch_interrogate")
-                            if cmd_opts.deepdanbooru:
-                                img2img_batch_deepbooru = gr.Button('Interrogate input dir. with Deepbooru', elem_id="img2img_batch_interrogate_booru")
->>>>>>> d151eac (Init commit, added a checkbox to the batch img2img panel that will allow a CSV file to be read and override the prompts for each individual image)
 
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -865,6 +865,15 @@ def create_ui(wrap_gradio_gpu_call):
                         gr.HTML(f"<p class=\"text-gray-500\">Process images in a directory on the same machine where the server is running.<br>Use an empty output directory to save pictures normally instead of writing to the output directory.{hidden}</p>")
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs)
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
+<<<<<<< HEAD
+=======
+                        with gr.Row():
+                            img2img_batch_read_prompts_from_csv = gr.Checkbox(label="Read prompts from 'batch_prompts.csv' in the input directory?", value=False)
+                        with gr.Row():
+                            img2img_batch_clip = gr.Button('Interrogate input dir. with CLIP', elem_id="img2img_batch_interrogate")
+                            if cmd_opts.deepdanbooru:
+                                img2img_batch_deepbooru = gr.Button('Interrogate input dir. with Deepbooru', elem_id="img2img_batch_interrogate_booru")
+>>>>>>> d151eac (Init commit, added a checkbox to the batch img2img panel that will allow a CSV file to be read and override the prompts for each individual image)
 
                 with gr.Row():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
@@ -980,6 +989,7 @@ def create_ui(wrap_gradio_gpu_call):
                     inpainting_mask_invert,
                     img2img_batch_input_dir,
                     img2img_batch_output_dir,
+                    img2img_batch_read_prompts_from_csv,
                 ] + custom_inputs,
                 outputs=[
                     img2img_gallery,


### PR DESCRIPTION
Related to PR #3682 but is standalone, though it can work well together

This will allow the batch img2img feature to read a CSV named "batch_prompts.csv" located in the input directory and use the prompts from the CSV's columns

![Screenshot_20221027_220253](https://user-images.githubusercontent.com/93455333/198402034-255c4c29-78b3-4237-a4b5-b954afd24423.png)


Input folder on the right, output folder on the left. After generating the batch_prompts.csv I removed the rows for images "00001-0-3.png" and "00001-1-3.png" just to test and make sure it'll still work when images don't have a row, those two were generated with just the prompts from a selected Style and as you can see, they are very different to their corresponding inputs:
![Screenshot_20221027_222743](https://user-images.githubusercontent.com/93455333/198402054-81d0b61e-58ea-43a4-990d-40229cf72209.png)

First column of the CSV is the image filename, second column is the (positive) prompts, and third column is for the negative prompt (PR #3682 does not generate negative prompts but thought to include them anyway.)

If prompts are not found in the CSV, it will use the ones in the prompt fields as a fallback.

Like the other PR, I can only test this on Linux, although in theory this should also work on Windows as it's just reading an extra file and the image name from the image path (as far as platform-specific stuff goes).
