### PR TITLE
Fix log off by 1 #3847

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -428,7 +428,9 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
 
             optimizer.step()
 
-        if torch.isnan(losses[hypernetwork.step % losses.shape[0]]):
+        steps_done = hypernetwork.step + 1
+
+        if torch.isnan(losses[hypernetwork.step % losses.shape[0]]): 
             raise RuntimeError("Loss diverged.")
         
         if len(previous_mean_losses) > 1:
@@ -438,9 +440,9 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
         dataset_loss_info = f"dataset loss:{mean(previous_mean_losses):.3f}" + u"\u00B1" + f"({std / (len(previous_mean_losses) ** 0.5):.3f})"
         pbar.set_description(dataset_loss_info)
 
-        if hypernetwork.step > 0 and hypernetwork_dir is not None and hypernetwork.step % save_hypernetwork_every == 0:
+        if hypernetwork_dir is not None and steps_done % save_hypernetwork_every == 0:
             # Before saving, change name to match current checkpoint.
-            hypernetwork.name = f'{hypernetwork_name}-{hypernetwork.step}'
+            hypernetwork.name = f'{hypernetwork_name}-{steps_done}'
             last_saved_file = os.path.join(hypernetwork_dir, f'{hypernetwork.name}.pt')
             hypernetwork.save(last_saved_file)
 
@@ -449,8 +451,8 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
             "learn_rate": scheduler.learn_rate
         })
 
-        if hypernetwork.step > 0 and images_dir is not None and hypernetwork.step % create_image_every == 0:
-            forced_filename = f'{hypernetwork_name}-{hypernetwork.step}'
+        if images_dir is not None and steps_done % create_image_every == 0:
+            forced_filename = f'{hypernetwork_name}-{steps_done}'
             last_saved_image = os.path.join(images_dir, forced_filename)
 
             optimizer.zero_grad()

--- a/modules/textual_inversion/learn_schedule.py
+++ b/modules/textual_inversion/learn_schedule.py
@@ -52,7 +52,7 @@ class LearnRateScheduler:
         self.finished = False
 
     def apply(self, optimizer, step_number):
-        if step_number <= self.end_step:
+        if step_number < self.end_step:
             return
 
         try:


### PR DESCRIPTION
Fix #3847

Additionally, csv loss log was inconsistent with console output.

- csv: epoch 1-based index, step 1-based index
- output: epoch 0-based index, step 1-based index

I made it to be the same as output (epoch 0-based index).

Also, learn scheduler was weird that it used "<=" sign, so 0.01:10 doesn't mean the first 10 steps, but first 11 steps (applies until step 10 in 0-based steps). I changed this to "<" sign.

Screenshots: (debug prints have been cleaned)
<details>
<summary>Hypernetwork training</summary>

![image](https://user-images.githubusercontent.com/1442761/198622612-61c83c25-0de1-4903-8e07-730654e61676.png)
</details>
<details>
<summary>Textual embedding training</summary>

![image](https://user-images.githubusercontent.com/1442761/198622823-8a11faf2-6df4-4548-be23-4b8f74b7ff51.png)
</details>
<details>
<summary>CSV log</summary>

![image](https://user-images.githubusercontent.com/1442761/198623630-64dfd732-9f2e-4a08-9650-187a8fabee77.png)
</details>