### PR TITLE
Minor feature: inpaint with a specific color

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -58,7 +58,7 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, inpainting_fill_red: int, inpainting_fill_green: int, inpainting_fill_blue: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -110,6 +110,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         mask=mask,
         mask_blur=mask_blur,
         inpainting_fill=inpainting_fill,
+        inpainting_fill_colors=[inpainting_fill_red, inpainting_fill_green, inpainting_fill_blue],
         resize_mode=resize_mode,
         denoising_strength=denoising_strength,
         inpaint_full_res=inpaint_full_res,

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -58,7 +58,7 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, inpainting_fill_red: int, inpainting_fill_green: int, inpainting_fill_blue: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, inpainting_fill_red: int, inpainting_fill_green: int, inpainting_fill_blue: int, inpainting_fill_alpha: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -110,7 +110,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         mask=mask,
         mask_blur=mask_blur,
         inpainting_fill=inpainting_fill,
-        inpainting_fill_colors=[inpainting_fill_red, inpainting_fill_green, inpainting_fill_blue],
+        inpainting_fill_colors=[inpainting_fill_red, inpainting_fill_green, inpainting_fill_blue, inpainting_fill_alpha],
         resize_mode=resize_mode,
         denoising_strength=denoising_strength,
         inpaint_full_res=inpaint_full_res,

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -58,7 +58,7 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, inpainting_fill_red: int, inpainting_fill_green: int, inpainting_fill_blue: int, inpainting_fill_alpha: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, inpainting_fill_color: str, inpainting_fill_alpha: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -110,7 +110,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         mask=mask,
         mask_blur=mask_blur,
         inpainting_fill=inpainting_fill,
-        inpainting_fill_colors=[inpainting_fill_red, inpainting_fill_green, inpainting_fill_blue, inpainting_fill_alpha],
+        inpainting_fill_colors=[int(inpainting_fill_color[i:i+2],16) for i in (1,3,5)]+[inpainting_fill_alpha],
         resize_mode=resize_mode,
         denoising_strength=denoising_strength,
         inpaint_full_res=inpaint_full_res,

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -724,11 +724,14 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
             if self.image_mask is not None:
                 if self.inpainting_fill == 4: # 'paint' mode
-                    image = Image.composite(
-                        image,
-                        Image.new("RGB", image.size, tuple(self.inpainting_fill_colors)),
-                        ImageOps.invert(latent_mask)
+                    color_layer = Image.new("RGBA", image.size, (0,0,0,0))
+                    color_layer.paste(
+                        Image.new("RGBA", image.size, tuple(self.inpainting_fill_colors)),
+                        None, latent_mask
                     )
+                    image_rgba = image.convert("RGBA")
+                    image_rgba.alpha_composite(color_layer)
+                    image = image_rgba.convert("RGB")
                 elif self.inpainting_fill != 1:
                     image = masking.fill(image, latent_mask)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -646,7 +646,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     sampler = None
 
-    def __init__(self, init_images: list=None, resize_mode: int=0, denoising_strength: float=0.75, mask: Any=None, mask_blur: int=4, inpainting_fill: int=0, inpaint_full_res: bool=True, inpaint_full_res_padding: int=0, inpainting_mask_invert: int=0, **kwargs):
+    def __init__(self, init_images: list=None, resize_mode: int=0, denoising_strength: float=0.75, mask: Any=None, mask_blur: int=4, inpainting_fill: int=0, inpainting_fill_colors: list[int]=[], inpaint_full_res: bool=True, inpaint_full_res_padding: int=0, inpainting_mask_invert: int=0, **kwargs):
         super().__init__(**kwargs)
 
         self.init_images = init_images
@@ -659,6 +659,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.mask_for_overlay = None
         self.mask_blur = mask_blur
         self.inpainting_fill = inpainting_fill
+        self.inpainting_fill_colors = inpainting_fill_colors
         self.inpaint_full_res = inpaint_full_res
         self.inpaint_full_res_padding = inpaint_full_res_padding
         self.inpainting_mask_invert = inpainting_mask_invert
@@ -722,7 +723,13 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 image = images.resize_image(2, image, self.width, self.height)
 
             if self.image_mask is not None:
-                if self.inpainting_fill != 1:
+                if self.inpainting_fill == 4: # 'paint' mode
+                    image = Image.composite(
+                        image,
+                        Image.new("RGB", image.size, tuple(self.inpainting_fill_colors)),
+                        ImageOps.invert(latent_mask)
+                    )
+                elif self.inpainting_fill != 1:
                     image = masking.fill(image, latent_mask)
 
             if add_color_corrections:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -856,14 +856,9 @@ def create_ui(wrap_gradio_gpu_call):
 
                         inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing', 'paint'], value='original', type="index")
 
-                        inpainting_fill_colors = []
                         with gr.Row(visible=False) as row_of_colors:
-                            with gr.Box():
-                                for color_name in ("Red", "Green", "Blue", "Alpha"):
-                                    with gr.Row(elem_id="color_row_"+color_name):
-                                        inpainting_fill_colors.append(
-                                            gr.Slider(label=color_name, value=255 if color_name == 'Alpha' else 0, minimum=0, maximum=255, step=1)
-                                        )
+                            inpainting_fill_color = gr.ColorPicker("#000000", label="Color", interactive=True, elem_id="inpainting_fill_color")
+                            inpainting_fill_alpha = gr.Slider(label="Alpha", value=255, minimum=0, maximum=255, step=1)
                         def change_visibility(idx: int):
                             show = idx == 4 # 'paint' was used.
                             return {row_of_colors: gr_show(show)}
@@ -977,7 +972,8 @@ def create_ui(wrap_gradio_gpu_call):
                     sampler_index,
                     mask_blur,
                     inpainting_fill,
-                    *inpainting_fill_colors,
+                    inpainting_fill_color,
+                    inpainting_fill_alpha,
                     restore_faces,
                     tiling,
                     batch_count,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -854,7 +854,21 @@ def create_ui(wrap_gradio_gpu_call):
                             mask_mode = gr.Radio(label="Mask mode", show_label=False, choices=["Draw mask", "Upload mask"], type="index", value="Draw mask", elem_id="mask_mode")
                             inpainting_mask_invert = gr.Radio(label='Masking mode', show_label=False, choices=['Inpaint masked', 'Inpaint not masked'], value='Inpaint masked', type="index")
 
-                        inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing'], value='original', type="index")
+                        inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing', 'paint'], value='original', type="index")
+
+                        inpainting_fill_colors = []
+                        with gr.Row(visible=False) as row_of_colors:
+                            with gr.Box() as box:
+                                with gr.Row(elem_id='color_row_1'):
+                                    inpainting_fill_colors += [
+                                        gr.Slider(label='Red', value=0, minimum=0, maximum=255, step=1),
+                                        gr.Slider(label='Green', value=0, minimum=0, maximum=255, step=1),
+                                        gr.Slider(label='Blue', value=0, minimum=0, maximum=255, step=1)
+                                    ]
+                        def change_visibility(idx: int):
+                            show = idx == 4 # 'paint' was used.
+                            return {row_of_colors: gr_show(show)}
+                        inpainting_fill.change(change_visibility, show_progress=False, inputs=[inpainting_fill], outputs=[row_of_colors])
 
                         with gr.Row():
                             inpaint_full_res = gr.Checkbox(label='Inpaint at full resolution', value=False)
@@ -964,6 +978,7 @@ def create_ui(wrap_gradio_gpu_call):
                     sampler_index,
                     mask_blur,
                     inpainting_fill,
+                    *inpainting_fill_colors,
                     restore_faces,
                     tiling,
                     batch_count,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -858,13 +858,12 @@ def create_ui(wrap_gradio_gpu_call):
 
                         inpainting_fill_colors = []
                         with gr.Row(visible=False) as row_of_colors:
-                            with gr.Box() as box:
-                                with gr.Row(elem_id='color_row_1'):
-                                    inpainting_fill_colors += [
-                                        gr.Slider(label='Red', value=0, minimum=0, maximum=255, step=1),
-                                        gr.Slider(label='Green', value=0, minimum=0, maximum=255, step=1),
-                                        gr.Slider(label='Blue', value=0, minimum=0, maximum=255, step=1)
-                                    ]
+                            with gr.Box():
+                                for color_name in ("Red", "Green", "Blue", "Alpha"):
+                                    with gr.Row(elem_id="color_row_"+color_name):
+                                        inpainting_fill_colors.append(
+                                            gr.Slider(label=color_name, value=255 if color_name == 'Alpha' else 0, minimum=0, maximum=255, step=1)
+                                        )
                         def change_visibility(idx: int):
                             show = idx == 4 # 'paint' was used.
                             return {row_of_colors: gr_show(show)}

--- a/style.css
+++ b/style.css
@@ -589,3 +589,7 @@ Then, you will need to add the RTL counterpart only if needed in the rtl section
         left: 0.5em;
     }
 }
+
+#inpainting_fill_color {
+    flex-grow: unset
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54623771/198651691-dfafeb3e-f059-4d1f-a263-792d1ebf3c0e.png)
> A portrait of a man, photorealistic, green shirt
> Steps: 21, Sampler: Euler a, CFG scale: 7, Seed: 3657819881, Size: 512x512, Model hash: 81761151, Denoising strength: 0.95, Mask blur: 19

## Explanation

Currently, the `Masked content: Fill` option does a blurring effect on the inpainted area:

![image](https://user-images.githubusercontent.com/54623771/198644962-340a57d8-f60a-4042-9ae9-203ef633ad33.png)

This pull request adds a `Masked content: paint` option, that fills the inpainted mask region with a user-determined color:

![image](https://user-images.githubusercontent.com/54623771/198646574-f0ad5df3-5e51-437b-bb62-1a0d47161d56.png)

## Considerations
> Won't it be confusing to see a black colored brush while using this option?

It is, but I am unable to change the brush color in the gradio sketch interface easily. One possible alternative might be to add a color indicator next to the RGB sliders added with this PR.

Edit: A color picker is now used instead of sliders. See:
![](https://user-images.githubusercontent.com/54623771/198814569-b55badef-b573-451c-a813-035d828b22f7.png)

> Why not use `gr.Image(..., tool="color-sketch")`?

I'm thinking a lot of code will break if the UI allows more than one colour at a time.