### PR TITLE
Extras Tab - Option to upscale before face fix, caching improvements

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -141,7 +141,7 @@ def run_extras(extras_mode, resize_mode, image, image_folder, input_dir, output_
                             upscaling_resize_w, upscaling_resize_h, upscaling_crop)
             cache_key = LruCache.Key(image_hash=hash(np.array(image.getdata()).tobytes()),
                                      info_hash=hash(info),
-                                     args_hash=hash(upscale_args + (upscaler.blend_alpha,)))
+                                     args_hash=hash(upscale_args))
             cached_entry = cached_images.get(cache_key)
             if cached_entry is None:
                 res = upscale(image, *upscale_args)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1178,6 +1178,11 @@ def create_ui(wrap_gradio_gpu_call):
             outputs=[init_img_with_mask],
         )
 
+        extras_image.change(
+            fn=modules.extras.clear_cache,
+            inputs=[], outputs=[]
+        )
+
     with gr.Blocks(analytics_enabled=False) as pnginfo_interface:
         with gr.Row().style(equal_height=False):
             with gr.Column(variant='panel'):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1119,6 +1119,9 @@ def create_ui(wrap_gradio_gpu_call):
                     codeformer_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="CodeFormer visibility", value=0, interactive=modules.codeformer_model.have_codeformer)
                     codeformer_weight = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="CodeFormer weight (0 = maximum effect, 1 = minimum effect)", value=0, interactive=modules.codeformer_model.have_codeformer)
 
+                with gr.Group():
+                    upscale_before_face_fix = gr.Checkbox(label='Upscale Before Restoring Faces', value=False)
+
                 submit = gr.Button('Generate', elem_id="extras_generate", variant='primary')
 
             with gr.Column(variant='panel'):
@@ -1152,6 +1155,7 @@ def create_ui(wrap_gradio_gpu_call):
                 extras_upscaler_1,
                 extras_upscaler_2,
                 extras_upscaler_2_visibility,
+                upscale_before_face_fix,
             ],
             outputs=[
                 result_images,


### PR DESCRIPTION
This patch makes some updates to the 'extras' page:

* It adds an option to run upscaling before running face restoration. This seems to work much better for me, since the face restoration gets a chance to fix the upscaler artifacts.

* Reworks the caching upscaler mechanism to allow a bit more freedom in experimenting with the settings without retriggering long upscales. The cache now holds more items (was 2, now 5), uses LRU eviction and is cleared when the source UI image changes.
* Also fixes a bug where the Extras page could not process consecutive similar images, since the 'cache key' was only considering a cropped portion of the image, so could ignore new images.