### PR TITLE
Saving paramters to exif as dict type

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import math
 import os
+import ast
 
 import numpy as np
 from PIL import Image
@@ -64,9 +65,7 @@ def get_image_info(image):
             exif_comment = exif_comment.decode('utf8', errors="ignore")
         
         if exif_comment.startswith("{'"):
-            exist_exif_data = eval(exif_comment)
-            print(exist_exif_data)
-            print(type(exist_exif_data))
+            exist_exif_data = ast.literal_eval(exif_comment)
             for k, v in exist_exif_data.items():
                 image_info[k] = v
         else:

--- a/modules/images.py
+++ b/modules/images.py
@@ -504,7 +504,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     def exif_bytes():
         return piexif.dump({
             "Exif": {
-                piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(info or "", encoding="unicode")
+                piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(str(pnginfo) or "", encoding="unicode")
             },
         })
 
@@ -518,7 +518,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     elif extension.lower() in (".jpg", ".jpeg", ".webp"):
         image.save(fullfn, quality=opts.jpeg_quality)
 
-        if opts.enable_pnginfo and info is not None:
+        if opts.enable_pnginfo and pnginfo is not None:
             piexif.insert(exif_bytes(), fullfn)
     else:
         image.save(fullfn, quality=opts.jpeg_quality)


### PR DESCRIPTION
- Fixed handling (".jpg", ".jpeg", ".webp") files from 'images.py'
Currently it gives only 'info' data if image is not png format, so when process images on extras tab above file types lose original parameters and saved only extras info. So I changed to give whole pnginfo as dict type which is converted to string.

- Make 'get_image_info' function to handle exif data
By referring to the existing logic, I changed it to a function and changed it to use it by calling it. It read exif data and if it is saved in dict type as string, convert to dict type and return it like same format as pnginfo. If exif has only parameters as general string, a function change it th dict with 'parameters' key. It's for already saved jpg images with general string.

- Now, jpg files can store different parameters using dict type.
![image_info](https://user-images.githubusercontent.com/65882974/198824105-f8302356-bc8c-485d-bd8e-7d0930d0ea59.jpg)
![image_info2](https://user-images.githubusercontent.com/65882974/198824159-9bd1acb8-05f9-42aa-99cf-ff7e2ccfc4ed.jpg)
