### PR TITLE
Add mid-kdiffusion cfgdenoiser script callback - access latents, conditionings and sigmas mid-sampling

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -48,7 +48,7 @@ def clear_callbacks():
     callbacks_ui_settings.clear()
     callbacks_before_image_saved.clear()
     callbacks_image_saved.clear()
-
+    callbacks_cfg_denoiser.clear()
 
 def model_loaded_callback(sd_model):
     for c in callbacks_model_loaded:

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -24,13 +24,22 @@ class ImageSaveParams:
         """dictionary with parameters for image's PNG info data; infotext will have the key 'parameters'"""
 
 
-class CGFDenoiserParams:
-    def __init__(self, x_in, image_cond_in, sigma_in, sampling_step, total_sampling_steps):
-        self.x_in = x_in
-        self.image_cond_in = image_cond_in
-        self.sigma_in = sigma_in
+class CFGDenoiserParams:
+    def __init__(self, x, image_cond, sigma, sampling_step, total_sampling_steps):
+        self.x = x
+        """Latent image representation in the process of being denoised"""
+        
+        self.image_cond = image_cond
+        """Conditioning image"""
+        
+        self.sigma = sigma
+        """Current sigma noise step value"""
+        
         self.sampling_step = sampling_step
+        """Current Sampling step number"""
+        
         self.total_sampling_steps = total_sampling_steps
+        """Total number of sampling steps planned"""
 
 
 ScriptCallback = namedtuple("ScriptCallback", ["script", "callback"])
@@ -94,7 +103,7 @@ def image_saved_callback(params: ImageSaveParams):
             report_exception(c, 'image_saved_callback')
 
 
-def cfg_denoiser_callback(params: CGFDenoiserParams):
+def cfg_denoiser_callback(params: CFGDenoiserParams):
     for c in callbacks_cfg_denoiser:
         try:
             c.callback(params)
@@ -153,7 +162,7 @@ def on_image_saved(callback):
 def on_cfg_denoiser(callback):
     """register a function to be called in the kdiffussion cfg_denoiser method after building the inner model inputs.
     The callback is called with one argument:
-        - params: CGFDenoiserParams - parameters to be passed to the inner model and sampling state details.
+        - params: CFGDenoiserParams - parameters to be passed to the inner model and sampling state details.
     """
     add_callback(callbacks_cfg_denoiser, callback)
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -11,6 +11,7 @@ from modules import prompt_parser, devices, processing, images
 
 from modules.shared import opts, cmd_opts, state
 import modules.shared as shared
+from modules.script_callbacks import CGFDenoiserParams, cfg_denoiser_callback
 
 
 SamplerData = namedtuple('SamplerData', ['name', 'constructor', 'aliases', 'options'])
@@ -277,6 +278,8 @@ class CFGDenoiser(torch.nn.Module):
         x_in = torch.cat([torch.stack([x[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [x])
         image_cond_in = torch.cat([torch.stack([image_cond[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [image_cond])
         sigma_in = torch.cat([torch.stack([sigma[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [sigma])
+
+        cfg_denoiser_callback(CGFDenoiserParams(x_in, image_cond_in, sigma_in, state.sampling_step, state.sampling_steps))
 
         if tensor.shape[1] == uncond.shape[1]:
             cond_in = torch.cat([tensor, uncond])

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -11,7 +11,7 @@ from modules import prompt_parser, devices, processing, images
 
 from modules.shared import opts, cmd_opts, state
 import modules.shared as shared
-from modules.script_callbacks import CGFDenoiserParams, cfg_denoiser_callback
+from modules.script_callbacks import CFGDenoiserParams, cfg_denoiser_callback
 
 
 SamplerData = namedtuple('SamplerData', ['name', 'constructor', 'aliases', 'options'])
@@ -279,7 +279,11 @@ class CFGDenoiser(torch.nn.Module):
         image_cond_in = torch.cat([torch.stack([image_cond[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [image_cond])
         sigma_in = torch.cat([torch.stack([sigma[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [sigma])
 
-        cfg_denoiser_callback(CGFDenoiserParams(x_in, image_cond_in, sigma_in, state.sampling_step, state.sampling_steps))
+        denoiser_params = CFGDenoiserParams(x_in, image_cond_in, sigma_in, state.sampling_step, state.sampling_steps)
+        cfg_denoiser_callback(denoiser_params)
+        x_in = denoiser_params.x
+        image_cond_in = denoiser_params.image_cond
+        sigma_in = denoiser_params.sigma
 
         if tensor.shape[1] == uncond.shape[1]:
             cond_in = torch.cat([tensor, uncond])


### PR DESCRIPTION
Briefly discussed in the context allowing scripts to force various symmetries onto the image latents here: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/2441

Script with basic mirroring and rotation operation here:
https://gist.github.com/dfaker/ac031e87174a94d8a170d897caac9ff6