### PR TITLE
Show hash of HyperNetworks in dropdown

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -211,7 +211,7 @@ def list_hypernetworks(path):
         name = os.path.splitext(os.path.basename(filename))[0]
         # Prevent a hypothetical "None.pt" from being listed.
         if name != "None":
-            res[name] = filename
+            res[name + f"({sd_models.model_hash(filename)})"] = filename
     return res
 
 

--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -356,7 +356,8 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
         os.makedirs(hypernetwork_dir, exist_ok=True)
     else:
         hypernetwork_dir = None
-
+    hypernetwork_name = hypernetwork_name.rsplit('(', 1)[0]
+        
     if create_image_every > 0:
         images_dir = os.path.join(log_directory, "images")
         os.makedirs(images_dir, exist_ok=True)


### PR DESCRIPTION
Since there are currently multiple HNs from single style / characters, we need to show the file hash. ([related korean issue](https://arca.live/b/hypernetworks/61868651?p=1))

![image](https://user-images.githubusercontent.com/35677394/198999377-aca1fe78-33c0-47af-be0b-51a3e50ec8be.png)

