### PR TITLE
Add PNG info to pngs only if option is enabled.

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -510,8 +510,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     if extension.lower() == '.png':
         pnginfo_data = PngImagePlugin.PngInfo()
-        for k, v in params.pnginfo.items():
-            pnginfo_data.add_text(k, str(v))
+        if opts.enable_pnginfo:
+            for k, v in params.pnginfo.items():
+                pnginfo_data.add_text(k, str(v))
 
         image.save(fullfn, quality=opts.jpeg_quality, pnginfo=pnginfo_data)
 


### PR DESCRIPTION
Fixes #3875. `exif_bytes` now makes sure `enable_pnginfo` is True before adding pnginfo to pngs.