### PR TITLE
make save dir if save dir is not exists

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -55,6 +55,7 @@ def process_batch(p, input_dir, output_dir, args):
                 filename = f"{left}-{n}{right}"
 
             if not save_normally:
+                os.makedirs(output_dir, exist_ok=True)
                 processed_image.save(os.path.join(output_dir, filename))
 
 


### PR DESCRIPTION
Batch image2image has an error when saving if the directory specified in Output directory does not exist. 
If the directory does not exist before saving, it will be created before saving.