### PR TITLE
Caused error in latest pytorch-lightning==1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ opencv-python
 requests
 piexif
 Pillow
-pytorch_lightning
+pytorch_lightning==1.7.7
 realesrgan
 scikit-image>=0.19
 timm==0.4.12


### PR DESCRIPTION
caused error below in pytorch-lightning==1.8.0 and it worked in 1.7.7

Already up to date.
Warning: k_diffusion not found at path /notebooks/stable-diffusion-webui/repositories/k-diffusion/k_diffusion/sampling.py
Traceback (most recent call last):
  File "/notebooks/stable-diffusion-webui/webui.py", line 12, in <module>
    from modules import devices, sd_samplers, upscaler, extensions
  File "/notebooks/stable-diffusion-webui/modules/sd_samplers.py", line 11, in <module>
    from modules import prompt_parser, devices, processing, images
  File "/notebooks/stable-diffusion-webui/modules/processing.py", line 14, in <module>
    import modules.sd_hijack
  File "/notebooks/stable-diffusion-webui/modules/sd_hijack.py", line 10, in <module>
    import modules.textual_inversion.textual_inversion
  File "/notebooks/stable-diffusion-webui/modules/textual_inversion/textual_inversion.py", line 13, in <module>
    from modules import shared, devices, sd_hijack, processing, sd_models, images
  File "/notebooks/stable-diffusion-webui/modules/shared.py", line 14, in <module>
    import modules.sd_models
  File "/notebooks/stable-diffusion-webui/modules/sd_models.py", line 14, in <module>
    from modules.sd_hijack_inpainting import do_inpainting_hijack, should_hijack_inpainting
  File "/notebooks/stable-diffusion-webui/modules/sd_hijack_inpainting.py", line 6, in <module>
    import ldm.models.diffusion.ddpm
  File "/notebooks/stable-diffusion-webui/repositories/stable-diffusion/ldm/models/diffusion/ddpm.py", line 19, in <module>
    from pytorch_lightning.utilities.distributed import rank_zero_only
ImportError: cannot import name 'rank_zero_only' from 'pytorch_lightning.utilities.distributed' (/usr/local/lib/python3.9/dist-packages/pytorch_lightning/utilities/distributed.py)