### PR TITLE
Change assert into print for extension access disabled

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -17,7 +17,7 @@ available_extensions = {"extensions": []}
 
 
 def check_access():
-    assert not shared.cmd_opts.disable_extension_access, "extension access disabed because of commandline flags"
+    if shared.cmd_opts.disable_extension_access: print("extension access disabled because of commandline flags")
 
 
 def apply_and_restart(disable_list, update_list):


### PR DESCRIPTION
The assert produces unnecessary traceback logs that 'scares' new users and occupy the console. See https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/4065

Change asserts into print for extension access disabled
Fixes typo in 'disabled'