### PR TITLE
Regional outpainting prototype - tab.

### DIFF
--- a/javascript/aspectRatioOverlay.js
+++ b/javascript/aspectRatioOverlay.js
@@ -25,6 +25,8 @@ function dimensionChange(e, is_width, is_height){
 		targetElement = gradioApp().querySelector('div[data-testid=image] img');
 	} else if(tabIndex == 1){
 		targetElement = gradioApp().querySelector('#img2maskimg div[data-testid=image] img');
+	} else if(tabIndex == 3){
+		targetElement = gradioApp().querySelector('#img2mask_outpaint div[data-testid=image] img');
 	}
 
 	if(targetElement){

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -65,6 +65,13 @@ function switch_to_extras(){
     return args_to_array(arguments);
 }
 
+function switch_to_img2img_outpaint(){
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
+    gradioApp().getElementById('mode_img2img').querySelectorAll('button')[3].click();
+
+    return args_to_array(arguments);
+}
+
 function get_tab_index(tabId){
     var res = 0
 
@@ -116,11 +123,44 @@ function submit(){
 }
 
 function submit_img2img(){
+    var img1 = null
+    var objc = null
+    var objw = null
+
+    img1 = document.body.children[0].shadowRoot.getElementById('img2img_outpaint')
+    if(typeof(img1) != 'undefined' && img1 != null)
+    {
+        objc = img1.getElementsByClassName('cropper-crop-box')
+        if(typeof(objc) != 'undefined' && objc != null && objc.length > 0)
+        {
+            objc = objc[0]
+            objw = objc.getElementsByTagName('img')[0]
+        }
+        else
+        {
+            objc = null
+            objw = null
+        }
+    }
     requestProgress('img2img')
 
     res = create_submit_args(arguments)
 
     res[0] = get_tab_index('mode_img2img')
+
+    if(typeof(objw) != 'undefined' && objw != null)
+    {
+        res[1] = objw.src
+        res[2] = objw.style['transform']
+        res[3] = objw.style['width']
+        res[4] = objw.style['height']
+    }
+    if(typeof(objc) != 'undefined' && objc != null)
+    {
+        res[5] = objc.style['transform']
+        res[6] = objc.style['width']
+        res[7] = objc.style['height']
+    }
 
     return res
 }

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -65,7 +65,7 @@ function switch_to_extras(){
     return args_to_array(arguments);
 }
 
-function switch_to_img2img_outpaint(){
+function switch_to_outpaint(){
     gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
     gradioApp().getElementById('mode_img2img').querySelectorAll('button')[3].click();
 

--- a/style.css
+++ b/style.css
@@ -530,6 +530,13 @@ img2maskimg, #img2maskimg > .h-60, #img2maskimg > .h-60 > div, #img2maskimg > .h
     min-height: 480px !important;
 }
 
+#img2img_outpaint, #img2img_outpaint > .h-60, #img2img_outpaint > .h-60 > div, #img2img_outpaint > .h-60 > div > img
+{
+    height: 720px !important;
+    max-height: 720px !important;
+    min-height: 720px !important;
+}
+
 /* Extensions */
 
 #tab_extensions table{


### PR DESCRIPTION
This is a cleanup of #3693 (which shall be closed promptly), added an outpainting tab and incorporated this week's changes.
It uses scipy.ndimage, not sure whether that's automatically included with other requirements.
Other than that, tested (not through --tests, requests wouldn't fire up for some reason) with a basic installation on windows.

[Demo](https://user-images.githubusercontent.com/41131377/199332748-7d9d8fcb-00b0-425b-b2f9-23a3dda2ffa3.mp4)

@AUTOMATIC1111 Noticed there was a section about discussing major changes with you, but it's gone now. Comments?