### PR TITLE
prompts_from_file: allow random seeds to be preserved for the list of prompts

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -96,6 +96,7 @@ class Script(scripts.Script):
 
     def ui(self, is_img2img):
         checkbox_iterate = gr.Checkbox(label="Iterate seed every line", value=False)
+        checkbox_iterate_batch = gr.Checkbox(label="Preserve random seed across lines (for use with \"Generate Forever\")", value=False)
 
         prompt_txt = gr.Textbox(label="List of prompt inputs", lines=1)
         file = gr.File(label="Upload prompt inputs", type='bytes')
@@ -106,9 +107,9 @@ class Script(scripts.Script):
         # We don't shrink back to 1, because that causes the control to ignore [enter], and it may
         # be unclear to the user that shift-enter is needed.
         prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt])
-        return [checkbox_iterate, file, prompt_txt]
+        return [checkbox_iterate, checkbox_iterate_batch, file, prompt_txt]
 
-    def run(self, p, checkbox_iterate, file, prompt_txt: str):
+    def run(self, p, checkbox_iterate, checkbox_iterate_batch, file, prompt_txt: str):
         lines = [x.strip() for x in prompt_txt.splitlines()]
         lines = [x for x in lines if len(x) > 0]
 
@@ -137,7 +138,7 @@ class Script(scripts.Script):
             jobs.append(args)
 
         print(f"Will process {len(lines)} lines in {job_count} jobs.")
-        if (checkbox_iterate and p.seed == -1):
+        if ((checkbox_iterate or checkbox_iterate_batch) and p.seed == -1):
             p.seed = int(random.randrange(4294967294))
 
         state.job_count = job_count


### PR DESCRIPTION
### tl;dr - This is a small change to `prompts_from_file.py` in order to make it work better with random seeds and "Generate Forever".

When using the `prompts_from_file.py` script, if the user has selected random (-1), then every line in the file will get a different seed.  For cases where the user wants to see/use the slight variations between lines on the same seed, this isn't the desired outcome.  For a single run, the user can just set a fixed seed.  However, if the user wants to run repeatedly without manually resetting the seed, or use "Generate Forever", it gets in the way.

This adds a new checkbox that enables this specific case, with the text `Preserve random seed across lines (for use with "Generate Forever")`.

Here is example output when running with a batch size = 2 and 2 iterations, when used with "Generate Forever", and a list of 3 prompts like "A woman wearing a black t-shirt with a <dog|cat|bird> printed on it."   Notice how the women for the 3 prompts stay consistent when going down, at least for that group of 12 images.

![Screen Shot 2022-11-01 at 6 48 21 PM](https://user-images.githubusercontent.com/299084/199383776-60f01faf-a74f-4de6-a962-1458960e755b.png)

Some possible questions you might have:

* The name `Preserve random seed across lines (for use with "Generate Forever")` - I'm open to suggestions to make this more concise, or better describe what it's doing.
* Seed behavior is now 3-state - If both checkboxes are checked, this new checkbox will be ignored.  Would it be suitable to switch the checkbox to a 3-state radio button?  I'm happy to do it that way instead, but I went this route, as it means a smaller diff (for my first contribution to this project!).
