### PR TITLE
fix: should invoke callback as well in api only mode

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -2,6 +2,7 @@ import sys
 import traceback
 from collections import namedtuple
 import inspect
+from typing import Optional
 
 from fastapi import FastAPI
 from gradio import Blocks
@@ -62,7 +63,7 @@ def clear_callbacks():
     callbacks_image_saved.clear()
     callbacks_cfg_denoiser.clear()
 
-def app_started_callback(demo: Blocks, app: FastAPI):
+def app_started_callback(demo: Optional[Blocks], app: FastAPI):
     for c in callbacks_app_started:
         try:
             c.callback(demo, app)

--- a/webui.py
+++ b/webui.py
@@ -114,6 +114,8 @@ def api_only():
     app.add_middleware(GZipMiddleware, minimum_size=1000)
     api = create_api(app)
 
+    modules.script_callbacks.app_started_callback(None, app)
+
     api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
 
 


### PR DESCRIPTION
This is the following of #3982 that I forgot to invoke the callback in API only mode.
Sorry about that!