### PR TITLE
bump transformers version for better caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytorch_lightning==1.7.7
 realesrgan
 scikit-image>=0.19
 timm==0.4.12
-transformers==4.19.2
+transformers==4.24.0
 torch
 einops
 jsonmerge

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,4 +1,4 @@
-transformers==4.19.2
+transformers==4.24.0
 diffusers==0.3.0
 basicsr==1.4.2
 gfpgan==1.3.8


### PR DESCRIPTION
~/.cache/huggingface/transformers holds all cached files in a random mess. New location is ~/.cache/huggingface/hub/ with every model in its own folder.

No further code change needed, models will get re-downloaded one time.