### PR TITLE
Added option to preview Created images on batch completion.

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -276,7 +276,7 @@ def check_progress_call(id_part):
     image = gr_show(False)
     preview_visibility = gr_show(False)
 
-    if opts.show_progress_every_n_steps > 0:
+    if opts.show_progress_every_n_steps != 0:
         shared.state.set_current_image()
         image = shared.state.current_image
 


### PR DESCRIPTION
Added an option to preview created images on batch completion.
To enable, set "Show image creation progress every N sampling steps." in settings to -1.

Tested with arguments --skip-torch-cuda-test --deepdanbooru --no-half-vae --api. Everything's ok.