### PR TITLE
licensing phase 1 - esrgan code from @victorca25/iNNfer

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,4 @@
+# Licenses
+
+Various parts of this codebase have been sourced from differently licensed codebases.
+Where a license is used by a particular segment of code, this folder houses the relevant attribution and license data referenced by the code. None of the licenses in this folder are the license for the project at large.

--- a/LICENSES/esrgan_victorca25_iNNfer.md
+++ b/LICENSES/esrgan_victorca25_iNNfer.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 victorca25
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/modules/codeformer/LICENSE
+++ b/modules/codeformer/LICENSE
@@ -1,0 +1,35 @@
+S-Lab License 1.0
+
+Copyright 2022 S-Lab
+
+Redistribution and use for non-commercial purpose in source and 
+binary forms, with or without modification, are permitted provided 
+that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in 
+   the documentation and/or other materials provided with the 
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its 
+   contributors may be used to endorse or promote products derived 
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+In the event that redistribution and/or use for commercial purpose in 
+source or binary forms, with or without modification is required, 
+please contact the contributor(s) of the work.

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -14,6 +14,7 @@ from modules.shared import opts
 
 def mod2normal(state_dict):
     # this code is copied from https://github.com/victorca25/iNNfer
+    # license reference in LICENSES/esrgan_victorca25_iNNfer.md
     if 'conv_first.weight' in state_dict:
         crt_net = {}
         items = []
@@ -49,6 +50,7 @@ def mod2normal(state_dict):
 
 def resrgan2normal(state_dict, nb=23):
     # this code is copied from https://github.com/victorca25/iNNfer
+    # license reference in LICENSES/esrgan_victorca25_iNNfer.md
     if "conv_first.weight" in state_dict and "body.0.rdb1.conv1.weight" in state_dict:
         re8x = 0
         crt_net = {}
@@ -94,6 +96,7 @@ def resrgan2normal(state_dict, nb=23):
 
 def infer_params(state_dict):
     # this code is copied from https://github.com/victorca25/iNNfer
+    # license reference in LICENSES/esrgan_victorca25_iNNfer.md
     scale2x = 0
     scalemin = 6
     n_uplayer = 0

--- a/modules/esrgan_model_arch.py
+++ b/modules/esrgan_model_arch.py
@@ -1,4 +1,5 @@
 # this file is adapted from https://github.com/victorca25/iNNfer
+# license reference in LICENSES/esrgan_victorca25_iNNfer.md
 
 import math
 import functools


### PR DESCRIPTION
Whether or not this repo has a license for the code written by @AUTOMATIC1111 and other contributors is up to the authors (re issue #2059)--however, at the very least, this repo is out of compliance with the license requirements of all the places where it copied code from projects that contain licenses requiring inclusion of _their_ licenses.

Example (just picking one place at random):
The code here: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/codeformer/codeformer_arch.py#L1 -- which notes that it was copied from [sczhou/CodeFormer](https://github.com/sczhou/CodeFormer/blob/3be238a2416ea1cffcdeff0f6eac0f4c1c400233/basicsr/archs/codeformer_arch.py) does not include a copy of the license from that codebase as noted in the repo for that source:
https://github.com/sczhou/CodeFormer/blob/master/LICENSE#L1-L10

however, this is even more tricky because that license does not provide any allowance for modification of the code, which has been done. So even including the license does not bring this code into legal compliance until @sczhou adds a provision in the license for code modification.

Any place that has copied code from other projects will need to be addressed before this software is legally usable.

I have started the process of proper licensing with this pull-request to add a license for a simpler case in code copied and derived from https://github.com/victorca25/iNNfer
