### PR TITLE
add --cors-allow-origins cmd opt

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -86,6 +86,7 @@ parser.add_argument("--nowebui", action='store_true', help="use api=True to laun
 parser.add_argument("--ui-debug-mode", action='store_true', help="Don't load model to quickly launch UI")
 parser.add_argument("--device-id", type=str, help="Select the default CUDA device to use (export CUDA_VISIBLE_DEVICES=0,1,etc might be needed before)", default=None)
 parser.add_argument("--administrator", action='store_true', help="Administrator rights", default=False)
+parser.add_argument("--cors-allow-origins", type=str, help="Allowed CORS origins", default=None)
 
 cmd_opts = parser.parse_args()
 restricted_opts = {
@@ -147,9 +148,9 @@ class State:
         self.interrupted = True
 
     def nextjob(self):
-        if opts.show_progress_every_n_steps == -1: 
+        if opts.show_progress_every_n_steps == -1:
             self.do_set_current_image()
-            
+
         self.job_no += 1
         self.sampling_step = 0
         self.current_image_sampling_step = 0
@@ -198,7 +199,7 @@ class State:
             return
         if self.current_latent is None:
             return
-            
+
         if opts.show_progress_grid:
             self.current_image = sd_samplers.samples_to_image_grid(self.current_latent)
         else:


### PR DESCRIPTION
Rescue current API usage after https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/5f0117154382eb0e2547c72630256681673e353b.

This command argument works in both `--api` and `--nowebui` mode.

* Use `--cors-allow-origins=*` to allow all origins
* Use `--cors-allow-origins=http://127.0.0.1:5173,https://codesandbox.io` to allow CORS requests from `http://127.0.0.1:5173` and `https://codesandbox.io`