### PR TITLE
Fix crash when trying to difference merge w/o third model

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -290,7 +290,7 @@ def run_modelmerger(primary_model_name, secondary_model_name, teritary_model_nam
     if theta_func1:
         for key in tqdm.tqdm(theta_1.keys()):
             if 'model' in key:
-                if key in theta_2:
+                if theta_2 is not None and key in theta_2:
                     t2 = theta_2.get(key, torch.zeros_like(theta_1[key]))
                     theta_1[key] = theta_func1(theta_1[key], t2)
                 else:


### PR DESCRIPTION
While difference merging is supposed to use three models according to the formula, it is probably preferable to have this operation also succeed without specifying a third model rather than crashing the UI and requiring a restart.