### PR TITLE
Python 3.8 typing compatibility

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -5,7 +5,7 @@ from typing_extensions import Literal
 from inflection import underscore
 from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img
 from modules.shared import sd_upscalers, opts, parser
-from typing import List
+from typing import Dict, List
 
 API_NOT_ALLOWED = [
     "self",
@@ -193,8 +193,8 @@ FlagsModel = create_model("Flags", **flags)
 
 class SamplerItem(BaseModel):
     name: str = Field(title="Name")
-    aliases: list[str] = Field(title="Aliases")
-    options: dict[str, str] = Field(title="Options")
+    aliases: List[str] = Field(title="Aliases")
+    options: Dict[str, str] = Field(title="Options")
 
 class UpscalerItem(BaseModel):
     name: str = Field(title="Name")


### PR DESCRIPTION
Solves problems with --api arg (I'm on b8f2dfed3c0085f1df359b9dc5b3841ddc2196f0)

```python
Traceback (most recent call last):
  File "webui.py", line 201, in <module>
    webui()
  File "webui.py", line 178, in webui
    create_api(app)
  File "webui.py", line 117, in create_api
    from modules.api.api import Api
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\api.py", line 9, in <module>
    from modules.api.models import *
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\models.py", line 194, in <module>
    class SamplerItem(BaseModel):
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\models.py", line 196, in SamplerItem
    aliases: list[str] = Field(title="Aliases")
TypeError: 'type' object is not subscriptable
```

and

```python
Traceback (most recent call last):
  File "webui.py", line 201, in <module>
    webui()
  File "webui.py", line 178, in webui
    create_api(app)
  File "webui.py", line 117, in create_api
    from modules.api.api import Api
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\api.py", line 9, in <module>
    from modules.api.models import *
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\models.py", line 194, in <module>
    class SamplerItem(BaseModel):
  File "H:\AIart\stable-diffusion\stable-diffusion-webui\modules\api\models.py", line 197, in SamplerItem
    options: dict[str, str] = Field(title="Options")
TypeError: 'type' object is not subscriptable
```

on python 3.8 env