### PR TITLE
Bump gradio to 3.9 to fix image clear button.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fairscale==0.4.4
 fonts
 font-roboto
 gfpgan
-gradio==3.8
+gradio==3.9
 invisible-watermark
 numpy
 omegaconf

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -2,7 +2,7 @@ transformers==4.19.2
 diffusers==0.3.0
 basicsr==1.4.2
 gfpgan==1.3.8
-gradio==3.8
+gradio==3.9
 numpy==1.23.3
 Pillow==9.2.0
 realesrgan==0.3.0

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -18,19 +18,20 @@ class UtilsTests(unittest.TestCase):
   def test_options_get(self):
     self.assertEqual(requests.get(self.url_options).status_code, 200)
 
-  def test_options_write(self):
-    response = requests.get(self.url_options)
-    self.assertEqual(response.status_code, 200)
+  # Currently not supported by api, uncomment when it's fixed
+  # def test_options_write(self):
+  #   response = requests.get(self.url_options)
+  #   self.assertEqual(response.status_code, 200)
     
-    pre_value = response.json()["send_seed"]
+  #   pre_value = response.json()["send_seed"]
 
-    self.assertEqual(requests.post(self.url_options, json={"send_seed":not pre_value}).status_code, 200)
+  #   self.assertEqual(requests.post(self.url_options, json={"send_seed":not pre_value}).status_code, 200)
 
-    response = requests.get(self.url_options)
-    self.assertEqual(response.status_code, 200)
-    self.assertEqual(response.json()["send_seed"], not pre_value)
+  #   response = requests.get(self.url_options)
+  #   self.assertEqual(response.status_code, 200)
+  #   self.assertEqual(response.json()["send_seed"], not pre_value)
 
-    requests.post(self.url_options, json={"send_seed": pre_value})
+  #   requests.post(self.url_options, json={"send_seed": pre_value})
 
   def test_cmd_flags(self):
     self.assertEqual(requests.get(self.url_cmd_flags).status_code, 200)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fix issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2963 . This went on for 19 days on Windows, extremely annoying. It was an upstream issue but i managed to fix it there and it got merged https://github.com/gradio-app/gradio/pull/2577 and just in time to be packed under 3.9 tag. This nightmare of a problem will be over, finally.

**Additional notes and description of your changes**

Auto tests are all ok, no visible problems in the ui or extensions. I did not test EVERY feature, though. Been using it for 2 days with bumped version, no issues encountered. I noticed that previous transfer to 3.8 required some changes in this rep https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/95c6308ccd2e075d1fb804f5b98a4f0b07b87b7d , so better to double check. 

Commented test_options_write, since it was disabled in the commit b6cfaaa20b81d16a978524c952412cfc4d89a414 a bit after the test itself was added.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB