### PR TITLE
Fixes #800 #1562 #2075 #2304 #2931 LDSR upscaler producing black bars

### DIFF
--- a/modules/ldsr_model_arch.py
+++ b/modules/ldsr_model_arch.py
@@ -101,8 +101,8 @@ class LDSR:
         down_sample_rate = target_scale / 4
         wd = width_og * down_sample_rate
         hd = height_og * down_sample_rate
-        width_downsampled_pre = int(wd)
-        height_downsampled_pre = int(hd)
+        width_downsampled_pre = int(np.ceil(wd))
+        height_downsampled_pre = int(np.ceil(hd))
 
         if down_sample_rate != 1:
             print(
@@ -110,7 +110,12 @@ class LDSR:
             im_og = im_og.resize((width_downsampled_pre, height_downsampled_pre), Image.LANCZOS)
         else:
             print(f"Down sample rate is 1 from {target_scale} / 4 (Not downsampling)")
-        logs = self.run(model["model"], im_og, diffusion_steps, eta)
+        
+        # pad width and height to multiples of 64, pads with the edge values of image to avoid artifacts
+        pad_w, pad_h = np.max(((2, 2), np.ceil(np.array(im_og.size) / 64).astype(int)), axis=0) * 64 - im_og.size
+        im_padded = Image.fromarray(np.pad(np.array(im_og), ((0, pad_h), (0, pad_w), (0, 0)), mode='edge'))
+        
+        logs = self.run(model["model"], im_padded, diffusion_steps, eta)
 
         sample = logs["sample"]
         sample = sample.detach().cpu()
@@ -119,6 +124,9 @@ class LDSR:
         sample = sample.numpy().astype(np.uint8)
         sample = np.transpose(sample, (0, 2, 3, 1))
         a = Image.fromarray(sample[0])
+
+        # remove padding
+        a = a.crop((0, 0) + tuple(np.array(im_og.size) * 4))
 
         del model
         gc.collect()


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes issues: #800 #1562 #2075 #2304 #2931
When using the LDSR upscaler, the resulting image cuts off part of the image, towards the bottom and right, filling it with black bars instead.
The black bars are also present in Hafiidz/latent-diffusion and Sygil-Dev/sygil-webui, in fact, I traced this bug all the way to the source CompVis/stable-diffusion, even the official code has black bars.
This fix works for all resolutions and aspect ratios, and has been tested on images from the tiny to the large.

**Additional notes and description of your changes**

1. Pad width and height to multiples of 64 with the edge values of image to avoid artifacts.
2. do_upscale.
3. Crop out padding.

Also fixes a double upscaling bug, if downsampling is required.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1080Ti 11GB
