### PR TITLE
Add DeepDanbooru to the interrogate API

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -170,6 +170,7 @@ class ProgressResponse(BaseModel):
 
 class InterrogateRequest(BaseModel):
     image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")
+    model: str = Field(default="clip", title="Model", description="The interrogate model used.")
 
 class InterrogateResponse(BaseModel):
     caption: str = Field(default=None, title="Caption", description="The generated caption for the image.")


### PR DESCRIPTION
A parameter `model` is added to the interrogate API.
This enables users to select the interrogate model by specifying its name, `clip` (default) or `deepdanbooru` (if launches with `--deepdanbooru`).
The input image is converted to RGB because images with transparency will crash interrogate models.