### PR TITLE
Show current step/total steps on generation progressbar

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -271,10 +271,11 @@ def check_progress_call(id_part):
         shared.state.time_left_force_display = True
 
     progress = min(progress, 1)
+    progress_steps = f"&nbsp;" * 2 + "STEPS" + "&nbsp" + str(shared.state.sampling_step) + "/" + str(shared.state.sampling_steps) + "&nbsp"
 
     progressbar = ""
     if opts.show_progressbar:
-        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:visible;width:{progress * 100}%;white-space:nowrap;">{"&nbsp;" * 2 + str(int(progress*100))+"%" + time_left if progress > 0.01 else ""}</div></div>"""
+        progressbar = f"""<div class='progressDiv'><div class='progress' style="overflow:visible;width:{progress * 100}%;white-space:nowrap;">{"&nbsp;" * 2 + str(int(progress*100))+"%" + progress_steps + time_left if progress > 0.01 else ""}</div></div>"""
 
     image = gr_show(False)
     preview_visibility = gr_show(False)


### PR DESCRIPTION
Example:

Before:     32% ETA: 10s
After:       32%  STEPS 21/64  ETA: 10s