### PR TITLE
add `--gradio-inpaint-tool` and option to specify `color-sketch`

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 import numpy as np
-from PIL import Image, ImageOps, ImageChops
+from PIL import Image, ImageOps, ImageFilter, ImageEnhance
 
 from modules import devices
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
@@ -40,7 +40,7 @@ def process_batch(p, input_dir, output_dir, args):
 
         img = Image.open(image)
         # Use the EXIF orientation of photos taken by smartphones.
-        img = ImageOps.exif_transpose(img) 
+        img = ImageOps.exif_transpose(img)
         p.init_images = [img] * p.batch_size
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
@@ -59,7 +59,7 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_with_mask_orig, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_with_mask_orig, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -68,15 +68,20 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         if mask_mode == 0:
             image = init_img_with_mask
             is_mask_sketch = isinstance(image, dict)
-            if is_mask_sketch:  
+            is_mask_paint = not is_mask_sketch
+            if is_mask_sketch:
                 # Sketch: mask iff. not transparent
                 image, mask = image["image"], image["mask"]
-                mask = np.array(mask)[..., -1] > 0
+                pred = np.array(mask)[..., -1] > 0
             else:
                 # Color-sketch: mask iff. painted over
                 orig = init_img_with_mask_orig or image
-                mask = np.any(np.array(image) != np.array(orig), axis=-1)
-            mask = Image.fromarray(mask.astype(np.uint8) * 255, "L")
+                pred = np.any(np.array(image) != np.array(orig), axis=-1)
+            mask = Image.fromarray(pred.astype(np.uint8) * 255, "L")
+            if is_mask_paint:
+                mask = ImageEnhance.Brightness(mask).enhance(1 - mask_alpha / 100)
+                blur = ImageFilter.GaussianBlur(mask_blur)
+                image = Image.composite(image.filter(blur), orig, mask.filter(blur))
             image = image.convert("RGB")
         # Uploaded mask
         else:
@@ -89,7 +94,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
 
     # Use the EXIF orientation of photos taken by smartphones.
     if image is not None:
-        image = ImageOps.exif_transpose(image) 
+        image = ImageOps.exif_transpose(image)
 
     assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -71,6 +71,7 @@ parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui
 parser.add_argument("--gradio-debug",  action='store_true', help="launch gradio with --debug option")
 parser.add_argument("--gradio-auth", type=str, help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
 parser.add_argument("--gradio-img2img-tool", type=str, help='gradio image uploader tool: can be either editor for ctopping, or color-sketch for drawing', choices=["color-sketch", "editor"], default="editor")
+parser.add_argument("--gradio-inpaint-tool", type=str, choices=["sketch", "color-sketch"], default="sketch", help="gradio inpainting editor: can be either sketch to only blur/noise the input, or color-sketch to paint over it")
 parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
 parser.add_argument("--styles-file", type=str, help="filename to use for styles", default=os.path.join(script_path, 'styles.csv'))
 parser.add_argument("--autolaunch", action='store_true', help="open the webui URL in the system's default browser upon launch", default=False)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -941,6 +941,7 @@ def create_ui(wrap_gradio_gpu_call):
                     img2img_prompt_style2,
                     init_img,
                     init_img_with_mask,
+                    init_img_with_mask_orig,
                     init_img_inpaint,
                     init_mask_inpaint,
                     mask_mode,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -840,8 +840,17 @@ def create_ui(wrap_gradio_gpu_call):
                         init_img = gr.Image(label="Image for img2img", elem_id="img2img_image", show_label=False, source="upload", interactive=True, type="pil", tool=cmd_opts.gradio_img2img_tool).style(height=480)
 
                     with gr.TabItem('Inpaint', id='inpaint'):
-                        init_img_with_mask = gr.Image(label="Image for inpainting with mask",  show_label=False, elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool="sketch", image_mode="RGBA").style(height=480)
+                        init_img_with_mask_orig = gr.State(None)
+                        init_img_with_mask = gr.Image(label="Image for inpainting with mask", show_label=False, elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool=cmd_opts.gradio_inpaint_tool, image_mode="RGBA").style(height=480)
 
+                        def update_orig(image, state):
+                            if image is not None:
+                                same_size = state is not None and state.size == image.size
+                                has_exact_match = np.any(np.all(np.array(image) == np.array(state), axis=-1))
+                                edited = same_size and has_exact_match
+                                return image if not edited or state is None else state
+
+                        init_img_with_mask.change(update_orig, [init_img_with_mask, init_img_with_mask_orig], init_img_with_mask_orig)
                         init_img_inpaint = gr.Image(label="Image for img2img", show_label=False, source="upload", interactive=True, type="pil", visible=False, elem_id="img_inpaint_base")
                         init_mask_inpaint = gr.Image(label="Mask", source="upload", interactive=True, type="pil", visible=False, elem_id="img_inpaint_mask")
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -854,6 +854,8 @@ def create_ui(wrap_gradio_gpu_call):
                         init_img_inpaint = gr.Image(label="Image for img2img", show_label=False, source="upload", interactive=True, type="pil", visible=False, elem_id="img_inpaint_base")
                         init_mask_inpaint = gr.Image(label="Mask", source="upload", interactive=True, type="pil", visible=False, elem_id="img_inpaint_mask")
 
+                        show_mask_alpha = cmd_opts.gradio_inpaint_tool == "color-sketch"
+                        mask_alpha = gr.Slider(label="Mask transparency", interactive=show_mask_alpha, visible=show_mask_alpha)
                         mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=4)
 
                         with gr.Row():
@@ -948,6 +950,7 @@ def create_ui(wrap_gradio_gpu_call):
                     steps,
                     sampler_index,
                     mask_blur,
+                    mask_alpha,
                     inpainting_fill,
                     restore_faces,
                     tiling,


### PR DESCRIPTION
Following a [comment] by @matrix4767 on the discussion post for [img2img-color-sketch], I implemented rudimentary functionality to let end users color on top of their uploaded images in the browser to better guide the inpainting process. The new feature infers a mask for diffusion sampling by caching the image upon its first upload. It then cross-references the cache with the subsequent edits of the image to determine altered regions after the end user is allowed to paint on top.

The state machine that implements this functionality is a little wonky, and I didn't want to surprise consumers of this repository who are already used to the other way of doing things. So, following in line with [img2img-color-sketch], new behavior can be enabled by appending `--gradio-inpaint-tool color-sketch` to the command line arguments, with the prior behavior, `sketch`, set as the default.

## Caveat Emptor
I couldn't figure out how to implement the state machine such that it ignores when an image is merely _edited,_ as opposed to cleared and reuploaded. GradIO's [docs] indicate that the `Image` component has `upload` and `change` events, which might lead one to believe these hooks have distinct triggers, but they seem to fire when images are edited, as well. I could perhaps have wired up the `edit` event to _cancel_ the `upload` event using coroutines if it turned out to be more exclusive, but that would have been more complicated, might have required enabling [queue] functionality, and could have introduced a race condition in cases where the events did not fire in the expected order.

Instead of heading further into the weeds, I opted to check whether channel vectors at corresponding locations between the two images are exactly equal, given that the two images are the same size. So, one possible issue is that a fresh upload might contain a pixel-perfect color match on top of the same spatial coordinate, and so falsely be identified as an edit. However, there's a low probability of this happening in different images given uniformly distributed values for each pixel's channels-- of which there are four, in this case $(R, G, B, A)$. Supposing we drop Alpha (maybe the end user uploaded a JPEG), we still only have 

$$
P(\mathrm{collision}) = \frac{1}{256\mathrm{\ possible\ values\ }^{3\ \mathrm{channels}}} \approx 5 \times 10^{-8}
$$

or, a false positive on the order of once every hundred million fresh uploads.

I recognize there are flaws in assuming conditional independence between regions of spatially correlated pixels or between the color channels, but pragmatically, in order for this heuristic to fail, the end user would have to paint over the image _completely_ or upload a new image of an identical size, with an exactly identical pixel located at an exactly identical spatial coordinate. I found a helpful [blog] with some alternative computer vision algorithms designed for detecting duplicates that I'll consider implementing if branching on the chosen condition is found to be insufficient.

[queue]: https://gradio.app/docs/#queue
[docs]: https://gradio.app/docs/#image
[img2img-color-sketch]: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/2329
[comment]: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/2329#discussioncomment-3942624
[blog]: https://www.hackerfactor.com/blog/?/archives/529-Kind-of-Like-That.html