### PR TITLE
add allow-code as an argument capable of unlocking the extensions

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -104,7 +104,7 @@ restricted_opts = {
     "outdir_save",
 }
 
-cmd_opts.disable_extension_access = (cmd_opts.share or cmd_opts.listen) and not cmd_opts.enable_insecure_extension_access
+cmd_opts.disable_extension_access = (cmd_opts.share or cmd_opts.listen) and not (cmd_opts.enable_insecure_extension_access or cmd_opts.allow_code)
 
 devices.device, devices.device_interrogate, devices.device_gfpgan, devices.device_swinir, devices.device_esrgan, devices.device_scunet, devices.device_codeformer = \
 (devices.cpu if any(y in cmd_opts.use_cpu for y in [x, 'all']) else devices.get_optimal_device() for x in ['sd', 'interrogate', 'gfpgan', 'swinir', 'esrgan', 'scunet', 'codeformer'])


### PR DESCRIPTION
Since it already allows to execute arbitrary code, that argument should also unlock that option.