### PR TITLE
Update title of the 'install on apple silicon' section to be more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ sudo pacman -S wget git python3
 bash <(wget -qO- https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh)
 ```
 
-### Installation on Apple Silicon
+### Installation on macOS (Both newer Apple Silicon (M1/M2), as well as older Intel Macs)
 
 Find the instructions [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Installation-on-Apple-Silicon).
 


### PR DESCRIPTION
I find myself searching for 'macOS' every time I'm looking for this section, and it takes me a while to remember how it's named. The instructions also work for the older Intel-based non-Apple silicon macs, so figured this new title would be more descriptive and point more people in the right direction easier.