### PR TITLE
Fix interrogation via API

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -220,7 +220,7 @@ class Api:
         if image_b64 is None:
             raise HTTPException(status_code=404, detail="Image not found") 
 
-        img = self.__base64_to_image(image_b64)
+        img = decode_base64_to_image(image_b64)
 
         # Override object param
         with self.queue_lock:


### PR DESCRIPTION
Trying to interrogate via API endpoint "interrogate" gives 
`AttributeError: 'Api' object has no attribute '_Api__base64_to_image'`
This commit fixes this error.