### PR TITLE
update requirements_versions.txt for dreambooth extension

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -24,3 +24,4 @@ kornia==0.6.7
 lark==1.1.2
 inflection==0.5.1
 GitPython==3.1.27
+accelerate


### PR DESCRIPTION
dreambooth extension has dependency on accelerate. if accelerate is not installed from beginning, apply and restart UI does not work. so it would be nice to install accelerate from beginning.

I use stable-diffusion-webui-docker by the way. 