### PR TITLE
Add username and password in ngrok

### DIFF
--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -1,6 +1,7 @@
 from pyngrok import ngrok, conf, exception
 
 def connect(token, port, region):
+    account = None
     if token == None:
         token = 'None'
     else:
@@ -13,10 +14,10 @@ def connect(token, port, region):
         auth_token=token, region=region
     )
     try:
-        if account:
-            public_url = ngrok.connect(port, pyngrok_config=config, auth=account).public_url
-        else:
+        if account == None:
             public_url = ngrok.connect(port, pyngrok_config=config).public_url
+        else:
+            public_url = ngrok.connect(port, pyngrok_config=config, auth=account).public_url
     except exception.PyngrokNgrokError:
         print(f'Invalid ngrok authtoken, ngrok connection aborted.\n'
               f'Your token: {token}, get the right one on https://dashboard.ngrok.com/get-started/your-authtoken')

--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -1,14 +1,22 @@
 from pyngrok import ngrok, conf, exception
 
-
 def connect(token, port, region):
     if token == None:
         token = 'None'
+    else:
+        if ':' in token:
+            # token = authtoken:username:password
+            account = token.split(':')[1] + ':' + token.split(':')[-1]
+            token = token.split(':')[0]
+
     config = conf.PyngrokConfig(
         auth_token=token, region=region
     )
     try:
-        public_url = ngrok.connect(port, pyngrok_config=config).public_url
+        if account:
+            public_url = ngrok.connect(port, pyngrok_config=config, auth=account).public_url
+        else:
+            public_url = ngrok.connect(port, pyngrok_config=config).public_url
     except exception.PyngrokNgrokError:
         print(f'Invalid ngrok authtoken, ngrok connection aborted.\n'
               f'Your token: {token}, get the right one on https://dashboard.ngrok.com/get-started/your-authtoken')


### PR DESCRIPTION
Allows specifying the user of ngrok by username and password using the : --ngrok authtoken:username:password
and keep old args for not using username and password only use authtoken : --ngrok authtoken