### PR TITLE
Fix all arguments not getting passed to `webui-user.bat`

### DIFF
--- a/webui-share-online.bat
+++ b/webui-share-online.bat
@@ -1,0 +1,1 @@
+.\webui-user.bat --share

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -5,4 +5,4 @@ set GIT=
 set VENV_DIR=
 set COMMANDLINE_ARGS=
 
-call webui.bat
+call webui.bat %*


### PR DESCRIPTION
Just adds `%*` to `webui-user.bat`, and `webui-share-online.bat` for online sharing.