### PR TITLE
Fix: `error: Your local changes to the following files would be overwritten by merge` when trying to update extensions in WSL2 Docker

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -65,9 +65,12 @@ class Extension:
         self.can_update = False
         self.status = "latest"
 
-    def pull(self):
+    def fetch_and_reset_hard(self):
         repo = git.Repo(self.path)
-        repo.remotes.origin.pull()
+        # Fix: `error: Your local changes to the following files would be overwritten by merge`,
+        # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
+        repo.git.fetch('--all')
+        repo.git.reset('--hard', 'origin')
 
 
 def list_extensions():

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -36,9 +36,9 @@ def apply_and_restart(disable_list, update_list):
             continue
 
         try:
-            ext.pull()
+            ext.fetch_and_reset_hard()
         except Exception:
-            print(f"Error pulling updates for {ext.name}:", file=sys.stderr)
+            print(f"Error getting updates for {ext.name}:", file=sys.stderr)
             print(traceback.format_exc(), file=sys.stderr)
 
     shared.opts.disabled_extensions = disabled


### PR DESCRIPTION
Hello, @AUTOMATIC1111.

This pull request fixes error with updating extensions WSL2 Docker that set 755 file permissions instead of 644, this results to the error.

Instead of using the `git pull origin` command, I use `git fetch --all` and `git reset --hard origin` to force update directory.

## Error

### Example

```
Error pulling updates for ddetailer:
Traceback (most recent call last):
  File "/stable-diffusion-webui/modules/ui_extensions.py", line 39, in apply_and_restart
    ext.pull()
  File "/stable-diffusion-webui/modules/extensions.py", line 70, in pull
    repo.remotes.origin.pull()
  File "/usr/local/lib/python3.10/site-packages/git/remote.py", line 910, in pull
    res = self._get_fetch_info_from_stderr(proc, progress,
  File "/usr/local/lib/python3.10/site-packages/git/remote.py", line 750, in _get_fetch_info_from_stderr
    proc.wait(stderr=stderr_text)
  File "/usr/local/lib/python3.10/site-packages/git/cmd.py", line 502, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git pull -v origin
  stderr: 'error: Your local changes to the following files would be overwritten by merge:'
```

### Details

```
cd /stable-diffusion-webui/extensions/ddetailer
```

<details>
  <summary><code>ls -la</code></summary>

```
total 4
drwxrwxrwx 1 1000 1000 4096 Nov  9 13:25 .
drwxrwxrwx 1 1000 1000 4096 Nov  9 13:32 ..
drwxrwxrwx 1 1000 1000 4096 Nov 12 18:52 .git
-rwxrwxrwx 1 1000 1000   63 Nov  9 13:25 .gitignore
-rwxrwxrwx 1 1000 1000 2888 Nov  9 13:25 README.md
drwxrwxrwx 1 1000 1000 4096 Nov  9 13:25 misc
drwxrwxrwx 1 1000 1000 4096 Nov  9 13:25 scripts
```
</details>


<details>
  <summary><code>git diff</code></summary>

```
diff --git a/.gitignore b/.gitignore
old mode 100644
new mode 100755
diff --git a/README.md b/README.md
old mode 100644
new mode 100755
diff --git a/misc/ddetailer_example_1.png b/misc/ddetailer_example_1.png
old mode 100644
new mode 100755
diff --git a/misc/ddetailer_example_2.png b/misc/ddetailer_example_2.png
old mode 100644
new mode 100755
diff --git a/misc/ddetailer_example_3.gif b/misc/ddetailer_example_3.gif
old mode 100644
new mode 100755
diff --git a/scripts/ddetailer.py b/scripts/ddetailer.py
old mode 100644
new mode 100755
```
</details>



<details>
  <summary><code>git pull origin</code></summary>


```
hint: Pulling without specifying how to reconcile divergent branches is
hint: discouraged. You can squelch this message by running one of the following
hint: commands sometime before your next pull:
hint: 
hint:   git config pull.rebase false  # merge (the default strategy)
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
Updating 52d2e57..8e58e7f
error: Your local changes to the following files would be overwritten by merge:
        README.md
Please commit your changes or stash them before you merge.
Aborting
```


</details>
