### PR TITLE
Fix for #4651 - avoid error when switching checkpoints

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -165,7 +165,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
 
     cache_enabled = shared.opts.sd_checkpoint_cache > 0
 
-    if cache_enabled:
+    if cache_enabled and hasattr(model, "sd_checkpoint_info"):
         sd_vae.restore_base_vae(model)
 
     vae_file = sd_vae.resolve_vae(checkpoint_file, vae_file=vae_file)


### PR DESCRIPTION
Fix for #4651
- avoid AttributeError: 'LatentDiffusion' object has no attribute 'sd_checkpoint_info' when switching between checkpoints
- re-added the hasattr() check which was removed in PR #4514

This fix avoids the error, but as R-N mentioned, the vae restore might be completely removed ?
I don't have enough knowledge about this currently