### PR TITLE
Improved VAE selector (stripped down)

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -10,6 +10,22 @@ from modules.upscaler import Upscaler
 from modules.paths import script_path, models_path
 
 
+def model_places(model_path: str, command_path: str = None):
+    places = []
+
+    if command_path is not None and command_path != model_path:
+        pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
+        if os.path.exists(pretrained_path):
+            print(f"Appending path: {pretrained_path}")
+            places.append(pretrained_path)
+        elif os.path.exists(command_path):
+            places.append(command_path)
+
+    places.append(model_path)
+
+    return places
+
+
 def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None) -> list:
     """
     A one-and done loader to try finding the desired models in specified directories.
@@ -27,17 +43,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
         ext_filter = []
 
     try:
-        places = []
-
-        if command_path is not None and command_path != model_path:
-            pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
-            if os.path.exists(pretrained_path):
-                print(f"Appending path: {pretrained_path}")
-                places.append(pretrained_path)
-            elif os.path.exists(command_path):
-                places.append(command_path)
-
-        places.append(model_path)
+        places = model_places(model_path=model_path, command_path=command_path)
 
         for place in places:
             if os.path.exists(place):

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -220,6 +220,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
     model.sd_model_checkpoint = checkpoint_file
     model.sd_checkpoint_info = checkpoint_info
 
+    sd_vae.clear_loaded_vae()
     sd_vae.load_vae(model, vae_file)
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -165,16 +165,9 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
 
     cache_enabled = shared.opts.sd_checkpoint_cache > 0
 
-    if cache_enabled:
-        sd_vae.restore_base_vae(model)
-
-    vae_file = sd_vae.resolve_vae(checkpoint_file, vae_file=vae_file)
-
     if cache_enabled and checkpoint_info in checkpoints_loaded:
         # use checkpoint cache
-        vae_name = sd_vae.get_filename(vae_file) if vae_file else None
-        vae_message = f" with {vae_name} VAE" if vae_name else ""
-        print(f"Loading weights [{sd_model_hash}]{vae_message} from cache")
+        print(f"Loading weights [{sd_model_hash}] from cache")
         model.load_state_dict(checkpoints_loaded[checkpoint_info])
     else:
         # load from file
@@ -221,6 +214,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
     model.sd_checkpoint_info = checkpoint_info
 
     sd_vae.clear_loaded_vae()
+    vae_file = sd_vae.resolve_vae(checkpoint_file, vae_file=vae_file)
     sd_vae.load_vae(model, vae_file)
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -213,6 +213,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
     model.sd_model_checkpoint = checkpoint_file
     model.sd_checkpoint_info = checkpoint_info
 
+    sd_vae.delete_base_vae()
     sd_vae.clear_loaded_vae()
     vae_file = sd_vae.resolve_vae(checkpoint_file, vae_file=vae_file)
     sd_vae.load_vae(model, vae_file)

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -173,7 +173,7 @@ def load_vae(model, vae_file=None):
         if vae_opt not in vae_dict:
             vae_dict[vae_opt] = vae_file
             vae_list.append(vae_opt)
-    else:
+    elif loaded_vae_file:
         restore_base_vae(model)
 
     loaded_vae_file = vae_file

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -15,7 +15,7 @@ vae_dir = os.path.abspath(os.path.join(models_path, vae_dir_name))
 vae_ignore_keys = {"model_ema.decay", "model_ema.num_updates"}
 
 
-default_vae_dict = {"auto": "auto", "None": None}
+default_vae_dict = {"auto": "auto", "None": None, None: None}
 default_vae_list = ["auto", "None"]
 
 
@@ -39,6 +39,7 @@ def get_base_vae(model):
 def store_base_vae(model):
     global base_vae, checkpoint_info
     if checkpoint_info != model.sd_checkpoint_info:
+        assert not loaded_vae_file, "Trying to store non-base VAE!"
         base_vae = model.first_stage_model.state_dict().copy()
         checkpoint_info = model.sd_checkpoint_info
 
@@ -50,9 +51,11 @@ def delete_base_vae():
 
 
 def restore_base_vae(model):
+    global loaded_vae_file
     if base_vae is not None and checkpoint_info == model.sd_checkpoint_info:
         print("Restoring base VAE")
         load_vae_dict(model, base_vae)
+        loaded_vae_file = None
     delete_base_vae()
 
 
@@ -149,10 +152,10 @@ def load_vae(model, vae_file=None):
 
     if vae_file:
         print(f"Loading VAE weights from: {vae_file}")
+        store_base_vae(model)
         vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
         vae_dict_1 = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss" and k not in vae_ignore_keys}
         load_vae_dict(model, vae_dict_1)
-        store_base_vae(model)
 
         # If vae used is not in dict, update it
         # It will be removed on refresh though
@@ -166,15 +169,6 @@ def load_vae(model, vae_file=None):
 
     loaded_vae_file = vae_file
 
-    """
-    # Save current VAE to VAE settings, maybe? will it work?
-    if save_settings:
-        if vae_file is None:
-            vae_opt = "None"
-
-        # shared.opts.sd_vae = vae_opt
-    """
-
     first_load = False
 
 
@@ -183,6 +177,9 @@ def load_vae_dict(model, vae_dict_1):
     model.first_stage_model.load_state_dict(vae_dict_1)
     model.first_stage_model.to(devices.dtype_vae)
 
+def clear_loaded_vae():
+    global loaded_vae_file
+    loaded_vae_file = None
 
 def reload_vae_weights(sd_model=None, vae_file="auto"):
     from modules import lowvram, devices, sd_hijack

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -50,8 +50,8 @@ def delete_base_vae():
 
 
 def restore_base_vae(model):
-    global base_vae, checkpoint_info
     if base_vae is not None and checkpoint_info == model.sd_checkpoint_info:
+        print("Restoring base VAE")
         load_vae_dict(model, base_vae)
     delete_base_vae()
 
@@ -152,6 +152,7 @@ def load_vae(model, vae_file=None):
         vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
         vae_dict_1 = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss" and k not in vae_ignore_keys}
         load_vae_dict(model, vae_dict_1)
+        store_base_vae(model)
 
         # If vae used is not in dict, update it
         # It will be removed on refresh though
@@ -160,6 +161,8 @@ def load_vae(model, vae_file=None):
             vae_dict[vae_opt] = vae_file
             vae_list.append(vae_opt)
             # shared.opts.data['sd_vae'] = vae_opt
+    else:
+        restore_base_vae(model)
 
     loaded_vae_file = vae_file
 
@@ -176,12 +179,8 @@ def load_vae(model, vae_file=None):
 
 
 # don't call this from outside
-def load_vae_dict(model, vae_dict_1=None):
-    if vae_dict_1:
-        store_base_vae(model)
-        model.first_stage_model.load_state_dict(vae_dict_1)
-    else:
-        restore_base_vae()
+def load_vae_dict(model, vae_dict_1):
+    model.first_stage_model.load_state_dict(vae_dict_1)
     model.first_stage_model.to(devices.dtype_vae)
 
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -59,7 +59,7 @@ def restore_base_vae(model):
 def get_filename(filepath):
     if not filepath:
         return "None"
-    return os.path.splitext(os.path.basename(filepath))[0]
+    return os.path.relpath(filepath, models_path)
 
 
 def refresh_vae_list(vae_dir=vae_dir, model_dir=model_dir):

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from modules import shared, devices, script_callbacks
 from modules.paths import models_path
 import glob
+from copy import deepcopy
 
 
 model_dir_name = "Stable-diffusion"
@@ -40,7 +41,7 @@ def store_base_vae(model):
     global base_vae, checkpoint_info
     if checkpoint_info != model.sd_checkpoint_info:
         assert not loaded_vae_file, "Trying to store non-base VAE!"
-        base_vae = model.first_stage_model.state_dict().copy()
+        base_vae = deepcopy(model.first_stage_model.state_dict())
         checkpoint_info = model.sd_checkpoint_info
 
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -5,10 +5,12 @@ from modules import shared, devices, script_callbacks
 from modules.paths import models_path
 import glob
 from copy import deepcopy
+from pathlib import Path
 
 
 model_dir_name = "Stable-diffusion"
 model_dir = os.path.abspath(os.path.join(models_path, model_dir_name))
+model_dir_path = Path(model_dir)
 vae_dir_name = "VAE"
 vae_dir = os.path.abspath(os.path.join(models_path, vae_dir_name))
 
@@ -127,16 +129,19 @@ def resolve_vae(checkpoint_file=None, vae_file="auto"):
     # if still not found, try look for VAE similar to model
     if vae_file == "auto" and checkpoint_file:
         model_path = os.path.splitext(checkpoint_file)[0]
-        rel_path = os.path.relpath(model_path, model_dir)
-        vae_path = os.path.join(vae_dir, rel_path)
         trials = [
             model_path + ".vae.pt",
-            model_path + ".vae.ckpt",
-            vae_path + ".vae.pt",
-            vae_path + ".vae.ckpt",
-            vae_path + ".pt",
-            vae_path + ".ckpt",
+            model_path + ".vae.ckpt"
         ]
+        if model_dir_path in Path(checkpoint_file).parents:
+            rel_path = os.path.relpath(model_path, model_dir)
+            vae_path = os.path.join(vae_dir, rel_path)
+            trials += [
+                vae_path + ".vae.pt",
+                vae_path + ".vae.ckpt",
+                vae_path + ".pt",
+                vae_path + ".ckpt"
+            ]
         for vae_file_try in trials:
             if os.path.isfile(vae_file_try):
                 vae_file = vae_file_try

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -160,6 +160,7 @@ def load_vae(model, vae_file=None):
     # save_settings = False
 
     if vae_file:
+        assert os.path.isfile(vae_file), f"VAE file doesn't exist: {vae_file}"
         print(f"Loading VAE weights from: {vae_file}")
         store_base_vae(model)
         vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
@@ -172,7 +173,6 @@ def load_vae(model, vae_file=None):
         if vae_opt not in vae_dict:
             vae_dict[vae_opt] = vae_file
             vae_list.append(vae_opt)
-            # shared.opts.data['sd_vae'] = vae_opt
     else:
         restore_base_vae(model)
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -15,6 +15,8 @@ model_dirs = [model_dir]
 model_dirs_paths = [Path(x) for x in model_dirs]
 vae_dir_name = "VAE"
 vae_dir = os.path.abspath(os.path.join(models_path, vae_dir_name))
+vae_dirs = model_dirs + [vae_dir]
+vae_dirs_paths = [Path(x) for x in vae_dirs]
 
 
 vae_ignore_keys = {"model_ema.decay", "model_ema.num_updates"}
@@ -35,13 +37,15 @@ loaded_vae_file = None
 checkpoint_info = None
 
 
-def init():
+def refresh_dirs():
     global model_dir, model_dirs, model_dirs_paths
     from modules.sd_models import model_path
     model_dir = model_path
     model_dirs = model_places(model_path=model_dir, command_path=shared.cmd_opts.ckpt_dir)
     model_dirs_paths = [Path(x) for x in model_dirs]
-    refresh_vae_list()
+    global vae_dirs, vae_dirs_paths
+    vae_dirs = model_dirs + [vae_dir]
+    vae_dirs_paths = [Path(x) for x in vae_dirs]
 
 
 def get_base_vae(model):
@@ -76,7 +80,11 @@ def restore_base_vae(model):
 def get_filename(filepath):
     if not filepath:
         return "None"
-    return os.path.relpath(filepath, models_path)
+    path = Path(filepath)
+    for p in vae_dirs_paths:
+        if p in path.parents:
+            return os.path.relpath(filepath, str(p))
+    return os.path.basename(filepath)
 
 
 def search_parent(file):
@@ -96,12 +104,13 @@ def search_parent(file):
 
 def refresh_vae_list(vae_dir=vae_dir, model_dir=model_dir):
     global vae_dict, vae_list
+    refresh_dirs()
     res = {}
     candidates = []
-    for model_dir in model_dirs:
+    for p in vae_dirs:
         candidates += [
-            *glob.iglob(os.path.join(model_dir, '**/*.vae.ckpt'), recursive=True),
-            *glob.iglob(os.path.join(model_dir, '**/*.vae.pt'), recursive=True)
+            *glob.iglob(os.path.join(p, '**/*.vae.ckpt'), recursive=True),
+            *glob.iglob(os.path.join(p, '**/*.vae.pt'), recursive=True)
         ]
     candidates += [
         *glob.iglob(os.path.join(vae_dir, '**/*.ckpt'), recursive=True),
@@ -117,7 +126,7 @@ def refresh_vae_list(vae_dir=vae_dir, model_dir=model_dir):
         res[name] = filepath
     vae_list.clear()
     vae_list.extend(default_vae_list)
-    vae_list.extend(list(res.keys()))
+    vae_list.extend(sorted(res.keys()))
     vae_dict.clear()
     vae_dict.update(res)
     vae_dict.update(default_vae_dict)

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -68,7 +68,7 @@ def restore_base_vae(model):
     global loaded_vae_file
     if base_vae is not None and checkpoint_info == model.sd_checkpoint_info:
         print("Restoring base VAE")
-        load_vae_dict(model, base_vae)
+        _load_vae_dict(model, base_vae)
         loaded_vae_file = None
     delete_base_vae()
 
@@ -205,7 +205,7 @@ def load_vae(model, vae_file=None):
         store_base_vae(model)
         vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
         vae_dict_1 = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss" and k not in vae_ignore_keys}
-        load_vae_dict(model, vae_dict_1)
+        _load_vae_dict(model, vae_dict_1)
 
         # If vae used is not in dict, update it
         # It will be removed on refresh though
@@ -222,7 +222,7 @@ def load_vae(model, vae_file=None):
 
 
 # don't call this from outside
-def load_vae_dict(model, vae_dict_1):
+def _load_vae_dict(model, vae_dict_1):
     model.first_stage_model.load_state_dict(vae_dict_1)
     model.first_stage_model.to(devices.dtype_vae)
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -95,8 +95,8 @@ def get_vae_from_settings(vae_file="auto"):
         vae_file = vae_dict.get(shared.opts.sd_vae, "auto")
         # if VAE selected but not found, fallback to auto
         if vae_file not in default_vae_values and not os.path.isfile(vae_file):
+            print(f"Selected VAE doesn't exist: {vae_file}")
             vae_file = "auto"
-            print("Selected VAE doesn't exist")
     return vae_file
 
 
@@ -106,15 +106,15 @@ def resolve_vae(checkpoint_file=None, vae_file="auto"):
     # if vae_file argument is provided, it takes priority, but not saved
     if vae_file and vae_file not in default_vae_list:
         if not os.path.isfile(vae_file):
+            print(f"VAE provided as function argument doesn't exist: {vae_file}")
             vae_file = "auto"
-            print("VAE provided as function argument doesn't exist")
     # for the first load, if vae-path is provided, it takes priority, saved, and failure is reported
     if first_load and shared.cmd_opts.vae_path is not None:
         if os.path.isfile(shared.cmd_opts.vae_path):
             vae_file = shared.cmd_opts.vae_path
             shared.opts.data['sd_vae'] = get_filename(vae_file)
         else:
-            print("VAE provided as command line argument doesn't exist")
+            print(f"VAE provided as command line argument doesn't exist: {vae_file}")
     # fallback to selector in settings, if vae selector not set to act as default fallback
     if not shared.opts.sd_vae_as_default:
         vae_file = get_vae_from_settings(vae_file)
@@ -122,7 +122,7 @@ def resolve_vae(checkpoint_file=None, vae_file="auto"):
     if vae_file == "auto" and shared.cmd_opts.vae_path is not None:
         if os.path.isfile(shared.cmd_opts.vae_path):
             vae_file = shared.cmd_opts.vae_path
-            print("Using VAE provided as command line argument")
+            print(f"Using VAE provided as command line argument: {vae_file}")
     # if still not found, try look for VAE similar to model
     if vae_file == "auto" and checkpoint_file:
         model_path = os.path.splitext(checkpoint_file)[0]
@@ -139,7 +139,7 @@ def resolve_vae(checkpoint_file=None, vae_file="auto"):
         for vae_file_try in trials:
             if os.path.isfile(vae_file_try):
                 vae_file = vae_file_try
-                print("Using VAE found similar to selected model")
+                print(f"Using VAE found similar to selected model: {vae_file}")
                 break
     # if vae selector were set as default fallback, call here
     if shared.opts.sd_vae_as_default:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -336,6 +336,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": modules.sd_models.checkpoint_tiles()}, refresh=sd_models.list_models),
     "sd_checkpoint_cache": OptionInfo(0, "Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
     "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": list(sd_vae.vae_list)}, refresh=sd_vae.refresh_vae_list),
+    "sd_vae_as_default": OptionInfo(False, "Use selected VAE as default fallback instead"),
     "sd_hypernetwork": OptionInfo("None", "Hypernetwork", gr.Dropdown, lambda: {"choices": ["None"] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
     "sd_hypernetwork_strength": OptionInfo(1.0, "Hypernetwork strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.001}),
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -335,7 +335,7 @@ options_templates.update(options_section(('training', "Training"), {
 options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": modules.sd_models.checkpoint_tiles()}, refresh=sd_models.list_models),
     "sd_checkpoint_cache": OptionInfo(0, "Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
-    "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": list(sd_vae.vae_list)}, refresh=sd_vae.refresh_vae_list),
+    "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": sd_vae.vae_list}, refresh=sd_vae.refresh_vae_list),
     "sd_vae_as_default": OptionInfo(False, "Use selected VAE as default fallback instead"),
     "sd_hypernetwork": OptionInfo("None", "Hypernetwork", gr.Dropdown, lambda: {"choices": ["None"] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
     "sd_hypernetwork_strength": OptionInfo(1.0, "Hypernetwork strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.001}),

--- a/webui.py
+++ b/webui.py
@@ -82,6 +82,7 @@ def initialize():
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
+    shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("sd_hypernetwork", wrap_queued_call(lambda: modules.hypernetworks.hypernetwork.load_hypernetwork(shared.opts.sd_hypernetwork)))
     shared.opts.onchange("sd_hypernetwork_strength", modules.hypernetworks.hypernetwork.apply_strength)
 

--- a/webui.py
+++ b/webui.py
@@ -78,7 +78,7 @@ def initialize():
 
     modules.scripts.load_scripts()
 
-    modules.sd_vae.refresh_vae_list()
+    modules.sd_vae.init()
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)

--- a/webui.py
+++ b/webui.py
@@ -78,7 +78,7 @@ def initialize():
 
     modules.scripts.load_scripts()
 
-    modules.sd_vae.init()
+    modules.sd_vae.refresh_vae_list()
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)


### PR DESCRIPTION
This is a stripped down PR of #4214, cherry picked and added a few changes

There was still some issue or room for improvements in #3986:

1. restore_base_vae was actually never called (you can see I actually called it wrong but error was never thrown), so "None" VAE option was bugged.
2. Base VAE caching was done after loading selected VAE. Should be before

So yeah here's some updates:

1. Fix "None" VAE option, both the caching and the usage (previously never called). Somehow it now requires deepcopy as mentioned in #4283. Used for #3866 
2. Use relative path as dropdown entries, similar to checkpoint dropdown
3. Added more fallback for auto (It will now search for similarly relatively located VAE in VAE folder. (e.g. you have Stable-diffusion/mymodel/mymodel.ckpt it will also try to fallback to VAE/mymodel/mymodel.vae.pt etc)
4. Added option to treat the VAE selector as default fallback. Priority will then become: (1) vae-path arg, (2) similar VAE as checkpoint (e.g. "beside" checkpoint, same path but .vae.pt ext), (3) selected VAE. Ref: #3655 and [a comment](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3986#issuecomment-1300971842)

Additionally, because the caching was reverted back to after checkpoint was loaded, I removed the restore_base_vae at the top of load_model_weights which might have caused #4651 .

![image](https://user-images.githubusercontent.com/1442761/202787578-40e8e9a5-db1d-4de5-a6cd-a864a223261c.png)
![image](https://user-images.githubusercontent.com/1442761/201505908-ce734f24-aa60-4197-9ad6-206c6a378704.png)


## 2 rounds of test just like [before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4214):
Prompt: 
```
ganyu \(genshin impact\),
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1, Size: 512x512, Model hash: 925997e9, Eta: 0.0022321428125, Clip skip: 2, ENSD: 31337
```

Order (2 rounds):
1. auto (final_pruned.vae.pt) (animevae)
2. wd_kl-f8-anime2
3. sd_1.5_mse
4. None

<details><summary>First round (for comparison between VAEs used, they should be different even just a little)</summary>

animevae:
![00008-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441438-0360fc79-b02d-4b76-9f6f-92afd4272018.png)

wd_kl-f8-anime2:
![00009-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441444-bd2f7a2c-fedf-4ad7-938b-e5fc60076c01.png)

sd_1.5_mse:
![00010-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441447-4415eb94-40ea-4a12-a49b-c27a306834df.png)

None:
![00011-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441460-5184371f-b618-4e7e-a045-0c47d29004d2.png)

</details>

For comparison between rounds (grouped by VAEs, each having two images which should be the same):
<details><summary>animevae</summary>

![00008-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441438-0360fc79-b02d-4b76-9f6f-92afd4272018.png)
![00012-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441597-f50df9b6-9bd0-4364-a4ec-563c4366ceb4.png)

</details>

<details><summary>wd_kl-f8-anime2</summary>

![00009-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441444-bd2f7a2c-fedf-4ad7-938b-e5fc60076c01.png)
![00013-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441620-0569d24c-61f7-4fea-a411-f39ea36f8974.png)

</details>

<details><summary>sd_1.5_mse</summary>

![00010-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441447-4415eb94-40ea-4a12-a49b-c27a306834df.png)
![00014-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441621-f73486c5-ad13-4a9b-b0e8-02b590b3bed9.png)

</details>

<details><summary>None</summary>

![00011-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441460-5184371f-b618-4e7e-a045-0c47d29004d2.png)
![00015-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441628-4d5ced2b-0fc8-49a1-8e04-99bfad512fd6.png)

</details>

## None Option test
Test alternating between animevae and none. Same prompts.
Order:
1. auto (animevae)
2. None

<details><summary>First round (for comparison between VAEs used, they should be different even just a little)</summary>

animevae:
![00004-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429598-3663f005-241d-4c31-996b-0cdd451a139a.png)

None:
![00005-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429597-820dbe5d-6fb8-46d4-9cbc-df06b6cbb17b.png)
</details>

<details><summary>animevae</summary>

![00004-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429598-3663f005-241d-4c31-996b-0cdd451a139a.png)
![00006-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429667-035a6a62-91a4-4df2-bbc0-05605a9bc1d6.png)
</details>

<details><summary>None</summary>

![00005-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429597-820dbe5d-6fb8-46d4-9cbc-df06b6cbb17b.png)
![00007-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429685-851f5f19-6e04-4bdb-89d8-fc66a1418ab3.png)
</details>


<details><summary>Comparison between this one's None and the previous one (from the test with 4 options tried)</summary>

Current:
![00005-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202429597-820dbe5d-6fb8-46d4-9cbc-df06b6cbb17b.png)
Previous:
![00011-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202441460-5184371f-b618-4e7e-a045-0c47d29004d2.png)
</details>


## Embedding training test
Embedding training after switching to None.
To ensure "None" option works for embedding training (it goes bad if VAE is loaded).
NAI model. "auto" resolves to animevae

<details><summary>Parameters</summary>

![image](https://user-images.githubusercontent.com/1442761/202506833-382c6dcd-d1d7-4d56-8dd4-eb3acdc9101d.png)
![image](https://user-images.githubusercontent.com/1442761/202506857-8585174a-e7d6-4db0-86eb-ca1bae4f3379.png)
![image](https://user-images.githubusercontent.com/1442761/202506881-22047c2a-9ce6-4535-a366-fadffaf4e09d.png)
</details>

<details><summary>VAE "auto", select "None", then train</summary>

![image](https://user-images.githubusercontent.com/1442761/202506910-ebde2b4e-3611-4a8c-8864-70ef7fcb501c.png)
</details>