### PR TITLE
resolve [name] after resolving [filewords] in training

### DIFF
--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -97,13 +97,13 @@ class PersonalizedBase(Dataset):
 
     def create_text(self, filename_text):
         text = random.choice(self.lines)
-        text = text.replace("[name]", self.placeholder_token)
         tags = filename_text.split(',')
         if shared.opts.tag_drop_out != 0:
             tags = [t for t in tags if random.random() > shared.opts.tag_drop_out]
         if shared.opts.shuffle_tags:
             random.shuffle(tags)
         text = text.replace("[filewords]", ','.join(tags))
+        text = text.replace("[name]", self.placeholder_token)
         return text
 
     def __len__(self):


### PR DESCRIPTION
I'm fitting embeddings with textual inversion, using a prompt template file that contains just `[filewords]` and a text file with the prompt per image in the training data. I tried using `[name]` in the prompts in those text files, but it doesn't get translated to the token for the embedding, the `Last prompt` shown in the training progress part of the UI always literally has `[name]` in it instead of the token. This tiny change solves that issue.

I tested to confirm this works as intended and embedding training still happens. When I try to run the repo tests, I get a generic error message (see below) and I don't think any of the tests actually run... I personally think this change is simple enough that it could just be merged given it "works for me" and there don't even seem to be any meaningful tests of embedding or hypernetwork training yet. Up to you.

```
Launching Web UI in another process for testing with arguments: --skip-torch-cuda-test --deepdanbooru --no-half-vae --api
Launch unsuccessful
Stopping Web UI process with id 30880
Press any key to continue . . .
```