### PR TITLE
Use proper quoting in batch files.

### DIFF
--- a/webui-user.bat
+++ b/webui-user.bat
@@ -1,8 +1,8 @@
 @echo off
 
-set PYTHON=
-set GIT=
-set VENV_DIR=
-set COMMANDLINE_ARGS=
+set "PYTHON="
+set "GIT="
+set "VENV_DIR="
+set "COMMANDLINE_ARGS="
 
 call webui.bat

--- a/webui.bat
+++ b/webui.bat
@@ -3,7 +3,7 @@
 if not defined PYTHON (set PYTHON=python)
 if not defined VENV_DIR (set VENV_DIR=venv)
 
-set ERROR_REPORTING=FALSE
+set "ERROR_REPORTING=FALSE"
 
 mkdir tmp 2>NUL
 


### PR DESCRIPTION
As discussed https://github.com/d8ahazard/sd_dreambooth_extension/pull/149

and 

https://stackoverflow.com/a/8582277

This resolves potential issues with spaces in bat files.