### PR TITLE
Add --server-name to the list of arguments considered insecure

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -106,7 +106,7 @@ restricted_opts = {
     "outdir_save",
 }
 
-cmd_opts.disable_extension_access = (cmd_opts.share or cmd_opts.listen) and not cmd_opts.enable_insecure_extension_access
+cmd_opts.disable_extension_access = (cmd_opts.share or cmd_opts.listen or cmd_opts.server_name) and not cmd_opts.enable_insecure_extension_access
 
 devices.device, devices.device_interrogate, devices.device_gfpgan, devices.device_swinir, devices.device_esrgan, devices.device_scunet, devices.device_codeformer = \
 (devices.cpu if any(y in cmd_opts.use_cpu for y in [x, 'all']) else devices.get_optimal_device() for x in ['sd', 'interrogate', 'gfpgan', 'swinir', 'esrgan', 'scunet', 'codeformer'])

--- a/webui.py
+++ b/webui.py
@@ -33,7 +33,10 @@ from modules.shared import cmd_opts
 import modules.hypernetworks.hypernetwork
 
 queue_lock = threading.Lock()
-server_name = "0.0.0.0" if cmd_opts.listen else cmd_opts.server_name
+if cmd_opts.server_name:
+    server_name = cmd_opts.server_name
+else:
+    server_name = "0.0.0.0" if cmd_opts.listen else None
 
 def wrap_queued_call(func):
     def f(*args, **kwargs):


### PR DESCRIPTION
I was able to connect to SDWUI while running my new extension by using `--server-name 0.0.0.0` instead of `--listen` without having to pass `--enable-insecure-extension-access`. lf `--listen` is considered insecure without user confirmation then `--server-name` should be as well. Additionally I have given `--server-name` priority over `--listen` to prevent confusion. This is because if a user wants the server name to be bear.com by passing `--server-name bear.com` but also passes `--listen`, currently, it would not work as the user expects as the server name would still be set to **0.0.0.0**.