### PR TITLE
feat: add http basic authentication for api

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -81,6 +81,7 @@ parser.add_argument("--enable-console-prompts", action='store_true', help="print
 parser.add_argument('--vae-path', type=str, help='Path to Variational Autoencoders model', default=None)
 parser.add_argument("--disable-safe-unpickle", action='store_true', help="disable checking pytorch models for malicious code", default=False)
 parser.add_argument("--api", action='store_true', help="use api=True to launch the api with the webui")
+parser.add_argument("--api-auth", type=str, help='Set authentication for api like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
 parser.add_argument("--nowebui", action='store_true', help="use api=True to launch the api instead of the webui")
 parser.add_argument("--ui-debug-mode", action='store_true', help="Don't load model to quickly launch UI")
 parser.add_argument("--device-id", type=str, help="Select the default CUDA device to use (export CUDA_VISIBLE_DEVICES=0,1,etc might be needed before)", default=None)


### PR DESCRIPTION
If the WebUI was exposed to the Internet, the API might be harmed, so add the HTTP Basic Authentication.

**Note**: I am not a whatever security expert or even networking engineer or something, but as far as I know, the HTTP basic authentication was still not safe. For example, the timing attack or MITM (man in the middle) attack could get the credenticals. But it is still a good enough approach to protecting your service.

**Usage**:
1. Add `--api-auth user:pass` to command arguments
2. Encode `user:pass` into base64 encoding.
3. Add `Authorization: Basic <base64>` to every request headers while `<base64>` is the base64-encoded string from 2).
4. If the `Authentication` is not provided, API would return a 401 error.