### PR TITLE
Hide Gradio progress again

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -69,8 +69,11 @@ sample_img2img = sample_img2img if os.path.exists(sample_img2img) else None
 css_hide_progressbar = """
 .wrap .m-12 svg { display:none!important; }
 .wrap .m-12::before { content:"Loading..." }
+.wrap .z-20 svg { display:none!important; }
+.wrap .z-20::before { content:"Loading..." }
 .progress-bar { display:none!important; }
 .meta-text { display:none!important; }
+.meta-text-center { display:none!important; }
 """
 
 # Using constants for these since the variation selector isn't visible.


### PR DESCRIPTION
Why?
as state in cmd help, `we hide it because it slows down ML if you have hardware acceleration in browser`

As Gradio version bump to 3.9 at 804d9fb83d0c63ca3acd36378707ce47b8f12599
it changes some property thus the old code not able to hide it
changes:
https://github.com/gradio-app/gradio/commit/c08b12a487d633a5f9e20b4a8093bb42b65c5e9b#diff-d2cd6ef7d789a4bb148dd3c174e8a4ebf5fd8f9c930261ff0d35f25840c26881
https://github.com/gradio-app/gradio/commit/f79a76ca8f6e081310c01c7cd8b2b3c13eb0c0b0#diff-627ef0c33bdebb0f38edab24ee4be0da0687bcd1080b1259ccd17b943ded608d

I am new to css, I saw class z-20 has been referenced at other places, idk if it affecting other components. If it does, or if there are any other better method, plz tell me or suggest change.