### PR TITLE
Fix Loopback script to work with "inpaint at full resolution"

### DIFF
--- a/scripts/loopback.py
+++ b/scripts/loopback.py
@@ -39,6 +39,7 @@ class Script(scripts.Script):
         grids = []
         all_images = []
         original_init_image = p.init_images
+        original_mask = p.image_mask
         state.job_count = loops * batch_count
 
         initial_color_corrections = [processing.setup_color_correction(p.init_images[0])]
@@ -48,7 +49,8 @@ class Script(scripts.Script):
 
             # Reset to original init image at the start of each batch
             p.init_images = original_init_image
-
+            # Reset to original mask at the start of each batch
+            p.image_mask = original_mask
             for i in range(loops):
                 p.n_iter = 1
                 p.batch_size = 1
@@ -68,6 +70,7 @@ class Script(scripts.Script):
                 init_img = processed.images[0]
 
                 p.init_images = [init_img]
+                p.image_mask = original_mask
                 p.seed = processed.seed + 1
                 p.denoising_strength = min(max(p.denoising_strength * denoising_strength_change_factor, 0.1), 1)
                 history.append(processed.images[0])


### PR DESCRIPTION
# Problem:
Loopback script throws an error when the "inpaint at full resolution" feature is enabled. This is due to the loopback script trying to re-use the same processing instance which modifies the mask image in place. Essentially trying to mask the full image with the cropped mask on the iterations following the first one.
# Solution:
Retain the original `image_mask` between iterations and update it along with `init_images`.

## Error message for the reference:
```
Traceback (most recent call last):
  File "C:\stable-diffusion-webui\modules\ui.py", line 185, in f
    res = list(func(*args, **kwargs))
  File "C:\stable-diffusion-webui\webui.py", line 54, in f
    res = func(*args, **kwargs)
  File "C:\stable-diffusion-webui\modules\img2img.py", line 137, in img2img
    processed = modules.scripts.scripts_img2img.run(p, *args)
  File "C:\stable-diffusion-webui\modules\scripts.py", line 290, in run
    processed = script.run(p, *script_args)
  File "C:\stable-diffusion-webui\scripts\loopback.py", line 67, in run
    processed = processing.process_images(p)
  File "C:\stable-diffusion-webui\modules\processing.py", line 423, in process_images
    res = process_images_inner(p)
  File "C:\stable-diffusion-webui\modules\processing.py", line 485, in process_images_inner
    p.init(p.all_prompts, p.all_seeds, p.all_subseeds)
  File "C:\stable-diffusion-webui\modules\processing.py", line 792, in init
    image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(self.mask_for_overlay.convert('L')))
  File "C:\stable-diffusion-webui\venv\lib\site-packages\PIL\Image.py", line 1628, in paste
    self.im.paste(im, box, mask.im)
ValueError: images do not match
```