### PR TITLE
Fix unbounded prompt growth/determinism in scripts that loop

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -450,6 +450,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     modules.sd_hijack.model_hijack.clear_comments()
 
     comments = {}
+    prompt_tmp = p.prompt
+    negative_prompt_tmp = p.negative_prompt
 
     shared.prompt_styles.apply_styles(p)
 
@@ -595,6 +597,9 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
     if p.scripts is not None:
         p.scripts.postprocess(p, res)
+
+    p.prompt = prompt_tmp
+    p.negative_prompt = negative_prompt_tmp
 
     return res
 


### PR DESCRIPTION
### Problem

When running scripts that loop and you have a style (large prompt), subsequent iterations slow down, eventually to a crawl.

### Affects

* Loopback
* SD upscale
* `batch size` (not quite as extreme)

### Fix

Store incoming prompts and restore them at the end to prevent unbounded prompt growth causing slowdowns.

This also fixes determinism regardless if you use a 'text' prompt or a style (with same content).

(Disclaimer: not a Python programmer, just did enough to verify the issue and fix)

### Test

Below is a test for loopback script on 100+ prompt for 6 iterations. Result 2x speed up.

##### Before

```
Running DDIM Sampling with 56 timesteps
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.32it/s]
Running DDIM Sampling with 56 timesteps██████████████████▊                                                                                                                                                                                            | 56/342 [00:08<00:45,  6.32it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:09<00:00,  6.14it/s]
Running DDIM Sampling with 56 timesteps███████████████████████████████████████████████████████▎                                                                                                                                                      | 112/342 [00:20<00:36,  6.28it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:09<00:00,  6.13it/s]
Running DDIM Sampling with 56 timesteps████████████████████████████████████████████████████████████████████████████████████████████                                                                                                                  | 168/342 [00:34<00:28,  6.15it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:09<00:00,  6.04it/s]
Running DDIM Sampling with 56 timesteps████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                                             | 224/342 [00:55<00:19,  6.09it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:09<00:00,  6.00it/s]
Running DDIM Sampling with 56 timesteps█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▍                                        | 280/342 [01:22<00:10,  6.07it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:09<00:00,  5.95it/s]
Total progress:  98%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████    | 336/342 [02:01<00:02,  2.76it/s]
```

##### After

```
Running DDIM Sampling with 56 timesteps
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.28it/s]
Running DDIM Sampling with 56 timesteps██████████████████▊                                                                                                                                                                                            | 56/342 [00:08<00:44,  6.49it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.25it/s]
Running DDIM Sampling with 56 timesteps███████████████████████████████████████████████████████▎                                                                                                                                                      | 112/342 [00:20<00:36,  6.33it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.27it/s]
Running DDIM Sampling with 56 timesteps████████████████████████████████████████████████████████████████████████████████████████████                                                                                                                  | 168/342 [00:30<00:28,  6.20it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.22it/s]
Running DDIM Sampling with 56 timesteps████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                                             | 224/342 [00:40<00:18,  6.30it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.27it/s]
Running DDIM Sampling with 56 timesteps█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▍                                        | 280/342 [00:50<00:09,  6.22it/s]
Decoding image: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56/56 [00:08<00:00,  6.25it/s]
Total progress:  98%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████    | 336/342 [01:01<00:01,  5.43it/s]
```
