### PR TITLE
Added feature : batch post processing

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -555,7 +555,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.scripts is not None:
-                    scripts.batch_postprocess(p, image)
+                    scripts.batch_postprocess(p, image, batch_number=n, prompts=prompts, seeds=seeds, subseeds=subseeds)
                     
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -555,7 +555,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.scripts is not None:
-                    scripts.batch_postprocess(p, image, batch_number=n, prompts=prompts, seeds=seeds, subseeds=subseeds)
+                    p.scripts.batch_postprocess(p, image, seed=seeds[i], prompt=prompts[i], info=infotext(n, i))
                     
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -555,8 +555,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.scripts is not None:
-                    image = p.scripts.batch_postprocess(p, image)
-
+                    scripts.batch_postprocess(p, image)
+                    
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 
                 if opts.samples_save and not p.do_not_save_samples:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -555,7 +555,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 if p.scripts is not None:
-                    p.scripts.batch_postprocess(p, image)
+                    image = p.scripts.batch_postprocess(p, image)
 
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -85,6 +85,13 @@ class Script:
 
         pass
 
+    def batch_postprocess(self, p, image, *args, **kwargs):
+        """
+        Called for every batch after processing.
+        Result image added for visual post-processing ease.
+        """
+        pass
+
     def postprocess(self, p, processed, *args):
         """
         This function is called after processing ends for AlwaysVisible scripts.
@@ -356,4 +363,3 @@ def reload_scripts():
 
     scripts_txt2img = ScriptRunner()
     scripts_img2img = ScriptRunner()
-

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -318,6 +318,15 @@ class ScriptRunner:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
 
+    def batch_postprocess(self, p, **kwargs):
+        for script in self.alwayson_scripts:
+            try:
+                script_args = p.script_args[script.args_from:script.args_to]
+                script.batch_postprocess(p, *script_args, **kwargs)
+            except Exception:
+                print(f"Error running process_batch: {script.filename}", file=sys.stderr)
+                print(traceback.format_exc(), file=sys.stderr)
+
     def postprocess(self, p, processed):
         for script in self.alwayson_scripts:
             try:

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -85,7 +85,7 @@ class Script:
 
         pass
 
-    def batch_postprocess(self, p, image, *args, **kwargs):
+    def batch_postprocess(self, p, image, *args):
         """
         Called for every batch after processing.
         Result image added for visual post-processing ease.
@@ -318,11 +318,11 @@ class ScriptRunner:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
 
-    def batch_postprocess(self, p, image, **kwargs):
+    def batch_postprocess(self, p, image):
         for script in self.alwayson_scripts:
             try:
                 script_args = p.script_args[script.args_from:script.args_to]
-                script.batch_postprocess(p, *script_args, **kwargs)
+                script.batch_postprocess(p, image, *script_args)
             except Exception:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -318,7 +318,7 @@ class ScriptRunner:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
 
-    def batch_postprocess(self, p, **kwargs):
+    def batch_postprocess(self, p, image, **kwargs):
         for script in self.alwayson_scripts:
             try:
                 script_args = p.script_args[script.args_from:script.args_to]

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -85,7 +85,7 @@ class Script:
 
         pass
 
-    def batch_postprocess(self, p, image, *args):
+    def batch_postprocess(self, p, image, *args, **kwargs):
         """
         Called for every batch after processing.
         Result image added for visual post-processing ease.
@@ -318,11 +318,11 @@ class ScriptRunner:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
 
-    def batch_postprocess(self, p, image):
+    def batch_postprocess(self, p, image, **kwargs):
         for script in self.alwayson_scripts:
             try:
                 script_args = p.script_args[script.args_from:script.args_to]
-                script.batch_postprocess(p, image, *script_args)
+                script.batch_postprocess(p, image, *script_args, **kwargs)
             except Exception:
                 print(f"Error running process_batch: {script.filename}", file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -88,7 +88,11 @@ class Script:
     def batch_postprocess(self, p, image, *args, **kwargs):
         """
         Called for every batch after processing.
-        Result image added for visual post-processing ease.
+        It recieves the result image for visual post-processing ease.
+        **kwargs will have those items:
+          - seed : the current seed
+          - prompt : the current prompt
+          - info : the current infotext
         """
         pass
 


### PR DESCRIPTION
Hello,

I added a batch_postprocess functionnality, taking example on the script related ones that were already there.

This one allows to have post processing during a batch. The advantage is for when you generate big batches or when you are used to generate until you think you should change something. It makes it possible to have your post-processing without having to wait for the full batch to be generated. Or to simply add a new task to the global workflow without necessarily having to make a complete script managing the normal processing.

Sample script that I've made to work with it :
https://github.com/Extraltodeus/temp/blob/main/simple_upscale.py
<sub>It simply saves an upscaled (by stretching so it's quick) version of the output image for viewing comfort.</sub>

Just a note if this is approved : people using this should be aware that they could trigger a recursive processing.