### PR TITLE
Cleanly undo circular hijack to fix tiling getting stuck on #4818

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -96,8 +96,8 @@ class StableDiffusionModelHijack:
         if type(model_embeddings.token_embedding) == EmbeddingsWithFixes:
             model_embeddings.token_embedding = model_embeddings.token_embedding.wrapped
 
+        self.apply_circular(False)
         self.layers = None
-        self.circular_enabled = False
         self.clip = None
 
     def apply_circular(self, enable):


### PR DESCRIPTION
Fix for issue #4818 where tiling can get stuck enabled after switching checkpoints.

I'm not sure if this is the correct fix, but it looked like undo_hijack was not cleaning up the apply_circular correctly. This should be the appropriate fix if this is the case.