### PR TITLE
Fix None option of VAE selector

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -220,6 +220,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
     model.sd_model_checkpoint = checkpoint_file
     model.sd_checkpoint_info = checkpoint_info
 
+    sd_vae.clear_loaded_vae()
     sd_vae.load_vae(model, vae_file)
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -220,6 +220,7 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
     model.sd_model_checkpoint = checkpoint_file
     model.sd_checkpoint_info = checkpoint_info
 
+    sd_vae.delete_base_vae()
     sd_vae.clear_loaded_vae()
     sd_vae.load_vae(model, vae_file)
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -154,8 +154,7 @@ def load_vae(model, vae_file=None):
         if vae_opt not in vae_dict:
             vae_dict[vae_opt] = vae_file
             vae_list.append(vae_opt)
-            # shared.opts.data['sd_vae'] = vae_opt
-    else:
+    elif loaded_vae_file:
         restore_base_vae(model)
 
     loaded_vae_file = vae_file

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from modules import shared, devices, script_callbacks
 from modules.paths import models_path
 import glob
+from copy import deepcopy
 
 
 model_dir = "Stable-diffusion"
@@ -40,7 +41,7 @@ def store_base_vae(model):
     global base_vae, checkpoint_info
     if checkpoint_info != model.sd_checkpoint_info:
         assert not loaded_vae_file, "Trying to store non-base VAE!"
-        base_vae = model.first_stage_model.state_dict().copy()
+        base_vae = deepcopy(model.first_stage_model.state_dict())
         checkpoint_info = model.sd_checkpoint_info
 
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -55,7 +55,7 @@ def restore_base_vae(model):
     global loaded_vae_file
     if base_vae is not None and checkpoint_info == model.sd_checkpoint_info:
         print("Restoring base VAE")
-        load_vae_dict(model, base_vae)
+        _load_vae_dict(model, base_vae)
         loaded_vae_file = None
     delete_base_vae()
 
@@ -147,7 +147,7 @@ def load_vae(model, vae_file=None):
         store_base_vae(model)
         vae_ckpt = torch.load(vae_file, map_location=shared.weight_load_location)
         vae_dict_1 = {k: v for k, v in vae_ckpt["state_dict"].items() if k[0:4] != "loss" and k not in vae_ignore_keys}
-        load_vae_dict(model, vae_dict_1)
+        _load_vae_dict(model, vae_dict_1)
 
         # If vae used is not in dict, update it
         # It will be removed on refresh though
@@ -164,7 +164,7 @@ def load_vae(model, vae_file=None):
 
 
 # don't call this from outside
-def load_vae_dict(model, vae_dict_1):
+def _load_vae_dict(model, vae_dict_1):
     model.first_stage_model.load_state_dict(vae_dict_1)
     model.first_stage_model.to(devices.dtype_vae)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -335,7 +335,7 @@ options_templates.update(options_section(('training', "Training"), {
 options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": modules.sd_models.checkpoint_tiles()}, refresh=sd_models.list_models),
     "sd_checkpoint_cache": OptionInfo(0, "Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
-    "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": list(sd_vae.vae_list)}, refresh=sd_vae.refresh_vae_list),
+    "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": sd_vae.vae_list}, refresh=sd_vae.refresh_vae_list),
     "sd_hypernetwork": OptionInfo("None", "Hypernetwork", gr.Dropdown, lambda: {"choices": ["None"] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
     "sd_hypernetwork_strength": OptionInfo(1.0, "Hypernetwork strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.001}),
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),


### PR DESCRIPTION
This is a split PR of #4666

There was still some issue for the VAE selector:

1. restore_base_vae was actually never called (you can see I actually called it wrong but error was never thrown), so "None" VAE option was bugged.
2. Base VAE caching was done after loading selected VAE. Should be before
3. Base VAE caching didn't work because it now requires deepcopy

So here's fixes for them. The None option is used for #3866 

## 2 rounds of test just like before:
Prompt: 
```
ganyu \(genshin impact\),
Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1, Size: 512x512, Model hash: 925997e9, Eta: 0.0022321428125, Clip skip: 2, ENSD: 31337
```

Order (2 rounds):
1. auto (final_pruned.vae.pt) (animevae)
2. wd_kl-f8-anime2
3. sd_1.5_mse
4. None

<details><summary>First round (for comparison between VAEs used, they should be different even just a little)</summary>

animevae:
![00000-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838942-baafff2a-67eb-4c7e-a715-f9d46351b1f2.png)

wd_kl-f8-anime2:
![00001-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838948-2741b12e-721e-4b35-ad25-b091e8042c6d.png)

sd_1.5_mse:
![00002-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838952-839da8ec-07a1-42d5-bf38-708f91723d57.png)

None:
![00003-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838955-68d7d142-9809-48ae-9d68-1014fc4d7093.png)

</details>

For comparison between rounds (grouped by VAEs, each having two images which should be the same):
<details><summary>animevae</summary>

![00000-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838942-baafff2a-67eb-4c7e-a715-f9d46351b1f2.png)
![00004-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838979-dee57e80-d4f5-4856-a292-e2db8befb58b.png)

</details>

<details><summary>wd_kl-f8-anime2</summary>

![00001-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838948-2741b12e-721e-4b35-ad25-b091e8042c6d.png)
![00005-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838985-79b3f591-857a-4133-aa2a-5d3b9ed19d39.png)

</details>

<details><summary>sd_1.5_mse</summary>

![00002-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838952-839da8ec-07a1-42d5-bf38-708f91723d57.png)
![00006-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838989-d33ecbb4-3145-4d0f-b311-e8bc7d46d56e.png)

</details>

<details><summary>None</summary>

![00003-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838955-68d7d142-9809-48ae-9d68-1014fc4d7093.png)
![00007-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838992-56d64c30-8295-4d17-b9e6-62a33eb69d84.png)

</details>

## None Option test
Test alternating between animevae and none. Same prompts.
Order:
1. auto (animevae)
2. None

<details><summary>First round (for comparison between VAEs used, they should be different even just a little)</summary>

animevae:
![00008-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839062-2967ae7a-94c5-444c-8582-4b16583b1fbf.png)

None:
![00009-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839064-16dea394-2921-4317-8f36-1d1b72ea2836.png)

</details>

<details><summary>animevae</summary>

![00008-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839062-2967ae7a-94c5-444c-8582-4b16583b1fbf.png)
![00011-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839076-26a336fe-94e0-415d-b2d3-8cf0fa4498e3.png)

</details>

<details><summary>None</summary>

![00009-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839064-16dea394-2921-4317-8f36-1d1b72ea2836.png)
![00012-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839082-5d6e9170-8a66-44ff-9a2a-1f8c89cafab6.png)

</details>


<details><summary>Comparison between this one's None and the previous one (from the test with 4 options tried)</summary>

Current:
![00009-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202839064-16dea394-2921-4317-8f36-1d1b72ea2836.png)

Previous:
![00003-1-ganyu _(genshin impact___](https://user-images.githubusercontent.com/1442761/202838955-68d7d142-9809-48ae-9d68-1014fc4d7093.png)

</details>


## Embedding training test
Embedding training after switching to None.
To ensure "None" option works for embedding training (it goes bad if VAE is loaded).
NAI model. "auto" resolves to animevae

<details><summary>Parameters</summary>

![image](https://user-images.githubusercontent.com/1442761/202843551-3297a450-5dd3-43e5-aa08-2d5e1c0aa4cd.png)
![image](https://user-images.githubusercontent.com/1442761/202843555-603b0b44-969c-4f04-9fe4-77ff5cb24e83.png)
![image](https://user-images.githubusercontent.com/1442761/202843586-6bd1c9b2-f32e-4771-8d6e-f462575c283e.png)
</details>

<details><summary>VAE "auto", select "None", then train</summary>

![image](https://user-images.githubusercontent.com/1442761/202844591-73382b9f-4b93-4d38-81b5-6b6219f7b494.png)
</details>