### PR TITLE
Option to use selected VAE as default fallback instead of primary option

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -336,6 +336,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": modules.sd_models.checkpoint_tiles()}, refresh=sd_models.list_models),
     "sd_checkpoint_cache": OptionInfo(0, "Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
     "sd_vae": OptionInfo("auto", "SD VAE", gr.Dropdown, lambda: {"choices": list(sd_vae.vae_list)}, refresh=sd_vae.refresh_vae_list),
+    "sd_vae_as_default": OptionInfo(False, "Use selected VAE as default fallback instead"),
     "sd_hypernetwork": OptionInfo("None", "Hypernetwork", gr.Dropdown, lambda: {"choices": ["None"] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
     "sd_hypernetwork_strength": OptionInfo(1.0, "Hypernetwork strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.001}),
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),

--- a/webui.py
+++ b/webui.py
@@ -82,6 +82,7 @@ def initialize():
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
+    shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("sd_hypernetwork", wrap_queued_call(lambda: modules.hypernetworks.hypernetwork.load_hypernetwork(shared.opts.sd_hypernetwork)))
     shared.opts.onchange("sd_hypernetwork_strength", modules.hypernetworks.hypernetwork.apply_strength)
 


### PR DESCRIPTION
This is a split PR of #4666

Added option to treat the VAE selector as default fallback. Priority will then become: (1) vae-path arg, (2) similar VAE as checkpoint (e.g. "beside" checkpoint, same path but .vae.pt ext), (3) selected VAE. Ref: #3655 and [a comment](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3986#issuecomment-1300971842)

![image](https://user-images.githubusercontent.com/1442761/201505908-ce734f24-aa60-4197-9ad6-206c6a378704.png)

## Test 1: Toggling the option on and off

Model: final_pruned.ckpt
VAE exists beside it: final_pruned.vae.pt
Selected VAE: Anything-V3.0.vae.pt

<details><summary>With the option unchecked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839315-8212193a-f82f-4b96-b2e0-0dbd508d93e2.png)
</details>


<details><summary>With the option checked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839388-e8c501ba-7025-4ede-accd-f3c601acd8dd.png)
</details>

## Test 2: Switching to another checkpoint

Model: sd_1.4.ckpt
VAE exists beside it: None
Selected VAE: Anything-V3.0.vae.pt

<details><summary>With the option unchecked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839660-0ef752d1-9869-41e0-b9e1-607b1dc1db2e.png)
</details>


<details><summary>With the option checked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839570-1be0db14-dc97-4844-bdbc-f9bf9595cd12.png)
</details>

## Test 3: Switching to other VAE

Model: sd_1.4.ckpt
VAE exists beside it: None
Selected VAE: Anything-V3.0.vae.pt
Switch to VAE: final_pruned.vae.pt

<details><summary>With the option unchecked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839792-77f36e2a-9dd1-4ce5-b6bc-d260b5b608c5.png)
</details>


<details><summary>With the option checked:</summary>

![image](https://user-images.githubusercontent.com/1442761/202839807-e0175198-7d3c-45ba-8f94-0b3e361b9eb1.png)
</details>