### PR TITLE
Add more lookup for VAE dropdown entries and the auto fallback

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -10,6 +10,22 @@ from modules.upscaler import Upscaler
 from modules.paths import script_path, models_path
 
 
+def model_places(model_path: str, command_path: str = None):
+    places = []
+
+    if command_path is not None and command_path != model_path:
+        pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
+        if os.path.exists(pretrained_path):
+            print(f"Appending path: {pretrained_path}")
+            places.append(pretrained_path)
+        elif os.path.exists(command_path):
+            places.append(command_path)
+
+    places.append(model_path)
+
+    return places
+
+
 def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None) -> list:
     """
     A one-and done loader to try finding the desired models in specified directories.
@@ -27,17 +43,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
         ext_filter = []
 
     try:
-        places = []
-
-        if command_path is not None and command_path != model_path:
-            pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
-            if os.path.exists(pretrained_path):
-                print(f"Appending path: {pretrained_path}")
-                places.append(pretrained_path)
-            elif os.path.exists(command_path):
-                places.append(command_path)
-
-        places.append(model_path)
+        places = model_places(model_path=model_path, command_path=command_path)
 
         for place in places:
             if os.path.exists(place):

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -4,10 +4,13 @@ from collections import namedtuple
 from modules import shared, devices, script_callbacks
 from modules.paths import models_path
 import glob
+from copy import deepcopy
+from pathlib import Path
 
 
 model_dir_name = "Stable-diffusion"
 model_dir = os.path.abspath(os.path.join(models_path, model_dir_name))
+model_dir_path = Path(model_dir)
 vae_dir_name = "VAE"
 vae_dir = os.path.abspath(os.path.join(models_path, vae_dir_name))
 
@@ -117,16 +120,19 @@ def resolve_vae(checkpoint_file, vae_file="auto"):
     # if still not found, try look for VAE similar to model
     if vae_file == "auto" and checkpoint_file:
         model_path = os.path.splitext(checkpoint_file)[0]
-        rel_path = os.path.relpath(model_path, model_dir)
-        vae_path = os.path.join(vae_dir, rel_path)
         trials = [
             model_path + ".vae.pt",
-            model_path + ".vae.ckpt",
-            vae_path + ".vae.pt",
-            vae_path + ".vae.ckpt",
-            vae_path + ".pt",
-            vae_path + ".ckpt",
+            model_path + ".vae.ckpt"
         ]
+        if model_dir_path in Path(checkpoint_file).parents:
+            rel_path = os.path.relpath(model_path, model_dir)
+            vae_path = os.path.join(vae_dir, rel_path)
+            trials += [
+                vae_path + ".vae.pt",
+                vae_path + ".vae.ckpt",
+                vae_path + ".pt",
+                vae_path + ".ckpt"
+            ]
         for vae_file_try in trials:
             if os.path.isfile(vae_file_try):
                 vae_file = vae_file_try

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -3,6 +3,7 @@ import os
 from collections import namedtuple
 from modules import shared, devices, script_callbacks
 from modules.paths import models_path
+from modules.modelloader import model_places
 import glob
 from copy import deepcopy
 from pathlib import Path
@@ -10,7 +11,8 @@ from pathlib import Path
 
 model_dir_name = "Stable-diffusion"
 model_dir = os.path.abspath(os.path.join(models_path, model_dir_name))
-model_dir_path = Path(model_dir)
+model_dirs = [model_dir]
+model_dirs_paths = [Path(x) for x in model_dirs]
 vae_dir_name = "VAE"
 vae_dir = os.path.abspath(os.path.join(models_path, vae_dir_name))
 
@@ -31,6 +33,15 @@ first_load = True
 base_vae = None
 loaded_vae_file = None
 checkpoint_info = None
+
+
+def init():
+    global model_dir, model_dirs, model_dirs_paths
+    from modules.sd_models import model_path
+    model_dir = model_path
+    model_dirs = model_places(model_path=model_dir, command_path=shared.cmd_opts.ckpt_dir)
+    model_dirs_paths = [Path(x) for x in model_dirs]
+    refresh_vae_list()
 
 
 def get_base_vae(model):
@@ -65,16 +76,38 @@ def get_filename(filepath):
     return os.path.splitext(os.path.basename(filepath))[0]
 
 
+def search_parent(file):
+    if file is not None and os.path.isfile(file):
+        path = Path(file)
+        for p in model_dirs_paths:
+            if p in path.parents:
+                path = None
+                break
+        if path:
+            return [
+                *glob.iglob(os.path.join(str(path.parent), '**/*.vae.ckpt'), recursive=True),
+                *glob.iglob(os.path.join(str(path.parent), '**/*.vae.pt'), recursive=True)
+            ]
+    return []
+
+
 def refresh_vae_list(vae_dir=vae_dir, model_dir=model_dir):
     global vae_dict, vae_list
     res = {}
-    candidates = [
-        *glob.iglob(os.path.join(model_dir, '**/*.vae.ckpt'), recursive=True),
-        *glob.iglob(os.path.join(model_dir, '**/*.vae.pt'), recursive=True),
+    candidates = []
+    for model_dir in model_dirs:
+        candidates += [
+            *glob.iglob(os.path.join(model_dir, '**/*.vae.ckpt'), recursive=True),
+            *glob.iglob(os.path.join(model_dir, '**/*.vae.pt'), recursive=True)
+        ]
+    candidates += [
         *glob.iglob(os.path.join(vae_dir, '**/*.ckpt'), recursive=True),
         *glob.iglob(os.path.join(vae_dir, '**/*.pt'), recursive=True)
     ]
+    if shared.cmd_opts.ckpt is not None:
+        candidates += search_parent(shared.cmd_opts.ckpt)
     if shared.cmd_opts.vae_path is not None and os.path.isfile(shared.cmd_opts.vae_path):
+        candidates += search_parent(shared.cmd_opts.vae_path)
         candidates.append(shared.cmd_opts.vae_path)
     for filepath in candidates:
         name = get_filename(filepath)
@@ -124,15 +157,16 @@ def resolve_vae(checkpoint_file, vae_file="auto"):
             model_path + ".vae.pt",
             model_path + ".vae.ckpt"
         ]
-        if model_dir_path in Path(checkpoint_file).parents:
-            rel_path = os.path.relpath(model_path, model_dir)
-            vae_path = os.path.join(vae_dir, rel_path)
-            trials += [
-                vae_path + ".vae.pt",
-                vae_path + ".vae.ckpt",
-                vae_path + ".pt",
-                vae_path + ".ckpt"
-            ]
+        for model_dir_path in model_dirs_paths:
+            if model_dir_path in Path(checkpoint_file).parents:
+                rel_path = os.path.relpath(model_path, model_dir)
+                vae_path = os.path.join(vae_dir, rel_path)
+                trials += [
+                    vae_path + ".vae.pt",
+                    vae_path + ".vae.ckpt",
+                    vae_path + ".pt",
+                    vae_path + ".ckpt"
+                ]
         for vae_file_try in trials:
             if os.path.isfile(vae_file_try):
                 vae_file = vae_file_try

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -136,15 +136,15 @@ def resolve_vae(checkpoint_file, vae_file="auto"):
     # if vae_file argument is provided, it takes priority, but not saved
     if vae_file and vae_file not in default_vae_list:
         if not os.path.isfile(vae_file):
+            print(f"VAE provided as function argument doesn't exist: {vae_file}")
             vae_file = "auto"
-            print("VAE provided as function argument doesn't exist")
     # for the first load, if vae-path is provided, it takes priority, saved, and failure is reported
     if first_load and shared.cmd_opts.vae_path is not None:
         if os.path.isfile(shared.cmd_opts.vae_path):
             vae_file = shared.cmd_opts.vae_path
             shared.opts.data['sd_vae'] = get_filename(vae_file)
         else:
-            print("VAE provided as command line argument doesn't exist")
+            print(f"VAE provided as command line argument doesn't exist: {vae_file}")
     # else, we load from settings
     if vae_file == "auto" and shared.opts.sd_vae is not None:
         # if saved VAE settings isn't recognized, fallback to auto
@@ -152,13 +152,12 @@ def resolve_vae(checkpoint_file, vae_file="auto"):
         # if VAE selected but not found, fallback to auto
         if vae_file not in default_vae_values and not os.path.isfile(vae_file):
             vae_file = "auto"
-            print("Selected VAE doesn't exist")
+            print(f"Selected VAE doesn't exist: {vae_file}")
     # vae-path cmd arg takes priority for auto
     if vae_file == "auto" and shared.cmd_opts.vae_path is not None:
         if os.path.isfile(shared.cmd_opts.vae_path):
             vae_file = shared.cmd_opts.vae_path
-            print("Using VAE provided as command line argument")
-
+            print(f"Using VAE provided as command line argument: {vae_file}")
     # if still not found, try look for VAE similar to model
     if vae_file == "auto" and checkpoint_file:
         model_path = os.path.splitext(checkpoint_file)[0]
@@ -179,7 +178,7 @@ def resolve_vae(checkpoint_file, vae_file="auto"):
         for vae_file_try in trials:
             if os.path.isfile(vae_file_try):
                 vae_file = vae_file_try
-                print("Using VAE found similar to selected model")
+                print(f"Using VAE found similar to selected model: {vae_file}")
                 break
 
     # No more fallbacks for auto

--- a/webui.py
+++ b/webui.py
@@ -78,7 +78,7 @@ def initialize():
 
     modules.scripts.load_scripts()
 
-    modules.sd_vae.refresh_vae_list()
+    modules.sd_vae.init()
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)

--- a/webui.py
+++ b/webui.py
@@ -78,7 +78,7 @@ def initialize():
 
     modules.scripts.load_scripts()
 
-    modules.sd_vae.init()
+    modules.sd_vae.refresh_vae_list()
     modules.sd_models.load_model()
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)


### PR DESCRIPTION
This is a split PR of #4666

1. Lookup for VAEs in --ckpt-dir just like checkpoint dropdown does
2. Use relative path as dropdown entries, similar to checkpoint dropdown
3. Added more fallback for auto (It will now search for similarly relatively located VAE in VAE folder. (e.g. you have Stable-diffusion/mymodel/mymodel.ckpt it will also try to fallback to VAE/mymodel/mymodel.vae.pt etc)

![image](https://user-images.githubusercontent.com/1442761/202787578-40e8e9a5-db1d-4de5-a6cd-a864a223261c.png)

This is a draft PR because I haven't done the previous tests but I hope people having trouble with [VAEs from ckpt_dir cmd option not showing up](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4666#issuecomment-1319813826) can try it out. **The following is just template for tests to do.**

## Test 1: Using --ckpt outside the designated folder 

final_pruned.ckpt and final_pruned.vae.pt moved outside

![image](https://user-images.githubusercontent.com/1442761/202841229-7dcb5549-26df-44b6-a8bf-52141a03c732.png)
![image](https://user-images.githubusercontent.com/1442761/202841292-8859703a-7310-4a12-9263-e870710c91fe.png)

## Test 2: Using --ckpt-dir outside the designated folder

The folder for --ckpt-dir is the one from Test 1, but now final_pruned.vae.pt is copied too. So there are 2 VAEs in that folder and both should show up.

![image](https://user-images.githubusercontent.com/1442761/202841688-db2fc4de-cd25-4f04-b04e-3791bd06f6a8.png)
![image](https://user-images.githubusercontent.com/1442761/202841695-78947e3d-7ccc-4c4f-9000-693f22767dbe.png)