### PR TITLE
Move progress info to beginning of site title

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -23,7 +23,7 @@ function check_progressbar(id_part, id_progressbar, id_progressbar_span, id_skip
     
     if(opts.show_progress_in_title && progressbar && progressbar.offsetParent){
         if(progressbar.innerText){
-            let newtitle = 'Stable Diffusion - ' + progressbar.innerText
+            let newtitle = '[' + progressbar.innerText.trim() + '] Stable Diffusion';
             if(document.title != newtitle){
                 document.title =  newtitle;          
             }


### PR DESCRIPTION
Very small UI change, because who has so few tabs open that they can see to the end of a tab name?