### PR TITLE
Fixed issue with selected_gallery_index()

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -8,8 +8,8 @@ function set_theme(theme){
 }
 
 function selected_gallery_index(){
-    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem .gallery-item')
-    var button = gradioApp().querySelector('[style="display: block;"].tabitem .gallery-item.\\!ring-2')
+    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery] .gallery-item')
+    var button = gradioApp().querySelector('[style="display: block;"].tabitem div[id$=_gallery] .gallery-item.\\!ring-2')
 
     var result = -1
     buttons.forEach(function(v, i){ if(v==button) { result = i } })


### PR DESCRIPTION
I fixed a small bug I discovered with the selected_gallery_index function:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4573#issuecomment-1315688133

> The function that is supposed to keep track of which image is selected in the gallery (selected_gallery_index()) uses a selector that selects too broadly. It should work like "Get the index of the selected image inside the txt2img gallery" but instead it's "Get the index of the selected image inside any of the galleries on the page"
So if a custom script adds a gallery to the txt2img tab (like yours does), the function returns an incorrect index which prevents the displayed generation text from updating properly.

I fixed it by modifying the selectors to be a little bit more restrictive - they now only look inside galleries that have ids which end in the string "_gallery"

With this PR, custom scripts and extensions will be able to include galleries of images without breaking the existing code. They just need to be sure to either not give the gallery an id, or give it an id that doesn't end with "_gallery"