### PR TITLE
fix samplers using name, respects function call

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -74,7 +74,7 @@ def apply_sampler(p, x, xs):
     if sampler_index is None:
         raise RuntimeError(f"Unknown sampler: {x}")
 
-    p.sampler_index = sampler_index
+    p.sampler_name = sd_samplers.all_samplers[sampler_index].name
 
 
 def confirm_samplers(p, xs):


### PR DESCRIPTION
Fixes apply_sampler() using name instead of index while respecting the function and keeping case insensitivity.

#4860