### PR TITLE
Fixes apply_sampler() using name instead of index

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -70,11 +70,12 @@ def build_samplers_dict():
 
 
 def apply_sampler(p, x, xs):
-    sampler_index = build_samplers_dict().get(x.lower(), None)
+    sampler_dict = build_samplers_dict()
+    sampler_index = samplers_dict.get(x.lower(), None)
     if sampler_index is None:
         raise RuntimeError(f"Unknown sampler: {x}")
 
-    p.sampler_index = sampler_index
+    p.sampler_name = sampler_dict[sampler_index].name
 
 
 def confirm_samplers(p, xs):


### PR DESCRIPTION
#4860
Fixes apply_sampler() using name instead of index while respecting the function and keeping case insensitivity.
I closed the last pull request because I left redundancy, had to clean it up