### PR TITLE
Fix img2img & x/y_grid sampler selection and enable sampler wildcard option

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -99,7 +99,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         seed_resize_from_h=seed_resize_from_h,
         seed_resize_from_w=seed_resize_from_w,
         seed_enable_extras=seed_enable_extras,
-        sampler_index=sd_samplers.samplers_for_img2img[sampler_index].name,
+        sampler_name=sd_samplers.samplers_for_img2img[sampler_index].name,
         batch_size=batch_size,
         n_iter=n_iter,
         steps=steps,

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -83,7 +83,7 @@ def confirm_samplers(p, xs):
         if x.lower() not in samplers_dict:
             raise RuntimeError(f"Unknown sampler: {x}")
         if p.enable_hr and sd_samplers.all_samplers[samplers_dict[x.lower()]].name == 'PLMS':
-            raise RuntimeError(f"Sampler PLMS not supported for img2img or highres fix used")
+            raise RuntimeError(f"Sampler PLMS not supported for img2img or highres fix enabled in txt2img")
 
 
 def apply_checkpoint(p, x, xs):

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -72,7 +72,7 @@ def confirm_samplers(p, xs):
     for x in xs:
         if x.lower() not in sd_samplers.samplers_map:
             raise RuntimeError(f"Unknown sampler: {x}")
-        if p.enable_hr and sd_samplers.samplers_map.get(x.lower(), None) == 'PLMS':
+        if p.enable_hr and x.upper() == 'PLMS':
             raise RuntimeError(f"Sampler PLMS not supported for img2img or when highres fix enabled in txt2img")
 
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

img2img & xy_grid aren't setting sampler after changing from using sampler_index to sampler_name

**Additional notes and description of your changes**

For the Sampler option in xy_grid, it now allows using * to select all the valid samplers for one of the axes.

Fixes #4860

The easiest check for img2img is to select DPM Adaptive and see that runs for the number of steps set in the UI and the completed image doesn't have a Sampler Name displayed below the image.

