### PR TITLE
Fix support for devices other than CUDA in DeepBooru

### DIFF
--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -58,7 +58,7 @@ class DeepDanbooru:
         a = np.expand_dims(np.array(pic, dtype=np.float32), 0) / 255
 
         with torch.no_grad(), devices.autocast():
-            x = torch.from_numpy(a).cuda()
+            x = torch.from_numpy(a).to(devices.device)
             y = self.model(x)[0].detach().cpu().numpy()
 
         probability_dict = {}


### PR DESCRIPTION
Replaces `.cuda()` with `.to(devices.device)`. Fixes #4901, fixes #4923, fixes #4945.