### PR TITLE
Supporting `*.safetensors` format.

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -45,7 +45,7 @@ def checkpoint_tiles():
 
 def list_models():
     checkpoints_list.clear()
-    model_list = modelloader.load_models(model_path=model_path, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt"])
+    model_list = modelloader.load_models(model_path=model_path, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"])
 
     def modeltitle(path, shorthash):
         abspath = os.path.abspath(path)
@@ -180,7 +180,14 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
         # load from file
         print(f"Loading weights [{sd_model_hash}] from {checkpoint_file}")
 
-        pl_sd = torch.load(checkpoint_file, map_location=shared.weight_load_location)
+        if checkpoint_file.endswith(".safetensors"):
+            try:
+                from safetensors.torch import load_file
+            except ImportError as e:
+                raise ImportError(f"The model is in safetensors format and it is not installed, use `pip install safetensors`: {e}")
+            pl_sd = load_file(checkpoint_file, device=shared.weight_load_location)
+        else:
+            pl_sd = torch.load(checkpoint_file, map_location=shared.weight_load_location)
         if "global_step" in pl_sd:
             print(f"Global Step: {pl_sd['global_step']}")
 


### PR DESCRIPTION
If a model file exists with extension `.safetensors` then we can load it more safely than with PyTorch weights.

Existing hacks are in the wild: https://twitter.com/amli_art/status/1593312723898552320
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/4714

This PR proposes to use `safetensors` as a safe way to store the model weights. That way users can exchange model without risking to be compromised.

Other alternatives to be considered:

- Use `torch.load(..., weight_only=True)` (torch 1.13.0 only). But this will fail on the original checkpoint since it uses some real pickled class (pytorch_lightning).  There is no way to load those file securely with PyTorch in that format afaik.
- There is actually a way to load safetensors files without `safetensors` https://gist.github.com/Narsil/3edeec2669a5e94e4707aa0f901d2282 (This could be done when it's not installed too).

As a side benefit, the model will load faster on CPU and GPU: https://twitter.com/narsilou/status/1590640997431939072

I'm creating this PR, since I think someone in the community seemed to have been interested @pattontim

If you're interested, I can provide a simple script to convert automatically checkpoints.
Unfortunately, converting will require loading the weights and won't be by itself secure.

Conversion script
```python
!wget https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt

import torch
from safetensors.torch import save_file

weights = torch.load("sd-v1-4.ckpt")["state_dict"]
save_file(weights, "model.safetensors")
```


Test locally:
```
wget https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/refs%2Fpr%2F224/model.safetensors
mv model.safetensors models/Stable-diffusion/
```