### PR TITLE
Advanced lr schedulers for Hypernetwork

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -466,6 +466,9 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
     pbar = tqdm.tqdm(enumerate(ds), total=steps - ititial_step)
     for i, entries in pbar:
         hypernetwork.step = i + ititial_step
+        if use_beta_scheduler:
+            scheduler_beta.step(hypernetwork.step)
+            scheduler_gamma.step(hypernetwork.step)
         if len(loss_dict) > 0:
             previous_mean_losses = [i[-1] for i in loss_dict.values()]
             previous_mean_loss = mean(previous_mean_losses)
@@ -500,9 +503,6 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, data_root, log
             assert steps_without_grad < 10, 'no gradient found for the trained weight after backward() for 10 steps in a row; this is a bug; training cannot continue'
 
             optimizer.step()
-            if use_beta_scheduler:
-                scheduler_beta.step(hypernetwork.step)
-                scheduler_gamma.step(hypernetwork.step)
                 
         steps_done = hypernetwork.step + 1
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1284,7 +1284,12 @@ def create_ui(wrap_gradio_gpu_call):
                     with gr.Row():
                         embedding_learn_rate = gr.Textbox(label='Embedding Learning rate', placeholder="Embedding Learning rate", value="0.005")
                         hypernetwork_learn_rate = gr.Textbox(label='Hypernetwork Learning rate', placeholder="Hypernetwork Learning rate", value="0.00001")
-
+                        use_beta_scheduler_checkbox = gr.Checkbox(label='Show advanced learn rate scheduler options(for Hypernetworks)')
+                    with gr.Row(visible=False) as beta_scheduler_options:
+                        use_beta_scheduler = gr.Checkbox(label='Uses CosineAnnealingWarmRestarts Scheduler')
+                        beta_repeat_epoch = gr.Textbox(label='Epoch for cycle', placeholder="Cycles every nth epoch", value="4000")
+                        min_lr = gr.Textbox(label='Minimum learning rate for beta scheduler', placeholder="restricts decay value, but does not restrict gamma rate decay", value="1e-7")
+                        gamma_rate = gr.Textbox(label='Separate learning rate decay for ExponentialLR', placeholder="Value should be in (0-1]", value="1")
                     batch_size = gr.Number(label='Batch size', value=1, precision=0)
                     dataset_directory = gr.Textbox(label='Dataset directory', placeholder="Path to directory with input images")
                     log_directory = gr.Textbox(label='Log directory', placeholder="Path to directory where to write outputs", value="textual_inversion")
@@ -1301,7 +1306,11 @@ def create_ui(wrap_gradio_gpu_call):
                         interrupt_training = gr.Button(value="Interrupt")
                         train_hypernetwork = gr.Button(value="Train Hypernetwork", variant='primary')
                         train_embedding = gr.Button(value="Train Embedding", variant='primary')
-
+                    use_beta_scheduler_checkbox.change(
+                        fn=lambda show: gr_show(show),
+                        inputs=[use_beta_scheduler_checkbox],
+                        outputs=[beta_scheduler_options],
+                    )
                 params = script_callbacks.UiTrainTabParams(txt2img_preview_params)
 
                 script_callbacks.ui_train_tabs_callback(params)
@@ -1395,6 +1404,10 @@ def create_ui(wrap_gradio_gpu_call):
                 save_image_with_stored_embedding,
                 preview_from_txt2img,
                 *txt2img_preview_params,
+                use_beta_scheduler,
+                beta_repeat_epoch,
+                min_lr,
+                gamma_rate
             ],
             outputs=[
                 ti_output,


### PR DESCRIPTION
This allows people to use standard ml method, **CosineAnnealingWarmRestarts, ExponentialLR**

Recently people uses these templates : 
```
5e-5:100, 5e-6:1500, 5e-7:2000, 5e-5:2100, 5e-7:3000, 5e-5:3100, 5e-7:4000, 5e-5:4100, 5e-7:5000, 5e-5:5100, 5e-7:6000, 5e-5:6100, 5e-7:7000, 5e-5:7100, 5e-7:8000, 5e-5:8100, 5e-7:9000, 5e-5:9100, 5e-7:10000, 5e-6:10100, 5e-8:11000, 5e-6:11100, 5e-8:12000, 5e-6:12100, 5e-8:13000, 5e-6:13100, 5e-8:14000, 5e-6:14100, 5e-8:15000, 5e-6:15100, 5e-8:16000, 5e-6:16100, 5e-8:17000, 5e-6:17100, 5e-8:18000, 5e-6:18100, 5e-8:19000, 5e-6:19100, 5e-8:20000, 5e-5:20100, 5e-7:21000, 5e-5:21100, 5e-7:22000, 5e-5:22100, 5e-7:23000, 5e-5:23100, 5e-7:24000, 5e-5:24100, 5e-7:25000, 5e-5:25100, 5e-7:26000, 5e-5:26100, 5e-7:27000, 5e-5:27100, 5e-7:28000, 5e-5:28100, 5e-7:29000, 5e-5:29100, 5e-7:30000, 5e-6:30100, 5e-8:31000, 5e-6:31100, 5e-8:32000, 5e-6:32100, 5e-8:33000, 5e-6:33100, 5e-8:34000, 5e-6:34100, 5e-8:35000, 5e-6:35100, 5e-8:36000, 5e-6:36100, 5e-8:37000, 5e-6:37100, 5e-8:38000, 5e-6:38100, 5e-8:39000, 5e-6:39100, 5e-8:40000
```

Which is actually Cosine Annealing and Gamma(Exponential) Decay.

![image](https://user-images.githubusercontent.com/35677394/203331197-49c23b7a-76e5-4dd6-8262-7dea7c479a59.png)

This pr adds option for learn rate schedulers in UI.
With option enabled, scheduler will only be created with initial value. i.e. 5e-5. other values will be ignored.

Cycle value is recommended to be **multiple of 'preview image cycle'** to check differences.
Minimum learning rate only restricts **Cosine Annealing minimal value**. Gamma Decay will be applied after restriction.
![image](https://user-images.githubusercontent.com/35677394/203380799-4ecda910-d5bd-4d2d-8c25-3a9728be7564.png)
Learning rate and loss trend (multiplied to see trend)


This also fixes optimizer type being loaded even when optimizer has invalid hash.