### PR TITLE
fix: include_init_images missing from StableDiffusionProcessingImg2Img

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -734,7 +734,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     sampler = None
 
-    def __init__(self, init_images: list=None, resize_mode: int=0, denoising_strength: float=0.75, mask: Any=None, mask_blur: int=4, inpainting_fill: int=0, inpaint_full_res: bool=True, inpaint_full_res_padding: int=0, inpainting_mask_invert: int=0, **kwargs):
+    def __init__(self, init_images: list=None, resize_mode: int=0, denoising_strength: float=0.75, mask: Any=None, mask_blur: int=4, inpainting_fill: int=0, inpaint_full_res: bool=True, inpaint_full_res_padding: int=0, inpainting_mask_invert: int=0, include_init_images: bool=False, **kwargs):
         super().__init__(**kwargs)
 
         self.init_images = init_images
@@ -752,6 +752,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.mask = None
         self.nmask = None
         self.image_conditioning = None
+        self.include_init_images = include_init_images
 
     def init(self, all_prompts, all_seeds, all_subseeds):
         self.sampler = sd_samplers.create_sampler(self.sampler_name, self.sd_model)


### PR DESCRIPTION
The missing `include_init_images` causes [painthua](https://github.com/BlinkDL/Hua) to crash; I could not find a reason this would have been removed on purpose, especially with tests still supplying that value: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/828438b4a190759807f9054932cae3a8b880ddf1/test/img2img_test.py#L43

This PR adds it back with a default `False` as seen here:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/828438b4a190759807f9054932cae3a8b880ddf1/modules/api/models.py#L109