### PR TITLE
Support NAI style exif in PNG Info for Send... buttons

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -233,6 +233,20 @@ def run_pnginfo(image):
 
     geninfo = items.get('parameters', geninfo)
 
+    # nai prompt
+    if "Software" in items.keys() and items["Software"] == "NovelAI":
+        import json
+        json_info = json.loads(items["Comment"])
+        geninfo = f'{items["Description"]}\r\nNegative prompt: {json_info["uc"]}\r\n'
+        sampler = "Euler a"
+        if json_info["sampler"] == "k_euler_ancestral":
+            sampler = "Euler a"
+        elif json_info["sampler"] == "k_euler":
+            sampler = "Euler"
+        model_hash = '925997e9'  # assuming this is the correct model hash
+        # not sure with noise and strength parameter
+        geninfo += f'Steps: {json_info["steps"]}, Sampler: {sampler}, CFG scale: {json_info["scale"]}, Seed: {json_info["seed"]}, Size: {image.width}x{image.height}, Model hash: {model_hash}'  # , Denoising strength: {json_info["noise"]}'
+
     info = ''
     for key, text in items.items():
         info += f"""


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Support importing novelAI style exif for PNG Info

**Additional notes and description of your changes**

`strength` and `noise` parameters are not imported, as I don't know how to map these parameters.
Expected to have values of `"strength": 0.69, "noise": 0.667,` to have similar output with NovelAI

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [Windows11]
 - Browser [Vivaldi 5.5.x]
 - Graphics card [NVIDIA RTX 3070 Ti Laptop GPU 8GB]

**Screenshots or videos of your changes**
From NAI generated pngs.
![image](https://user-images.githubusercontent.com/836867/203682878-1820d7b9-2479-4eca-bba1-60918fdf9818.png)

after clicking Send to txt2img button
![image](https://user-images.githubusercontent.com/836867/203683023-bcb92338-1c1a-4175-a96f-969a4e0f642a.png)

