### PR TITLE
torch.cuda.empty_cache() defaults to cuda:0 device unless explicitly …

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -44,8 +44,18 @@ def get_optimal_device():
 
 def torch_gc():
     if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-        torch.cuda.ipc_collect()
+        from modules import shared
+
+        device_id = shared.cmd_opts.device_id
+        
+        if device_id is not None:
+            cuda_device = f"cuda:{device_id}"
+        else:
+            cuda_device = "cuda"
+        
+        with torch.cuda.device(cuda_device):
+            torch.cuda.empty_cache()
+            torch.cuda.ipc_collect()
 
 
 def enable_tf32():


### PR DESCRIPTION
Updating `torch_gc()` to explicitly set the correct CUDA device first before GC (to properly support multi-GPU systems using a non-zero `--device-id`.

Garbage collection (torch_gc in modules/devices.py) currently causes an incorrect OOM on multi-GPU systems if the first CUDA device is already fully allocated. This is because `torch.cuda.empty_cache()` defaults to `cuda:0` unless explicitly set otherwise first. Possibly another edge case here is that anyone currently running a non-zero `--device-id` doesn't have garbage collection working correctly.