### PR TITLE
Make VAE step sequential to prevent VRAM spikes, will fix #3059, #2082, #2561, #3462

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -530,8 +530,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             with devices.autocast():
                 samples_ddim = p.sample(conditioning=c, unconditional_conditioning=uc, seeds=seeds, subseeds=subseeds, subseed_strength=p.subseed_strength, prompts=prompts)
 
-            samples_ddim = samples_ddim.to(devices.dtype_vae)
-            x_samples_ddim = decode_first_stage(p.sd_model, samples_ddim)
+            x_samples_ddim = [decode_first_stage(p.sd_model, samples_ddim[i:i+1].to(dtype=devices.dtype_vae))[0].cpu() for i in range(samples_ddim.size(0))]
+            x_samples_ddim = torch.stack(x_samples_ddim).float()
             x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
 
             del samples_ddim


### PR DESCRIPTION
Many people are upset when they have just enough VRAM to process a large batch of images, but CUDA usage spikes up at the very end throwing error at 100% progress, not saving images.

This comes from the VAE final step. The code:

```
samples_ddim = samples_ddim.to(devices.dtype_vae)
x_samples_ddim = decode_first_stage(p.sd_model, samples_ddim)
```

I believe the problem is because we ask VAE to convert from latent space the whole batch of images, which requires additional VRAM, since we don't delete latent representation from CUDA memory.

Then, the code goes:

```
x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
del samples_ddim
if shared.cmd_opts.lowvram or shared.cmd_opts.medvram:
    lowvram.send_everything_to_cpu()
devices.torch_gc()
if opts.filter_nsfw:
    import modules.safety as safety
    x_samples_ddim = modules.safety.censor_batch(x_samples_ddim)
for i, x_sample in enumerate(x_samples_ddim):
    x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
    x_sample = x_sample.astype(np.uint8)
    …
```

Image-space tensor is always transferred to CPU: either at x_sample.cpu(), or inside modules.safety.censor_batch (it starts with  `def censor_batch(x): x_samples_ddim_numpy = x.cpu().permute(0, 2, 3, 1).numpy()`).

This means we can process the batch with VAE sequentially, one-by-one image, storing results to CPU directly. It will avoid requesting more VRAM memory at the cost of ___slightly___ increased final step time.

My fix to original code is:

```
x_samples_ddim = [decode_first_stage(p.sd_model, samples_ddim[i:i+1].to(dtype=devices.dtype_vae))[0].cpu() for i in range(samples_ddim.size(0))]
x_samples_ddim = torch.stack(x_samples_ddim).float()
```

I use tensor slices to make decode_first_stage() believe that we always have batch of 1 image. Then I concatenate resulting CPU tensors and cast them to float32. The subsequent code works as is, and doesn't require any other modifications.

Reasons for making this direct change, rather than option (either runtime or command-line):
- The delay caused by sequential processing is already very little and not noticeable.
- It affects only final stage of each batch. The more sampler Steps you have – the less relative time VAE takes, so the overall delay impact will be shorter.
- If you had batch size = 1, nothing changes for you.
- The delay is proportional to batch size, which can't be larger than 8.
- Guys with low-end cards often cannot use batches at all, but with this fix they might.
- Largest theoretical delay will be for those who already have a lot of VRAM and use largest batch sizes – but their GPU is actually pretty fast and the delay itself will be shorter!

With this fix, I am able to run 768x768 with batch size = 8 on RTX 3060 with 11.7/12 Gb VRAM (--xformers --no-half --no-half-vae); and 512x512 with batch size = 2 on 940MX with 3.7/4 Gb VRAM (--medvram).
