### PR TITLE
Slightly improve page scroll jumping with focus

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -92,14 +92,26 @@ function check_gallery(id_gallery){
             if (prevSelectedIndex !== -1 && galleryButtons.length>prevSelectedIndex && !galleryBtnSelected) {
                 // automatically re-open previously selected index (if exists)
                 activeElement = gradioApp().activeElement;
+                let scrollX = window.scrollX;
+                let scrollY = window.scrollY;
 
                 galleryButtons[prevSelectedIndex].click();
                 showGalleryImage();
 
+                // When the gallery button is clicked, it gains focus and scrolls itself into view
+                // We need to scroll back to the previous position
+                setTimeout(function (){
+                    window.scrollTo(scrollX, scrollY);
+                }, 50);
+
                 if(activeElement){
                     // i fought this for about an hour; i don't know why the focus is lost or why this helps recover it
-                    // if somenoe has a better solution please by all means
-                    setTimeout(function() { activeElement.focus() }, 1);
+                    // if someone has a better solution please by all means
+                    setTimeout(function (){
+                        activeElement.focus({
+                            preventScroll: true // Refocus the element that was focused before the gallery was opened without scrolling to it
+                        })
+                    }, 1);
                 }
             }
         })


### PR DESCRIPTION
This PR slightly improves the behaviour of the UI when an image generation completes and the user has an image enlarged in the gallery.

Previously, the UI would give focus back to the last element the user had focused before the gallery item stole focus.
This caused it to scroll the gallery item into view (due to it being `.click()`'d to enlarge the user's existing selection) and then scroll the last active element into view due to giving it focus.

This is only a slight improvement to the current workaround as the gallery item still steals focus and preventing this in the first place would be the best move, however this will make it so that focus is given back to the right element and the user is put back to where they were on the page.