### PR TITLE
Update Inpainting hijack to work with SafeTensors

### DIFF
--- a/modules/sd_hijack_inpainting.py
+++ b/modules/sd_hijack_inpainting.py
@@ -319,7 +319,8 @@ class LatentInpaintDiffusion(LatentDiffusion):
 
 
 def should_hijack_inpainting(checkpoint_info):
-    return str(checkpoint_info.filename).endswith("inpainting.ckpt") and not checkpoint_info.config.endswith("inpainting.yaml")
+    checkpoint_filename = str(checkpoint_info.filename)
+    return (checkpoint_filename.endswith("inpainting.ckpt") or checkpoint_filename.endswith("inpainting.safetensors")) and not checkpoint_info.config.endswith("inpainting.yaml")
 
 
 def do_inpainting_hijack():


### PR DESCRIPTION
The inpainting hijack that's currently in place does not work with SafeTensors because the it fails to identify the checkpoint as needing hijacking.

This PR fixes that, as suggested by [/u/patrickas](https://www.reddit.com/user/patrickas) on the [SafeTensors Reddit post](https://www.reddit.com/r/StableDiffusion/comments/z8mnak/switching_models_too_slow_in_automatic1111_use/).