### PR TITLE
Add model name to output image metadata to differentiate output from trained models with same hashes

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -394,6 +394,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
         "Seed": all_seeds[index],
         "Face restoration": (opts.face_restoration_model if p.restore_faces else None),
         "Size": f"{p.width}x{p.height}",
+        'Model name': shared.sd_model.sd_checkpoint_info.model_name,        
         "Model hash": getattr(p, 'sd_model_hash', None if not opts.add_model_hash_to_info or not shared.sd_model.sd_model_hash else shared.sd_model.sd_model_hash),
         "Model": (None if not opts.add_model_name_to_info or not shared.sd_model.sd_checkpoint_info.model_name else shared.sd_model.sd_checkpoint_info.model_name.replace(',', '').replace(':', '')),
         "Hypernet": (None if shared.loaded_hypernetwork is None else shared.loaded_hypernetwork.name),


### PR DESCRIPTION
It's a simple improvement to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4546, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/4298, https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/2459

This problem appears when you have a lot of dreambooth-trained models, they all have the same hash. It's quite a problem when you train on a lot of subjects or pause at different steps. Imagine you have 50 models with the same hash and all the 5000 images that use those models load only one model from for example PNG Info.

This simple 1-line of code at least adds model file's name to the result image, so we could recall which model has been used.