### PR TITLE
Add macOS (Darwin) installation defaults

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -186,6 +186,7 @@ def prepare_enviroment():
     parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui settings", default='config.json')
     args, _ = parser.parse_known_args(sys.argv)
 
+    sys.argv, _ = extract_arg(sys.argv, '-f')
     sys.argv, skip_torch_cuda_test = extract_arg(sys.argv, '--skip-torch-cuda-test')
     sys.argv, reinstall_xformers = extract_arg(sys.argv, '--reinstall-xformers')
     sys.argv, update_check = extract_arg(sys.argv, '--update-check')

--- a/launch.py
+++ b/launch.py
@@ -194,20 +194,6 @@ def prepare_enviroment():
     xformers = '--xformers' in sys.argv
     ngrok = '--ngrok' in sys.argv
 
-    if platform.system() == 'Darwin':
-        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-        torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1 torchvision==0.13.1")
-        k_diffusion_repo = os.environ.get('K_DIFFUSION_REPO', 'https://github.com/brkirch/k-diffusion.git')
-        k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "51c9778f269cedb55a4d88c79c0246d35bdadb71")
-        if os.environ.get('COMMANDLINE_ARGS') == None:
-            if '--use-cpu' in sys.argv:
-                idx = sys.argv.index('--use-cpu')
-                if idx < len(sys.argv) and sys.argv[idx+1][0] != '-':
-                    sys.argv.insert(idx+1, 'interrogate')
-            else:
-                sys.argv += ['--use-cpu', 'interrogate']
-            sys.argv.append('--no-half')
-
     try:
         commit = run(f"{git} rev-parse HEAD").strip()
     except Exception:
@@ -219,7 +205,7 @@ def prepare_enviroment():
     if not is_installed("torch") or not is_installed("torchvision"):
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch")
 
-    if not skip_torch_cuda_test and platform.system() != 'Darwin':
+    if not skip_torch_cuda_test:
         run_python("import torch; assert torch.cuda.is_available(), 'Torch is not able to use GPU; add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'")
 
     if not is_installed("gfpgan"):
@@ -245,9 +231,6 @@ def prepare_enviroment():
 
     if not is_installed("pyngrok") and ngrok:
         run_pip("install pyngrok", "ngrok")
-
-    if platform.system() == 'Darwin' and not is_installed("psutil"):
-        run_pip("install psutil", "psutil")
 
     os.makedirs(dir_repos, exist_ok=True)
 

--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+####################################################################
+#                          macOS defaults                          #
+# Please modify webui-user.sh to change these instead of this file #
+####################################################################
+
+export COMMANDLINE_ARGS="--skip-torch-cuda-test --no-half --use-cpu interrogate"
+export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
+export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
+export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+
+####################################################################

--- a/webui-user.sh
+++ b/webui-user.sh
@@ -10,7 +10,7 @@
 #clone_dir="stable-diffusion-webui"
 
 # Commandline arguments for webui.py, for example: export COMMANDLINE_ARGS="--medvram --opt-split-attention"
-export COMMANDLINE_ARGS=""
+#export COMMANDLINE_ARGS=""
 
 # python3 executable
 #python_cmd="python3"

--- a/webui.sh
+++ b/webui.sh
@@ -51,10 +51,11 @@ fi
 can_run_as_root=0
 
 # read any command line flags to the webui.sh script
-while getopts "f" flag
+while getopts "f" flag > /dev/null 2>&1
 do
     case ${flag} in
         f) can_run_as_root=1;;
+        *) break;;
     esac
 done
 

--- a/webui.sh
+++ b/webui.sh
@@ -4,6 +4,14 @@
 # change the variables in webui-user.sh instead #
 #################################################
 
+# If run from macOS, load defaults from webui-macos-env.sh
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -f webui-macos-env.sh ]]
+        then
+        source ./webui-macos-env.sh
+    fi
+fi
+
 # Read variables from webui-user.sh
 # shellcheck source=/dev/null
 if [[ -f webui-user.sh ]]


### PR DESCRIPTION
~~This adds macOS support to launch.py. With this change, webui.sh can be used unmodified on macOS (this PR does change webui.sh, but it is because of a bug unrelated to macOS). This means that if this PR is merged then no scripts are needed from outside this repository to install on macOS.~~

~~Some details on the launch.py changes:~~
- ~~The PYTORCH_ENABLE_MPS_FALLBACK environment variable is set so that PyTorch doesn't throw an exception when encountering ops not yet implementing in MPS; instead it falls back to CPU for those ops~~
- ~~Torch 1.12.1 is installed for macOS because it is currently the best version of Torch on macOS for Stable Diffusion. Torch 1.13 has some broken functionality that I am unaware of any workarounds for.~~
-  ~~K-Diffusion does unfortunately need a MPS compatibility fork for macOS to ensure complete functionality. I created a fork to add to an existing MPS compatibility fork for K-Diffusion (by Birch-san). [Here's a comparison](https://github.com/crowsonkb/k-diffusion/compare/master...brkirch:k-diffusion:mps) to show what changes it has compared to the original K-Diffusion by crowsonkb. With this fork and #5194, all samplers work on macOS expect for PLMS not working with the Stable Diffusion 2.0 model.~~
- ~~Default command line arguments `--use-cpu interrogate --no-half` are added when run on macOS if the environment variable COMMANDLINE_ARGS is not set. If `--use-cpu` is already specified then `interrogate` is merged in.~~
- ~~The CUDA test is skipped for macOS as it is normal for it to fail~~
- ~~The psutil package is installed so that the InvokeAI cross attention optimization can be used for MPS~~

This PR no longer makes the above changes directly to launch.py. See comments below.

Also included is a fix for a bug that prevents the `-f` run as root flag in webui.sh from working correctly.