### PR TITLE
BUGFIX: Simple change to add --no-cache-dir in the pip install command.

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -158,7 +158,7 @@ def run_extensions_installers(settings_file):
 
 
 def prepare_enviroment():
-    torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
+    torch_command = os.environ.get('TORCH_COMMAND', "pip install --no-cache-dir torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
     commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
 


### PR DESCRIPTION
Without this command --no-cache-dir, your PC just freeze sometimes, this will override the cache (pre-downloaded files) and download the files all over again.