### PR TITLE
Fixed AttributeError where openaimodel is not found

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -17,6 +17,7 @@ from modules.sd_hijack_optimizations import invokeAI_mps_available
 
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
+import ldm.modules.diffusionmodules.openaimodel
 import ldm.models.diffusion.ddim
 import ldm.models.diffusion.plms
 import ldm.modules.encoders.modules


### PR DESCRIPTION
Fixes this small error when loading a non-standard model as the first model on startup:
```AttributeError: module 'ldm.modules.diffusionmodules' has no attribute 'openaimodel'```
On line: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/4b3c5bc24bffdf429c463a465763b3077fe55eb8/modules/sd_hijack.py#L71