### PR TITLE
Fix png info api and add verbose info option

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -218,11 +218,11 @@ class Api:
                 resp.pop(0)  # remove the first empty element
                 response = {}
                 for pair in resp:
-                    pair = pair.split("</p></b></p><p><p>") #
+                    pair = pair.split("</p></b></p><p><p>")  # Split the title and content by the tags between them
                     # unescape HTML entities
-                    pairKey = html.unescape(pair[0])
-                    pairValue = html.unescape(pair[1].replace("</p></p>", ""))
-                    response.update({pairKey: pairValue})
+                    pair_key = html.unescape(pair[0])
+                    pair_value = html.unescape(pair[1].replace("</p></p>", ""))
+                    response.update({pair_key: pair_value})
                 return PNGInfoResponse(info=result[2], verbose_info=response)
             else:
                 return PNGInfoResponse(info=result[2], verbose_info={})

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -155,9 +155,11 @@ class ExtrasBatchImagesResponse(ExtraBaseResponse):
 
 class PNGInfoRequest(BaseModel):
     image: str = Field(title="Image", description="The base64 encoded PNG image")
+    verbose: bool = Field(default=False, title="Verbose", description="If false (default), only the info used to generate the image will be returned in a plain string. If true, all info will be returned in verbose_info.")
 
 class PNGInfoResponse(BaseModel):
     info: str = Field(title="Image info", description="A string with all the info the image had")
+    verbose_info: dict = Field(title="Verbose info", description="An object with all the info the image had")
 
 class ProgressRequest(BaseModel):
     skip_current_image: bool = Field(default=False, title="Skip current image", description="Skip current image serialization")


### PR DESCRIPTION
This PR prevents the exception that is thrown when an image doesn't contain generation info.
It also adds a `verbose` option to the PNG Info API parameters that returns all the info shown in the UI rather than just the image generation info as it currently works.

This is returned in a separate field named `verbose_info` to avoid breaking changes for anyone using the existing `info` that is returned.