### PR TITLE
add noise strength parameter similar to NAI

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -861,6 +861,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
     def sample(self, conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
         x = create_random_tensors([opt_C, self.height // opt_f, self.width // opt_f], seeds=seeds, subseeds=subseeds, subseed_strength=self.subseed_strength, seed_resize_from_h=self.seed_resize_from_h, seed_resize_from_w=self.seed_resize_from_w, p=self)
+        x = x*shared.opts.initial_noise_multiplier
 
         samples = self.sampler.sample_img2img(self, self.init_latent, x, conditioning, unconditional_conditioning, image_conditioning=self.image_conditioning)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -364,6 +364,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_hypernetwork": OptionInfo("None", "Hypernetwork", gr.Dropdown, lambda: {"choices": ["None"] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
     "sd_hypernetwork_strength": OptionInfo(1.0, "Hypernetwork strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.001}),
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+    "initial_noise_multiplier": OptionInfo(1.0, "Multiply initial noise by this factor, may result in less or more detailed img2img", gr.Slider, {"minimum": 0.5, "maximum": 1.5, "step": 0.01 }),
     "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
     "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies (normally you'd do less with less denoising)."),
     "enable_quantization": OptionInfo(False, "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds. Requires restart to apply."),


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Apply suggested changes from those discussions: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/5351 https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/4988

Multiply initial noise N(0,1) by small factor which leads to slightly more detailed img2img results without using high denoise values.
Basically this addition allows to unbalance noise-denoise cycle in your favor.
As stated in discussions, feature is similar to NAI "noise strength", but not yet confirmed to be exactly the same

**Additional notes and description of your changes**



I have a strong feeling that some of those settings might be the thing, but better, since those are internal parameters for samplers. I followed them values right into the sampler, but didnt trace further.
![image](https://user-images.githubusercontent.com/32306715/205448057-c06b7b95-7bb9-4836-a966-95f789004219.png)
I tried using churn, increased eta threshold and tested different values for Euler sampler but it doesnt look like more or less noise being added, it's just a bit different.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB

**Screenshots or videos of your changes**
![image](https://user-images.githubusercontent.com/32306715/205448245-5cf9b10f-8f44-4982-ba86-8d07124a693d.png)
![example](https://user-images.githubusercontent.com/32306715/205448248-6999bdab-1860-4ab6-9d96-63c356f2874c.png)
![example 2](https://user-images.githubusercontent.com/32306715/205448251-92d161e3-9bd6-4dc2-a42b-7f0539ab86a5.png)

