### PR TITLE
Allows to show every generated image in a batch, even with medvram and lowvram options

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -204,7 +204,7 @@ class State:
             self.do_set_current_image()
 
     def do_set_current_image(self):
-        if not parallel_processing_allowed:
+        if not parallel_processing_allowed and opts.show_progress_every_n_steps > 0:
             return
         if self.current_latent is None:
             return

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,7 @@
+@echo off
+
+set PYTHON=
+set GIT=
+set VENV_DIR=
+set COMMANDLINE_ARGS=--autolaunch --xformers --theme dark --opt-channelslast --vae-path "D:\AI\automatic\models\Stable-diffusion\newVAE.vae.pt" --medvram
+call webui.bat

--- a/run.bat
+++ b/run.bat
@@ -1,7 +1,0 @@
-@echo off
-
-set PYTHON=
-set GIT=
-set VENV_DIR=
-set COMMANDLINE_ARGS=--autolaunch --xformers --theme dark --opt-channelslast --vae-path "D:\AI\automatic\models\Stable-diffusion\newVAE.vae.pt" --medvram
-call webui.bat


### PR DESCRIPTION
In the current implementation, if --medvram or --lowvram options are used, it is not possible to see each generated image of a batch immediately after it is done. Instead, we have to wait till the batch is fully complete to see the image thumbnails. It is due to the fact that those VRAM options don't allow for parallel processing, as seen in this function:

```
def do_set_current_image(self):
        if not parallel_processing_allowed:
            return
        if self.current_latent is None:
            return
```

However, for people who just want to see each image thumbnail once it is fully generated (where no parallel processing is required), this restriction is not necessary. So by changing the code to :

```
def do_set_current_image(self):
        if not parallel_processing_allowed and opts.show_progress_every_n_steps > 0:
            return
        if self.current_latent is None:
            return
```

Then it allows to set the "Show image creation progress every N sampling steps" setting to -1, and have the desired effect even with those vram optimizations.

Note: interestingly, this change also makes positive values of the "Show image creation progress every N sampling steps" setting to work properly without crashing. I'm not sure exactly why, as I didn't trace the code fully, but this change then makes this option fully work as intended even with --lowvram and --medvram, whatever the setting value.
