### PR TITLE
Prevent cropping on non square resolution targets with High res fix

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -633,7 +633,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             self.extra_generation_params["First pass size"] = f"{self.firstphase_width}x{self.firstphase_height}"
 
             if self.firstphase_width == 0 or self.firstphase_height == 0:
-                desired_pixel_count = 512 * 512
+                desired_pixel_count = self.width /2 * self.height /2
                 actual_pixel_count = self.width * self.height
                 scale = math.sqrt(desired_pixel_count / actual_pixel_count)
                 self.firstphase_width = math.ceil(scale * self.width / 64) * 64


### PR DESCRIPTION
Prevent cropping on non square resolution targets with High res fix when using Firstpass width and height = 0

Currently leaving both Firstpass parameters to = 0 with High res fix defaults to internally setting those parameters to 512x512. This causes unintentional minor cropping on the high res upscale pass when the desired target resolution is non square, like 1280x768. 

This commit changes the current behavior in modules/processing.py in line 636: 
 
`if self.firstphase_width == 0 or self.firstphase_height == 0:`

from: 
`desired_pixel_count = 512 * 512`

to:
`desired_pixel_count = self.width /2 * self.height /2`

By setting Firstpass height and width to half of the target resolution, it prevents cropping when setting both Firstpass parameters to 0 on non square resolution targets. This commit makes it so it's always half when Firstpass is set to 0, while still allowing custom Firstpass resolutions. 

Fixes
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/3187
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5341