### PR TITLE
Add correct install directory for MacOS

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -9,5 +9,6 @@ export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
 export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"
 export PYTORCH_ENABLE_MPS_FALLBACK=1
+export install_dir="/Users/$(whoami)"
 
 ####################################################################


### PR DESCRIPTION
Currently `webui.sh` automatically installs to `/home/$(whoami)` which is only valid on Linux. This PR adds in the correct install directory to `webui-macos-env.sh`.