### PR TITLE
Use clearer seed icons, more intuitive placement.

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -11,7 +11,7 @@ titles = {
 	"Batch size": "How many image to create in a single batch",
     "CFG Scale": "Classifier Free Guidance Scale - how strongly the image should conform to prompt - lower values produce more creative results",
     "Seed": "A value that determines the output of random number generator - if you create an image with same parameters and seed as another image, you'll get the same result",
-    "\u{1f3b2}\ufe0f": "Set seed to -1, which will cause a new random number to be used every time",
+    "\u274c\ufe0f": "Set seed to -1, which will cause a new random number to be used every time",
     "\u267b\ufe0f": "Reuse seed from last generation, mostly useful if it was randomed",
     "\u{1f3a8}": "Add a random artist to the prompt.",
     "\u2199\ufe0f": "Read generation parameters from prompt or last generation if prompt is empty into user interface.",

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -74,7 +74,7 @@ css_hide_progressbar = """
 
 # Using constants for these since the variation selector isn't visible.
 # Important that they exactly match script.js for tooltip to work.
-random_symbol = '\U0001f3b2\ufe0f'  # 🎲️
+discard_symbol = '\U0000274c\ufe0f'  # ❌
 reuse_symbol = '\u267b\ufe0f'  # ♻️
 art_symbol = '\U0001f3a8'  # 🎨
 paste_symbol = '\u2199\ufe0f'  # ↙
@@ -281,8 +281,8 @@ def create_seed_inputs():
             with gr.Row(elem_id='seed_row'):
                 seed = (gr.Textbox if cmd_opts.use_textbox_seed else gr.Number)(label='Seed', value=-1)
                 seed.style(container=False)
-                random_seed = gr.Button(random_symbol, elem_id='random_seed')
                 reuse_seed = gr.Button(reuse_symbol, elem_id='reuse_seed')
+                discard_seed = gr.Button(discard_symbol, elem_id='discard_seed')
 
         with gr.Box(elem_id='subseed_show_box'):
             seed_checkbox = gr.Checkbox(label='Extra', elem_id='subseed_show', value=False)
@@ -296,8 +296,8 @@ def create_seed_inputs():
             with gr.Row(elem_id='subseed_row'):
                 subseed = gr.Number(label='Variation seed', value=-1)
                 subseed.style(container=False)
-                random_subseed = gr.Button(random_symbol, elem_id='random_subseed')
                 reuse_subseed = gr.Button(reuse_symbol, elem_id='reuse_subseed')
+                discard_subseed = gr.Button(discard_symbol, elem_id='discard_subseed')
         subseed_strength = gr.Slider(label='Variation strength', value=0.0, minimum=0, maximum=1, step=0.01)
 
     with gr.Row(visible=False) as seed_extra_row_2:
@@ -305,8 +305,8 @@ def create_seed_inputs():
         seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0)
         seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0)
 
-    random_seed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[seed])
-    random_subseed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[subseed])
+    discard_seed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[seed])
+    discard_subseed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[subseed])
 
     def change_visibility(show):
         return {comp: gr_show(show) for comp in seed_extras}

--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@
     margin-right: auto;
 }
 
-#random_seed, #random_subseed, #reuse_seed, #reuse_subseed, #open_folder{
+#discard_seed, #discard_subseed, #reuse_seed, #reuse_subseed, #open_folder{
     min-width: auto;
     flex-grow: 0;
     padding-left: 0.25em;


### PR DESCRIPTION
As discussed in #5442; Have the two seed icons swap places, and change the dice to a red X.
<details><summary>Before: (click to view)</summary>

![image](https://user-images.githubusercontent.com/116157310/205645736-06985439-835e-4dcb-970f-5abbd6a12f31.png)

</details>

<details><summary>After: (click to view)</summary>

![image](https://user-images.githubusercontent.com/116157310/205645694-db115f3b-cbb4-430a-880c-d36426851a50.png)

</details>

♻️and ❌ are more intuitive at a glance, thanks to their new ordering and their consistent coloring across all platforms. 

This PR does not change the ordering of the entire seed row itself.