### PR TITLE
Fix WebUI not working inside of iframes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 function gradioApp(){
-    return !!document.getElementsByTagName('gradio-app')[0].shadowRoot ? document.getElementsByTagName('gradio-app')[0].shadowRoot : document
+    return !!document.getElementsByTagName('gradio-app')[0].shadowRoot ? document.getElementsByTagName('gradio-app')[0].shadowRoot : document;
 }
 
 function get_uiCurrentTab() {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 function gradioApp(){
-    return document
+    return !!document.getElementsByTagName('gradio-app')[0].shadowRoot ? document.getElementsByTagName('gradio-app')[0].shadowRoot : document
 }
 
 function get_uiCurrentTab() {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 function gradioApp(){
-    return document.getElementsByTagName('gradio-app')[0].shadowRoot;
+    return document
 }
 
 function get_uiCurrentTab() {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
-function gradioApp(){
-    return !!document.getElementsByTagName('gradio-app')[0].shadowRoot ? document.getElementsByTagName('gradio-app')[0].shadowRoot : document;
+function gradioApp() {
+    const gradioShadowRoot = document.getElementsByTagName('gradio-app')[0].shadowRoot
+    return !!gradioShadowRoot ? gradioShadowRoot : document;
 }
 
 function get_uiCurrentTab() {


### PR DESCRIPTION
Somehow a ShadowRoot does not work inside iframes with Gradio (https://github.com/gradio-app/gradio/issues/2763). 

So this checks whether the ShadowRoot is there, if so uses that, otherwise uses the document 