### PR TITLE
macOS install improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ inflection
 GitPython
 torchsde
 safetensors
+psutil; sys_platform == 'darwin'

--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -9,6 +9,7 @@ then
     python_cmd="python3.10"
 fi
 
+export install_dir="$HOME"
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --no-half --use-cpu interrogate"
 export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"

--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -4,6 +4,11 @@
 # Please modify webui-user.sh to change these instead of this file #
 ####################################################################
 
+if [[ -x "$(command -v python3.10)" ]]
+then
+    python_cmd="python3.10"
+fi
+
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --no-half --use-cpu interrogate"
 export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"


### PR DESCRIPTION
Add a few improvements to the way the macOS install is done to reduce the chance users will encounter problems:
- Set correct default install_dir value for macOS (thanks to @Ephil012 for pointing this out this is sometimes needed)
- If an executable named `python3.10` is available, use it instead of `python3`. This highly reduces the likelihood of the wrong Python install being used.
- Add psutil to requirements.txt, but with the condition `sys_platform == 'darwin'` to indicate that only macOS needs it