### PR TITLE
Modify embedding overlay for more visible preview

### DIFF
--- a/modules/textual_inversion/image_embedding.py
+++ b/modules/textual_inversion/image_embedding.py
@@ -129,6 +129,26 @@ def extract_image_data_embed(image):
     data = zlib.decompress(data_block)
     return json.loads(data, cls=EmbeddingDecoder)
 
+def make_gradient(image, size, rotate=0):
+    width, height = image.size
+    gradient = 1.
+    alpha_gradient = Image.new('L', (1, width), color=0xFF)
+    for x in range(height):
+        a = int((0.95 * 255.) * (1. - gradient * float(x)/size))
+        if a > 0:
+            alpha_gradient.putpixel((0, x), a)
+        else:
+            alpha_gradient.putpixel((0, x), 0)
+    alpha = alpha_gradient.resize(image.size)
+
+    # create black image, apply gradient
+    black_im = Image.new('RGBA', (width, height), color=0) # i.e. black
+    black_im.putalpha(alpha)
+
+    # make composite with original image
+    image = Image.alpha_composite(image.convert('RGBA'), black_im.rotate(rotate))
+    return image
+
 
 def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, textfont=None):
     from math import cos
@@ -142,23 +162,40 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
         except Exception:
             textfont = Roboto
 
-    factor = 1.5
-    gradient = Image.new('RGBA', (1, image.size[1]), color=(0, 0, 0, 0))
-    for y in range(image.size[1]):
-        mag = 1-cos(y/image.size[1]*factor)
-        mag = max(mag, 1-cos((image.size[1]-y)/image.size[1]*factor*1.1))
-        gradient.putpixel((0, y), (0, 0, 0, int(mag*255)))
-    image = Image.alpha_composite(image.convert('RGBA'), gradient.resize(image.size))
-
     draw = ImageDraw.Draw(image)
 
     font = ImageFont.truetype(textfont, fontsize)
     padding = 10
 
+    # Make the textboxes to get gradient sizes and make gradients
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
     fontsize = min(int(fontsize * (((image.size[0]*0.75)-(padding*4))/w)), 72)
     font = ImageFont.truetype(textfont, fontsize)
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
+
+    # Make the top gradient
+    image = make_gradient(image, fontsize * 1.7)
+
+    _, _, w, h = draw.textbbox((0, 0), footerLeft, font=font)
+    fontsize_left = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+    _, _, w, h = draw.textbbox((0, 0), footerMid, font=font)
+    fontsize_mid = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+    _, _, w, h = draw.textbbox((0, 0), footerRight, font=font)
+    fontsize_right = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+
+    # Make the bottom gradient
+    image = make_gradient(image, min(fontsize_left, fontsize_mid, fontsize_right) * 1.7, 180)
+
+    # repeat textboxes for text this time
+    draw = ImageDraw.Draw(image)
+    font = ImageFont.truetype(textfont, fontsize)
+
+    _, _, w, h = draw.textbbox((0, 0), title, font=font)
+    fontsize = min(int(fontsize * (((image.size[0]*0.75)-(padding*4))/w)), 72)
+    font = ImageFont.truetype(textfont, fontsize)
+    _, _, w, h = draw.textbbox((0, 0), title, font=font)
+
+    # Add the title
     draw.text((padding, padding), title, anchor='lt', font=font, fill=(255, 255, 255, 230))
 
     _, _, w, h = draw.textbbox((0, 0), footerLeft, font=font)
@@ -170,6 +207,7 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
 
     font = ImageFont.truetype(textfont, min(fontsize_left, fontsize_mid, fontsize_right))
 
+    # Add the footers
     draw.text((padding, image.size[1]-padding),               footerLeft, anchor='ls', font=font, fill=(255, 255, 255, 230))
     draw.text((image.size[0]/2, image.size[1]-padding),       footerMid, anchor='ms', font=font, fill=(255, 255, 255, 230))
     draw.text((image.size[0]-padding, image.size[1]-padding), footerRight, anchor='rs', font=font, fill=(255, 255, 255, 230))


### PR DESCRIPTION
This PR makes a cosmetic change to the PNG embeddings so that the gradient overlay that is applied is more on the upper and lower edges than in the middle.  Readability of the text should not be affected; I have tested it even on white backgrounds and have been using it in my own local branch for some time.

I realize this change is subjective, but with embeddings seeing more use lately, I wanted to put this out there.

Examples: This is the new overlay look in this PR
![test-new](https://user-images.githubusercontent.com/6970043/206086932-81047a0a-b21d-4f1d-8400-6c19ab6b03da.jpg)


This is the current overlay look
![test-old](https://user-images.githubusercontent.com/6970043/206086939-5eb8e72a-0a44-4eb0-bb12-91a571254741.jpg)



*Note: not a usable embedding - just a blank initialized embedding with the encoded sides cropped off for demonstration of the overlay.  The overlay does not affect the encoded info on the sides.