### PR TITLE
Add ability to automagically determine which model config to load

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -174,7 +174,7 @@ def prepare_enviroment():
     codeformer_repo = os.environ.get('CODEFORMER_REPO', 'https://github.com/sczhou/CodeFormer.git')
     blip_repo = os.environ.get('BLIP_REPO', 'https://github.com/salesforce/BLIP.git')
 
-    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "47b6b607fdd31875c9279cd2f4f16b92e4ea958e")
+    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "c12d960d1ee4f9134c2516862ef991ec52d3f59e")
     taming_transformers_commit_hash = os.environ.get('TAMING_TRANSFORMERS_COMMIT_HASH', "24268930bf1dce879235a7fddd0b2355b84d7ea6")
     k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "5b3af030dd83e0297272d861c19477735d0317ec")
     codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -232,22 +232,23 @@ def load_model_weights(model, checkpoint_info, vae_file="auto"):
 def get_config(checkpoint_info):
     path = checkpoint_info[0]
     model_config = checkpoint_info.config
-    try:
-        checkpoint = torch.load(path)
-        c_dict = checkpoint["state_dict"]
-        v2_key = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
-        if v2_key in c_dict:
-            print(f"We have the v2 key: {c_dict[v2_key].size()}")
-            if "global_step" in checkpoint and checkpoint_info.config == shared.cmd_opts.config:
-                if checkpoint["global_step"] == 875000:
-                    model_config = os.path.join(shared.script_path, "v2-inference.yaml")
-                else:
-                    model_config = os.path.join(shared.script_path, "v2-inference-v.yaml")
-        del checkpoint
-    except Exception as e:
-        print(f"Exception: {e}")
-        traceback.print_exc()
-        pass
+    if model_config == shared.cmd_opts.config:
+        try:
+            checkpoint = torch.load(path)
+            c_dict = checkpoint["state_dict"]
+            v2_key = "cond_stage_model.model.ln_final.weight"
+            if v2_key in checkpoint or v2_key in c_dict:
+                if "global_step" in checkpoint and checkpoint_info.config == shared.cmd_opts.config:
+                    if checkpoint["global_step"] == 875000:
+                        model_config = os.path.join(shared.script_path, "v2-inference.yaml")
+                    else:
+                        model_config = os.path.join(shared.script_path, "v2-inference-v.yaml")
+                print(f"V2 Model detected, selecting model config: {model_config}")
+            del checkpoint
+        except Exception as e:
+            print(f"Exception: {e}")
+            traceback.print_exc()
+            pass
     return model_config
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -249,7 +249,7 @@ def get_config(checkpoint_info):
                     os.environ["ATTN_PRECISION"] = "fp16"
             if v2_key in c_dict:
                 if "global_step" in checkpoint and checkpoint_info.config == shared.cmd_opts.config:
-                    if checkpoint["global_step"] == 875000:
+                    if checkpoint["global_step"] == 875000 or checkpoint["global_step"] == 220000:
                         model_config = os.path.join(shared.script_path, "v2-inference.yaml")
                     else:
                         model_config = os.path.join(shared.script_path, "v2-inference-v.yaml")
@@ -301,11 +301,8 @@ def load_model(checkpoint_info=None):
     else:
         sd_model.to(shared.device)
 
-    if not is_v21_model:
-        sd_hijack.model_hijack.hijack(sd_model)
-    else:
-        if not shared.cmd_opts.xformers and not shared.cmd_opts.force_enable_xformers and not shared.cmd_opts.no_half:
-            ldm.modules.attention.CrossAttention.forward = sd_hijack.attention_CrossAttention_forward
+    if not shared.cmd_opts.xformers and not shared.cmd_opts.force_enable_xformers and not shared.cmd_opts.no_half:
+        ldm.modules.attention.CrossAttention.forward = sd_hijack.attention_CrossAttention_forward
 
     sd_model.eval()
     shared.sd_model = sd_model
@@ -343,11 +340,9 @@ def reload_model_weights(sd_model=None, info=None):
 
     load_model_weights(sd_model, checkpoint_info)
 
-    if not is_v21_model:
-        sd_hijack.model_hijack.hijack(sd_model)
-    else:
-        if not shared.cmd_opts.xformers and not shared.cmd_opts.force_enable_xformers and not shared.cmd_opts.no_half:
-            ldm.modules.attention.CrossAttention.forward = sd_hijack.attention_CrossAttention_forward
+    if not shared.cmd_opts.xformers and not shared.cmd_opts.force_enable_xformers and not shared.cmd_opts.no_half:
+        ldm.modules.attention.CrossAttention.forward = sd_hijack.attention_CrossAttention_forward
+
     script_callbacks.model_loaded_callback(sd_model)
 
     if not shared.cmd_opts.lowvram and not shared.cmd_opts.medvram:

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,5 +1,5 @@
 transformers==4.19.2
-diffusers==0.3.0
+diffusers==0.10.2
 accelerate==0.12.0
 basicsr==1.4.2
 gfpgan==1.3.8

--- a/v2-inference-v.yaml
+++ b/v2-inference-v.yaml
@@ -1,0 +1,68 @@
+model:
+  base_learning_rate: 1.0e-4
+  target: ldm.models.diffusion.ddpm.LatentDiffusion
+  params:
+    parameterization: "v"
+    linear_start: 0.00085
+    linear_end: 0.0120
+    num_timesteps_cond: 1
+    log_every_t: 200
+    timesteps: 1000
+    first_stage_key: "jpg"
+    cond_stage_key: "txt"
+    image_size: 64
+    channels: 4
+    cond_stage_trainable: false
+    conditioning_key: crossattn
+    monitor: val/loss_simple_ema
+    scale_factor: 0.18215
+    use_ema: False # we set this to false because this is an inference only config
+
+    unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        use_checkpoint: True
+        use_fp16: True
+        image_size: 32 # unused
+        in_channels: 4
+        out_channels: 4
+        model_channels: 320
+        attention_resolutions: [ 4, 2, 1 ]
+        num_res_blocks: 2
+        channel_mult: [ 1, 2, 4, 4 ]
+        num_head_channels: 64 # need to fix for flash-attn
+        use_spatial_transformer: True
+        use_linear_in_transformer: True
+        transformer_depth: 1
+        context_dim: 1024
+        legacy: False
+
+    first_stage_config:
+      target: ldm.models.autoencoder.AutoencoderKL
+      params:
+        embed_dim: 4
+        monitor: val/rec_loss
+        ddconfig:
+          #attn_type: "vanilla-xformers"
+          double_z: true
+          z_channels: 4
+          resolution: 256
+          in_channels: 3
+          out_ch: 3
+          ch: 128
+          ch_mult:
+          - 1
+          - 2
+          - 4
+          - 4
+          num_res_blocks: 2
+          attn_resolutions: []
+          dropout: 0.0
+        lossconfig:
+          target: torch.nn.Identity
+
+    cond_stage_config:
+      target: ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder
+      params:
+        freeze: True
+        layer: "penultimate"

--- a/v2-inference.yaml
+++ b/v2-inference.yaml
@@ -1,0 +1,67 @@
+model:
+  base_learning_rate: 1.0e-4
+  target: ldm.models.diffusion.ddpm.LatentDiffusion
+  params:
+    linear_start: 0.00085
+    linear_end: 0.0120
+    num_timesteps_cond: 1
+    log_every_t: 200
+    timesteps: 1000
+    first_stage_key: "jpg"
+    cond_stage_key: "txt"
+    image_size: 64
+    channels: 4
+    cond_stage_trainable: false
+    conditioning_key: crossattn
+    monitor: val/loss_simple_ema
+    scale_factor: 0.18215
+    use_ema: False # we set this to false because this is an inference only config
+
+    unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        use_checkpoint: True
+        use_fp16: True
+        image_size: 32 # unused
+        in_channels: 4
+        out_channels: 4
+        model_channels: 320
+        attention_resolutions: [ 4, 2, 1 ]
+        num_res_blocks: 2
+        channel_mult: [ 1, 2, 4, 4 ]
+        num_head_channels: 64 # need to fix for flash-attn
+        use_spatial_transformer: True
+        use_linear_in_transformer: True
+        transformer_depth: 1
+        context_dim: 1024
+        legacy: False
+
+    first_stage_config:
+      target: ldm.models.autoencoder.AutoencoderKL
+      params:
+        embed_dim: 4
+        monitor: val/rec_loss
+        ddconfig:
+          #attn_type: "vanilla-xformers"
+          double_z: true
+          z_channels: 4
+          resolution: 256
+          in_channels: 3
+          out_ch: 3
+          ch: 128
+          ch_mult:
+          - 1
+          - 2
+          - 4
+          - 4
+          num_res_blocks: 2
+          attn_resolutions: []
+          dropout: 0.0
+        lossconfig:
+          target: torch.nn.Identity
+
+    cond_stage_config:
+      target: ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder
+      params:
+        freeze: True
+        layer: "penultimate"


### PR DESCRIPTION
Might be a bit heavy for lower-VRAM users, and it also depends on the global step of the source model not changing, but it does work with both the base 512 and 768 models, plus non v2 models. No YAML files required. 

Also, might be a good idea to put the configs in their own subdirectory, but I was trying to keep this short and sweet.