### PR TITLE
Add latent upscale option to img2img

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -829,7 +829,7 @@ def create_ui():
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs)
 
                 with gr.Row():
-                    resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
+                    resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", show_label=False, choices=["Just resize", "Crop and resize", "Resize and fill", "Upscale Latent Space"], type="index", value="Just resize")
 
                 steps = gr.Slider(minimum=1, maximum=150, step=1, label="Sampling Steps", value=20)
                 sampler_index = gr.Radio(label='Sampling method', choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="index")


### PR DESCRIPTION
Recently, the option to do latent upscale was added to txt2img highres fix. This feature runs by scaling the latent sample of the image, and then running a second pass of img2img.

But, in this edition of highres fix, the image and parameters cannot be changed between the first pass and second pass. We might want to do a fixup in img2img before doing the second pass, or might want to run the second pass at a different resolution.

This change adds the option for img2img to perform its upscale in latent space, rather than image space, giving very similar results to highres fix with latent upscale.  The result is not exactly the same because there is an additional latent -> decoder -> image -> encoder -> latent that won't happen in highres fix, but this conversion has relatively small losses

Highres fix 
Steps: 25, Sampler: DPM++ 2M Karras, CFG scale: 9.5, Seed: 58, Size: 1536x1536, Model hash: 1a7df6b8, Denoising strength: 0.6, Clip skip: 2, ENSD: 31337, First pass size: 768x768
![hires fix](https://user-images.githubusercontent.com/89478935/206383778-c60e562a-8e9b-4ea7-85f8-4c4bafdbec4e.png)

Firstpass image:
![04319-58-masterpiece best quality highest detail HDR absurdres incredibly detailed intricate colorful a girl standing on a scenic-before-highres-fixibymfrrb](https://user-images.githubusercontent.com/89478935/206384041-ed5fbeaa-dd32-477d-9ab5-b5b5145be2b0.png)


Img2img latent upscale
Steps: 25, Sampler: DPM++ 2M Karras, CFG scale: 9.5, Seed: 58, Size: 1536x1536, Model hash: 1a7df6b8, Denoising strength: 0.6, Clip skip: 2, ENSD: 31337, Mask blur: 4
![img2img](https://user-images.githubusercontent.com/89478935/206383878-0c7f956f-64ea-47fe-be39-08649fa7ac11.png)

Img2img regular upscale
![01209-58-masterpiece, best quality, highest detail, HDR, absurdres, incredibly detailed, intricate, colorful, a girl standing on a scenic](https://user-images.githubusercontent.com/89478935/206512083-9b8fa09b-4d90-4eea-8854-2ce181e6a46e.png)


