### PR TITLE
Make "# settings changed" grammatically correct

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1450,7 +1450,7 @@ def create_ui():
             opts.save(shared.config_filename)
         except RuntimeError:
             return opts.dumpjson(), f'{len(changed)} settings changed without save: {", ".join(changed)}.'
-        return opts.dumpjson(), f'{len(changed)} settings changed: {", ".join(changed)}.'
+        return opts.dumpjson(), f'{len(changed)} settings changed{": " if len(changed) > 0 else ""}{", ".join(changed)}.'
 
     def run_settings_single(value, key):
         if not opts.same_type(value, opts.data_labels[key].default):


### PR DESCRIPTION
Make the ": " in the settings changed message not show if 0 settings were changed.
`0 settings changed: .` -> `0 settings changed.`