### PR TITLE
Fix token counter color on dark theme

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -88,7 +88,7 @@ function checkBrackets(evt) {
   if(counterElt.title != '') {
     counterElt.style = 'color: #FF5555;';
   } else {
-    counterElt.style = 'color: #000;';
+    counterElt.style = '';
   }
 }
 


### PR DESCRIPTION
The current implementation makes the valid token counter barely legible (black on very dark blue) when using the dark theme, so instead of explicitly specifying a text color for the valid state token counter, remove the previously added invalid state style completely.
This keeps the valid token counter state color black on the default theme and reverts it to its default white color on the dark theme.