### PR TITLE
LDSR improvements - cache / optimization / opt_channelslast

### DIFF
--- a/extensions-builtin/LDSR/ldsr_model_arch.py
+++ b/extensions-builtin/LDSR/ldsr_model_arch.py
@@ -110,7 +110,8 @@ class LDSR:
         down_sample_method = 'Lanczos'
 
         gc.collect()
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available:
+            torch.cuda.empty_cache()
 
         im_og = image
         width_og, height_og = im_og.size
@@ -147,7 +148,9 @@ class LDSR:
 
         del model
         gc.collect()
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available:
+            torch.cuda.empty_cache()
+
         return a
 
 
@@ -162,7 +165,7 @@ def get_cond(selected_path):
     c = rearrange(c, '1 c h w -> 1 h w c')
     c = 2. * c - 1.
 
-    c = c.to(torch.device("cuda"))
+    c = c.to(shared.device)
     example["LR_image"] = c
     example["image"] = c_up
 

--- a/extensions-builtin/LDSR/scripts/ldsr_model.py
+++ b/extensions-builtin/LDSR/scripts/ldsr_model.py
@@ -59,6 +59,7 @@ def on_ui_settings():
     import gradio as gr
 
     shared.opts.add_option("ldsr_steps", shared.OptionInfo(100, "LDSR processing steps. Lower = faster", gr.Slider, {"minimum": 1, "maximum": 200, "step": 1}, section=('upscaling', "Upscaling")))
+    shared.opts.add_option("ldsr_cached", shared.OptionInfo(False, "Cache LDSR model in memory", gr.Checkbox, {"interactive": True}, section=('upscaling', "Upscaling")))
 
 
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
The PR aims to improve the LDSR through the following means.

1. **Ability to cache the LDSR model (as an option in the Settings tab)** - Good if you use LDSR to upscale often and have the RAM to store it. You won't need to reload the model every time you upscale.

2. **Apply optimization (such as Xformers)** - This uses the `sd_hijack` logic to apply optimization to the LDSR model the same way it does to all the SD models. This may help lower-end machines.

3. **Allow Channels Last memory format** - The `--opt_channelslast` now affects the LDSR model as well and may improve performance.

4. **Device agnostic** - It should now allow CPU operation as well