### PR TITLE
Make the generated image count in desktop notifications only count new gens in the currently active tab

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -15,7 +15,7 @@ onUiUpdate(function(){
         }
     }
 
-    const galleryPreviews = gradioApp().querySelectorAll('img.h-full.w-full.overflow-hidden');
+    const galleryPreviews = gradioApp().querySelectorAll('div[id^="tab_"][style*="display: block"] img.h-full.w-full.overflow-hidden');
 
     if (galleryPreviews == null) return;
 


### PR DESCRIPTION
This fixes the desktop notification image count also counting already generated images in other tabs and in the image browser gallery when the Image Browser extension is installed, and also fixes desktop notifications not showing up for generations completed in the img2img tab.