### PR TITLE
Bugfix: Use /usr/bin/env bash instead of just /bin/bash

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #################################################
 # Please do not make any changes to this file,  #
 # change the variables in webui-user.sh instead #


### PR DESCRIPTION
The problem: Some Linux distrubutions, like NixOS, use a non-standard filesystem. This causes the bash program to not be at /bin/bash (though /usr/bin/env is always there).