### PR TITLE
Add a workaround patch for DPM2 a issue

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -494,7 +494,7 @@ class KDiffusionSampler:
 
         x = x * sigmas[0]
 
-        if self.funcname == "sample_dpm_2_ancestral": # workaround dpm2 a issue
+        if self.funcname in ['sample_dpm_2_ancestral', 'sample_dpm_2']:
             sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
 
         extra_params_kwargs = self.initialize(p)

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -454,6 +454,9 @@ class KDiffusionSampler:
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 
+        if self.funcname in ['sample_dpm_2_ancestral', 'sample_dpm_2']:
+            sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
+
         sigma_sched = sigmas[steps - t_enc - 1:]
         xi = x + noise * sigma_sched[0]
         

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -494,6 +494,9 @@ class KDiffusionSampler:
 
         x = x * sigmas[0]
 
+        if self.funcname == "sample_dpm_2_ancestral": # workaround dpm2 a issue
+            sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
+
         extra_params_kwargs = self.initialize(p)
         if 'sigma_min' in inspect.signature(self.func).parameters:
             extra_params_kwargs['sigma_min'] = self.model_wrap.sigmas[0].item()


### PR DESCRIPTION
DPM2 a and DPM2 a Karras samplers are both affected by an issue described by #3483 and can be resolved by a workaround suggested by the k-diffusion author at https://github.com/crowsonkb/k-diffusion/issues/43#issuecomment-1305195666

DPM2 (and DPM2 Karras) is also affected by this bug, though it is more subtle.

TLDR:
`DPM2 a, an adorable cat, 10 steps`

Step 9/10, it looks like this:
![sample-00008](https://github.com/user-attachments/assets/8c1724cc-7abf-44d0-9afc-7a15c31fede7)

Step 10/10, it looks like this:
![sample-00009](https://github.com/user-attachments/assets/d0894995-228b-4acb-befe-da50d306e11e)

The corrupted output can be avoided either by directly stopping 1 step early, or instead by altering the `sigmas` to be one shorter - the developer of k-diffusion suggested the sigmas method, saying

> you can do it better by `sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])` so you step with DPM to the next to last step then follow it up with a longer denoising step to sigma=0.

In practice, this works perfectly.

I left a comment at https://github.com/crowsonkb/k-diffusion/issues/43#issuecomment-1355177121 to suggest it or an equivalent be added to k-diffusion itself, but as that repo is not often updated, it may be a while before there's a response.


---

This PR was made after Discord user `IDK#1046` showed images demonstrating how borked DPM2 output was. That user claims it also applies to other DPM\* variants (eg DPM++) though I haven't been able to replicate issues - the last step of DPM++ is visibly adding way more detail than any other step is, but it seems to consistently be *good* detail in my own testing, not corrupt/buggy/bad detail, so the current version of this PR only applies to DPM2 and its core variants (karras vs not and ancestral vs not)