### PR TITLE
Add option to save upscaler to filename suffix in extras tab.

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -194,8 +194,9 @@ def run_extras(extras_mode, resize_mode, image, image_folder, input_dir, output_
             basename = ''
 
         # Add upscaler name as a suffix.
-        suffix = f"-{shared.sd_upscalers[extras_upscaler_1].name}"
-        if extras_upscaler_2 and extras_upscaler_2_visibility:
+        suffix = f"-{shared.sd_upscalers[extras_upscaler_1].name}" if shared.opts.use_upscaler_name_as_suffix else ""
+        # Add second upscaler if applicable.
+        if suffix and extras_upscaler_2 and extras_upscaler_2_visibility:
             suffix += f"-{shared.sd_upscalers[extras_upscaler_2].name}"
 
         images.save_image(image, path=outpath, basename=basename, seed=None, prompt=None, extension=opts.samples_format, info=info, short_filename=True,

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -193,8 +193,13 @@ def run_extras(extras_mode, resize_mode, image, image_folder, input_dir, output_
         else:
             basename = ''
 
+        # Add upscaler name as a suffix.
+        suffix = f"-{shared.sd_upscalers[extras_upscaler_1].name}"
+        if extras_upscaler_2 and extras_upscaler_2_visibility:
+            suffix += f"-{shared.sd_upscalers[extras_upscaler_2].name}"
+
         images.save_image(image, path=outpath, basename=basename, seed=None, prompt=None, extension=opts.samples_format, info=info, short_filename=True,
-                          no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=None)
+                          no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=None, suffix=suffix)
 
         if opts.enable_pnginfo:
             image.info = existing_pnginfo

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -293,7 +293,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "export_for_4chan": OptionInfo(True, "If PNG image is larger than 4MB or any dimension is larger than 4000, downscale and save copy as JPG"),
 
     "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process in extras tab"),
-    "use_upscaler_name_as_suffix": OptionInfo(False, "Add upscaler name to the end of filename in the extras tab"),
+    "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -293,6 +293,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "export_for_4chan": OptionInfo(True, "If PNG image is larger than 4MB or any dimension is larger than 4000, downscale and save copy as JPG"),
 
     "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process in extras tab"),
+    "use_upscaler_name_as_suffix": OptionInfo(False, "Add upscaler name to the end of filename in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),
 


### PR DESCRIPTION
Adds #5802, the *option* `use_upscaler_name_as_suffix` (false by default) to include the upscaler name as a suffix in the extras tab. Here is the option in the settings tab:

![new description for setting](https://user-images.githubusercontent.com/116157310/208253025-bb12c8c3-b1f1-4211-b4f0-dc08a0cceefa.png)

It includes the second upscaler when relevant. I decided against including 2's visibility weight, because, you gotta draw the line somewhere.

Testing with option unticked:
	+ Works with No upscaler 1, No upscaler 2
	+ Works with Some upscaler 1
	+ Works with both Upscaler 1 and 2
	+ Works with No upscaler 1, Some upscaler 2
Testing with option ticked:
	+ Works with No upscaler 1, No upscaler 2
	+ Works with Some upscaler 1
	+ Works with Some upscaler 1, Some upscaler 2
	+ Works with No upscaler 1, Some upscaler 2
	+ Works with batch process, Upscaler 1 and 2
	+ Works with batch process, Upscaler 1 only