### PR TITLE
Dirty fix for missing PIL supported file extensions

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import shlex
 import platform
 import argparse
 import json
+from PIL import Image
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/launch.py
+++ b/launch.py
@@ -7,7 +7,6 @@ import shlex
 import platform
 import argparse
 import json
-from PIL import Image
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 
+from PIL import Image
 import gradio as gr
 import tqdm
 


### PR DESCRIPTION
Fixes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5603
Fixes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5664

This is caused by a PIL issue: https://github.com/python-pillow/Pillow/issues/6809
Gradio imports matplotlib.figure which imports pnginfo from PIL and then causes this issue. The dirty solution as proposed by @jokkebk is to import PIL.Image before import gradio. Although this is definitely not a 'proper' fix, it depends on whether PIL fixes it in the future. For users with older versions of Pillow, this should be the only workaround.