### PR TITLE
Set httpcore version in requirements - fixes #4833

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -26,3 +26,4 @@ inflection==0.5.1
 GitPython==3.1.27
 torchsde==0.2.5
 safetensors==0.2.5
+httpcore<=0.15


### PR DESCRIPTION
When on windows without this addition you might get this issue: #4833 

Giving the following error description:
```
File "Letter:\stable-diffusion-webui\venv\lib\site-packages\httpcore\_sync\http11.py", line 140, in HTTP11Connection
    self, event: h11.Event, timeout: Optional[float] = None
AttributeError: module 'h11' has no attribute 'Event'
```
Adding given ´´´httpcore´´´ version in requirements solves this issue.