### PR TITLE
Attempting to solve slow loads for `safetensors`.

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -168,7 +168,10 @@ def get_state_dict_from_checkpoint(pl_sd):
 def read_state_dict(checkpoint_file, print_global_state=False, map_location=None):
     _, extension = os.path.splitext(checkpoint_file)
     if extension.lower() == ".safetensors":
-        pl_sd = safetensors.torch.load_file(checkpoint_file, device=map_location or shared.weight_load_location)
+        device = map_location or shared.weight_load_location
+        if device is None:
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        pl_sd = safetensors.torch.load_file(checkpoint_file, device=device)
     else:
         pl_sd = torch.load(checkpoint_file, map_location=map_location or shared.weight_load_location)
 

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -26,5 +26,5 @@ lark==1.1.2
 inflection==0.5.1
 GitPython==3.1.27
 torchsde==0.2.5
-safetensors==0.2.5
+safetensors==0.2.7
 httpcore<=0.15


### PR DESCRIPTION
Fixes #5893

- When loading with `safetensors` it is only faster if you can avoid all copies. And that means loading the weights directly on the device they are supposed to be used (original issue reports super slow times which I'm still not sure why it's the case).

- This PR proposes to force use a `device` to load on GPU directly when possible. (This avoids allocating on CPU and then moving on GPU which would be happening since the arguments would default to `None`).

This does seem to accelerate loading speeds on regular usage (see my post with timings in the issue). But doesn't fix OP loading times.

However it still seems that loading wieghts in isolation is still indeed faster with `safetensors` than `torch.load`. So the slowness must be coming from something else (most likely a copy of tensors somewhere, maybe multiple ones).


Here are a few measures I took. 


LINUX (Titan RTX, AMD EPYC 7742 64-Core Processor, Pretty beefy machine overall):
All timings are done after the SECOND load (to ignore potential real disk read, which can slow things down both for torch and safetensors)
All timings count the entirety of this function for completeness : https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/sd_models.py#L331

`sd-webui@master` (Same results with or without `SAFETENSORS_FAST_GPU)` : 
```
TORCH: Weights loaded. 0:00:02.334389
SAFETENSORS: Weights loaded. 0:00:01.508432
```

`with current PR`
```
TORCH Weights loaded. 0:00:02.005827
SAFETENSORS Weights loaded. 0:00:00.945253
```



Windows (AWS, g4dn.2xlarge):
`sd-webui@master` (Same results with or without `SAFETENSORS_FAST_GPU)` : 
```
TORCH Weights loaded. 0:00:04.701986
SAFETENSORS Weights loaded. 0:00:03.825006
```

`with current PR`
```
TORCH Weights loaded. 0:00:04.273007
SAFETENSORS Weights loaded. 0:00:03.653979 (Difference not as dramatic as Linux)
```

