### PR TITLE
implements api for train operations

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -137,6 +137,14 @@ class ExtrasBaseRequest(BaseModel):
 class ExtraBaseResponse(BaseModel):
     html_info: str = Field(title="HTML info", description="A series of HTML tags containing the process info.")
 
+class TrainRequest(BaseModel):
+    operation: Literal['create_embedding', 'create_hypernetwork', 'preprocess', 'train_embedding', 'train_hypernetwork'] = Field(default="", title="Train operation", description="Train operation")
+    create_embedding: dict
+    create_hypernetwork: dict
+    preprocess: dict
+    train_embedding: dict
+    train_hypernetwork: dict
+
 class ExtrasSingleImageRequest(ExtrasBaseRequest):
     image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")
 
@@ -158,6 +166,9 @@ class PNGInfoRequest(BaseModel):
 
 class PNGInfoResponse(BaseModel):
     info: str = Field(title="Image info", description="A string with all the info the image had")
+
+class TrainResponse(BaseModel):
+    info: str = Field(title="Train info", description="Generic info string")
 
 class ProgressRequest(BaseModel):
     skip_current_image: bool = Field(default=False, title="Skip current image", description="Skip current image serialization")

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -180,6 +180,8 @@ def create_embedding(name, num_vectors_per_token, overwrite_old, init_text='*'):
 
 
 def write_loss(log_directory, filename, step, epoch_len, values):
+    os.makedirs(log_directory, exist_ok=True) # log directory may not be created yet if save_embedding_every == 0
+
     if shared.opts.training_write_csv_every == 0:
         return
 

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -364,6 +364,8 @@ def train_embedding(embedding_name, learn_rate, batch_size, gradient_step, data_
                     "learn_rate": scheduler.learn_rate
                 })
 
+                shared.state.job = "train embedding loss {loss}".format(loss = loss_step)
+
                 if images_dir is not None and steps_done % create_image_every == 0:
                     forced_filename = f'{embedding_name}-{steps_done}'
                     last_saved_image = os.path.join(images_dir, forced_filename)


### PR DESCRIPTION
simple implementation of training api: `/sdapi/v1/train`:

- supports: **create embedding**, **image preprocess**, **train embedding** (with all known parameters)  
  (could be done with separate apis for each function, but i've bundled it under single api using operation tag)  
- does not (yet) support: create hyper-network, train hyper-network  
- compatible with progress api: `/sdapi/v1/progress`  

script with example usage: <https://github.com/vladmandic/generative-art/blob/main/sd/train.py>  

closes #5866