### PR TITLE
Run scripts via API

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -103,6 +103,40 @@ StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
     [{"key": "sampler_index", "type": str, "default": "Euler"}]
 ).generate_model()
 
+class StableDiffusionTxt2ImgScriptProcessing(StableDiffusionProcessingTxt2Img):
+    script_name = ''
+
+    def __init__(self, enable_hr: bool=False, denoising_strength: float=0.75, firstphase_width: int=0, firstphase_height: int=0, **kwargs):
+        self.script_name = kwargs.pop('script_name')
+        super().__init__(**kwargs)
+
+StableDiffusionTxt2ImgScriptProcessingAPI = PydanticModelGenerator(
+    "StableDiffusionTxt2ImgScriptProcessingAPI",
+    StableDiffusionTxt2ImgScriptProcessing,
+    [{"key": "sampler_index", "type": str, "default": "Euler"},
+     {"key": "script_name", "type": str, "default": ""},
+     {"key": "script_args", "type": list, "default": []}]
+).generate_model()
+
+class StableDiffusionImg2ImgScriptProcessing(StableDiffusionProcessingImg2Img):
+    script_name = ''
+
+    def __init__(self, enable_hr: bool=False, denoising_strength: float=0.75, firstphase_width: int=0, firstphase_height: int=0, **kwargs):
+        self.script_name = kwargs.pop('script_name')
+        super().__init__(**kwargs)
+
+StableDiffusionImg2ImgScriptProcessingAPI = PydanticModelGenerator(
+    "StableDiffusionImg2ImgScriptProcessingAPI",
+    StableDiffusionImg2ImgScriptProcessing,
+    [{"key": "script_name", "type": str, "default": ""}, {"key": "script_args", "type": list, "default": []}, {"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}]
+).generate_model()
+
+class TextToImageScriptResponse(BaseModel):
+    images: List[str] = Field(title="Images", description="The generated images in base64 format.")
+
+class ImageToImageScriptResponse(BaseModel):
+    images: List[str] = Field(title="Images", description="The generated images in base64 format.")
+
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingImg2Img",
     StableDiffusionProcessingImg2Img,
@@ -174,6 +208,7 @@ class InterrogateRequest(BaseModel):
 
 class InterrogateResponse(BaseModel):
     caption: str = Field(default=None, title="Caption", description="The generated caption for the image.")
+
 
 fields = {}
 for key, metadata in opts.data_labels.items():

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -77,7 +77,7 @@ class StableDiffusionProcessing():
     """
     The first set of paramaters: sd_models -> do_not_reload_embeddings represent the minimum required to create a StableDiffusionProcessing
     """
-    def __init__(self, sd_model=None, outpath_samples=None, outpath_grids=None, prompt: str = "", styles: List[str] = None, seed: int = -1, subseed: int = -1, subseed_strength: float = 0, seed_resize_from_h: int = -1, seed_resize_from_w: int = -1, seed_enable_extras: bool = True, sampler_name: str = None, batch_size: int = 1, n_iter: int = 1, steps: int = 50, cfg_scale: float = 7.0, width: int = 512, height: int = 512, restore_faces: bool = False, tiling: bool = False, do_not_save_samples: bool = False, do_not_save_grid: bool = False, extra_generation_params: Dict[Any, Any] = None, overlay_images: Any = None, negative_prompt: str = None, eta: float = None, do_not_reload_embeddings: bool = False, denoising_strength: float = 0, ddim_discretize: str = None, s_churn: float = 0.0, s_tmax: float = None, s_tmin: float = 0.0, s_noise: float = 1.0, override_settings: Dict[str, Any] = None, sampler_index: int = None):
+    def __init__(self, sd_model=None, outpath_samples=None, outpath_grids=None, prompt: str = "", styles: List[str] = None, seed: int = -1, subseed: int = -1, subseed_strength: float = 0, seed_resize_from_h: int = -1, seed_resize_from_w: int = -1, seed_enable_extras: bool = True, sampler_name: str = None, batch_size: int = 1, n_iter: int = 1, steps: int = 50, cfg_scale: float = 7.0, width: int = 512, height: int = 512, restore_faces: bool = False, tiling: bool = False, do_not_save_samples: bool = False, do_not_save_grid: bool = False, extra_generation_params: Dict[Any, Any] = None, overlay_images: Any = None, negative_prompt: str = None, eta: float = None, do_not_reload_embeddings: bool = False, denoising_strength: float = 0, ddim_discretize: str = None, s_churn: float = 0.0, s_tmax: float = None, s_tmin: float = 0.0, s_noise: float = 1.0, override_settings: Dict[str, Any] = None, sampler_index: int = None, script_args: list = None):
         if sampler_index is not None:
             print("sampler_index argument for StableDiffusionProcessing does not do anything; use sampler_name", file=sys.stderr)
 
@@ -127,7 +127,7 @@ class StableDiffusionProcessing():
             self.seed_resize_from_w = 0
 
         self.scripts = None
-        self.script_args = None
+        self.script_args = script_args
         self.all_prompts = None
         self.all_negative_prompts = None
         self.all_seeds = None


### PR DESCRIPTION
This PR adds the API endpoints `/sdapi/v1/txt2img/script` and `/sdapi/v1/img2img/script`.

The `POST` request bodies are extensions of the Txt2Img and Img2Img requests, adding the fields `script_name` and `script_args`.