### PR TITLE
feat(api): include job_timestamp in progress

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -171,6 +171,7 @@ class State:
             "interrupted": self.skipped,
             "job": self.job,
             "job_count": self.job_count,
+            "job_timestamp": self.job_timestamp,
             "job_no": self.job_no,
             "sampling_step": self.sampling_step,
             "sampling_steps": self.sampling_steps,


### PR DESCRIPTION
Very small PR, but should help disambiguate between multiple generation jobs