### PR TITLE
Added some more settings for the first pass of the highres fix.

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -250,12 +250,8 @@ class Processed:
         self.width = p.width
         self.height = p.height
         self.sampler_name = p.sampler_name
-        self.sampler_name_hr = p.sampler_name_hr
         self.cfg_scale = p.cfg_scale
-        self.cfg_scale_hr = p.cfg_scale_hr
-        self.latent_upscale_hr = p.latent_upscale_hr
         self.steps = p.steps
-        self.steps_hr = p.steps_hr
         self.batch_size = p.batch_size
         self.restore_faces = p.restore_faces
         self.face_restoration_model = opts.face_restoration_model if p.restore_faces else None
@@ -302,12 +298,8 @@ class Processed:
             "width": self.width,
             "height": self.height,
             "sampler_name": self.sampler_name,
-            "sampler_name_hr": self.sampler_name_hr,
             "cfg_scale": self.cfg_scale,
-            "cfg_scale_hr": self.cfg_scale_hr,
-            "latent_upscale_hr": self.latent_upscale_hr,
             "steps": self.steps,
-            "steps_hr": self.steps_hr,
             "batch_size": self.batch_size,
             "restore_faces": self.restore_faces,
             "face_restoration_model": self.face_restoration_model,
@@ -434,12 +426,8 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
 
     generation_params = {
         "Steps": p.steps,
-        "First Pass Steps": p.steps_hr,
         "Sampler": p.sampler_name,
-        "First Pass Sampler": p.sampler_name_hr,
         "CFG scale": p.cfg_scale,
-        "First Pass CFG": p.cfg_scale_hr,
-        "Latent Upscale": p.latent_upscale_hr,
         "Seed": all_seeds[index],
         "Face restoration": (opts.face_restoration_model if p.restore_faces else None),
         "Size": f"{p.width}x{p.height}",
@@ -683,6 +671,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         self.latent_upscale_hr = latent_upscale_hr
         if self.enable_hr:
             self.extra_generation_params["First pass size"] = f"{self.firstphase_width}x{self.firstphase_height}"
+            self.extra_generation_params["First Pass Steps"] = self.steps_hr
+            self.extra_generation_params["First Pass Sampler"] = self.sampler_name_hr
+            self.extra_generation_params["First Pass CFG"] = self.cfg_scale_hr
+            self.extra_generation_params["Latent Upscale"] = self.latent_upscale_hr
 
     def init(self, all_prompts, all_seeds, all_subseeds):
         if self.enable_hr:

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -249,7 +249,7 @@ class VanillaStableDiffusionSampler:
         
         return num_steps
 
-    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None, cfg_scale=None):
         steps, t_enc = setup_img2img_steps(p, steps)
         steps = self.adjust_steps_if_invalid(p, steps)
         self.initialize(p)
@@ -267,11 +267,11 @@ class VanillaStableDiffusionSampler:
             unconditional_conditioning = {"c_concat": [image_conditioning], "c_crossattn": [unconditional_conditioning]}
             
             
-        samples = self.launch_sampling(t_enc + 1, lambda: self.sampler.decode(x1, conditioning, t_enc, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning))
+        samples = self.launch_sampling(t_enc + 1, lambda: self.sampler.decode(x1, conditioning, t_enc, unconditional_guidance_scale=cfg_scale, unconditional_conditioning=unconditional_conditioning))
 
         return samples
 
-    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning=None, cfg_scale=None):
         self.initialize(p)
 
         self.init_latent = None
@@ -286,7 +286,7 @@ class VanillaStableDiffusionSampler:
             conditioning = {"dummy_for_plms": np.zeros((conditioning.shape[0],)), "c_crossattn": [conditioning], "c_concat": [image_conditioning]}
             unconditional_conditioning = {"c_crossattn": [unconditional_conditioning], "c_concat": [image_conditioning]}
 
-        samples_ddim = self.launch_sampling(steps, lambda: self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=p.cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=self.eta)[0])
+        samples_ddim = self.launch_sampling(steps, lambda: self.sampler.sample(S=steps, conditioning=conditioning, batch_size=int(x.shape[0]), shape=x[0].shape, verbose=False, unconditional_guidance_scale=cfg_scale, unconditional_conditioning=unconditional_conditioning, x_T=x, eta=self.eta)[0])
 
         return samples_ddim
 
@@ -474,7 +474,7 @@ class KDiffusionSampler:
 
         return sigmas
 
-    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None, cfg_scale=None):
         steps, t_enc = setup_img2img_steps(p, steps)
 
         sigmas = self.get_sigmas(p, steps)
@@ -502,12 +502,12 @@ class KDiffusionSampler:
             'cond': conditioning, 
             'image_cond': image_conditioning, 
             'uncond': unconditional_conditioning, 
-            'cond_scale': p.cfg_scale
+            'cond_scale': cfg_scale
         }, disable=False, callback=self.callback_state, **extra_params_kwargs))
 
         return samples
 
-    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning = None):
+    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning = None, cfg_scale=None):
         steps = steps or p.steps
 
         sigmas = self.get_sigmas(p, steps)
@@ -528,7 +528,7 @@ class KDiffusionSampler:
             'cond': conditioning, 
             'image_cond': image_conditioning, 
             'uncond': unconditional_conditioning, 
-            'cond_scale': p.cfg_scale
+            'cond_scale': cfg_scale
         }, disable=False, callback=self.callback_state, **extra_params_kwargs))
 
         return samples

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -327,7 +327,6 @@ options_templates.update(options_section(('upscaling', "Upscaling"), {
     "ESRGAN_tile_overlap": OptionInfo(8, "Tile overlap, in pixels for ESRGAN upscalers. Low values = visible seam.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}),
     "realesrgan_enabled_models": OptionInfo(["R-ESRGAN 4x+", "R-ESRGAN 4x+ Anime6B"], "Select which Real-ESRGAN models to show in the web UI. (Requires restart)", gr.CheckboxGroup, lambda: {"choices": realesrgan_models_names()}),
     "upscaler_for_img2img": OptionInfo(None, "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in sd_upscalers]}),
-    "use_scale_latent_for_hires_fix": OptionInfo(False, "Upscale latent space image when doing hires. fix"),
 }))
 
 options_templates.update(options_section(('face-restoration', "Face restoration"), {

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -8,7 +8,7 @@ import modules.processing as processing
 from modules.ui import plaintext_to_html
 
 
-def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, sampler_index_hr: str, steps_hr: int, *args):
+def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, sampler_index_hr: str, steps_hr: int, cfg_scale_hr: float, latent_upscale_hr: str, *args):
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
@@ -37,6 +37,8 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
         firstphase_height=firstphase_height if enable_hr else None,
         sampler_name_hr=sd_samplers.samplers[sampler_index_hr].name if enable_hr else None,
         steps_hr=steps_hr if enable_hr else None,
+        cfg_scale_hr=cfg_scale_hr if enable_hr else None,
+        latent_upscale_hr=latent_upscale_hr if enable_hr else None,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -8,7 +8,7 @@ import modules.processing as processing
 from modules.ui import plaintext_to_html
 
 
-def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, sampler_index_hr: str, steps_hr: int, cfg_scale_hr: float, latent_upscale_hr: str, *args):
+def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, enable_advanced_hr: bool, sampler_index_hr: str, steps_hr: int, cfg_scale_hr: float, latent_upscale_hr: str, *args):
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
@@ -35,10 +35,10 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
         denoising_strength=denoising_strength if enable_hr else None,
         firstphase_width=firstphase_width if enable_hr else None,
         firstphase_height=firstphase_height if enable_hr else None,
-        sampler_name_hr=sd_samplers.samplers[sampler_index_hr].name if enable_hr else None,
-        steps_hr=steps_hr if enable_hr else None,
-        cfg_scale_hr=cfg_scale_hr if enable_hr else None,
-        latent_upscale_hr=latent_upscale_hr if enable_hr else None,
+        sampler_name_hr=sd_samplers.samplers[sampler_index_hr].name if enable_hr and enable_advanced_hr else None,
+        steps_hr=steps_hr if enable_hr and enable_advanced_hr else None,
+        cfg_scale_hr=cfg_scale_hr if enable_hr and enable_advanced_hr else None,
+        latent_upscale_hr=latent_upscale_hr if enable_hr and enable_advanced_hr else None,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -8,7 +8,7 @@ import modules.processing as processing
 from modules.ui import plaintext_to_html
 
 
-def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, *args):
+def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, firstphase_width: int, firstphase_height: int, sampler_index_hr: str, steps_hr: int, *args):
     p = StableDiffusionProcessingTxt2Img(
         sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
@@ -35,6 +35,8 @@ def txt2img(prompt: str, negative_prompt: str, prompt_style: str, prompt_style2:
         denoising_strength=denoising_strength if enable_hr else None,
         firstphase_width=firstphase_width if enable_hr else None,
         firstphase_height=firstphase_height if enable_hr else None,
+        sampler_name_hr=sd_samplers.samplers[sampler_index_hr].name if enable_hr else None,
+        steps_hr=steps_hr if enable_hr else None,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -673,6 +673,8 @@ def create_ui():
                 with gr.Group(visible=False) as hr_options:
                     steps_hr = gr.Slider(minimum=1, maximum=150, step=1, label="Firstpass Steps", value=20)
                     sampler_index_hr = gr.Radio(label='Firstpass Sampling method', elem_id="txt2img_sampling_hr", choices=[x.name for x in samplers], value=samplers[0].name, type="index")
+                    latent_upscale_hr = gr.Radio(label='Latent upscaling method', choices=["Disabled", "nearest-exact", "bilinear", "area"], value=samplers[0].name, type="value")
+                    cfg_scale_hr = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Firstpass CFG Scale', value=7.0)
                     with gr.Row():
                         firstphase_width = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass width", value=0)
                         firstphase_height = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass height", value=0)
@@ -720,6 +722,8 @@ def create_ui():
                     firstphase_height,
                     sampler_index_hr,
                     steps_hr,
+                    cfg_scale_hr,
+                    latent_upscale_hr,
                 ] + custom_inputs,
 
                 outputs=[
@@ -783,6 +787,8 @@ def create_ui():
                 (firstphase_height, "First pass size-2"),
                 (sampler_index_hr, "First Pass Sampler"),
                 (steps_hr, "First Pass Steps"),
+                (cfg_scale_hr, "First Pass CFG"),
+                (latent_upscale_hr, "Latent Upscale"),
                 *modules.scripts.scripts_txt2img.infotext_fields
             ]
             parameters_copypaste.add_paste_fields("txt2img", None, txt2img_paste_fields)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -671,14 +671,18 @@ def create_ui():
                     enable_hr = gr.Checkbox(label='Highres. fix', value=False)
 
                 with gr.Group(visible=False) as hr_options:
-                    steps_hr = gr.Slider(minimum=1, maximum=150, step=1, label="Firstpass Steps", value=20)
-                    sampler_index_hr = gr.Radio(label='Firstpass Sampling method', elem_id="txt2img_sampling_hr", choices=[x.name for x in samplers], value=samplers[0].name, type="index")
-                    latent_upscale_hr = gr.Radio(label='Latent upscaling method', choices=["Disabled", "nearest-exact", "bilinear", "area"], value=samplers[0].name, type="value")
-                    cfg_scale_hr = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Firstpass CFG Scale', value=7.0)
                     with gr.Row():
                         firstphase_width = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass width", value=0)
                         firstphase_height = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass height", value=0)
                         denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7)
+
+                    enable_advanced_hr = gr.Checkbox(label='Firstpass Advanced Options', value=False)
+                    with gr.Group(visible=False) as advanced_hr_options:
+                        steps_hr = gr.Slider(minimum=1, maximum=150, step=1, label="Firstpass Steps", value=20)
+                        sampler_index_hr = gr.Radio(label='Firstpass Sampling method', elem_id="txt2img_sampling_hr", choices=[x.name for x in samplers], value=0, type="index")
+                        cfg_scale_hr = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Firstpass CFG Scale', value=7.0)
+                        latent_upscale_choices = ["Disabled", "nearest-exact", "bilinear", "area"]
+                        latent_upscale_hr = gr.Radio(label='Latent upscaling method. If disabled regular pixel space upscaling will be used.', choices=latent_upscale_choices, type="value", value=latent_upscale_choices[0])
 
                 with gr.Row(equal_height=True):
                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1)
@@ -720,6 +724,7 @@ def create_ui():
                     denoising_strength,
                     firstphase_width,
                     firstphase_height,
+                    enable_advanced_hr,
                     sampler_index_hr,
                     steps_hr,
                     cfg_scale_hr,
@@ -754,6 +759,12 @@ def create_ui():
                 outputs=[hr_options],
             )
 
+            enable_advanced_hr.change(
+                fn=lambda x: gr_show(x),
+                inputs=[enable_advanced_hr],
+                outputs=[advanced_hr_options],
+            )
+
             roll.click(
                 fn=roll_artist,
                 _js="update_txt2img_tokens",
@@ -785,6 +796,8 @@ def create_ui():
                 (hr_options, lambda d: gr.Row.update(visible="Denoising strength" in d)),
                 (firstphase_width, "First pass size-1"),
                 (firstphase_height, "First pass size-2"),
+                (enable_advanced_hr, lambda d: "First Pass Sampler" in d),
+                (advanced_hr_options, lambda d: gr.Row.update(visible="First Pass Sampler" in d)),
                 (sampler_index_hr, "First Pass Sampler"),
                 (steps_hr, "First Pass Steps"),
                 (cfg_scale_hr, "First Pass CFG"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -670,10 +670,13 @@ def create_ui():
                     tiling = gr.Checkbox(label='Tiling', value=False)
                     enable_hr = gr.Checkbox(label='Highres. fix', value=False)
 
-                with gr.Row(visible=False) as hr_options:
-                    firstphase_width = gr.Slider(minimum=0, maximum=1024, step=8, label="Firstpass width", value=0)
-                    firstphase_height = gr.Slider(minimum=0, maximum=1024, step=8, label="Firstpass height", value=0)
-                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7)
+                with gr.Group(visible=False) as hr_options:
+                    steps_hr = gr.Slider(minimum=1, maximum=150, step=1, label="Firstpass Steps", value=20)
+                    sampler_index_hr = gr.Radio(label='Firstpass Sampling method', elem_id="txt2img_sampling_hr", choices=[x.name for x in samplers], value=samplers[0].name, type="index")
+                    with gr.Row():
+                        firstphase_width = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass width", value=0)
+                        firstphase_height = gr.Slider(minimum=0, maximum=2048, step=8, label="Firstpass height", value=0)
+                        denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7)
 
                 with gr.Row(equal_height=True):
                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1)
@@ -715,6 +718,8 @@ def create_ui():
                     denoising_strength,
                     firstphase_width,
                     firstphase_height,
+                    sampler_index_hr,
+                    steps_hr,
                 ] + custom_inputs,
 
                 outputs=[
@@ -776,6 +781,8 @@ def create_ui():
                 (hr_options, lambda d: gr.Row.update(visible="Denoising strength" in d)),
                 (firstphase_width, "First pass size-1"),
                 (firstphase_height, "First pass size-2"),
+                (sampler_index_hr, "First Pass Sampler"),
+                (steps_hr, "First Pass Steps"),
                 *modules.scripts.scripts_txt2img.infotext_fields
             ]
             parameters_copypaste.add_paste_fields("txt2img", None, txt2img_paste_fields)


### PR DESCRIPTION
Sampling method, steps and CFG can now be set independently from the ones on the second pass.

use_scale_latent_for_hires_fix option is replaced with an option to either disable latent upscaling or select the latent upscaling method between nearest-exact, bilinear and area.

I also fixed the bug where the "read generation parameters" button didn't get the firstpass width and height from the params.txt because it was never written there in the first place.