### PR TITLE
fix(api): assign sd_model after settings change

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -121,7 +121,6 @@ class Api:
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):
         populate = txt2imgreq.copy(update={ # Override __init__ params
-            "sd_model": shared.sd_model,
             "sampler_name": validate_sampler_name(txt2imgreq.sampler_name or txt2imgreq.sampler_index),
             "do_not_save_samples": True,
             "do_not_save_grid": True
@@ -153,7 +152,6 @@ class Api:
             mask = decode_base64_to_image(mask)
 
         populate = img2imgreq.copy(update={ # Override __init__ params
-            "sd_model": shared.sd_model,
             "sampler_name": validate_sampler_name(img2imgreq.sampler_name or img2imgreq.sampler_index),
             "do_not_save_samples": True,
             "do_not_save_grid": True,

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -50,9 +50,9 @@ def apply_color_correction(correction, original_image):
         correction,
         channel_axis=2
     ), cv2.COLOR_LAB2RGB).astype("uint8"))
-    
+
     image = blendLayers(image, original_image, BlendType.LUMINOSITY)
-    
+
     return image
 
 
@@ -466,6 +466,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
             if k == 'sd_model_checkpoint': sd_models.reload_model_weights()  # make onchange call for changing SD model
             if k == 'sd_vae': sd_vae.reload_vae_weights()  # make onchange call for changing VAE
 
+        # Assign sd_model here to ensure that it reflects the model after any changes
+        p.sd_model = shared.sd_model
         res = process_images_inner(p)
 
     finally:


### PR DESCRIPTION
Fixes #5877.

Before this fix, `sd_model` was assigned before a potential model switch, resulting in the pipeline using the wrong model after a model switch. This fixes that by assigning `sd_model` after the switch. I was able to successfully generate images with both SD1 and SD2 models using `override_settings` after applying this fix.