### PR TITLE
Allow float values for CLIP skip (lerp between last layers)

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -75,6 +75,7 @@ def integrate_settings_paste_fields(component_dict):
         'sd_hypernetwork': 'Hypernet',
         'sd_hypernetwork_strength': 'Hypernet strength',
         'CLIP_stop_at_last_layers': 'Clip skip',
+        'CLIP_skip_lerp_after_norm': 'Clip skip lerp after norm',
         'inpainting_mask_weight': 'Conditional mask weight',
         'sd_model_checkpoint': 'Model hash',
         'eta_noise_seed_delta': 'ENSD',

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -446,7 +446,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
         "Conditional mask weight": getattr(p, "inpainting_mask_weight", shared.opts.inpainting_mask_weight) if p.is_using_inpainting_conditioning else None,
         "Eta": (None if p.sampler is None or p.sampler.eta == p.sampler.default_eta else p.sampler.eta),
         "Clip skip": None if clip_skip <= 1 else clip_skip,
-        "Clip skip lerp after norm": None if clip_skip is int else clip_skip_lerp_after_norm,
+        "Clip skip lerp after norm": None if clip_skip <= 1 else clip_skip_lerp_after_norm,
         "ENSD": None if opts.eta_noise_seed_delta == 0 else opts.eta_noise_seed_delta,
     }
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -446,7 +446,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
         "Conditional mask weight": getattr(p, "inpainting_mask_weight", shared.opts.inpainting_mask_weight) if p.is_using_inpainting_conditioning else None,
         "Eta": (None if p.sampler is None or p.sampler.eta == p.sampler.default_eta else p.sampler.eta),
         "Clip skip": None if clip_skip <= 1 else clip_skip,
-        "Clip skip lerp after norm": None if clip_skip is int else clip_skip,
+        "Clip skip lerp after norm": None if clip_skip is int else clip_skip_lerp_after_norm,
         "ENSD": None if opts.eta_noise_seed_delta == 0 else opts.eta_noise_seed_delta,
     }
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -264,6 +264,7 @@ class Processed:
         self.styles = p.styles
         self.job_timestamp = state.job_timestamp
         self.clip_skip = opts.CLIP_stop_at_last_layers
+        self.clip_skip_lerp_after_norm = opts.CLIP_skip_lerp_after_norm
 
         self.eta = p.eta
         self.ddim_discretize = p.ddim_discretize
@@ -422,6 +423,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
     index = position_in_batch + iteration * p.batch_size
 
     clip_skip = getattr(p, 'clip_skip', opts.CLIP_stop_at_last_layers)
+    clip_skip_lerp_after_norm = getattr(p, 'clip_skip_lerp_after_norm', opts.CLIP_skip_lerp_after_norm)
 
     generation_params = {
         "Steps": p.steps,
@@ -444,6 +446,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration
         "Conditional mask weight": getattr(p, "inpainting_mask_weight", shared.opts.inpainting_mask_weight) if p.is_using_inpainting_conditioning else None,
         "Eta": (None if p.sampler is None or p.sampler.eta == p.sampler.default_eta else p.sampler.eta),
         "Clip skip": None if clip_skip <= 1 else clip_skip,
+        "Clip skip lerp after norm": None if clip_skip is int else clip_skip,
         "ENSD": None if opts.eta_noise_seed_delta == 0 else opts.eta_noise_seed_delta,
     }
 

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -289,10 +289,6 @@ class FrozenCLIPEmbedderWithCustomWords(FrozenCLIPEmbedderWithCustomWordsBase):
         if clip_skip == 1:
             return outputs.last_hidden_state
 
-        if clip_skip is int:
-            z = outputs.hidden_states[-clip_skip]
-            return self.wrapped.transformer.text_model.final_layer_norm(z)
-        
         ceil = math.ceil(clip_skip)
         floor = math.floor(clip_skip)
         alpha = clip_skip - floor

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -370,7 +370,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
     "comma_padding_backtrack": OptionInfo(20, "Increase coherency by padding from the last comma within n tokens when using more than 75 tokens", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1 }),
-    'CLIP_stop_at_last_layers': OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 1}),
+    'CLIP_stop_at_last_layers': OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 0.1}),
     "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),
 }))
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -370,7 +370,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
     "comma_padding_backtrack": OptionInfo(20, "Increase coherency by padding from the last comma within n tokens when using more than 75 tokens", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1 }),
-    'CLIP_stop_at_last_layers': OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 0.1}),
+    'CLIP_stop_at_last_layers': OptionInfo(1.0, "Clip skip", gr.Slider, {"minimum": 1.0, "maximum": 12.0, "step": 0.1}),
     'CLIP_skip_lerp_after_norm': OptionInfo(False, "Interpolate Clip skip after layer normalization"),
     "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),
 }))

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -371,6 +371,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
     "comma_padding_backtrack": OptionInfo(20, "Increase coherency by padding from the last comma within n tokens when using more than 75 tokens", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1 }),
     'CLIP_stop_at_last_layers': OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 0.1}),
+    'CLIP_skip_lerp_after_norm': OptionInfo(False, "Interpolate Clip skip after layer normalization"),
     "random_artist_categories": OptionInfo([], "Allowed categories for random artists selection when using the Roll button", gr.CheckboxGroup, {"choices": artist_db.categories()}),
 }))
 

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -200,7 +200,7 @@ axis_options = [
     AxisOption("Sigma max", float, apply_field("s_tmax"), format_value_add_label, None),
     AxisOption("Sigma noise", float, apply_field("s_noise"), format_value_add_label, None),
     AxisOption("Eta", float, apply_field("eta"), format_value_add_label, None),
-    AxisOption("Clip skip", int, apply_clip_skip, format_value_add_label, None),
+    AxisOption("Clip skip", float, apply_clip_skip, format_value_add_label, None),
     AxisOption("Denoising", float, apply_field("denoising_strength"), format_value_add_label, None),
     AxisOption("Upscale latent space for hires.", str, apply_upscale_latent_space, format_value_add_label, None),
     AxisOption("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight"), format_value_add_label, None),


### PR DESCRIPTION
Example:
![00030-10000](https://user-images.githubusercontent.com/38468635/209480309-62a0ca3b-b4e6-4a08-bcd5-55419037ea59.jpg)

On a related note, clip skip is a setting that I find myself switching a lot, and it also gets auto changed on sending an image from PNG info... Maybe it would make sense to move it to generation params, away from settings?