### PR TITLE
Allow always discarding of penultimate sigma and fix doing 1 less step than specified

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -462,6 +462,9 @@ class KDiffusionSampler:
         return extra_params_kwargs
 
     def get_sigmas(self, p, steps):
+        disc = opts.always_discard_next_to_last_sigma or (self.config is not None and self.config.options.get('discard_next_to_last_sigma', False))
+        steps += 1 if disc else 0
+
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif self.config is not None and self.config.options.get('scheduler', None) == 'karras':
@@ -469,7 +472,7 @@ class KDiffusionSampler:
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 
-        if self.config is not None and self.config.options.get('discard_next_to_last_sigma', False):
+        if disc:
             sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
 
         return sigmas

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -418,6 +418,7 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
     's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
     's_noise': OptionInfo(1.0, "sigma noise", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
     'eta_noise_seed_delta': OptionInfo(0, "Eta noise seed delta", gr.Number, {"precision": 0}),
+    'always_discard_next_to_last_sigma': OptionInfo(False, "Always discard next-to-last sigma"),
 }))
 
 options_templates.update(options_section((None, "Hidden options"), {


### PR DESCRIPTION
Allows the user to specify if to always discard the penultimate/next-to-last sigma (regardless of the sampler), and makes it so even if you discard the step, you still do the amount of steps specified.

Currently, only the DPM2 (/a) samplers discard the penultimate sigma. However, the quality of other samplers can also be increased by doing the same. This is particularly noticeable if you are using a very low amount of steps (< 10) and are not using a suitably low CFG scale.

With DPM++ 2M Karras (7 steps, 9 CFG scale):

<details>

Not-discarding:
![2mka-no-discard](https://user-images.githubusercontent.com/112723046/209582796-315d159b-481b-4897-b803-f7adeceacc08.jpg)

Discarding:
![2mka-discard](https://user-images.githubusercontent.com/112723046/209582785-90bd094b-9d1e-411b-8be3-e663528ad2d5.jpg)

Particularly noticeable in the 2nd image across.
</details>

Also, currently if discarding the last step, it will sample one less step than the amount of steps specified (which also causes the progress bar to never fill). This is fixed by adding +1 to the steps when getting the sigmas if discarding.