### PR TITLE
Fix CLIP Tokenizer so that padding and special tokens are correct

### DIFF
--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -16,7 +16,8 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
         self.wrapped = wrapped
         self.hijack = hijack
         self.id_fill = 0
-        self.id_end = 49407 
+        self.id_start = 49406
+        self.id_end = 49407
 
     def tokenize(self, texts):
         raise NotImplementedError
@@ -83,7 +84,7 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
         prompt_target_length = get_target_prompt_token_count(token_count)
         tokens_to_add = prompt_target_length - len(remade_tokens)
 
-        remade_tokens = remade_tokens + [self.id_eot] + [self.id_fill] * (tokens_to_add - 1)
+        remade_tokens = [self.id_start] + remade_tokens + [self.id_end] + [self.id_fill] * (tokens_to_add - 2)
         multipliers = multipliers + [1.0] * tokens_to_add
 
         return remade_tokens, fixes, multipliers, token_count
@@ -166,7 +167,7 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
                     hijack_comments.append(f"Warning: too many input tokens; some ({len(overflowing_words)}) have been truncated:\n{overflowing_text}\n")
 
                 token_count = len(remade_tokens)
-                remade_tokens = [self.id_sot] + remade_tokens[:maxlen - 2] + [self.id_eot]
+                remade_tokens = [self.id_sot] + remade_tokens[:maxlen - 2] + [self.id_end]
                 remade_tokens += [self.id_fill] * (maxlen - len(remade_tokens))
                 cache[tuple_tokens] = (remade_tokens, fixes, multipliers)
 

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -16,6 +16,7 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
         self.wrapped = wrapped
         self.hijack = hijack
         self.id_fill = 0
+        self.id_end = 49407 
 
     def tokenize(self, texts):
         raise NotImplementedError


### PR DESCRIPTION
Both OpenAI's CLIP (like in SD 1.x) and OpenCLIP (like in SD 2.x) use the same CLIP tokenizer. The tokenizer is what takes words, letters, numbers, punctuation, etc... and converts them into integers to be fed into the text model.

This tokenizer is supposed to place a special starting token before your text prompt and it is supposed to add a special ending token after the prompt. This is why the max CLIP input size is normally 75 tokens rather than 77, because 2 of the slots are used by the special tokens. If your text prompt doesn't end up creating 75 tokens, then a padding value is used to fill in the rest.

Currently this repo's code seems to not add the starting token, and the ending token is repeated as the padding value. The padding for CLIP tokenizers is normally 0, and I don't see any evidence that it's different for Stable Diffusion.


The fixes in this PR may cause issues with some user made extensions, but the changes should hopefully improve output quality (though prompts may have to be altered, and embeddings / models may have to be retrained). Unfortunately these changes will produce different outputs even with the same seed, if you try to replicate outputs from before the change.


The fixes in this PR are based on changes from here: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5011#issuecomment-1327613212, and the PR here: https://github.com/uservar/stable-diffusion-webui/commit/49df7c9aca39bccec623dd54ae33fb6963e41464, however I am applying them to both 1.x and 2.x models.