### PR TITLE
validate textual inversion embeddings

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -325,6 +325,9 @@ def load_model(checkpoint_info=None):
     script_callbacks.model_loaded_callback(sd_model)
 
     print("Model loaded.")
+
+    sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload = True) # Reload embeddings after model load as they may or may not fit the model
+
     return sd_model
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1157,8 +1157,6 @@ def create_ui():
             with gr.Column(variant='panel'):
                 submit_result = gr.Textbox(elem_id="modelmerger_result", show_label=False)
 
-    sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings()
-
     with gr.Blocks(analytics_enabled=False) as train_interface:
         with gr.Row().style(equal_height=False):
             gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation.</p>")


### PR DESCRIPTION
- embeddings were loaded from `ui.py` which is really a wrong place
  - embeddings dont work when running as API-only?  
  - no need to reload embeddings when reloading UI?  
  - depending on the model config, embeddings may need to be reregistered if model is using a different tokenizer  

  moved embeddings load to execute immediately after model load in `sd_models.py`  
- added option `force_load` to reload embeddings on-demand  
- add embedding shape and vector count to embedding object in `textual_inversion.py`  
- get expected embedding size from the first embedding in the current model's tokenizer in `textual_inversion.py:get_expected_shape`  
- perform sanity checks during embedding loading to see if the embedding shape matches size in `textual_inversion.py:process_file`  
- print summary messages at the end of `textual_inversion.py:load_textual_inversion_embeddings`  


example output when loading **sd15** embeddings with **sd20** model:
```text
Loading weights [09dd2ae4] from /home/vlado/dev/automatic/models/Stable-diffusion/sd-v20-512-base-ema-stabilityai.ckpt
Loading VAE weights from: /home/vlado/dev/automatic/models/VAE/vae-ft-mse-840000-ema-pruned.ckpt
Applying cross attention optimization (Doggettx).
Model loaded.
Textual inversion embeddings 0 loaded:
Textual inversion embeddings 1 skipped: vlado
```
