### PR TITLE
Included DS_Store files in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ notification.mp3
 /extensions
 /test/stdout.txt
 /test/stderr.txt
+
+# Ignore/omit macOS DS_Store metadata files, they're meant for local setups only, not for git.
+.DS_Store


### PR DESCRIPTION
DS_Store files are commonly ignored since they're generated by macOS, and frequently encountered by Mac developers.

Merging this should prevent them from being pushed by a Mac user contributor in the future and cluttering up their git status.

example:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.DS_Store
	.github/.DS_Store
	extensions-builtin/.DS_Store
	modules/.DS_Store
	test/.DS_Store
```