### PR TITLE
Save Optimizer next to TI embedding

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -355,7 +355,7 @@ options_templates.update(options_section(('system', "System"), {
 options_templates.update(options_section(('training', "Training"), {
     "unload_models_when_training": OptionInfo(False, "Move VAE and CLIP to RAM when training if possible. Saves VRAM."),
     "pin_memory": OptionInfo(False, "Turn on pin_memory for DataLoader. Makes training slightly faster but can increase memory usage."),
-    "save_optimizer_state": OptionInfo(False, "Saves Optimizer state as separate *.optim file. Training can be resumed with HN itself and matching optim file."),
+    "save_optimizer_state": OptionInfo(False, "Saves Optimizer state as separate *.optim file. Training of embedding or HN can be resumed with the matching optim file."),
     "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
     "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
     "training_image_repeats_per_epoch": OptionInfo(1, "Number of repeats for a single input image per epoch; used only for displaying epoch number", gr.Number, {"precision": 0}),


### PR DESCRIPTION
Also add check to load only .PT and .BIN files as embeddings. (since we add .optim files in the same directory)

Currently, the Optimizer state is not saved. Interrupting the training of Textual Inversion and resuming will result in the training going in a different direction. (In effect, it screws up the first X amount of steps to get back on track again. Maybe not even getting on track again.)

![test_interrupt02-21-vector-100-vector-limit](https://user-images.githubusercontent.com/1111394/210338075-182cbe07-5ace-4bd5-8292-61ff5b2e4f6f.jpg)
These are the vectors during training. The training has been interrupted at step 12.