### PR TITLE
better targetting, class tabs was autoassigned

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ function gradioApp() {
 }
 
 function get_uiCurrentTab() {
-    return gradioApp().querySelector('.tabs button:not(.border-transparent)')
+    return gradioApp().querySelector('#tabs button:not(.border-transparent)')
 }
 
 function get_uiCurrentTabContent() {


### PR DESCRIPTION
I moved a preset manager into quicksettings, this function was targeting my component instead of the tabs. This is because class tabs is autoassigned, while element id #tabs is not, this allows a tabbed component to live in the quicksettings.