### PR TITLE
Remove NumPy requirement, as it torch's requirements already download & install it

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -4,7 +4,6 @@ accelerate==0.12.0
 basicsr==1.4.2
 gfpgan==1.3.8
 gradio==3.15.0
-numpy==1.23.3
 Pillow==9.4.0
 realesrgan==0.3.0
 torch


### PR DESCRIPTION
NumPy is a requirement of PyTorch, so we we don't need to make it a requirement as installing PyTorch also installs NumPy