### PR TITLE
Make pnginfoapi return all image info

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -157,7 +157,8 @@ class PNGInfoRequest(BaseModel):
     image: str = Field(title="Image", description="The base64 encoded PNG image")
 
 class PNGInfoResponse(BaseModel):
-    info: str = Field(title="Image info", description="A string with all the info the image had")
+    info: str = Field(title="Image info", description="A string with the parameters used to generate the image")
+    items: dict = Field(title="Items", description="An object containing all the info the image had")
 
 class ProgressRequest(BaseModel):
     skip_current_image: bool = Field(default=False, title="Skip current image", description="Skip current image serialization")


### PR DESCRIPTION
I couldn't reopen #5349 so opening a new PR, this one should be more appropriate.

This will prevent the exception when an image contains no generation info and adds in the rest of the information read from the image in an `items` object.