### PR TITLE
Fixes webui.sh to exec LAUNCH_SCRIPT

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -160,10 +160,10 @@ then
     printf "\n%s\n" "${delimiter}"
     printf "Accelerating launch.py..."
     printf "\n%s\n" "${delimiter}"
-    accelerate launch --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
+    exec accelerate launch --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
 else
     printf "\n%s\n" "${delimiter}"
     printf "Launching launch.py..."
     printf "\n%s\n" "${delimiter}"
-    "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+    exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
 fi


### PR DESCRIPTION
Without `exec`, webui.sh spawns LAUNCH_SCRIPT as a new child process.

With `exec`, it correctly replaces the webui.sh process with the new LAUNCH_SCRIPT, enabling process signals to forward properly.