### PR TITLE
hires-fix: add "nearest-exact" latent upscale mode.

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -576,6 +576,7 @@ latent_upscale_modes = {
     "Latent (bicubic)": {"mode": "bicubic", "antialias": False},
     "Latent (bicubic antialiased)": {"mode": "bicubic", "antialias": True},
     "Latent (nearest)": {"mode": "nearest", "antialias": False},
+    "Latent (nearest-exact)": {"mode": "nearest-exact", "antialias": False},
 }
 
 sd_upscalers = []


### PR DESCRIPTION
In #6299 the author states that `nearest-exact` mode produces no difference to `nearest`. However, this is only true for integer scaling factors. 

This PR adds `nearest-exact` scaling mode, as it does produce sufficiently different and sometimes "better" results (see examples below) for non-integer scaling factors.

![nearest](https://user-images.githubusercontent.com/12952180/210824097-087dab79-fdd4-46ed-85f2-e3afafc8b67f.jpg)
![nearest-exact](https://user-images.githubusercontent.com/12952180/210824105-fe2126c8-2836-42ef-8cac-8d50700f9812.jpg)

IMHO, the plain `nearest` mode should be removed, because it is based on broken OpenCV implementation and is kept that way for backward compatibility. But that would be a breaking change at this point.
