### PR TITLE
Save hypernet and textual inversion settings to text file, revised.

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -402,30 +402,22 @@ def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None,
 
     shared.reload_hypernetworks()
 # Note: textual_inversion.py has a nearly identical function of the same name.
-def save_settings_to_file(initial_step, num_of_dataset_images, hypernetwork_name, layer_structure, activation_func, weight_init, add_layer_norm, use_dropout, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_hypernetwork_every, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
-    checkpoint = sd_models.select_checkpoint()
-    model_name = checkpoint.model_name
-    model_hash = '[{}]'.format(checkpoint.hash)
+def save_settings_to_file(model_name, model_hash, initial_step, num_of_dataset_images, hypernetwork_name, layer_structure, activation_func, weight_init, add_layer_norm, use_dropout, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_hypernetwork_every, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
     # Starting index of preview-related arguments.
-    border_index = 19
-
-    # Get a list of the argument names, excluding default argument.
-    sig = inspect.signature(save_settings_to_file)
-    arg_names = [p.name for p in sig.parameters.values() if p.default == p.empty]
-    
+    border_index = 21
+    # Get a list of the argument names.
+    arg_names = inspect.getfullargspec(save_settings_to_file).args
     # Create a list of the argument names to include in the settings string.
     names = arg_names[:border_index]  # Include all arguments up until the preview-related ones.
-
-    # Include preview-related arguments if applicable.
     if preview_from_txt2img:
-        names.extend(arg_names[border_index:])
-
+        names.extend(arg_names[border_index:])  # Include preview-related arguments if applicable.
     # Build the settings string.
     settings_str = "datetime : " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n"
     for name in names:
-        value = locals()[name]
-        settings_str += f"{name}: {value}\n"
-
+        if name != 'log_directory': # It's useless and redundant to save log_directory.
+            value = locals()[name]
+            settings_str += f"{name}: {value}\n"
+    # Create or append to the file.
     with open(os.path.join(log_directory, 'settings.txt'), "a+") as fout:
         fout.write(settings_str + "\n\n")
 
@@ -485,7 +477,7 @@ def train_hypernetwork(hypernetwork_name, learn_rate, batch_size, gradient_step,
     ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=hypernetwork_name, model=shared.sd_model, cond_model=shared.sd_model.cond_stage_model, device=devices.device, template_file=template_file, include_cond=True, batch_size=batch_size, gradient_step=gradient_step, shuffle_tags=shuffle_tags, tag_drop_out=tag_drop_out, latent_sampling_method=latent_sampling_method)
 
     if shared.opts.save_training_settings_to_txt:
-        save_settings_to_file(initial_step, len(ds), hypernetwork_name, hypernetwork.layer_structure, hypernetwork.activation_func, hypernetwork.weight_init, hypernetwork.add_layer_norm, hypernetwork.use_dropout, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_hypernetwork_every, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
+        save_settings_to_file(checkpoint.model_name, '[{}]'.format(checkpoint.hash), initial_step, len(ds), hypernetwork_name, hypernetwork.layer_structure, hypernetwork.activation_func, hypernetwork.weight_init, hypernetwork.add_layer_norm, hypernetwork.use_dropout, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_hypernetwork_every, template_file, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
 
     latent_sampling_method = ds.latent_sampling_method
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -362,6 +362,7 @@ options_templates.update(options_section(('training', "Training"), {
     "unload_models_when_training": OptionInfo(False, "Move VAE and CLIP to RAM when training if possible. Saves VRAM."),
     "pin_memory": OptionInfo(False, "Turn on pin_memory for DataLoader. Makes training slightly faster but can increase memory usage."),
     "save_optimizer_state": OptionInfo(False, "Saves Optimizer state as separate *.optim file. Training of embedding or HN can be resumed with the matching optim file."),
+    "save_train_settings_to_txt": OptionInfo(False, "Save textual inversion and hypernet settings to a text file when training starts."),
     "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
     "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
     "training_image_repeats_per_epoch": OptionInfo(1, "Number of repeats for a single input image per epoch; used only for displaying epoch number", gr.Number, {"precision": 0}),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -362,7 +362,7 @@ options_templates.update(options_section(('training', "Training"), {
     "unload_models_when_training": OptionInfo(False, "Move VAE and CLIP to RAM when training if possible. Saves VRAM."),
     "pin_memory": OptionInfo(False, "Turn on pin_memory for DataLoader. Makes training slightly faster but can increase memory usage."),
     "save_optimizer_state": OptionInfo(False, "Saves Optimizer state as separate *.optim file. Training of embedding or HN can be resumed with the matching optim file."),
-    "save_train_settings_to_txt": OptionInfo(False, "Save textual inversion and hypernet settings to a text file when training starts."),
+    "save_training_settings_to_txt": OptionInfo(False, "Save textual inversion and hypernet settings to a text file whenever training starts."),
     "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
     "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
     "training_image_repeats_per_epoch": OptionInfo(1, "Number of repeats for a single input image per epoch; used only for displaying epoch number", gr.Number, {"precision": 0}),

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -231,26 +231,22 @@ def write_loss(log_directory, filename, step, epoch_len, values):
         })
 
 # Note: hypernetwork.py has a nearly identical function of the same name. 
-def save_settings_to_file(initial_step, num_of_dataset_images, embedding_name, vectors_per_token, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
-    checkpoint = sd_models.select_checkpoint()
-    model_name = checkpoint.model_name
-    model_hash = '[{}]'.format(checkpoint.hash)
+def save_settings_to_file(model_name, model_hash, initial_step, num_of_dataset_images, embedding_name, vectors_per_token, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
     # Starting index of preview-related arguments.
-    border_index = 16
+    border_index = 18
     # Get a list of the argument names.
-    arg_names = inspect.getfullargspec(save_settings_to_file).args
-    
+    arg_names = inspect.getfullargspec(save_settings_to_file).args    
     # Create a list of the argument names to include in the settings string.
     names = arg_names[:border_index]  # Include all arguments up until the preview-related ones.
     if preview_from_txt2img:
-        names.extend(arg_names[border_index:])  # Include all remaining arguments if `preview_from_txt2img` is True.
-
+        names.extend(arg_names[border_index:])  # Include preview-related arguments if applicable.
     # Build the settings string.
     settings_str = "datetime : " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n"
     for name in names:
-        value = locals()[name]
-        settings_str += f"{name}: {value}\n"
-
+        if name != 'log_directory': # It's useless and redundant to save log_directory.
+            value = locals()[name]
+            settings_str += f"{name}: {value}\n"
+    # Create or append to the file.
     with open(os.path.join(log_directory, 'settings.txt'), "a+") as fout:
         fout.write(settings_str + "\n\n")
 
@@ -333,7 +329,7 @@ def train_embedding(embedding_name, learn_rate, batch_size, gradient_step, data_
     ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=embedding_name, model=shared.sd_model, cond_model=shared.sd_model.cond_stage_model, device=devices.device, template_file=template_file, batch_size=batch_size, gradient_step=gradient_step, shuffle_tags=shuffle_tags, tag_drop_out=tag_drop_out, latent_sampling_method=latent_sampling_method)
 
     if shared.opts.save_training_settings_to_txt:
-            save_settings_to_file(initial_step, len(ds), embedding_name, len(embedding.vec), learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
+            save_settings_to_file(checkpoint.model_name, '[{}]'.format(checkpoint.hash), initial_step, len(ds), embedding_name, len(embedding.vec), learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
 
     latent_sampling_method = ds.latent_sampling_method
 

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -230,18 +230,20 @@ def write_loss(log_directory, filename, step, epoch_len, values):
             **values,
         })
 
+# Note: hypernetwork.py has a nearly identical function of the same name. 
 def save_settings_to_file(initial_step, num_of_dataset_images, embedding_name, vectors_per_token, learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height):
     checkpoint = sd_models.select_checkpoint()
     model_name = checkpoint.model_name
     model_hash = '[{}]'.format(checkpoint.hash)
-
+    # Starting index of preview-related arguments.
+    border_index = 16
     # Get a list of the argument names.
     arg_names = inspect.getfullargspec(save_settings_to_file).args
     
     # Create a list of the argument names to include in the settings string.
-    names = arg_names[:16]  # Include all arguments up until the preview-related ones.
+    names = arg_names[:border_index]  # Include all arguments up until the preview-related ones.
     if preview_from_txt2img:
-        names.extend(arg_names[16:])  # Include all remaining arguments if `preview_from_txt2img` is True.
+        names.extend(arg_names[border_index:])  # Include all remaining arguments if `preview_from_txt2img` is True.
 
     # Build the settings string.
     settings_str = "datetime : " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n"
@@ -329,8 +331,10 @@ def train_embedding(embedding_name, learn_rate, batch_size, gradient_step, data_
     pin_memory = shared.opts.pin_memory
 
     ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=embedding_name, model=shared.sd_model, cond_model=shared.sd_model.cond_stage_model, device=devices.device, template_file=template_file, batch_size=batch_size, gradient_step=gradient_step, shuffle_tags=shuffle_tags, tag_drop_out=tag_drop_out, latent_sampling_method=latent_sampling_method)
-    if shared.opts.save_train_settings_to_txt:
-            save_settings_to_file(initial_step , len(ds) , embedding_name, len(embedding.vec) , learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
+
+    if shared.opts.save_training_settings_to_txt:
+            save_settings_to_file(initial_step, len(ds), embedding_name, len(embedding.vec), learn_rate, batch_size, data_root, log_directory, training_width, training_height, steps, create_image_every, save_embedding_every, template_file, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_index, preview_cfg_scale, preview_seed, preview_width, preview_height)
+
     latent_sampling_method = ds.latent_sampling_method
 
     dl = modules.textual_inversion.dataset.PersonalizedDataLoader(ds, latent_sampling_method=latent_sampling_method, batch_size=ds.batch_size, pin_memory=pin_memory)


### PR DESCRIPTION
Adds #3352 (to ti AND hypernet) by building upon pull requests #3601 and #3750 (but is mostly based on the former). Specifically addresses Auto's [concerns](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3601?notification_referrer_id=NT_kwDOBuxrfrQ0Njc1OTQxOTM2OjExNjE1NzMxMA&notifications_query=reason%3Amention#issuecomment-1371045105):

> Why is eval there? This should be optional and off by default. I would very much prefer if the implementation didn't list the same long list 3 times.

This pull request removes eval, adds the setting `save_training_settings_to_txt` (off by default), and uses the inspect module to iterate over arguments directly.

<details><summary>Click to view a screenshot of the new setting.</summary>

![image](https://user-images.githubusercontent.com/116157310/210828786-58a59eb7-4b37-4f43-bb68-28101e80c841.png)

</details>

<details> <summary>Click to view circumstances tested.</summary>

Hypernet training:
+Works with new setting disabled and enabled.
+Works training, Interrupting training, changing a setting, and resuming training.
+Works with Read parameters from txt2img... disabled and enabled.
Textual inversion training:
+Works with new setting disabled and enabled.
+Works training, Interrupting training, changing a setting, and resuming training.
+Works with Read parameters from txt2img... disabled and enabled.

</details>

A few last things to note: 
1) seeds are saved to the log file as a float. For instance, the seed `4545` is saved as `4545.0`; and `-1` is saved as `-1.0`. 
2) I used ChatGPT to help write this. Please scrutinize the final result; but here's the ChatGPT [raw output](https://imgur.com/a/R7LNt1c) if you're curious.
3) I tried a more modular version that attempted to funnel both hypernetwork's and textual_inversion's cases into 1 function, but this proved needlessly complex.