### PR TITLE
Add support for using PyTorch nightly and local builds

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -4,7 +4,7 @@ import threading
 import time
 import importlib
 import signal
-import threading
+import re
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -12,6 +12,11 @@ from fastapi.middleware.gzip import GZipMiddleware
 from modules import import_hook, errors
 from modules.call_queue import wrap_queued_call, queue_lock, wrap_gradio_gpu_call
 from modules.paths import script_path
+
+import torch
+# Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
+if ".dev" in torch.__version__ or "+git" in torch.__version__:
+    torch.__version__ = re.search(r'[\d.]+', torch.__version__).group(0)
 
 from modules import shared, devices, sd_samplers, upscaler, extensions, localization, ui_tempdir
 import modules.codeformer_model as codeformer


### PR DESCRIPTION
- Remove duplicate `import threading` from webui.py
- Add check for torch versions containing ".dev" or "+git" and truncate it so that CodeFormer and Safetensors don't throw an exception due to being unable to parse it
- Add cumsum and narrow fixes for MPS, gets the latest nightly builds and a fork from a PyTorch MPS maintainer that has a ~25% MPS performance improvement ([kulinseth/pytorch](http://github.com/kulinseth/pytorch)) working for macOS (the default torch for macOS remains 1.12.1 because training is still broken for MPS in all newer builds)