### PR TITLE
Fix version truncation for nightly PyTorch

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -16,7 +16,7 @@ from modules.paths import script_path
 import torch
 # Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
 if ".dev" in torch.__version__ or "+git" in torch.__version__:
-    torch.__version__ = re.search(r'[\d.]+', torch.__version__).group(0)
+    torch.__version__ = re.search(r'[\d.]+[\d]', torch.__version__).group(0)
 
 from modules import shared, devices, sd_samplers, upscaler, extensions, localization, ui_tempdir
 import modules.codeformer_model as codeformer


### PR DESCRIPTION
#6402 is truncating the version correctly for local builds [but not nightly builds](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6402#issuecomment-1373537161), this fixes that.