### PR TITLE
Show upscaled resolution on hires fix

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -260,7 +260,7 @@ def calc_resolution_hires(x, y, scale):
     scaled_x = int(x * scale // 8) * 8
     scaled_y = int(y * scale // 8) * 8
     
-    return "<p style='margin: -1em 0em 0.7em 1.35em'>Upscaled resolution: "+str(scaled_x)+"x"+str(scaled_y)+"</p>"
+    return str(scaled_x)+"x"+str(scaled_y)
 
 def apply_styles(prompt, prompt_neg, style1_name, style2_name):
     prompt = shared.prompt_styles.apply_styles_to_prompt(prompt, [style1_name, style2_name])
@@ -726,7 +726,10 @@ def create_ui():
                                 hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
                             
                             with FormRow(elem_id="txt2img_hires_fix_row3"):        
-                                hr_final_resolution = gr.HTML(value=calc_resolution_hires(width.value, height.value, hr_scale.value), elem_id="txtimg_hr_finalres")
+                                hr_final_resolution = gr.Textbox(value=calc_resolution_hires(width.value, height.value, hr_scale.value), 
+                                    elem_id="txtimg_hr_finalres", 
+                                    label="Upscaled resolution",
+                                    interactive=False)
                                 hr_scale.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)
                                 width.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)
                                 height.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -255,6 +255,12 @@ def add_style(name: str, prompt: str, negative_prompt: str):
 
     return [gr.Dropdown.update(visible=True, choices=list(shared.prompt_styles.styles)) for _ in range(4)]
 
+def calc_resolution_hires(x, y, scale):
+    #final res can only be a multiple of 8
+    scaled_x = int(x * scale // 8) * 8
+    scaled_y = int(y * scale // 8) * 8
+    
+    return "<p style='margin: -1em 0em 0.7em 1.35em'>Upscaled Resolution: "+str(scaled_x)+"x"+str(scaled_y)+"</p>"
 
 def apply_styles(prompt, prompt_neg, style1_name, style2_name):
     prompt = shared.prompt_styles.apply_styles_to_prompt(prompt, [style1_name, style2_name])
@@ -718,6 +724,12 @@ def create_ui():
                                 hr_scale = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label="Upscale by", value=2.0, elem_id="txt2img_hr_scale")
                                 hr_resize_x = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize width to", value=0, elem_id="txt2img_hr_resize_x")
                                 hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
+                            
+                            with FormRow(elem_id="txt2img_hires_fix_row3"):        
+                                hr_final_resolution = gr.HTML(value=calc_resolution_hires(width.value, height.value, hr_scale.value), elem_id="txtimg_hr_finalres")
+                                hr_scale.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)
+                                width.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)
+                                height.change(fn=calc_resolution_hires, inputs=[width, height, hr_scale], outputs=hr_final_resolution, show_progress=False)
 
                     elif category == "batch":
                         if not opts.dimensions_and_batch_together:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -260,7 +260,7 @@ def calc_resolution_hires(x, y, scale):
     scaled_x = int(x * scale // 8) * 8
     scaled_y = int(y * scale // 8) * 8
     
-    return "<p style='margin: -1em 0em 0.7em 1.35em'>Upscaled Resolution: "+str(scaled_x)+"x"+str(scaled_y)+"</p>"
+    return "<p style='margin: -1em 0em 0.7em 1.35em'>Upscaled resolution: "+str(scaled_x)+"x"+str(scaled_y)+"</p>"
 
 def apply_styles(prompt, prompt_neg, style1_name, style2_name):
     prompt = shared.prompt_styles.apply_styles_to_prompt(prompt, [style1_name, style2_name])


### PR DESCRIPTION
**Issue**
The new hires fix doesn't show what the resolution will be of your final image, this is a bit inconvenient as you will need to manually calculate what the resolution will be after upscaling.

**What I added**
I added a new row to the hires fix which shows what the resolution of the image will be after upscaling, this updates whenever the "Upscale by", "Width" or "Height" sliders are changed.
![image](https://user-images.githubusercontent.com/47387831/211121069-0abc66e7-b4d0-47ba-aecc-e147dd3e9a0a.png)


