### PR TITLE
Fix quicksetting name overlapping with its controls.

### DIFF
--- a/style.css
+++ b/style.css
@@ -512,13 +512,24 @@ input[type="range"]{
     border: none;
     background: none;
     flex: unset;
-    gap: 0.5em;
+    gap: 1em;
 }
 
 #quicksettings > div > div{
     max-width: 32em;
     min-width: 24em;
     padding: 0;
+}
+
+#quicksettings > div > div > div > div > label > span {
+    position: relative;
+    margin-right: 9em;
+    margin-bottom: -1em;
+}
+
+#quicksettings > div > div > label > span {
+    position: relative;
+    margin-bottom: -1em;
 }
 
 canvas[key="mask"] {


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes #6449

**Additional notes and description of your changes**
The problem itself is probably caused by other, more general css fixes, imho some of those tricks might be obsolete, this needs verifying. For now, just a cheap fix.
Still a bit messy, checkboxes , sliders, text inputs are fine with any length, but some dropdowns are acting weird (hypernetworks), text continuing to the right in one line, tho its properties are exactly the same as on neighboring dropdown.
Also i added some space between quicksettings, they were overlapping between each other too. 

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB

**Screenshots or videos of your changes**
**Before:**
![image](https://user-images.githubusercontent.com/32306715/211160859-1d730739-dee9-4925-a22e-19d75551badf.png)
**After:**
![image](https://user-images.githubusercontent.com/32306715/211160861-045953eb-b775-435b-b2a4-fab4e668b520.png)


This is **required** for anything that touches the user interface.