### PR TITLE
Add fallback for Protocol import

### DIFF
--- a/modules/sub_quadratic_attention.py
+++ b/modules/sub_quadratic_attention.py
@@ -15,7 +15,13 @@ import torch
 from torch import Tensor
 from torch.utils.checkpoint import checkpoint
 import math
-from typing import Optional, NamedTuple, Protocol, List
+
+try:
+    from typing import Protocol
+except:
+    from typing_extensions import Protocol
+    
+from typing import Optional, NamedTuple, List
 
 def narrow_trunc(
     input: Tensor,


### PR DESCRIPTION
Solves the `ImportError: cannot import name 'Protocol' from 'typing'` error.

The `Protocol` import from typing in not available on every Python version, so this PR ensures backwards compatibility.

Version of Python that lack the `Protocol` import, can still use it via `typing_extensions `: https://pypi.org/project/typing-extensions/

The typing_extensions library is an official Python library that backports new Python functionality to previous versions: https://github.com/python/typing_extensions