### PR TITLE
Add latent upscale mode dropdown selector to img2img

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -59,7 +59,7 @@ def process_batch(p, input_dir, output_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_with_mask_orig, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
+def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, prompt_style2: str, init_img, init_img_with_mask, init_img_with_mask_orig, init_img_inpaint, init_mask_inpaint, mask_mode, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, latent_upscale_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, *args):
     is_inpaint = mode == 1
     is_batch = mode == 2
 
@@ -126,6 +126,7 @@ def img2img(mode: int, prompt: str, negative_prompt: str, prompt_style: str, pro
         mask_blur=mask_blur,
         inpainting_fill=inpainting_fill,
         resize_mode=resize_mode,
+        latent_upscale_mode=latent_upscale_mode,
         denoising_strength=denoising_strength,
         inpaint_full_res=inpaint_full_res,
         inpaint_full_res_padding=inpaint_full_res_padding,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -927,6 +927,7 @@ def create_ui():
 
                 with FormRow():
                     resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", choices=["Just resize", "Crop and resize", "Resize and fill", "Just resize (latent upscale)"], type="index", value="Just resize")
+                    latent_upscale_mode = gr.Dropdown(label='Latent method', elem_id="latent_mode", choices=list(shared.latent_upscale_modes.keys()), value=list(shared.latent_upscale_modes.keys())[0], type="index")
 
                 for category in ordered_ui_categories():
                     if category == "sampler":
@@ -1028,6 +1029,7 @@ def create_ui():
                     height,
                     width,
                     resize_mode,
+                    latent_upscale_mode,
                     inpaint_full_res,
                     inpaint_full_res_padding,
                     inpainting_mask_invert,


### PR DESCRIPTION
Add a dropdown list to allow Latent mode selection in img2img.

![image](https://user-images.githubusercontent.com/15424198/211225442-2b34e881-6da3-4d19-b09e-074aa019e371.png)

NB : The `latent_upscale_mode` selection was copied from the `processing.sample` code, and is using `shared.latent_upscale_modes` values.