### PR TITLE
Fix for "Send To img2img" Type Buttons

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -37,6 +37,8 @@ def quote(text):
 
 
 def image_from_url_text(filedata):
+    if filedata == None: return None
+
     if type(filedata) == list and len(filedata) > 0 and type(filedata[0]) == dict and filedata[0].get("is_file", False):
         filedata = filedata[0]
 
@@ -55,9 +57,10 @@ def image_from_url_text(filedata):
 
     if filedata.startswith("data:image/png;base64,"):
         filedata = filedata[len("data:image/png;base64,"):]
-
-    filedata = base64.decodebytes(filedata.encode('utf-8'))
-    image = Image.open(io.BytesIO(filedata))
+        filedata = base64.decodebytes(filedata)
+    
+    filedata = filedata.encode('utf-8')
+    image = Image.open(filedata)
     return image
 
 

--- a/update_venv_pip.bat
+++ b/update_venv_pip.bat
@@ -1,0 +1,9 @@
+@echo off
+set VENV_DIR=venv
+set PYTHON="%~dp0%VENV_DIR%\Scripts\Python.exe"
+%PYTHON% -m pip list %*
+pause
+%PYTHON% -m pip install --upgrade pip %*
+pause
+%PYTHON% -m pip list %*
+pause

--- a/update_venv_pip.bat
+++ b/update_venv_pip.bat
@@ -1,9 +1,6 @@
-@echo off
 set VENV_DIR=venv
 set PYTHON="%~dp0%VENV_DIR%\Scripts\Python.exe"
 %PYTHON% -m pip list %*
 pause
 %PYTHON% -m pip install --upgrade pip %*
-pause
-%PYTHON% -m pip list %*
 pause


### PR DESCRIPTION
Small tweak to prevent an error where sending an image to another tab via a "Send To" type button expects base64 encoded text and attempts to decode it, but fails because image may not be base64 encoded. This occurs because `image_from_url_text()` attempts a decode whether or not the `filedata` has the "data:image/png;base64," string in front, which I expect to be an identifier that the decoding is necessary. My fix performs the decoding if the base64 identifier is present, or skips it if unnecessary. While I was digging around, I also realized that clicking any "Send To" type button while no image was present in the above viewer would cause an error, since the `if filedata.startswith("data:image/png;base64,")` check would be performed on a `None` type which obviously has no `.startswith()`, so I added a small check `if filedata == None: return None` to circumvent this error. This change was made in light of the error being caused by the extension [Image Browser](https://github.com/yfszzx/stable-diffusion-webui-images-browser) as described in issue [#69](https://github.com/yfszzx/stable-diffusion-webui-images-browser/issues/69), which is where I first offered my fix.

Although "Send To" type buttons work outside of the Image Browser extension without this change, they are not negatively impacted by this change. I have done moderate testing (i.e. pushing all "Send To" type buttons in most/all tabs) on my client and have experienced no new errors or bugs as a result of these changes. I am unfamiliar with how the Web GUI encodes and sends its `filedata` between tabs, so please advise or correct me if some of my changes were made in error. 

I also created a small .bat file to manually update the python venv pip module since there was a recent pip update, and decided to suggest adding it to the repo as well.

Deployed on:
OS: Windows 10 Pro
Browser: Brave (chromium based)
Graphics Card: NVIDIA RTX 2070 8 GB