### PR TITLE
Move PR template so github could use it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,8 @@ More technical discussion about your changes go here, plus anything that a maint
 
 List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
  - OS: [e.g. Windows, Linux]
- - Browser [e.g. chrome, safari]
- - Graphics card [e.g. NVIDIA RTX 2080 8GB, AMD RX 6600 8GB]
+ - Browser: [e.g. chrome, safari]
+ - Graphics card: [e.g. NVIDIA RTX 2080 8GB, AMD RX 6600 8GB]
 
 **Screenshots or videos of your changes**
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Currently PR template is not being used automatically, multiple templates in folder are supported only via API, more info here
 https://stackoverflow.com/questions/52139192/github-pull-requests-template-not-showing . Looks like there's a selector for issue templates, but not for PR templates, and one has to manually insert this parameter into query.

**Screenshots or videos of your changes**
Template fills in automatically on PR to my master branch with this change.
![image](https://user-images.githubusercontent.com/32306715/211401117-900b95ad-dc67-46b4-ac8a-eb9168294ea2.png)
