### PR TITLE
Fix issues with testing process

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -282,6 +282,7 @@ def tests(test_dir):
 
     print(f"Launching Web UI in another process for testing with arguments: {' '.join(sys.argv[1:])}")
 
+    os.environ['COMMANDLINE_ARGS'] = ""
     with open('test/stdout.txt', "w", encoding="utf8") as stdout, open('test/stderr.txt', "w", encoding="utf8") as stderr:
         proc = subprocess.Popen([sys.executable, *sys.argv], stdout=stdout, stderr=stderr)
 

--- a/test/basic_features/txt2img_test.py
+++ b/test/basic_features/txt2img_test.py
@@ -43,6 +43,7 @@ class TestTxt2ImgWorking(unittest.TestCase):
 
     def test_txt2img_with_complex_prompt_performed(self):
         self.simple_txt2img["prompt"] = "((emphasis)), (emphasis1:1.1), [to:1], [from::2], [from:to:0.3], [alt|alt1]"
+        self.assertEqual(requests.post(self.url_txt2img, json=self.simple_txt2img).status_code, 200)
 
     def test_txt2img_not_square_image_performed(self):
         self.simple_txt2img["height"] = 128


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Found some more problems with running tests https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6192

1) From the very first addition to `launch.py` removing `--tests` argument from argv did not work, if tests were ran with .bat or .sh, exported/set environment variable `COMMANDLINE_ARGS` leaked in subprocess and recursion happened anyway. Clear it explicitly before `popen` to fix this issue.

2) I forgot to add assertion to prompt_parser test, was too focused on writing a prompt

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB