### PR TITLE
Make VENV environment variable accept absolute path instead of relative path.

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined PYTHON (set PYTHON=python)
-if not defined VENV_DIR (set VENV_DIR=venv)
+if not defined VENV_DIR (set VENV_DIR=%~dp0\venv)
 
 set ERROR_REPORTING=FALSE
 
@@ -26,7 +26,7 @@ echo Unable to create venv in directory %VENV_DIR%
 goto :show_stdout_stderr
 
 :activate_venv
-set PYTHON="%~dp0%VENV_DIR%\Scripts\Python.exe"
+set PYTHON="%VENV_DIR%\Scripts\Python.exe"
 echo venv %PYTHON%
 if [%ACCELERATE%] == ["True"] goto :accelerate
 goto :launch
@@ -35,7 +35,7 @@ goto :launch
 
 :accelerate
 echo "Checking for accelerate"
-set ACCELERATE="%~dp0%VENV_DIR%\Scripts\accelerate.exe"
+set ACCELERATE="%VENV_DIR%\Scripts\accelerate.exe"
 if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes #6608 
VENV currently can only be set as relative to webui.bat location, which seems incorrect, because [this section](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Command-Line-Arguments-and-Settings#webui-user) of wiki says otherwise.

**Additional notes and description of your changes**

While discussing issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6608 with the author, it turned out that setting absolute path for VENV results in paths like this `E:\sdwebui\E:\1\2\3\myvenv\Scripts\Python.exe` , because of %~dp0 concatenation by default. 
BUT it strucks me as **extremely weird** that in [4 months it was there](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/efa0a6483c9dfbdde6717bec202942c6036e72ff) no one used full path for different venv, so it feels like i misunderstood something, and this PR is incorrect.

Looks like there's no such possibility for .sh analogues?

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 1060 6GB
