### PR TITLE
Support loading textual inversion embeddings from safetensors files

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -9,6 +9,7 @@ import tqdm
 import html
 import datetime
 import csv
+import safetensors.torch
 
 from PIL import Image, PngImagePlugin
 
@@ -150,6 +151,8 @@ class EmbeddingDatabase:
                 name = data.get('name', name)
         elif ext in ['.BIN', '.PT']:
             data = torch.load(path, map_location="cpu")
+        elif ext in ['.SAFETENSORS']:
+            data = safetensors.torch.load_file(path, device="cpu")
         else:
             return
 


### PR DESCRIPTION
I looked into adding support for creating and training safetensors embeddings, but this proves to be tricky as safetensors' metadata format isn't advanced enough. It only supports string values, and it only supports saving metadata (not loading it). For the time being, I've only added support for loading safetensors for that reason, but I might later look at improving safetensors' metadata support and revisiting saving them :)

On that note, I also looked into supporting safetensors for hypernetworks, but that also proves to be tricky because of the simplicity of the safetensors format.