### PR TITLE
Fix prompt parser default step transformer

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -3,11 +3,6 @@ from collections import namedtuple
 from typing import List
 import lark
 
-try:
-    from modules.shared import opts
-except:
-    pass
-
 # a prompt like this: "fantasy landscape with a [mountain:lake:0.25] and [an oak:a christmas tree:0.75][ in foreground::0.6][ in background:0.25] [shoddy:masterful:0.5]"
 # will be represented with prompt_schedule like this (assuming steps=100):
 # [25, 'fantasy landscape with a mountain and an oak in foreground shoddy']
@@ -91,13 +86,7 @@ def get_learned_conditioning_prompt_schedules(prompts, steps):
                 yield args[0].value
             def __default__(self, data, children, meta):
                 for child in children:
-                    try:
-                        if opts.use_old_prompt_parser_default_step_transformer:
-                            yield from child
-                        else:
-                            yield child
-                    except:
-                        yield child
+                    yield child
         return AtStep().transform(tree)
 
     def get_schedule(prompt):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -400,7 +400,6 @@ options_templates.update(options_section(('compatibility', "Compatibility"), {
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
     "use_old_hires_fix_width_height": OptionInfo(False, "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to)."),
-    "use_old_prompt_parser_default_step_transformer": OptionInfo(False, "Use old prompt parser default step transformer. In particular, alternating words that contained emphasis were not parsed correctly. Useful to reproduce old seeds."),
 }))
 
 options_templates.update(options_section(('interrogate', "Interrogate Options"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -400,6 +400,7 @@ options_templates.update(options_section(('compatibility', "Compatibility"), {
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
     "use_old_hires_fix_width_height": OptionInfo(False, "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to)."),
+    "use_old_prompt_parser_default_step_transformer": OptionInfo(False, "Use old prompt parser default step transformer. In particular, alternating words that contained emphasis were not parsed correctly. Useful to reproduce old seeds."),
 }))
 
 options_templates.update(options_section(('interrogate', "Interrogate Options"), {


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This PR aims to fix the prompt parser's default step transformer as part of processing the prompt AST. In particular, the current implementation causes a case where if emphasis is used in the [alternating words syntax](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#alternating-words), it incorrectly parses the prompt. Ultimately, I believe this is a very simple fix.

This is an output from doctest in the current implementation for this case:
```
Failed example:
    g("[a|(b:1.1)]")
Expected:
    [[1, 'a'], [2, '(b:1.1)'], [3, 'a'], [4, '(b:1.1)'], [5, 'a'], [6, '(b:1.1)'], [7, 'a'], [8, '(b:1.1)'], [9, 'a'], [10, '(b:1.1)']]
Got:
    [[1, 'a'], [2, '('], [3, 'a'], [4, '('], [5, 'a'], [6, '('], [7, 'a'], [8, '('], [9, 'a'], [10, '(']]
```

After implementing this PR, the test passes, and all other existing tests pass (besides the one explicitly labeled `not handling this right now`).

**Additional notes and description of your changes**

I've included a compatibility option incase users (like myself) had previously used this syntax and still want to replicate old seeds. If you believe this is unnecessary feel free to remove it.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090