### PR TITLE
Expose XY Grid module to extensions

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -152,7 +152,7 @@ def basedir():
 
 scripts_data = []
 ScriptFile = namedtuple("ScriptFile", ["basedir", "filename", "path"])
-ScriptClassData = namedtuple("ScriptClassData", ["script_class", "path", "basedir"])
+ScriptClassData = namedtuple("ScriptClassData", ["script_class", "path", "basedir", "module"])
 
 
 def list_scripts(scriptdirname, extension):
@@ -206,7 +206,7 @@ def load_scripts():
 
             for key, script_class in module.__dict__.items():
                 if type(script_class) == type and issubclass(script_class, Script):
-                    scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir))
+                    scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir, module))
 
         except Exception:
             print(f"Error loading script: {scriptfile.filename}", file=sys.stderr)
@@ -241,7 +241,7 @@ class ScriptRunner:
         self.alwayson_scripts.clear()
         self.selectable_scripts.clear()
 
-        for script_class, path, basedir in scripts_data:
+        for script_class, path, basedir, script_module in scripts_data:
             script = script_class()
             script.filename = path
             script.is_txt2img = not is_img2img


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I want to add new settings to the XY grid entirely using the extension code. For my use case, this is to add a new axis option to the XY grid script for LoRA models/weights. However it is currently impossible to do this because the `axis_options` variable is contained within a dynamically compiled module, so it can't be accessed from the additional_networks extension. And the compiled module used to make the script class is discarded after the class is compiled

**Additional notes and description of your changes**

All this does is expose the compiled module containing the script class to the global `scripts` module, so extensions can modify them. Then I can do everything I need for adding the axis option in an extension instead of the webui code, like `scripts.scripts_data[0].module.axis_options.append(...)`

**Environment this was tested in**

 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3090