### PR TITLE
Allow creation of zero vectors for TI

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -92,6 +92,7 @@ titles = {
     "Weighted sum": "Result = A * (1 - M) + B * M",
     "Add difference": "Result = A + (B - C) * M",
 
+	"Initialization text": "If the number of tokens is more than the number of vectors, some may be skipped.\nLeave the textbox empty to start with zeroed out vectors",
     "Learning rate": "How fast should training go. Low values will take longer to train, high values may fail to converge (not generate accurate results) and/or may break the embedding (This has happened if you see Loss: nan in the training info textbox. If this happens, you need to manually restore your embedding from an older not-broken backup).\n\nYou can set a single numeric value, or multiple learning rates using the syntax:\n\n   rate_1:max_steps_1, rate_2:max_steps_2, ...\n\nEG:   0.005:100, 1e-3:1000, 1e-5\n\nWill train with rate of 0.005 for first 100 steps, then 1e-3 until 1000 steps, then 1e-5 for all remaining steps.",
 
     "Clip skip": "Early stopping parameter for CLIP model; 1 is stop at last layer as usual, 2 is stop at penultimate layer, etc.",

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -248,11 +248,14 @@ def create_embedding(name, num_vectors_per_token, overwrite_old, init_text='*'):
     with devices.autocast():
         cond_model([""])  # will send cond model to GPU if lowvram/medvram is active
 
-    embedded = cond_model.encode_embedding_init_text(init_text, num_vectors_per_token)
+    #cond_model expects at least some text, so we provide '*' as backup.
+    embedded = cond_model.encode_embedding_init_text(init_text or '*', num_vectors_per_token)
     vec = torch.zeros((num_vectors_per_token, embedded.shape[1]), device=devices.device)
 
-    for i in range(num_vectors_per_token):
-        vec[i] = embedded[i * int(embedded.shape[0]) // num_vectors_per_token]
+    #Only copy if we provided an init_text, otherwise keep vectors as zeros
+    if init_text:
+        for i in range(num_vectors_per_token):
+            vec[i] = embedded[i * int(embedded.shape[0]) // num_vectors_per_token]
 
     # Remove illegal characters from name.
     name = "".join( x for x in name if (x.isalnum() or x in "._- "))


### PR DESCRIPTION
**What this pull request is trying to achieve.**

This will allow the ability to create zeroed out vectors for training embeddings.
I've found that sometimes it's beneficial to start from scratch, as to not begin with an existing bias. Sometimes it learns faster, because it doesn't need to unlearn some features first.

Mind you, this is merely an option. People can still use Initial Text normally. Nothing breaks. It's just another small tool in the toolbox.
If you want to create a zero vector embedding, simply leave the textbox for the initialization text black. (Remove the asterisk.)

**Additional notes and description of your changes**
It still creates an embedding from cond_model for the shape info. ('*' is used as fallback, because it errors out without any text)
Then, afterwards, if no init_text is provided, it simply skips the copy action and leaves the embedding vectors at zero.

**Environment this was tested in**
 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 2080 8GB

**Screenshots**

![xy_grid_zero_vectors](https://user-images.githubusercontent.com/1111394/212017087-c65a1a50-ebd0-4adc-8a6c-f17c087ff96e.jpg)
_(Image kindly provided by clay)_

You can see the following observations:
Starting with zeros makes the resemblance very quickly learned and quite consistent.
Starting with 'face' keeps masculine features for a very long time, for some reason.
Starting with 'woman' will "glamorize" the picture.
Starting with '*' has less bias, but quite some diversity.

Of course, it's a matter of preference. Using '*' can be beneficial if you want more randomness.

For reference, here's a training image:
![00005-0-ART_POSES__86](https://user-images.githubusercontent.com/1111394/212018457-91c77177-e528-4fdf-8015-1c77d4a1784f.png)
