### PR TITLE
bump gradio to newest version, and fix associated error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.ckpt
 *.safetensors
 *.pth
+custom.css
 /ESRGAN/*
 /SwinIR/*
 /repositories

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1631,6 +1631,7 @@ def create_ui():
         
     with open(os.path.join(script_path, "custom.css"), "w", encoding="utf8") as file:
          file.write(css)
+         file.close()
 
     interfaces += script_callbacks.ui_tabs_callback()
     interfaces += [(settings_interface, "Settings", "settings")]

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1620,11 +1620,11 @@ def create_ui():
             continue
 
         with open(cssfile, "r", encoding="utf8") as file:
-            css += file.read()
+            css += "".join(line.strip() for line in file) + "\n"
 
     if os.path.exists(os.path.join(script_path, "user.css")):
         with open(os.path.join(script_path, "user.css"), "r", encoding="utf8") as file:
-            css += file.read()
+            css += "".join(line.strip() for line in file) + "\n"
 
     if not cmd_opts.no_progressbar_hiding:
         css += css_hide_progressbar

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1620,11 +1620,11 @@ def create_ui():
             continue
 
         with open(cssfile, "r", encoding="utf8") as file:
-            css += file.read() + "\n"
+            css += file.read()
 
     if os.path.exists(os.path.join(script_path, "user.css")):
         with open(os.path.join(script_path, "user.css"), "r", encoding="utf8") as file:
-            css += file.read() + "\n"
+            css += file.read()
 
     if not cmd_opts.no_progressbar_hiding:
         css += css_hide_progressbar

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1620,14 +1620,17 @@ def create_ui():
             continue
 
         with open(cssfile, "r", encoding="utf8") as file:
-            css += "".join(line.strip() for line in file) + "\n"
+            css += file.read() + "\n"
 
     if os.path.exists(os.path.join(script_path, "user.css")):
         with open(os.path.join(script_path, "user.css"), "r", encoding="utf8") as file:
-            css += "".join(line.strip() for line in file) + "\n"
+            css += file.read() + "\n"
 
     if not cmd_opts.no_progressbar_hiding:
         css += css_hide_progressbar
+        
+    with open(os.path.join(script_path, "custom.css"), "w", encoding="utf8") as file:
+         file.write(css)
 
     interfaces += script_callbacks.ui_tabs_callback()
     interfaces += [(settings_interface, "Settings", "settings")]
@@ -1635,7 +1638,7 @@ def create_ui():
     extensions_interface = ui_extensions.create_ui()
     interfaces += [(extensions_interface, "Extensions", "extensions")]
 
-    with gr.Blocks(css=css, analytics_enabled=False, title="Stable Diffusion") as demo:
+    with gr.Blocks(css=os.path.join(script_path, "custom.css"), analytics_enabled=False, title="Stable Diffusion") as demo:
         with gr.Row(elem_id="quicksettings"):
             for i, k, item in sorted(quicksettings_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
                 component = create_setting_component(k, is_quicksettings=True)

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -3,7 +3,7 @@ transformers==4.19.2
 accelerate==0.12.0
 basicsr==1.4.2
 gfpgan==1.3.8
-gradio==3.15.0
+gradio
 numpy==1.23.3
 Pillow==9.4.0
 realesrgan==0.3.0


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
This PR aims to bump gradio to the newest version, but just bumping it leads to "File name too long" error, so I've made it save the current css configuration to `custom.css` and load that file instead

**Additional notes and description of your changes**
~~On Kaggle (I don't have a good machine to test on), I can't reach the link (`No interface is running right now`), but since links are displayed, I think it should be working well~~
nvm, tested in Colab, it works

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Linux (Kaggle Notebook)
 - Browser: chrome
 - Graphics card: Double NVIDIA T4 GPUs

**Screenshots or videos of your changes**