### PR TITLE
fix progress bar behavior for "Prompts from file or textbox" script

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -146,7 +146,7 @@ class Script(scripts.Script):
             else:
                 args = {"prompt": line}
 
-            n_iter = args.get("n_iter", 1)
+            n_iter = args.get("n_iter", p.n_iter)
             if n_iter != 1:
                 job_count += n_iter
             else:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fix "Prompts from file or textbox" script calculating progress incorrectly when "Batch count" value is bigger than 1.

**Bug in terminal:**
Shows: `Will process N lines in N jobs.`
Should be: `Will process N lines in (N * batch_count) jobs.`

**Bug in UI:**
Progress bar goes to 100% after generating N images, and stays there during generation of the rest of (N * batch_count)

**Environment this was tested in**
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3060 Laptop 6GB 