### PR TITLE
Exclude clip index from merge

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -326,8 +326,14 @@ def run_modelmerger(primary_model_name, secondary_model_name, tertiary_model_nam
 
     print("Merging...")
 
+    chckpoint_dict_skip_on_merge = ["cond_stage_model.transformer.text_model.embeddings.position_ids"]
+
     for key in tqdm.tqdm(theta_0.keys()):
         if 'model' in key and key in theta_1:
+
+            if key in chckpoint_dict_skip_on_merge:
+                continue
+
             a = theta_0[key]
             b = theta_1[key]
 
@@ -352,6 +358,10 @@ def run_modelmerger(primary_model_name, secondary_model_name, tertiary_model_nam
     # I believe this part should be discarded, but I'll leave it for now until I am sure
     for key in theta_1.keys():
         if 'model' in key and key not in theta_0:
+
+            if key in chckpoint_dict_skip_on_merge:
+                continue
+
             theta_0[key] = theta_1[key]
             if save_as_half:
                 theta_0[key] = theta_0[key].half()


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Skip specific key in add-difference merge to avoid un-intended effect.

Terget key of model is index, and it normaly torch.int64 which changed to torch.float32 by add-difference merge.
It causes confusion of treatment of embeddings from CLIP, and result "ignore first token" or/and "weakning token" in several place which have troube in coresponding index.
Target key is `cond_stage_model.transformer.text_model.embeddings.position_ids`

**Additional notes and description of your changes**

This change is proposed to stop re-generate this un-intended effect.

There are some method to fix this problem on already existing models.
- [arenatemp/stable-diffusion-webui-model-toolkit](https://github.com/arenatemp/stable-diffusion-webui-model-toolkit)
  - "option Fix broken CLIP position IDs"
- [bbc-mc/sdweb-merge-block-weighted-gui](https://github.com/bbc-mc/sdweb-merge-block-weighted-gui)
  - "Skip/Reset CLIP position_ids key value"

And Reproduction steps is below, there is problem in model `test_O2`.
```
test_O1 = __SD15__ + __WD13__ + __TRI__, 1.0  # Add difference 1.0, StableDiffusion1.5, WaifuDiffusion1.3, trinart_characters_it4_v1
test_O2 = __DERRIDA__ + __O1__, 0.1  # Weighted Sum 0.1, trinart_derrida_characters_v2_final.ckpt, and output of above
# before this process, I had checked all source models have correct `position_ids`
```

**Environment this was tested in**

 - OS:Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 1060 6GB, NVIDIA RTX 3060 12GB

**Screenshots or videos of your changes**

Show sample before/after this change.
**Before** this change, first token `smile`  is ignored, and in **After** token is correctly recognized and smile come back.
Generation info below,

```
smile woman sleepy
Steps: 20, Sampler: Euler a, CFG scale: 7.5, Seed: 1538003301, Face restoration: CodeFormer, Size: 512x512
```
![xy_grid-0000-20230114231418_e3b0c442_20-7 5_1538003301](https://user-images.githubusercontent.com/2047286/212476688-1a2863e4-92c1-4a4b-bcd9-e6fe66b57520.png)
