### PR TITLE
Add server start time to state info

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -168,6 +168,7 @@ class State:
     textinfo = None
     time_start = None
     need_restart = False
+    server_start = None
 
     def skip(self):
         self.skipped = True
@@ -241,6 +242,7 @@ class State:
 
 
 state = State()
+state.server_start = time.time()
 
 artist_db = modules.artists.ArtistsDatabase(os.path.join(script_path, 'artists.csv'))
 


### PR DESCRIPTION
small pr to add server start time to an existing `shared.state` object  
(feels like a better place than a new global variable plus this makes it automatically available to progress API)
