### PR TITLE
Custom Diffusion implementation

### DIFF
--- a/modules/pluggable.py
+++ b/modules/pluggable.py
@@ -1,0 +1,52 @@
+import glob
+import os
+from modules import sd_models, shared
+import torch
+from safetensors.torch import load_file
+
+model_name = None
+backup_weights = {}
+
+def list_pluggables(path):
+    res = {}
+    for filename in sorted(glob.iglob(os.path.join(path, '**/*.safetensors'), recursive=True)):
+        name = os.path.splitext(os.path.basename(filename))[0]
+        # Prevent a hypothetical "None.pt" from being listed.
+        if name != "None":
+            res[name + f"({sd_models.model_hash(filename)})"] = filename
+    return res
+
+def load_pluggable(filename):
+    global model_name, backup_weights
+    if filename == 'None':
+        restore_weights()
+        return
+    print('loading:', filename)
+    path = shared.pluggables[filename]
+    if model_name != shared.opts.sd_model_checkpoint:
+        backup_weights = {}
+        model_name = shared.opts.sd_model_checkpoint
+    pluggable = load_file(path, device='cuda')
+    for k, v in shared.sd_model.model.named_parameters():
+        if k in pluggable:
+            if k not in backup_weights:
+                backup_weights[k] = v.clone().detach()
+            with torch.no_grad():
+                v[:] = pluggable[k]
+            print(f'plugged in from {filename} {k}')
+        elif k in backup_weights:
+            with torch.no_grad():
+                v[:] = backup_weights[k]
+            del backup_weights[k]
+            print(f'restored {k}')
+
+
+def restore_weights():
+    global backup_weights
+    if model_name == shared.opts.sd_model_checkpoint:
+        for k, v in shared.sd_model.model.named_parameters():
+            if k in backup_weights:
+                with torch.no_grad():
+                    v[:] = backup_weights[k]
+                print(f'restored {k}')
+    backup_weights = {}

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1249,6 +1249,7 @@ def create_ui():
 
                     with FormRow():
                         embedding_learn_rate = gr.Textbox(label='Embedding Learning rate', placeholder="Embedding Learning rate", value="0.005", elem_id="train_embedding_learn_rate")
+                        kv_learn_rate = gr.Textbox(label='KV Learning rate', placeholder="KV Learning rate", value="1e-5", elem_id="train_kv_learn_rate")
                         hypernetwork_learn_rate = gr.Textbox(label='Hypernetwork Learning rate', placeholder="Hypernetwork Learning rate", value="0.00001", elem_id="train_hypernetwork_learn_rate")
                     
                     with FormRow():
@@ -1388,6 +1389,7 @@ def create_ui():
                 template_file,
                 save_image_with_stored_embedding,
                 preview_from_txt2img,
+                kv_learn_rate,
                 *txt2img_preview_params,
             ],
             outputs=[

--- a/webui.py
+++ b/webui.py
@@ -83,6 +83,7 @@ def initialize():
     shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("sd_hypernetwork", wrap_queued_call(lambda: shared.reload_hypernetworks()))
     shared.opts.onchange("sd_hypernetwork_strength", modules.hypernetworks.hypernetwork.apply_strength)
+    shared.opts.onchange("sd_pluggable", wrap_queued_call(lambda: shared.reload_pluggables()))
     shared.opts.onchange("temp_dir", ui_tempdir.on_tmpdir_changed)
 
     if cmd_opts.tls_keyfile is not None and cmd_opts.tls_keyfile is not None:


### PR DESCRIPTION
A very rudimentary Custom Diffusion implementation

## What is Custom Diffusion

[Custom Diffusion](https://www.cs.cmu.edu/~custom-diffusion/) is, in short, finetuning-lite with TI. Instead of tuning the whole model, only the K and V matrices of the cross-attention blocks are tuned simultaneously with token embedding(s). It has similar speed and memory requirements to TI and supposedly gives better results in less steps.

## How to use this
**(WIP, will sort out the UI/UX later)**

### Training
Currently the Textual Inversion training UI is hijacked for this. Just train as you would a normal TI embedding. Under the training log directory, alongside with `name-steps.pt` you should also see `name-steps.kv.safetensors`, which contain KV weights (~50MB at half precision uncompressed).

The original study used learning_rate=8e-5 at batch_size=8, but in my tests I found lr=1e-4 suits better for my dataset (batch_size=1). 

### Using trained weights
Place the `.safetensors` files under `models/pluggables` (`--pluggable-dir`). Select them in the `Stable Diffusion/Pluggable weights` options in the settings tab. The trained weights should be swapped in and now you can use them to generate images. Use the token embedding like a normal TI embedding.

Although the study claims that using a tuned token gives a better result, in my limited tests dropping the token or replacing it with the untrained version doesn't affect the generated image too much.

Anyways, this area is under-explored, and I encourage you to try out different settings and datasets.

## Todo (roughly ordered by priority)
- [ ] UI/UX
- [ ] More testing
- [x] Separate lr for embedding and model weights
- [ ] Let users choose what weights to finetune
- [ ] Regularization
- [ ] Multi-concept training