### PR TITLE
Fix Approx NN not working on torch devices other than CUDA

### DIFF
--- a/modules/sd_vae_approx.py
+++ b/modules/sd_vae_approx.py
@@ -36,7 +36,7 @@ def model():
 
     if sd_vae_approx_model is None:
         sd_vae_approx_model = VAEApprox()
-        sd_vae_approx_model.load_state_dict(torch.load(os.path.join(paths.models_path, "VAE-approx", "model.pt")))
+        sd_vae_approx_model.load_state_dict(torch.load(os.path.join(paths.models_path, "VAE-approx", "model.pt"), map_location='cpu' if devices.device.type != 'cuda' else None))
         sd_vae_approx_model.eval()
         sd_vae_approx_model.to(devices.device, devices.dtype)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Currently trying to use "Approx NN" with CUDA unavailable results in an error:
`RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`

This will fix that error by setting `map_location` to `'cpu'` if CUDA is not being used.

**Environment this was tested in**

 - OS: macOS
 - Browser: Safari
 - Graphics card: M1 Max 64 GB