### PR TITLE
increase block size

### DIFF
--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -34,9 +34,10 @@ def cache(subsection):
 
 def calculate_sha256(filename):
     hash_sha256 = hashlib.sha256()
+    blksize = 1024 * 1024
 
     with open(filename, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
+        for chunk in iter(lambda: f.read(blksize), b""):
             hash_sha256.update(chunk)
 
     return hash_sha256.hexdigest()


### PR DESCRIPTION
new sha256 hash calculation can be extremely slow in some cases, especially if model is present over non-standard filesystem.

worst-case is disk mounted over network loopback (shared between multiple vms) where new hash calculation takes ~100sec for a 4gb model.

analysis shows that 99% of time is spent in inner loop and actual disk read i/o is very low.

i've experimented with different methods such as `read`, `mmap.read`, `io.open`, `readinto`, etc.  
and existing method is actually fastest, but it does need a much larger block size to saturate disk reads.

this increases hash calculation performance in some cases **10x** and has no negative effects overall.

closes #6738
