### PR TITLE
Fix unexpected behavior when show_progress_every_n_steps is set to -1

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -228,7 +228,7 @@ class State:
         if not parallel_processing_allowed:
             return
 
-        if self.sampling_step - self.current_image_sampling_step >= opts.show_progress_every_n_steps and opts.live_previews_enable:
+        if self.sampling_step - self.current_image_sampling_step >= opts.show_progress_every_n_steps and opts.live_previews_enable and opts.show_progress_every_n_steps != -1:
             self.do_set_current_image()
 
     def do_set_current_image(self):


### PR DESCRIPTION
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ce13ced5dc5ce06634b3313bbfed6d479f8a4538/modules/shared.py#L231

When `show_progress_every_n_steps` is set to -1 and `live_previews_enable` is set to True, the conditional statement in the above code evaluates to true, resulting in previews being generated after every sampling step. 
However, when `show_progress_every_n_steps` is set to -1, the expected behavior is for previews to only be generated after the completion of a batch.

This bug was introduced in commit https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/f94a215abed85b34ae978853078812801d3e7738. It can be easily reproduced by disabling the lowvram and medvram startup parameters, setting `show_progress_every_n_steps` to -1 and `live_previews_enable` to True, then generating an image. In this case, a preview image is generated after every sampling step, instead of the expected behavior of "show after completion of batch.