### PR TITLE
Escape special symbols in paths

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined PYTHON (set PYTHON=python)
-if not defined VENV_DIR (set VENV_DIR=%~dp0%venv)
+if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
 
 set ERROR_REPORTING=FALSE
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Resolve issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6760

**Additional notes and description of your changes**

&()[]{}^=;!'+,`~<|> some symbols from this set are allowed to be in path and they break parser on the fourth line. Worked before, because %~dp0 was quoted.
Didn't want to do it, but what's been broken by me needs to be fixed. To my understanding this cannot break anything, because VENV_DIR remains unchanged, but please verify.

**Environment this was tested in**

Tested with path provided by the author of the issue, as well as usual one.