### PR TITLE
Make the live preview background transparent

### DIFF
--- a/style.css
+++ b/style.css
@@ -333,7 +333,7 @@ input[type="range"]{
 .livePreview{
     position: absolute;
     z-index: 300;
-    background-color: white;
+    background-color: transparent;
     margin: -4px;
 }
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I noticed after recent changes for live preview that the background is white. To me this was too bright when using the app in dark mode. This change makes the background transparent instead. 

**Additional notes and description of your changes**

This is a one-line change to the CSS class involved. My knowledge of CSS is shallow, but this seems like a decent change.

**Environment this was tested in**

This was tested on Windows 11 w/ RTX 2080 Ti GPU on Chrome using dark and light themes.

**Screenshots or videos of your changes**

### Dark Mode Before & After
![before-dark](https://user-images.githubusercontent.com/825994/212565724-378230ab-fd66-466d-8413-414c90921e77.png)
![after-dark](https://user-images.githubusercontent.com/825994/212565736-c9fedd2f-1447-4b7a-a9d5-86f107bf5baf.png)



### Light Mode Before & After
![before-light](https://user-images.githubusercontent.com/825994/212565740-921ef0f1-ae9b-42f0-9848-558bcc35078a.png)
![after-light](https://user-images.githubusercontent.com/825994/212565742-c6452026-64bb-4ebb-851e-5e55f782f421.png)

