### PR TITLE
Make XY grid cancellation much faster

### DIFF
--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -406,6 +406,9 @@ class Script(scripts.Script):
         grid_infotext = [None]
 
         def cell(x, y):
+            if shared.state.interrupted:
+                return Processed(p, [], p.seed, "")
+
             pc = copy(p)
             x_opt.apply(pc, x, xs)
             y_opt.apply(pc, y, ys)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

The XY Grid will attempt to go through the rest of the axis options if it's interrupted halfway through. If the axis options includes something like a model switch, this makes cancelling really slow.

So this PR skips all the processing if an interruption is detected

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090