### PR TITLE
Fix unable to find Real-ESRGAN model info error (AttributeError: 'NoneType' object has no attribute 'data_path')

### DIFF
--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -25,6 +25,9 @@ class UpscalerRealESRGAN(Upscaler):
             scalers = self.load_models(path)
             for scaler in scalers:
                 if scaler.name in opts.realesrgan_enabled_models:
+                    local_data_path = load_file_from_url(url=scaler.data_path, model_dir=self.model_path)
+                    if os.path.exists(local_data_path):
+                        scaler.data_path = local_data_path
                     self.scalers.append(scaler)
 
         except Exception:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
- Fix unable to find model info error with Real-ESRGAN related model.
- When upscale with Real-ESRGAN related model, the following error occurs. (Even though the models already exist in the RealESRGAN folder)

**Reproducing detail:**
1. Extras > Scale by > Resize > set value as 8
2. Upscaler1 choose Real-ESRGAN 4x+ or Real-ESRGAN 4x+anim6B

**Error Message:**
```
Unable to find model info: https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth
Error completing request
Arguments: (0, 0, <PIL.Image.Image image mode=RGB size=512x512 at 0x2B0CA4D6260>, None, '', '', True, 0, 0, 0, 8, 512, 512, True, 4, 0, 1, False) {}
Traceback (most recent call last):
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\call_queue.py", line 56, in f
    res = list(func(*args, **kwargs))
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\call_queue.py", line 37, in f
    res = func(*args, **kwargs)
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\extras.py", line 197, in run_extras
    image, info = op(image, info)
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\extras.py", line 155, in run_upscalers_blend
    res = upscale(image, *upscale_args)
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\extras.py", line 123, in upscale
    res = upscaler.scaler.upscale(image, resize, upscaler.data_path)
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\upscaler.py", line 64, in upscale
    img = self.do_upscale(img, selected_model)
  File "D:\WorkSpace\WS_SHIFTUP\stable-diffusion-webui\modules\realesrgan_model.py", line 41, in do_upscale
    if not os.path.exists(info.data_path):
AttributeError: 'NoneType' object has no attribute 'data_path'
```

**Similar Issue:** 
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5170


**Additional notes and description of your changes**
- I added the logic that, when load real-esrgan model, if the initial upscaler's data_path is url and corresponding model is already in the local folder, then update the upscaler's data_path to local data path.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3060 12GB
