### PR TITLE
Saves Extra Generation Parameters to params.txt

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -538,10 +538,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     if p.scripts is not None:
         p.scripts.process(p)
 
-    with open(os.path.join(shared.script_path, "params.txt"), "w", encoding="utf8") as file:
-        processed = Processed(p, [], p.seed, "")
-        file.write(processed.infotext(p, 0))
-
     infotexts = []
     output_images = []
 
@@ -571,6 +567,10 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     with torch.no_grad(), p.sd_model.ema_scope():
         with devices.autocast():
             p.init(p.all_prompts, p.all_seeds, p.all_subseeds)
+
+        with open(os.path.join(shared.script_path, "params.txt"), "w", encoding="utf8") as file:
+            processed = Processed(p, [], p.seed, "")
+            file.write(processed.infotext(p, 0))
 
         if state.job_count == -1:
             state.job_count = p.n_iter


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

Currently params.txt does not save any of the extra generation parameters such as `Hires upscale`, `Hires steps` , etc..
This is because the extra generation parameters are set when we call a custom init method on `StableDiffusionProcessingTxt2Img`.
When we save the actual image, the extra generation parameters are saved properly as the init method has been called since the photo is only saved when it is done processing. These parameters can be restored fine.

Loading from a saved image the extra generation parameters load fine, but loading from params.txt they are not present so params like `Hires Steps` are not set.

Moving it to after the init method is called fixes this, and we can restore all the parameters from params.txt without any additional changes.

## Additional notes and description of your changes

Moved the saving of params.txt to the after the init() method call.

To note this also would occur after the init method of  `StableDiffusionProcessingTxt2Img`, however it's init method does not modify the extra generation parameters at all, so there is no effect. Normally anyways the saving for the image with the parameters embedded happens after the init method calls so there are no issues there.

## Change to params.txt
Adds `Hires upscale`, `Hires steps` and `Hires upscaler` to params.txt when using txt2img

girl with an artist's beret, determined, blue eyes, desert scene, computer monitors, heavy makeup, by Alphonse Mucha and Charlie Bowater, ((eyeshadow)), (coquettish), detailed, intricate
Negative prompt: ugly, fat, obese, chubby, (((deformed))), [blurry], bad anatomy, disfigured, poorly drawn face, mutation, mutated, (extra_limb), (ugly), (poorly drawn hands), messy drawings
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 10, Seed: 3104584468, Face restoration: CodeFormer, Size: 384x576, Model hash: 0f7f264114, Denoising strength: 0.7, **Hires upscale: 2, Hires steps: 30, Hires upscaler: Latent**

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080