### PR TITLE
Mutually restrict hrfix and PLMS sampler in txt2img tab

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -63,6 +63,9 @@ if cmd_opts.ngrok is not None:
 def gr_show(visible=True):
     return {"visible": visible, "__type__": "update"}
 
+def gr_change_sampler_choices(new_choices):
+    return {"choices": [x.name for x in new_choices], "__type__": "update"}
+
 
 sample_img2img = "assets/stable-samples/img2img/sketch-mountains-input.jpg"
 sample_img2img = sample_img2img if os.path.exists(sample_img2img) else None
@@ -720,9 +723,16 @@ def create_ui():
             )
 
             enable_hr.change(
-                fn=lambda x: gr_show(x),
+                fn=lambda x: (gr_show(x), gr_change_sampler_choices(samplers_for_img2img if x else samplers)),
                 inputs=[enable_hr],
-                outputs=[hr_options],
+                outputs=[hr_options, sampler_index],
+                show_progress = False,
+            )
+
+            sampler_index.change(
+                fn=lambda x: gr_show(samplers[x].name != "PLMS"),
+                inputs=[sampler_index],
+                outputs=[enable_hr],
                 show_progress = False,
             )
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

PLMS is not capable to sample for img2img
Fix #795 Fix #1048 Fix #1468 Fix #1592 Fix #2521 Fix #2871

**Additional notes and description of your changes**

Does not account for all samplers hidden, or all but PLMS, but that already breaks UI in a way so that you need to edit config.json
Also does not account for API.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome

**Screenshots or videos of your changes**
![GIF 18 01 2023 0-11-36](https://user-images.githubusercontent.com/32306715/213013581-89ea82e5-4bc4-49c4-be97-88479c73f41a.gif)

