### PR TITLE
Filter UserWarnings generated in upstream libraries

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -41,6 +41,10 @@ from modules.textual_inversion import textual_inversion
 import modules.hypernetworks.ui
 from modules.generation_parameters_copypaste import image_from_url_text
 
+# filter user-warnings as many are generated in upstream libraries and cannot be addressed in webui
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
+
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
 mimetypes.add_type('application/javascript', '.js')


### PR DESCRIPTION
user-warnings are filtered by default due to init code in a built-in extension **LDSR**  
(`extensions-builtin/LDSR/ldsr_model_arch.py`)    

but if **LDSR** extension is disabled, tons of warnings start popping up  

i took a look at the few and most are not in this repo, but require fixes upstream  
thus this pr to filter warnings in the main `ui.py`, same if LDSR is enabled  

closes #6561

example of warnings thrown if they show up if not filtered out:  

```log
modules/safe.py:30: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
site-packages/gradio/components.py:2263: UserWarning: The `bytes` type is deprecated and may not work as expected. Please use `binary` instead.
site-packages/gradio/deprecation.py:43: UserWarning: You have unused kwarg parameters in JSON, please remove them: {'lines': 61}
site-packages/gradio/utils.py:805: UserWarning: Expected 1 arguments for function <function update_generation_info at 0x7f43945ef910>, received 2.
site-packages/gradio/utils.py:813: UserWarning: Expected maximum 1 arguments for function <function update_generation_info at 0x7f43945ef910>, received 2.
site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at ../aten/src/ATen/native/TensorShape.cpp:3453.)
site-packages/torch/utils/checkpoint.py:31: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=None`.
```
