### PR TITLE
Process interrogation on all img2img subtabs

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -109,6 +109,13 @@ function get_extras_tab_index(){
     return [get_tab_index('mode_extras'), get_tab_index('extras_resize_mode'), ...args]
 }
 
+function get_img2img_tab_index() {
+    let res = args_to_array(arguments)
+    res.splice(-2)
+    res[0] = get_tab_index('mode_img2img')
+    return res
+}
+
 function create_submit_args(args){
     res = []
     for(var i=0;i<args.length;i++){


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fix #835 #1434 #1635 #3010 #3480 #4380 #5564
Select an image for interrogation based on active tab. 
Simple batch interrogation where created captions are saved as .txt files with the same names as images. If the output directory is not specified, they will be created in the input dir.

**Additional notes and description of your changes**

I did not validate non-existing paths or missing images, the exception is self-explanatory.
Had to insert `dummy_component` to `outputs` to avoid the gradio bug, see https://github.com/gradio-app/gradio/issues/2815 It should be removed as soon as the bug is fixed.

Todo: interrupt interrogation and show progress, especially useful for batch processing. But that's not that important bcs most people do not interrogate on CPUs like me.


**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Chrome 
 - Graphics card: Nvidia gtx 1060 6gb