### PR TITLE
fixing error using lspci on macOsX

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -165,7 +165,7 @@ else
     printf "\n%s\n" "${delimiter}"
     printf "Launching launch.py..."
     printf "\n%s\n" "${delimiter}"
-    gpu_info=$(lspci | grep VGA)
+    gpu_info=$(lspci 2>/dev/null | grep VGA)
     if echo "$gpu_info" | grep -q "AMD"
     then
         if [[ -z "${TORCH_COMMAND}" ]]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

redirects stderr to /dev/null running `lspci` command in case it does not exists.

**Additional notes and description of changes**

webui.sh script is using `lspci` command to check VGA cards but it is not available on Mac OS X so it is displaying an error on console `./webui.sh: line 168: lspci: command not found`
The error is not critical (falls out to expected behavior anyways) but it draws attention for troubleshooting if there are other errors around. Redirecting stderr to /dev/null we avoid the error on console.

**Environment this was tested in**

 - OS: Mac OS X
 - Browser: Firefox
 - Graphics card: Apple M1 Pro

**Screenshots or videos of changes**
Error:
<img width="581" alt="command not found" src="https://user-images.githubusercontent.com/8185092/213309742-07809ba8-e82a-483a-b40a-271d598b6c04.png">

No error:
<img width="586" alt="no_error" src="https://user-images.githubusercontent.com/8185092/213310366-6b9dcf91-7f21-48ba-8436-1639018faa7e.png">
