### PR TITLE
Check model name values are set before merging

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -287,10 +287,19 @@ def run_modelmerger(primary_model_name, secondary_model_name, tertiary_model_nam
     def add_difference(theta0, theta1_2_diff, alpha):
         return theta0 + (alpha * theta1_2_diff)
 
+    if not primary_model_name:
+        shared.state.textinfo = "Failed: Merging requires a primary model."
+        shared.state.end()
+        return ["Failed: Merging requires a primary model."] + [gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)]
+
     primary_model_info = sd_models.checkpoints_list[primary_model_name]
+
+    if not secondary_model_name:
+        shared.state.textinfo = "Failed: Merging requires a secondary model."
+        shared.state.end()
+        return ["Failed: Merging requires a secondary model."] + [gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)]
+    
     secondary_model_info = sd_models.checkpoints_list[secondary_model_name]
-    tertiary_model_info = sd_models.checkpoints_list.get(tertiary_model_name, None)
-    result_is_inpainting_model = False
 
     theta_funcs = {
         "Weighted sum": (None, weighted_sum),
@@ -298,10 +307,15 @@ def run_modelmerger(primary_model_name, secondary_model_name, tertiary_model_nam
     }
     theta_func1, theta_func2 = theta_funcs[interp_method]
 
-    if theta_func1 and not tertiary_model_info:
+    tertiary_model_info = None
+    if theta_func1 and not tertiary_model_name:
         shared.state.textinfo = "Failed: Interpolation method requires a tertiary model."
         shared.state.end()
-        return ["Failed: Interpolation method requires a tertiary model."] + [gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)]
+        return [f"Failed: Interpolation method ({interp_method}) requires a tertiary model."] + [gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)]
+    else:
+        tertiary_model_info = sd_models.checkpoints_list.get(tertiary_model_name, None)
+
+    result_is_inpainting_model = False
 
     shared.state.textinfo = f"Loading {secondary_model_info.filename}..."
     print(f"Loading {secondary_model_info.filename}...")

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -307,13 +307,12 @@ def run_modelmerger(primary_model_name, secondary_model_name, tertiary_model_nam
     }
     theta_func1, theta_func2 = theta_funcs[interp_method]
 
-    tertiary_model_info = None
     if theta_func1 and not tertiary_model_name:
         shared.state.textinfo = "Failed: Interpolation method requires a tertiary model."
         shared.state.end()
         return [f"Failed: Interpolation method ({interp_method}) requires a tertiary model."] + [gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)]
-    else:
-        tertiary_model_info = sd_models.checkpoints_list.get(tertiary_model_name, None)
+    
+    tertiary_model_info = sd_models.checkpoints_list[tertiary_model_name] if theta_func1 else None
 
     result_is_inpainting_model = False
 


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

`run_modelmerger` receives an empty list for the model name parameters if there is no value set for them in the UI; these lists are unhashable. We are always looking up the third model in the checkpoints list dict, even when it is not necessary which is where an unhashable type: 'list' error occurs.
Thus when we are doing weighted sum and not specifying the third model (as is not necessary to do that for weighted sum) it causes the unhashable list error as mentioned in #6878 .

Fixing this allows us to successfully merge again and closes #6878.

## Additional notes and description of your changes

To fix this we could just check only lookup the tertiary model if the theta_func1 is set, so we are not unnecessarily doing it.

I do that, and I also check if the other model_name variables are also set, and if not providing error messages for them.

Previously if there were no models selected or only the primary model selected, it would not inform of you the error. We have a error message for the tertiary model so I believe adding ones for the primary and secondary makes sense, and would help a bit.

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080

## Error Messages

![Screenshot (254)](https://user-images.githubusercontent.com/23466035/213326935-76e76481-3645-4a99-a341-1b5dd055f380.png)
![Screenshot (255)](https://user-images.githubusercontent.com/23466035/213326925-2ecbecad-9112-4761-b1ab-9c61312c27ca.png)
![Screenshot (256)](https://user-images.githubusercontent.com/23466035/213326933-9a8d206b-5633-4dc6-bc3c-ae0d23077a6a.png)