### PR TITLE
internal progress relative path

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -160,7 +160,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     }
 
     var fun = function(id_task, id_live_preview){
-        request("/internal/progress", {"id_task": id_task, "id_live_preview": id_live_preview}, function(res){
+        request("./internal/progress", {"id_task": id_task, "id_live_preview": id_live_preview}, function(res){
             if(res.completed){
                 removeProgressBar()
                 return


### PR DESCRIPTION
When I started `webui` through `nginx proxy`, I found that `internal/progress` was not working.
> page url 192.168.0.100/ai/
> request to 192.168.0.100/internal/progress => 404 error
```
# nginx conf
location /ai/ {
	proxy_pass http://192.168.0.15:8080/;
}
```

Relative path fix it.

> page url 192.168.0.100/ai/
> request to 192.168.0.100/ai/internal/progress => 200