### PR TITLE
AMD environment variable and experimental APU support (Renoir)

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -110,7 +110,7 @@ case "$gpu_info" in
     ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
         printf "\n%s\n" "${delimiter}"
-        printf "Make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
+        printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
         printf "\n%s\n" "${delimiter}"
     ;;
     *) 

--- a/webui.sh
+++ b/webui.sh
@@ -105,7 +105,7 @@ fi
 
 # Check prerequisites
 gpu_info=$(lspci 2>/dev/null | grep VGA)
-if echo "$gpu_info" | grep -q "Navi"
+if echo "$gpu_info" | grep -qE "Navi (1|2)"
 then
     export HSA_OVERRIDE_GFX_VERSION=10.3.0
 fi

--- a/webui.sh
+++ b/webui.sh
@@ -109,6 +109,9 @@ case "$gpu_info" in
     *"Navi 1"*|*"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
     ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
+        printf "\n%s\n" "${delimiter}"
+		printf "Make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
+		printf "\n%s\n" "${delimiter}"
     ;;
     *) 
     ;;

--- a/webui.sh
+++ b/webui.sh
@@ -104,6 +104,12 @@ then
 fi
 
 # Check prerequisites
+gpu_info=$(lspci 2>/dev/null | grep VGA)
+if echo "$gpu_info" | grep -q "Navi"
+then
+    export HSA_OVERRIDE_GFX_VERSION=10.3.0
+fi
+
 for preq in "${GIT}" "${python_cmd}"
 do
     if ! hash "${preq}" &>/dev/null
@@ -165,20 +171,9 @@ else
     printf "\n%s\n" "${delimiter}"
     printf "Launching launch.py..."
     printf "\n%s\n" "${delimiter}"
-    gpu_info=$(lspci 2>/dev/null | grep VGA)
-    if echo "$gpu_info" | grep -q "AMD"
+    if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
     then
-        if [[ -z "${TORCH_COMMAND}" ]]
-        then	    
-            export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
-        fi
-        if echo "$gpu_info" | grep -q "Navi"
-        then
-            HSA_OVERRIDE_GFX_VERSION=10.3.0 exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
-        else
-            exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
-        fi
-    else
-        exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
-    fi
+        export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
+    fi        
+    exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
 fi

--- a/webui.sh
+++ b/webui.sh
@@ -110,8 +110,8 @@ case "$gpu_info" in
     ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
         printf "\n%s\n" "${delimiter}"
-		printf "Make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
-		printf "\n%s\n" "${delimiter}"
+        printf "Make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
+        printf "\n%s\n" "${delimiter}"
     ;;
     *) 
     ;;

--- a/webui.sh
+++ b/webui.sh
@@ -172,7 +172,12 @@ else
         then	    
             export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
         fi
-        HSA_OVERRIDE_GFX_VERSION=10.3.0 exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        if echo "$gpu_info" | grep -q "Navi"
+        then
+            HSA_OVERRIDE_GFX_VERSION=10.3.0 exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        else
+            exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        fi
     else
         exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
     fi

--- a/webui.sh
+++ b/webui.sh
@@ -105,10 +105,14 @@ fi
 
 # Check prerequisites
 gpu_info=$(lspci 2>/dev/null | grep VGA)
-if echo "$gpu_info" | grep -qE "Navi (1|2)"
-then
-    export HSA_OVERRIDE_GFX_VERSION=10.3.0
-fi
+case "$gpu_info" in
+    *"Navi 1"*|*"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
+    ;;
+    *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
+    ;;
+    *) 
+    ;;
+esac
 if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
 then
     export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"

--- a/webui.sh
+++ b/webui.sh
@@ -109,6 +109,10 @@ if echo "$gpu_info" | grep -q "Navi"
 then
     export HSA_OVERRIDE_GFX_VERSION=10.3.0
 fi
+if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
+then
+    export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
+fi  
 
 for preq in "${GIT}" "${python_cmd}"
 do
@@ -170,10 +174,6 @@ then
 else
     printf "\n%s\n" "${delimiter}"
     printf "Launching launch.py..."
-    printf "\n%s\n" "${delimiter}"
-    if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
-    then
-        export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
-    fi        
+    printf "\n%s\n" "${delimiter}"      
     exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
 fi


### PR DESCRIPTION
Setting HSA_OVERRIDE_GFX_VERSION=10.3.0 for all AMD cards seems to break compatibility for polaris and vega cards so it should just be enabled on Navi.

This change also adds the GFX version 9.0.0 in order to use Renoir GPUs with at least 4 GB of VRAM (it's possible to increase the virtual VRAM from the BIOS settings of some vendors). This will only be possible if the total ram is more than 8GB or the system will become unresponsive on launch. This change also changes the GPU check to a case statement to be able to add and maintain more GPUs efficiently.

I've tested this change on a Lenovo Yoga Slim 7 with a 4700U APU and an unlocked bios that allows increasing the reserved ram for the GPU. Everything that works on other AMD GPUs seems to work fine (txt2img, img2img, inpaint...)and the generation time for a 512x512 image with sd 1.5 is about 1 to 3 minutes (way better than a CPU generation).

I've created this repo (https://github.com/DaniAndTheWeb/sd-data-amd-gpu) to try collecting as much information about AMD GPUs and stable diffusion that I'll use to add or improve support to the webui.
