### PR TITLE
Alternative batching behavior for mix-sized training

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -595,8 +595,8 @@ def train_hypernetwork(id_task, hypernetwork_name, learn_rate, batch_size, gradi
                 if clip_grad:
                     clip_grad_sched.step(hypernetwork.step)
                 
-                with devices.autocast():
-                    for batch in superbatch:
+                def get_loss(batch):
+                    with devices.autocast():
                         x = batch.latent_sample.to(devices.device, non_blocking=pin_memory)
                         if tag_drop_out != 0 or shuffle_tags:
                             shared.sd_model.cond_stage_model.to(devices.device)
@@ -604,11 +604,10 @@ def train_hypernetwork(id_task, hypernetwork_name, learn_rate, batch_size, gradi
                             shared.sd_model.cond_stage_model.to(devices.cpu)
                         else:
                             c = stack_conds(batch.cond).to(devices.device, non_blocking=pin_memory)
-                        loss = shared.sd_model(x, c)[0] / gradient_step * len(batch) / batch_size
-                        del x
-                        del c
+                        return shared.sd_model(x, c)[0] / gradient_step * len(batch) / batch_size
 
-                        _loss_step += loss.item()
+                loss = sum(get_loss(batch) for batch in superbatch)
+                _loss_step += loss.item()
                 scaler.scale(loss).backward()
                 
                 # go back until we reach gradient accumulation steps
@@ -683,7 +682,7 @@ def train_hypernetwork(id_task, hypernetwork_name, learn_rate, batch_size, gradi
                         p.width = preview_width
                         p.height = preview_height
                     else:
-                        p.prompt = batch.cond_text[0]
+                        p.prompt = superbatch[0].cond_text[0]
                         p.steps = 20
                         p.width = training_width
                         p.height = training_height
@@ -715,7 +714,7 @@ def train_hypernetwork(id_task, hypernetwork_name, learn_rate, batch_size, gradi
 <p>
 Loss: {loss_step:.7f}<br/>
 Step: {steps_done}<br/>
-Last prompt: {html.escape(batch.cond_text[0])}<br/>
+Last prompt: {html.escape(superbatch[0].cond_text[0])}<br/>
 Last saved hypernetwork: {html.escape(last_saved_file)}<br/>
 Last saved image: {html.escape(last_saved_image)}<br/>
 </p>

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -146,39 +146,6 @@ class PersonalizedBase(Dataset):
         return entry
 
 
-class GroupedBatchSampler(Sampler):
-    def __init__(self, data_source: PersonalizedBase, batch_size: int):
-        super().__init__(data_source)
-
-        n = len(data_source)
-        self.groups = data_source.groups
-        self.len = n_batch = n // batch_size
-        expected = [len(g) / n * n_batch * batch_size for g in data_source.groups]
-        self.base = [int(e) // batch_size for e in expected]
-        self.n_rand_batches = nrb = n_batch - sum(self.base)
-        self.probs = [e%batch_size/nrb/batch_size if nrb>0 else 0 for e in expected]
-        self.batch_size = batch_size
-
-    def __len__(self):
-        return self.len
-
-    def __iter__(self):
-        b = self.batch_size
-
-        for g in self.groups:
-            random.shuffle(g)
-
-        batches = []
-        for g in self.groups:
-            batches.extend(g[i*b:(i+1)*b] for i in range(len(g) // b))
-        for _ in range(self.n_rand_batches):
-            rand_group = random.choices(self.groups, self.probs)[0]
-            batches.append(random.choices(rand_group, k=b))
-
-        random.shuffle(batches)
-
-        yield from batches
-
 def greedy_pack(tails, b):
     '''inefficient suboptimal packing of remainders from each bucket'''
     by_len = defaultdict(list)


### PR DESCRIPTION
Continuing #6620 

In this version, the dataset is batched almost like there is no bucketing. Internally, a batch is replaced with a superbatch consisting of one or more batches.

I don't have the hardware to test the performance of this but I expect a slight regression. If needed I can add back the previous behavior as an option.