### PR TITLE
Fix attention edit shortcut target

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -1,6 +1,6 @@
 addEventListener('keydown', (event) => {
 	let target = event.originalTarget || event.composedPath()[0];
-	if (!target.matches("#toprow textarea.gr-text-input[placeholder]")) return;
+	if (!target.matches("[id$=_toprow] textarea.gr-text-input[placeholder]")) return;
 	if (! (event.metaKey || event.ctrlKey)) return;
 
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This fixes the target element in `edit-attention.js` that broke due to layout change in 20a59ab3b171f398abd09087108c1ed087dbea9b.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090