### PR TITLE
Add --xformers-flash-attention option to improve the reproducibility

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -57,6 +57,7 @@ parser.add_argument("--realesrgan-models-path", type=str, help="Path to director
 parser.add_argument("--clip-models-path", type=str, help="Path to directory with CLIP model file(s).", default=None)
 parser.add_argument("--xformers", action='store_true', help="enable xformers for cross attention layers")
 parser.add_argument("--force-enable-xformers", action='store_true', help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work")
+parser.add_argument("--xformers-flash-attention", action='store_true', help="enable xformers with Flash Attention to improve reproducibility (supported for SD2.x or variant only)")
 parser.add_argument("--deepdanbooru", action='store_true', help="does not do anything")
 parser.add_argument("--opt-split-attention", action='store_true', help="force-enables Doggettx's cross-attention layer optimization. By default, it's on for torch cuda.")
 parser.add_argument("--opt-sub-quad-attention", action='store_true', help="enable memory efficient sub-quadratic cross-attention layer optimization")


### PR DESCRIPTION
# What does this PR do?

<img width="1152" alt="fig_with_wihout_flash_attn" src="https://user-images.githubusercontent.com/10776/213860713-9bc3f875-c335-4eda-bc6b-b75f8d0638ba.png">

Add the `--xformers-flash-attention` argument to enable the use of Flash Attention in xFormers. Using Flash Attention improves the reproducibility of SD image generation due to its deterministic behavior. 

xFormer's reproducibility problem has been discussed in several issues over the last year. I think [this comment](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/4011#issuecomment-1298026785) is the most exhaustive list by @0xdevalias in #4011.

# Limitation

Unfortunately, Flash Attention won't accept SD1.x attention shapes, but will accept SD2.x or variants.

# Test

I have tested this PR code using the following code on Ubuntu. I don't have a Windows environment personally, so I would appreciate it if someone could test it on Windows.
https://gist.github.com/takuma104/58fbd99a02006c67dbb9ff968c7417f2

## Test Environment
 - OS: Ubuntu 22.04
 - Browser: Chrome 109.0.5414.87 (on MacOS)
 - Graphics card: NVIDIA RTX 3060 12GB
 - xFormers Info:
```
$ python -m xformers.info
A matching Triton is not available, some optimizations will not be enabled.
Error caught was: No module named 'triton'
xFormers 0.0.15+3df785c.d20230111
memory_efficient_attention.cutlassF:               available
memory_efficient_attention.cutlassB:               available
memory_efficient_attention.flshattF:               available
memory_efficient_attention.flshattB:               available
memory_efficient_attention.smallkF:                available
memory_efficient_attention.smallkB:                available
memory_efficient_attention.tritonflashattF:        unavailable
memory_efficient_attention.tritonflashattB:        unavailable
swiglu.fused.p.cpp:                                available
is_triton_available:                               False
is_functorch_available:                            False
pytorch.version:                                   1.13.1
pytorch.cuda:                                      available
gpu.compute_capability:                            8.6
gpu.name:                                          NVIDIA GeForce RTX 3060
```

# Discussion

Any suggestions are welcome.
- The code now fallbacks to the default backend (usually Cutlass) if FlashAttention is not available. If a warning is given here, the SD1.x series will generate a huge amount of error logs. I think it would be better to give some sort of warning, but does anyone have a suggestion?