### PR TITLE
Fixes ui issues with checkbox and hires. sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -707,11 +707,15 @@ footer {
 
 #txt2img_checkboxes, #img2img_checkboxes{
     margin-bottom: 0.5em;
+    margin-left: 0em;
 }
 #txt2img_checkboxes > div, #img2img_checkboxes > div{
     flex: 0;
     white-space: nowrap;
     min-width: auto;
+}
+#txt2img_hires_fix{
+    margin-left: -0.8em;
 }
 
 .inactive{


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

Fixes margin issues with checkbox in txt2img and hires. fix in txt2img.

Gifs shown below, note I show img2img as well, but that is to show nothing changed with it.

Authored when working on commit f53527f7786575fe60da0223bd63ea3f0a06a754

## Additional notes and description of your changes

Set 0em margin left on the checkbox property. (Note that is also set for img2img_checkboxes, but as you can see in the videos this changes nothing for them)
Set -0.8em margin left on the txt2img_hires_fix,

## Issues, first one is Chrome, second is Firefox
![chrome-ui-orig](https://user-images.githubusercontent.com/23466035/213884256-bea7cc52-d940-47d8-9356-fb477e708c00.gif)
![firefox-ui-orig](https://user-images.githubusercontent.com/23466035/213884255-51e0538d-2666-4541-8bca-735f20d768fa.gif)

## Fixed version, first one is Chrome, second is Firefox
![chrome-ui-fix](https://user-images.githubusercontent.com/23466035/213884111-6756d0aa-cb06-4740-9f58-92496c08d371.gif)
![firefox-ui-fix](https://user-images.githubusercontent.com/23466035/213884114-277eade5-7c19-43f1-85bb-575808a64f24.gif)


## Environment this was tested in

 - OS: Windows
 - Browser: Chrome, Firefox
 - Graphics card: NVIDIA GTX 1080