### PR TITLE
Fixes various button overflowing UI and compact checkbox

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -919,7 +919,7 @@ def create_ui():
                         seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox = create_seed_inputs('img2img')
 
                     elif category == "checkboxes":
-                        with FormRow(elem_id="img2img_checkboxes"):
+                        with FormRow(elem_id="img2img_checkboxes", variant="compact"):
                             restore_faces = gr.Checkbox(label='Restore faces', value=False, visible=len(shared.face_restorers) > 1, elem_id="img2img_restore_faces")
                             tiling = gr.Checkbox(label='Tiling', value=False, elem_id="img2img_tiling")
 

--- a/scripts/xy_grid.py
+++ b/scripts/xy_grid.py
@@ -307,7 +307,7 @@ class Script(scripts.Script):
                     y_values = gr.Textbox(label="Y values", lines=1, elem_id=self.elem_id("y_values"))
                     fill_y_button = ToolButton(value=fill_values_symbol, elem_id="xy_grid_fill_y_tool_button", visible=False)
 
-        with gr.Row(variant="compact"):
+        with gr.Row(variant="compact", elem_id="axis_options"):
             draw_legend = gr.Checkbox(label='Draw legend', value=True, elem_id=self.elem_id("draw_legend"))
             include_lone_images = gr.Checkbox(label='Include Separate Images', value=False, elem_id=self.elem_id("include_lone_images"))
             no_fixed_seeds = gr.Checkbox(label='Keep -1 for seeds', value=False, elem_id=self.elem_id("no_fixed_seeds"))

--- a/style.css
+++ b/style.css
@@ -589,7 +589,7 @@ canvas[key="mask"] {
 
 /* Extensions */
 
-#tab_extensions table``{
+#tab_extensions table{
     border-collapse: collapse;
 }
 
@@ -716,6 +716,10 @@ footer {
 }
 #txt2img_hires_fix{
     margin-left: -0.8em;
+}
+
+#img2img_copy_to_img2img, #img2img_copy_to_sketch, #img2img_copy_to_inpaint, #img2img_copy_to_inpaint_sketch{
+    margin-left: 0em;
 }
 
 .inactive{

--- a/style.css
+++ b/style.css
@@ -722,6 +722,10 @@ footer {
     margin-left: 0em;
 }
 
+#axis_options {
+    margin-left: 0em;
+}
+
 .inactive{
     opacity: 0.5;
 }


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

Fixes overflow margin issues with x/y plot axis button in txt2img and img2img.

Fixes overflow margin issues in img2img with the copy to image tab buttons.

Makes the img2img_checkboxes a compact variant like txt2img, putting `Restore Faces` and `Tiling` on the same line.

Also fixes typo in `style.css` for #tab_extensions table. I didn't investigate too much but the extensions tab still seems fine.

Please also let me know if this is an actual issue that is occurring with the overflow for this one, and also #7020. I labeled the commits where I recorded the original video. These are from the very latest commits at that time, but I saw a recent PR with a screenshot from the page and that does not have these error.

Next, I am going to try and fix the css around the generate button but I have been looking at it and does seem a bit more rough.

## Original version in Firefox (taken from f2eae6127d16a80d1516d3f6245b648eeca26330)

![img2img-no-compact-btn-overflow](https://user-images.githubusercontent.com/23466035/213888714-90ffbf61-ffa5-465e-867c-9110e997f6e0.gif)

## New Version in Firefox

![img2img-compact-btn-overflow](https://user-images.githubusercontent.com/23466035/213888785-ad1f76c4-7547-4612-8779-10c7a234db67.gif)

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080