### PR TITLE
Fix dark mode

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1942,10 +1942,10 @@ def reload_javascript():
     if cmd_opts.theme is not None:
         inline += f"set_theme('{cmd_opts.theme}');"
 
-    head += f'<script type="text/javascript">{inline}</script>\n'
-
     for script in modules.scripts.list_scripts("javascript", ".js"):
         head += f'<script type="text/javascript" src="file={script.path}"></script>\n'
+
+    head += f'<script type="text/javascript">{inline}</script>\n'
 
     def template_response(*args, **kwargs):
         res = shared.GradioTemplateResponseOriginal(*args, **kwargs)


### PR DESCRIPTION
Fixes #7048
Co-Authored-By: @jjtolton

**Describe what this pull request is trying to achieve.**
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/78f59a4e014d090bce7df3b218bfbcd7f11e0894 broke user setting --theme=dark to enable mode by loading the theme script too early. This fixes that.

@jjtolton
    OS: Linux
    Browser: Chrome
    Graphics card: Dual Nvidia RTX 3090

@Shondoit
    OS: Windows
    Browser: Firefox
    Graphics card: Dual Nvidia RTX 2080
