### PR TITLE
Add deterministic training

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -369,6 +369,11 @@ def tests(test_dir):
 
 def start():
     print(f"Launching {'API server' if '--nowebui' in sys.argv else 'Web UI'} with arguments: {' '.join(sys.argv[1:])}")
+
+    #Do this before Torch is loaded
+    if '--deterministic-training' in sys.argv:
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
+
     import webui
     if '--nowebui' in sys.argv:
         webui.api_only()

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -61,6 +61,7 @@ parser.add_argument("--clip-models-path", type=str, help="Path to directory with
 parser.add_argument("--xformers", action='store_true', help="enable xformers for cross attention layers")
 parser.add_argument("--force-enable-xformers", action='store_true', help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work")
 parser.add_argument("--xformers-flash-attention", action='store_true', help="enable xformers with Flash Attention to improve reproducibility (supported for SD2.x or variant only)")
+parser.add_argument("--deterministic-training", action='store_true', help="Enable deterministic training of Hypernetworks and Textual Inversion. (Same settings and dataset will give the same result)")
 parser.add_argument("--deepdanbooru", action='store_true', help="does not do anything")
 parser.add_argument("--opt-split-attention", action='store_true', help="force-enables Doggettx's cross-attention layer optimization. By default, it's on for torch cuda.")
 parser.add_argument("--opt-sub-quad-attention", action='store_true', help="enable memory efficient sub-quadratic cross-attention layer optimization")


### PR DESCRIPTION
**What this pull request is trying to achieve.**
This will add deterministic behavior to training TIs and HNs.

Currently, when training, people can make changes to any of the training settings and see changes, making it better or worse. However, since currently it's random, the changes could cause by random luck or the changed settings.

To create better experiments and compare results between test runs, this PR introduces deterministic training as a command line option. If the same training settings and dataset are used, the same TI or HN will be produced.

**Additional notes and description of changes**

This PR introduces some seed fixing and deterministic algorithm selections.
I *believe* some of these are overkill and could be removed; the reason why it's currently in draft.
For now I decided to submit the PR so people can test it and play around with it, perhaps give some feedback on errors, misunderstandings or superfluous code.

Also, as a discussion point: currently it's introduced as a command line option, because the environment variable CUBLAS_WORKSPACE_CONFIG needs to be set before the rest starts.  I'm not sure if this is the best place to do, or if this even is the best choice.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 2080 8GB