### PR TITLE
Fix extra network thumbs label color

### DIFF
--- a/style.css
+++ b/style.css
@@ -857,6 +857,7 @@ footer {
     white-space: nowrap;
     text-overflow: ellipsis;
     background: rgba(0,0,0,.5);
+    color: white;
 }
 
 .extra-network-thumbs .card:hover .actions .name {


### PR DESCRIPTION
Added white color for labels.

Before:
![image](https://user-images.githubusercontent.com/6390413/214155532-f93cba12-5933-44cd-adc0-6879b2e7ed9d.png)


After:
![image](https://user-images.githubusercontent.com/6390413/214155656-693360d5-018c-48b8-ba04-01ef9b72ec0c.png)
