### PR TITLE
Add exception handling to API image decode

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -53,7 +53,11 @@ def setUpscalers(req: dict):
 def decode_base64_to_image(encoding):
     if encoding.startswith("data:image/"):
         encoding = encoding.split(";")[1].split(",")[1]
-    return Image.open(BytesIO(base64.b64decode(encoding)))
+    try:
+        image = Image.open(BytesIO(base64.b64decode(encoding)))
+        return image
+    except Exception as err:
+        raise HTTPException(status_code=500, detail="Invalid encoded image")
 
 def encode_pil_to_base64(image):
     with io.BytesIO() as output_bytes:


### PR DESCRIPTION
Malformed API request can crash WebUI server since there are no error checks performed while trying to decode image.

Example crash log:

```text
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 94, in receive
    return self.receive_nowait()
  File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 89, in receive_nowait
    raise WouldBlock
anyio.WouldBlock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py", line 77, in call_next
    message = await recv_stream.receive()
  File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 114, in receive
    raise EndOfStream
anyio.EndOfStream

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...
  File "/home/vlado/dev/automatic/modules/api/api.py", line 255, in extras_single_image_api
    reqDict['image'] = decode_base64_to_image(reqDict['image'])
  File "/home/vlado/dev/automatic/modules/api/api.py", line 56, in decode_base64_to_image
    return Image.open(BytesIO(base64.b64decode(encoding)))
  File "/home/vlado/.local/lib/python3.10/site-packages/PIL/Image.py", line 3283, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x7f5de5d06200>
```
