### PR TITLE
Make SwinIR upscaler interruptible and skippable

### DIFF
--- a/extensions-builtin/SwinIR/scripts/swinir_model.py
+++ b/extensions-builtin/SwinIR/scripts/swinir_model.py
@@ -145,11 +145,11 @@ def inference(img, model, tile, tile_overlap, window_size, scale):
 
     with tqdm(total=len(h_idx_list) * len(w_idx_list), desc="SwinIR tiles") as pbar:
         for h_idx in h_idx_list:
-            if state.interrupted:
+            if state.interrupted or state.skipped:
                 break
 
             for w_idx in w_idx_list:
-                if state.interrupted:
+                if state.interrupted or state.skipped:
                     break
                 
                 in_patch = img[..., h_idx: h_idx + tile, w_idx: w_idx + tile]

--- a/extensions-builtin/SwinIR/scripts/swinir_model.py
+++ b/extensions-builtin/SwinIR/scripts/swinir_model.py
@@ -8,7 +8,7 @@ from basicsr.utils.download_util import load_file_from_url
 from tqdm import tqdm
 
 from modules import modelloader, devices, script_callbacks, shared
-from modules.shared import cmd_opts, opts
+from modules.shared import cmd_opts, opts, state
 from swinir_model_arch import SwinIR as net
 from swinir_model_arch_v2 import Swin2SR as net2
 from modules.upscaler import Upscaler, UpscalerData
@@ -145,7 +145,13 @@ def inference(img, model, tile, tile_overlap, window_size, scale):
 
     with tqdm(total=len(h_idx_list) * len(w_idx_list), desc="SwinIR tiles") as pbar:
         for h_idx in h_idx_list:
+            if state.interrupted:
+                break
+
             for w_idx in w_idx_list:
+                if state.interrupted:
+                    break
+                
                 in_patch = img[..., h_idx: h_idx + tile, w_idx: w_idx + tile]
                 out_patch = model(in_patch)
                 out_patch_mask = torch.ones_like(out_patch)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

The SwinIR upscale process can sometimes take a while, and if the process is interrupted or skipped it shouldn't need to finish the upscale, so this change makes that possible.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090