### PR TITLE
Set Linux xformers 0.0.16RC425

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -245,7 +245,7 @@ def prepare_environment():
                 if not is_installed("xformers"):
                     exit(0)
         elif platform.system() == "Linux":
-            run_pip("install xformers", "xformers")
+            run_pip("install xformers==0.0.16rc425", "xformers")
 
     if not is_installed("pyngrok") and ngrok:
         run_pip("install pyngrok", "ngrok")


### PR DESCRIPTION
If you install or reinstall xformers on Linux, 0.0.13 will be installed
Therefore, at startup, xformers will not start correctly due to an error.

This fix is to specify the version of xformers to be installed as 0.0.16rc425, so that it will be installed correctly and can be launched properly as in the Windows version.
