### PR TITLE
Add option to not save images for interrupted/skipped processes

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -18,7 +18,7 @@ import string
 import json
 
 from modules import sd_samplers, shared, script_callbacks
-from modules.shared import opts, cmd_opts
+from modules.shared import opts, cmd_opts, state
 
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
 
@@ -480,6 +480,11 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         txt_fullfn (`str` or None):
             If a text file is saved for this image, this will be its full path. Otherwise None.
     """
+    if opts.do_not_save_interrupted_or_skipped and p.__class__.__module__ != 'modules.ui_common' and (state.interrupted or state.skipped):
+        state.interrupted = False
+        state.skipped = False
+        return
+    
     namegen = FilenameGenerator(p, seed, prompt, image)
 
     if save_to_dirs is None:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -330,7 +330,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process in extras tab"),
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
-    "do_not_save_interrupted_or_skipped": OptionInfo(False, "Do not save images images when process is interrupted or skipped"),
+    "do_not_save_interrupted_or_skipped": OptionInfo(False, "Do not save images when process is interrupted or skipped"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),
 
     "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -330,6 +330,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process in extras tab"),
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
+    "do_not_save_interrupted_or_skipped": OptionInfo(False, "Do not save images images when process is interrupted or skipped"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),
 
     "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -72,12 +72,13 @@ def save_files(js_data, images, do_make_zip, index):
 
             fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=p.all_seeds[i], prompt=p.all_prompts[i], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
 
-            filename = os.path.relpath(fullfn, path)
-            filenames.append(filename)
-            fullfns.append(fullfn)
-            if txt_fullfn:
-                filenames.append(os.path.basename(txt_fullfn))
-                fullfns.append(txt_fullfn)
+            if fullfn:
+                filename = os.path.relpath(fullfn, path)
+                filenames.append(filename)
+                fullfns.append(fullfn)
+                if txt_fullfn:
+                    filenames.append(os.path.basename(txt_fullfn))
+                    fullfns.append(txt_fullfn)
 
         writer.writerow([data["prompt"], data["seed"], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], data["negative_prompt"]])
 


### PR DESCRIPTION
Closes #5277

**Describe what this pull request is trying to achieve.**

This adds an option for when a process is interrupted or skipped to not save any images.

**Additional notes and description of your changes**

This modifies the `save_image` function so it will apply everywhere, except for when the `Save` button in the UI is manually invoked.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090