### PR TITLE
close socket on ctrl-c

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -140,6 +140,8 @@ def initialize():
     # make the program just exit at ctrl+c without waiting for anything
     def sigint_handler(sig, frame):
         print(f'Interrupted with signal {sig} in {frame}')
+        if shared.demo is not None:
+            shared.demo.close()
         os._exit(0)
 
     signal.signal(signal.SIGINT, sigint_handler)


### PR DESCRIPTION
It can take a while for Linux to recycle unclosed tcp sockets after an application exits, preventing restarting of the app until this has happened. 

**Environment this was tested in**

 - OS: Linux (Arch amd64)
 - Browser: N/A
 - Graphics card: N/A