### PR TITLE
allow symlinks in the textual inversion embeddings folder

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -194,7 +194,7 @@ class EmbeddingDatabase:
         if not os.path.isdir(embdir.path):
             return
 
-        for root, dirs, fns in os.walk(embdir.path):
+        for root, dirs, fns in os.walk(embdir.path, followlinks=True):
             for fn in fns:
                 try:
                     fullfn = os.path.join(root, fn)


### PR DESCRIPTION
Quick simple fix, no reason it'd break anything.

Allows symlinks in the `embeddings` folder.

Preview images do not currently work due to a gradio bug that appears to be fixed here: https://github.com/gradio-app/gradio/pull/3037
Already accepted for upcoming gradio `3.16.3`

Tested and validated both that TIs in symlinked folders show up, and that they render fine when used in a prompt.
