### PR TITLE
Add a Python version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ notification.mp3
 /test/stdout.txt
 /test/stderr.txt
 /cache.json
+no_py_ver_warning

--- a/launch.py
+++ b/launch.py
@@ -20,10 +20,10 @@ skip_install = False
 def check_python_version():
     version = sys.version_info
     version_range = None
-    if os.name == "nt":
-        version_range = range(7 + 1, 10 + 1)
-    else:
+    if platform.system() == "Linux":
         version_range = range(7 + 1, 11 + 1)
+    else:
+        version_range = range(7 + 1, 10 + 1)
 
     try:
         assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first and delete `venv` folder inside of WebUI's folder, too."

--- a/launch.py
+++ b/launch.py
@@ -25,7 +25,10 @@ def check_python_version():
     else:
         version_range = range(7, 12)
 
-    assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/"
+    try:
+        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/"
+    except AssertionError as e:
+        print(e)
 
 
 def commit_hash():

--- a/launch.py
+++ b/launch.py
@@ -18,18 +18,35 @@ skip_install = False
 
 
 def check_python_version():
-    version = sys.version_info
-    version_range = None
-    if platform.system() == "Linux":
-        version_range = range(7 + 1, 11 + 1)
-    else:
-        version_range = range(7 + 1, 10 + 1)
+    if not os.path.isfile("no_py_ver_warning"):
+        version = sys.version_info
+        version_range = None
+        if platform.system() == "Linux":
+            version_range = range(7 + 1, 11 + 1)
+        else:
+            version_range = range(7 + 1, 10 + 1)
 
-    try:
-        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first and delete `venv` folder inside of WebUI's folder, too."
-    except AssertionError as e:
-        print(e)
-        sys.exit(-1)
+        try:
+            assert version.major == 3 and version.minor in version_range, f"""
+=== Warning ===
+This program was tested only with 3.10 Python, but you have {version.major}.{version.minor} Python.
+If you encounter an error with "RuntimeError: Couldn't install torch." message,
+or any other error regarding unsuccessful package (library) installation,
+please downgrade (or upgrade) to the latest version of 3.10 Python
+and delete current Python and "venv" folder in WebUI's directory.
+
+You can download 3.10 Python from here: https://www.python.org/downloads/release/python-3109/
+
+You will see this warning only once, delete file "no_py_ver_warning" file to show this warning again.
+=== Warning ===
+
+Press ENTER to continue...\
+"""
+        except AssertionError as e:
+            print(e)
+            with open("no_py_ver_warning", "w"):
+                pass
+            input()
 
 
 def commit_hash():

--- a/launch.py
+++ b/launch.py
@@ -26,9 +26,10 @@ def check_python_version():
         version_range = range(7, 12)
 
     try:
-        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/"
+        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first."
     except AssertionError as e:
         print(e)
+        sys.exit(-1)
 
 
 def commit_hash():

--- a/launch.py
+++ b/launch.py
@@ -17,6 +17,17 @@ stored_commit_hash = None
 skip_install = False
 
 
+def check_python_version():
+    version = sys.version_info
+    version_range = None
+    if os.name == "nt":
+        version_range = range(7, 11)
+    else:
+        version_range = range(7, 12)
+
+    assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/"
+
+
 def commit_hash():
     global stored_commit_hash
 
@@ -321,5 +332,6 @@ def start():
 
 
 if __name__ == "__main__":
+    check_python_version()
     prepare_environment()
     start()

--- a/launch.py
+++ b/launch.py
@@ -26,7 +26,7 @@ def check_python_version():
         version_range = range(7, 12)
 
     try:
-        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first."
+        assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first and delete `venv` folder inside of WebUI's folder, too."
     except AssertionError as e:
         print(e)
         sys.exit(-1)

--- a/launch.py
+++ b/launch.py
@@ -21,9 +21,9 @@ def check_python_version():
     version = sys.version_info
     version_range = None
     if os.name == "nt":
-        version_range = range(7, 11)
+        version_range = range(7 + 1, 10 + 1)
     else:
-        version_range = range(7, 12)
+        version_range = range(7 + 1, 11 + 1)
 
     try:
         assert version.major == 3 and version.minor in version_range, "Unsupported Python version, please use Python 3.10.x instead. You can download latest release as of 25th January (3.10.9) from here: https://www.python.org/downloads/release/python-3109/. Please, make sure to first delete current version of Python first and delete `venv` folder inside of WebUI's folder, too."


### PR DESCRIPTION
This pull request tries to achieve making people not to ask/sumbit question/issues due to them installing wrong version of Python.

I use `sys.version_info` and `os.name`, along with `assert` to determine, whether current Python version is compatible.

---

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrom
 - Graphics card: NVidia GeForce GTX 1660 Super 6 GB

---

Before:
![image](https://user-images.githubusercontent.com/97038786/214642961-06fe8e72-f5aa-4b19-8059-35e775baf8e0.png)

After:
![image](https://user-images.githubusercontent.com/97038786/214642489-98953213-d72a-470a-b0a9-2c2078ae5458.png)

---

Notes: maybe I would like to check Python version before creating the venv