### PR TITLE
Update default Mac command line arguments to use --upcast-sampling instead of --no-half

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -10,7 +10,7 @@ then
 fi
 
 export install_dir="$HOME"
-export COMMANDLINE_ARGS="--skip-torch-cuda-test --no-half --use-cpu interrogate"
+export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --use-cpu interrogate"
 export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
 export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Updates default Mac command line arguments to use `--upcast-sampling` instead of `--no-half`. This will result in better performance with lower memory usage by default on Macs.

**Additional notes and description of your changes**

If this is merged then I can add a mention of this change to [`Seed breaking changes`](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Seed-breaking-changes), specificially mentioning that this change impacts Mac users and that old seeds can still be reproduced with `--no-half`.

**Environment this was tested in**

 - OS: macOS
 - Browser: Safari
 - Graphics card: M1 Max 64 GB