### PR TITLE
Fixes X/Y/Z Plot parameters not being restored from images

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -11,9 +11,8 @@ from modules import shared, ui_tempdir, script_callbacks
 import tempfile
 from PIL import Image
 
-re_param_code = r'\s*([\w ]+):\s*("(?:\\|\"|[^\"])+"|[^,]*)(?:,|$)'
+re_param_code = r'\s*([\w ]+):\s*(\"[^\"]*\"|[^,]+)'
 re_param = re.compile(re_param_code)
-re_params = re.compile(r"^(?:" + re_param_code + "){3,}$")
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")
 type_of_gr_update = type(gr.update())
@@ -243,7 +242,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     done_with_prompt = False
 
     *lines, lastline = x.strip().split("\n")
-    if not re_params.match(lastline):
+    if not re_param.match(lastline):
         lines.append(lastline)
         lastline = ''
 
@@ -262,6 +261,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     res["Negative prompt"] = negative_prompt
 
     for k, v in re_param.findall(lastline):
+        v = v[1:-1] if v[0] == '"' and v[-1] == '"' else v
         m = re_imagesize.match(v)
         if m is not None:
             res[k+"-1"] = m.group(1)

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -11,7 +11,7 @@ from modules import shared, ui_tempdir, script_callbacks
 import tempfile
 from PIL import Image
 
-re_param_code = r'\s*([\w ]+):\s*(\"[^\"]*\"|[^,]+)'
+re_param_code = r'\s*([\w ]+):\s*("(?:\\"[^,]|\\"|\\|[^\"])+"|[^,]*)(?:,|$)'
 re_param = re.compile(re_param_code)
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")
@@ -242,7 +242,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     done_with_prompt = False
 
     *lines, lastline = x.strip().split("\n")
-    if not re_param.match(lastline):
+    if len(re_param.findall(lastline)) < 3:
         lines.append(lastline)
         lastline = ''
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -330,6 +330,20 @@ class ScriptRunner:
             outputs=[script.group for script in self.selectable_scripts]
         )
 
+        self.script_load_ctr = 0
+        def onload_script_visibility(params):
+            title = params.get('Script', None)
+            if title:
+                title_index = self.titles.index(title)
+                visibility = title_index == self.script_load_ctr
+                self.script_load_ctr = (self.script_load_ctr + 1) % len(self.titles)
+                return gr.update(visible=visibility)
+            else:
+                return gr.update(visible=False)
+
+        self.infotext_fields.append( (dropdown, lambda x: gr.update(value=x.get('Script', 'None'))) )
+        self.infotext_fields.extend( [(script.group, onload_script_visibility) for script in self.selectable_scripts] )
+
         return inputs
 
     def run(self, p: StableDiffusionProcessing, *args):

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -383,6 +383,15 @@ class Script(scripts.Script):
         y_type.change(fn=select_axis, inputs=[y_type], outputs=[fill_y_button])
         z_type.change(fn=select_axis, inputs=[z_type], outputs=[fill_z_button])
 
+        self.infotext_fields = (
+            (x_type, "X Type"),
+            (x_values, "X Values"),
+            (y_type, "Y Type"),
+            (y_values, "Y Values"),
+            (z_type, "Z Type"),
+            (z_values, "Z Values"),
+        )
+
         return [x_type, x_values, y_type, y_values, z_type, z_values, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds]
 
     def run(self, p, x_type, x_values, y_type, y_values, z_type, z_values, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds):
@@ -541,6 +550,7 @@ class Script(scripts.Script):
 
             if grid_infotext[0] is None:
                 pc.extra_generation_params = copy(pc.extra_generation_params)
+                pc.extra_generation_params['Script'] = self.title()
 
                 if x_opt.label != 'Nothing':
                     pc.extra_generation_params["X Type"] = x_opt.label


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

Restoring X/Y/Z Plot parameters from an image by using "Send to txt2img" and "Send to img2img" right now does not work for a couple reasons.

1. The regex re_param messes up if there are commas between quotes, which is necessary for the X/Y/Z Plot.
2. No script has `self.infotext_fields` set to anything, but the functionality to use it exists as script infotexts will be automatically aggregated together into `modules.scripts.scripts_txt2img.infotext_fields`.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/6cff4401824299a983c8e13424018efc347b4a2b/modules/ui.py#L611 https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/6cff4401824299a983c8e13424018efc347b4a2b/modules/scripts.py#L289-L290
4. There is no Script Param itself being saved into infotext*

This pr fixes all of the above problems.

*I know you don't like stuff being added to infotext, but Script is not saved while the actual values of `X/Y/Z' are, so like for the xyz values to even work we really do need the script data to be present to load that script. The X Y Z Types and values are already being saved.

## Changes

- In xyz_grid.py
  - Added components to `infotext_fields`
  - Added `'Script'` to `extra_generation_params` and thus the infotext
- In scripts.py
  - Added components to `infotext_fields`, `self.script_load_ctr` is basically a manual index as we use it to figure out what script components to disable and enable.
- In generation_parameters_copypaste.py
  - ~Updates the regex~, uses Auto's new regex comparison described below
  - Removes unnecessary regex, replaced with python len check

## Regex Difference

We will use this as an example 
`Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 8.0, Seed: 5, Face restoration: CodeFormer, Size: 384x576, Model hash: 253908caaf, Model: VividMixv2.0-0.7_uberRealisticv1.2-0.3, X Type: Seed, X Values: "5, 10", Fixed X Values: "5, 10", Y Type: CFG Scale, Y Values: "8, 9, 10", Z Type: Prompt S/R, Z Values: "Yennefer, \"Triss Merigold\", Ciri"`

### Current Regex

`\s*([\w ]+):\s*("(?:\\|\"|[^\"])+"|[^,]*)(?:,|$)`

The current version executed is shown below

![image](https://user-images.githubusercontent.com/23466035/215277713-a16c1e96-8275-4175-b3bb-f4350f9bdc9d.png)

It is harder to tell as the colors are kind of confusing, but basically everything after X Values messes up because of the quotes.
It does not capture double quotes, or nested escaped quotes.

### Auto's New Regex

`\s*([\w ]+):\s*("(?:\\"[^,]|\\"|\\|[^\"])+"|[^,]*)(?:,|$)`

The new regex executed is shown below

![image](https://user-images.githubusercontent.com/23466035/215277735-cdf505c2-c030-4d6c-99f1-c29ce14c84d3.png)

Grabs everything properly, ignores commas if they are surrounded by quotes. Also allows for nested commas if escaped.
To note though, if there are double quotes present at the beginning in group 2, we have to manually strip them out with python.

### Also removed Unnecessary Regex

The `re_params` regex seemed unnecessary as it was only used once, and the new regex can be used in the exact same place.
It also seems to be ridiculously inefficient as well as on regex101.com it terminates after over 200k steps.

![image](https://user-images.githubusercontent.com/23466035/214774814-ebbdab54-160f-4a22-97cb-f28bccf3128a.png)

## Video Showcase

### Issue
![restore-xyz-plot](https://user-images.githubusercontent.com/23466035/214766898-85ef24cf-1b95-485a-abf2-735c21380603.gif)

### Fixed version (First shows it working, then shows a normal image resets it to None)
![fix-restore-xyz-plot](https://user-images.githubusercontent.com/23466035/214765920-ada78d0c-e03a-4848-83b3-dc03e2639d3a.gif)

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080