### PR TITLE
Fix full previews and--no-half-vae to work correctly with --upcast-sampling

### DIFF
--- a/modules/sd_hijack_utils.py
+++ b/modules/sd_hijack_utils.py
@@ -5,7 +5,7 @@ class CondFunc:
         self = super(CondFunc, cls).__new__(cls)
         if isinstance(orig_func, str):
             func_path = orig_func.split('.')
-            for i in range(len(func_path)-2, -1, -1):
+            for i in range(len(func_path)-1, -1, -1):
                 try:
                     resolved_obj = importlib.import_module('.'.join(func_path[:i]))
                     break


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes full previews and `--no-half-vae` to work correctly with `--upcast-sampling`. Also corrects a typo in CondFunc.

**Additional notes and description of your changes**

Casts the input to decode_first_stage and encode_first_stage to the VAE dtype. For encode_first_stage the  input was previously incorrectly casted to the UNet dtype which can result in dtype mismatch errors with `--no-half-vae`. For decode_first_stage the input was previously not casted to the correct dtype for full previews, resulting in dtype mismatch errors without `--no-half-vae`.

**Environment this was tested in**

 - OS: macOS
 - Browser: Safari
 - Graphics card: M1 Max 64 GB