### PR TITLE
Add train/embedding API request info and defaults

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -466,7 +466,7 @@ class Api:
             shared.state.end()
             return PreprocessResponse(info = 'preprocess error: {error}'.format(error = e))
 
-    def train_embedding(self, args: dict):
+    def train_embedding(self, args: TrainEmbeddingAPI):
         try:
             shared.state.begin()
             apply_optimizations = shared.opts.training_xattention_optimizations
@@ -475,7 +475,8 @@ class Api:
             if not apply_optimizations:
                 sd_hijack.undo_optimizations()
             try:
-                embedding, filename = train_embedding(**args) # can take a long time to complete
+                training_args = args.__dict__
+                embedding, filename = train_embedding(**training_args) # can take a long time to complete
             except Exception as e:
                 error = e
             finally:

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -269,7 +269,6 @@ class MemoryResponse(BaseModel):
     cuda: dict = Field(title="CUDA", description="nVidia CUDA memory stats")
 
 class TrainEmbeddingAPI(BaseModel):
-    id_task: str = Field(title="ID", description="ID Task")
     embedding_name: str = Field(
         title="Embedding Name", description="Name of the embedding"
     )
@@ -297,9 +296,9 @@ class TrainEmbeddingAPI(BaseModel):
     varsize: bool = Field(
         title="Do not resize images", description="Do not resize images", default=False
     )
-    steps: int = Field(title="Max steps", description="")
+    steps: int = Field(title="Max steps", description="", default=100000)
     clip_grad_mode: str = Field(
-        title="Gradient clipping", description="Gradient clip mode"
+        title="Gradient clipping", description="Gradient clip mode", default="disabled"
     )
     clip_grad_value: float = Field(title="", description="", default=0.1)
     shuffle_tags: bool = Field(
@@ -339,15 +338,18 @@ class TrainEmbeddingAPI(BaseModel):
         description="Read parameters (prompt, etc...) from txt2img tab when making previews",
         default=False,
     )
-    preview_prompt: str = Field(title="Preview prompt", description="")
+    preview_prompt: str = Field(title="Preview prompt", description="", default="")
     preview_negative_prompt: str = Field(
-        title="Preview negative prompt", description=""
+        title="Preview negative prompt", description="", default=""
     )
     preview_steps: int = Field(title="Preview steps", description="", default=20)
     preview_sampler_index: str = Field(
         title="Preview sampler", description="", default="Euler"
     )
-    preview_cfg_scale: float = Field(title="Preview CFG scale", description="")
-    preview_seed: float = Field(title="Preview seed", description="")
-    preview_width: int = Field(title="Preview width", description="")
-    preview_height: int = Field(title="Preview height", description="")
+    preview_cfg_scale: float = Field(
+        title="Preview CFG scale", description="", default=7.0
+    )
+    preview_seed: float = Field(title="Preview seed", description="", default=-1.0)
+    preview_width: int = Field(title="Preview width", description="", default=512)
+    preview_height: int = Field(title="Preview height", description="", default=512)
+    id_task: str = Field(title="ID Task", description="ID Task (unused)", default="")

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -294,7 +294,9 @@ class TrainEmbeddingAPI(BaseModel):
     )
     training_width: int = Field(title="Training width", description="", default=512)
     training_height: int = Field(title="Training height", description="", default=512)
-    varsize: str = Field(title="", description="")
+    varsize: bool = Field(
+        title="Do not resize images", description="Do not resize images", default=False
+    )
     steps: int = Field(title="Max steps", description="")
     clip_grad_mode: str = Field(
         title="Gradient clipping", description="Gradient clip mode"

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -329,9 +329,10 @@ class TrainEmbeddingAPI(BaseModel):
         description="Prompt template file",
         default="style_filewords.txt",
     )
-    save_image_with_stored_embedding: str = Field(
+    save_image_with_stored_embedding: bool = Field(
         title="Save image with embedding",
         description="Save images with embedding in PNG chunks",
+        default=True
     )
     preview_from_txt2img: bool = Field(
         title="Preview from txt2img",

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -267,3 +267,85 @@ class EmbeddingsResponse(BaseModel):
 class MemoryResponse(BaseModel):
     ram: dict = Field(title="RAM", description="System memory stats")
     cuda: dict = Field(title="CUDA", description="nVidia CUDA memory stats")
+
+class TrainEmbeddingAPI(BaseModel):
+    id_task: str = Field(title="ID", description="ID Task")
+    embedding_name: str = Field(
+        title="Embedding Name", description="Name of the embedding"
+    )
+    learn_rate: float = Field(
+        title="Learning rate", description="Rate of learning", default=0.005
+    )
+    batch_size: int = Field(
+        title="Batch size",
+        description="How many images to create in a single batch",
+        default=1,
+    )
+    gradient_step: int = Field(
+        title="Gradient accumulation steps",
+        description="Number of steps to accumulate the gradient",
+        default=1,
+    )
+    data_root: str = Field(
+        title="Dataset directory", description="Path to the directory with input images"
+    )
+    log_directory: str = Field(
+        title="Log directory", description="", default="textual_inversion"
+    )
+    training_width: int = Field(title="Training width", description="", default=512)
+    training_height: int = Field(title="Training height", description="", default=512)
+    varsize: str = Field(title="", description="")
+    steps: int = Field(title="Max steps", description="")
+    clip_grad_mode: str = Field(
+        title="Gradient clipping", description="Gradient clip mode"
+    )
+    clip_grad_value: float = Field(title="", description="", default=0.1)
+    shuffle_tags: bool = Field(
+        title="Shuffle tags",
+        description="Shuffle tags by ',' when creating prompts",
+        default=False,
+    )
+    tag_drop_out: bool = Field(
+        title="Drop tags",
+        description="Drop out tags when creating prompts",
+        default=False,
+    )
+    latent_sampling_method: str = Field(
+        title="Latent sampling method", description="", default="once"
+    )
+    create_image_every: int = Field(
+        title="Create image every",
+        description="Save an image to the log directory every N steps, 0 to disable",
+        default=500,
+    )
+    save_embedding_every: int = Field(
+        title="Save embedding",
+        description="Save a copy of embedding to log directory every N steps, 0 to disable",
+        default=500,
+    )
+    template_filename: str = Field(
+        title="Prompt template",
+        description="Prompt template file",
+        default="style_filewords.txt",
+    )
+    save_image_with_stored_embedding: str = Field(
+        title="Save image with embedding",
+        description="Save images with embedding in PNG chunks",
+    )
+    preview_from_txt2img: bool = Field(
+        title="Preview from txt2img",
+        description="Read parameters (prompt, etc...) from txt2img tab when making previews",
+        default=False,
+    )
+    preview_prompt: str = Field(title="Preview prompt", description="")
+    preview_negative_prompt: str = Field(
+        title="Preview negative prompt", description=""
+    )
+    preview_steps: int = Field(title="Preview steps", description="", default=20)
+    preview_sampler_index: str = Field(
+        title="Preview sampler", description="", default="Euler"
+    )
+    preview_cfg_scale: float = Field(title="Preview CFG scale", description="")
+    preview_seed: float = Field(title="Preview seed", description="")
+    preview_width: int = Field(title="Preview width", description="")
+    preview_height: int = Field(title="Preview height", description="")


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Add documentation and defaults for training embeddings in the API.

**Additional notes and description of your changes**

`id_task` doesn't seem to be used in the `train_embedding` function and not clear its intention. 

Currently, should work, but need's more testing. Once complete with testing, I will move from draft. Posting if others want to test in the meantime. 

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Linux
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 2080 8GB

**Screenshots or videos of your changes**

![Screenshot 2023-01-26 at 04-11-47 FastAPI - Swagger UI](https://user-images.githubusercontent.com/15027/214798435-49b6738e-be84-4dd8-9601-f4dbc462e61d.png)

