### PR TITLE
Add button to switch width and height

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -91,6 +91,13 @@ save_style_symbol = '\U0001f4be'  # 💾
 apply_style_symbol = '\U0001f4cb'  # 📋
 clear_prompt_symbol = '\U0001F5D1'  # 🗑️
 extra_networks_symbol = '\U0001F3B4'  # 🎴
+switch_values_symbol = '\U000021C5' # ⇅
+
+def switch_width_and_height(width, height):
+    width_temp = width
+    width = height
+    height = width_temp
+    return width, height
 
 
 def plaintext_to_html(text):
@@ -466,6 +473,7 @@ def create_ui():
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="txt2img_height")
 
                             if opts.dimensions_and_batch_together:
+                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn")
                                 with gr.Column(elem_id="txt2img_column_batch"):
                                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="txt2img_batch_count")
                                     batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="txt2img_batch_size")
@@ -566,6 +574,7 @@ def create_ui():
 
             txt2img_prompt.submit(**txt2img_args)
             submit.click(**txt2img_args)
+            res_switch_btn.click(switch_width_and_height, inputs=[width, height], outputs=[width, height])
 
             txt_prompt_img.change(
                 fn=modules.images.image_data,
@@ -728,6 +737,7 @@ def create_ui():
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="img2img_height")
 
                             if opts.dimensions_and_batch_together:
+                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="img2img_res_switch_btn")
                                 with gr.Column(elem_id="img2img_column_batch"):
                                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="img2img_batch_count")
                                     batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="img2img_batch_size")
@@ -865,6 +875,7 @@ def create_ui():
 
             img2img_prompt.submit(**img2img_args)
             submit.click(**img2img_args)
+            res_switch_btn.click(switch_width_and_height, inputs=[width, height], outputs=[width, height])
 
             img2img_interrogate.click(
                 fn=lambda *args: process_interrogate(interrogate, *args),


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adds a button to switch width and height, allowing quick and easy switching between landscape and portrait.

**Additional notes and description of your changes**

I'm not sure how to better adjust the position of the button, this was the best I could come up with - further suggestions are welcomed

**Environment this was tested in**

 - OS: Windows 11 21H2 
 - Browser: Firefox, Chrome, Edge
 - Graphics card: RTX 3050 Ti

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/73721238/215168280-aec51267-78c3-4238-aeee-343f34e5eb80.png)
