### PR TITLE
Allows for multiple Styles axii in X/Y/Z Plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A browser interface based on Gradio library for Stable Diffusion.
     - a man in a (tuxedo:1.21) - alternative syntax
     - select text and press ctrl+up or ctrl+down to automatically adjust attention to selected text (code contributed by anonymous user)
 - Loopback, run img2img processing multiple times
-- X/Y plot, a way to draw a 2 dimensional plot of images with different parameters
+- X/Y/Z plot, a way to draw a 3 dimensional plot of images with different parameters
 - Textual Inversion
     - have as many embeddings as you want and use any names you like for them
     - use multiple embeddings with different numbers of vectors per token

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -50,7 +50,7 @@ titles = {
 
     "None": "Do not do anything special",
     "Prompt matrix": "Separate prompts into parts using vertical pipe character (|) and the script will create a picture for every combination of them (except for the first part, which will be present in all combinations)",
-    "X/Y plot": "Create a grid where images will have different parameters. Use inputs below to specify which parameters will be shared by columns and rows",
+    "X/Y/Z plot": "Create grid(s) where images will have different parameters. Use inputs below to specify which parameters will be shared by columns and rows",
     "Custom code": "Run Python code. Advanced user only. Must run program with --allow-code for this to work",
 
     "Prompt S/R": "Separate a list of words with commas, and the first word will be used as a keyword: script will search for this word in the prompt, and replace it with others",

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -499,7 +499,7 @@ class Script(scripts.Script):
         image_cell_count = p.n_iter * p.batch_size
         cell_console_text = f"; {image_cell_count} images per cell" if image_cell_count > 1 else ""
         plural_s = 's' if len(zs) > 1 else ''
-        print(f"X/Y plot will create {len(xs) * len(ys) * len(zs) * image_cell_count} images on {len(zs)} {len(xs)}x{len(ys)} grid{plural_s}{cell_console_text}. (Total steps to process: {total_steps})")
+        print(f"X/Y/Z plot will create {len(xs) * len(ys) * len(zs) * image_cell_count} images on {len(zs)} {len(xs)}x{len(ys)} grid{plural_s}{cell_console_text}. (Total steps to process: {total_steps})")
         shared.total_tqdm.updateTotal(total_steps)
 
         grid_infotext = [None]

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -123,7 +123,7 @@ def apply_vae(p, x, xs):
 
 
 def apply_styles(p: StableDiffusionProcessingTxt2Img, x: str, _):
-    p.styles = x.split(',')
+    p.styles.extend(x.split(','))
 
 
 def format_value_add_label(p, opt, x):
@@ -533,6 +533,7 @@ class Script(scripts.Script):
                 return Processed(p, [], p.seed, "")
 
             pc = copy(p)
+            pc.styles = pc.styles[:]
             x_opt.apply(pc, x, xs)
             y_opt.apply(pc, y, ys)
             z_opt.apply(pc, z, zs)


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.
As mentioned in #7275, multiple style axis does not work.
This is because we are setting a list and not extending it. We should also deepcopy that list before, as otherwise the styles will persist between grid iterations.

Also changed X/Y to X/Y/Z plot in some places.

Closes #7275

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080

