### PR TITLE
Fix error when using img2img batch without masks

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -21,8 +21,10 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
 
     images = shared.listfiles(input_dir)
 
-    inpaint_masks = shared.listfiles(inpaint_mask_dir)
-    is_inpaint_batch = inpaint_mask_dir and len(inpaint_masks) > 0
+    is_inpaint_batch = False
+    if inpaint_mask_dir:
+        inpaint_masks = shared.listfiles(inpaint_mask_dir)
+        is_inpaint_batch = len(inpaint_masks) > 0
     if is_inpaint_batch:
         print(f"\nInpaint batch is enabled. {len(inpaint_masks)} masks found.")
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

When processing batches in 2img2img an empty "Inpaint batch mask directory" leads to the following error because Windows can't find the path for an empty string:
`FileNotFoundError: [WinError 3] The system cannot find the path specified: ''`

This PR fixes that by checking beforehand if that input was left empty.

Since `listfiles()` in `shared` is left untouched, mandatory inputs that are left empty will result in an error, which I assume is the wanted error handling for that case.