### PR TITLE
Reduce grid rows if larger than number of images available

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -36,6 +36,8 @@ def image_grid(imgs, batch_size=1, rows=None):
         else:
             rows = math.sqrt(len(imgs))
             rows = round(rows)
+    if rows > len(imgs):
+        rows = len(imgs)
 
     cols = math.ceil(len(imgs) / rows)
 


### PR DESCRIPTION
When a set number of grid rows is specified in settings, then it leads to situations where an entire row in the grid is empty. The most noticeable example is the processing preview when the row count is set to 2, where it shows the preview just fine but with a black rectangle under it.

**Describe what this pull request is trying to achieve.**

Prevent the grid of output images from having empty rows.

**Additional notes and description of your changes**

I am not sure if this should have an associated setting to have it go back to the traditional behavior.

**Environment this was tested in**

 - OS: Linux (gentoo)
 - Browser: Firefox 109
 - Graphics card: AMD 7900 XTX  (rocm 5.4.1)
