### PR TITLE
Fixes thumbnail cards not loading the preview image

### DIFF
--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -34,5 +34,5 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
             }
 
     def allowed_directories_for_previews(self):
-        return [shared.cmd_opts.ckpt_dir, sd_models.model_path]
+        return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]
 


### PR DESCRIPTION
Thumbnail cards are not loading the preview image as mentioned in #7338.

This is because `ui_extra_networks_checkpoints.py`'s `allowed_directories_for_previews` method can return None if `shared.cmd_opts.ckpt_dir` (which is the default) and causes the None error as described in #7338. 

We simply check if either are none before returning them.

Closes #7338

## Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA GTX 1080
