### PR TITLE
Adding tutorials playlist link to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Here's how to add code to this repo: [Contributing](https://github.com/AUTOMATIC
 ## Documentation
 The documentation was moved from this README over to the project's [wiki](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki).
 
+## Tutorials Playlist
+[Stable Diffusion Tutorials Playlist](https://www.youtube.com/playlist?list=PL_pbwdIyffsmclLl0O144nQRnezKlNdx3)
+
 ## Credits
 Licenses for borrowed code can be found in `Settings -> Licenses` screen, and also in `html/licenses.html` file.
 


### PR DESCRIPTION
I am working my hardest to prepare most accurate and technical tutorials for Stable Diffusion So far I have 12 and 9 of them are using Automatic1111 2 of them uses Google Colab Shivam and 1 of them uses NMKD gui - that is also open source

I believe this playlist will help tremendously to new users The link will not make any auto play. it will open the page where videos are listed

I am also replying every comment and trying to help with my best knowledge to the viewers 