### PR TITLE
[Prompt Matrix] Support for negative prompt + delimiter selector

### DIFF
--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -12,6 +12,7 @@ from modules.shared import opts, cmd_opts, state
 import modules.sd_samplers
 from pprint import pprint
 
+
 def draw_xy_grid(xs, ys, x_label, y_label, cell):
     res = []
 
@@ -33,7 +34,8 @@ def draw_xy_grid(xs, ys, x_label, y_label, cell):
             res.append(processed.images[0])
 
     grid = images.image_grid(res, rows=len(ys))
-    grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
+    grid = images.draw_grid_annotations(
+        grid, res[0].width, res[0].height, hor_texts, ver_texts)
 
     first_processed.images = [grid]
 
@@ -45,56 +47,73 @@ class Script(scripts.Script):
         return "Prompt matrix"
 
     def ui(self, is_img2img):
-        put_at_start = gr.Checkbox(label='Put variable parts at start of prompt', value=False, elem_id=self.elem_id("put_at_start"))
-        different_seeds = gr.Checkbox(label='Use different seed for each picture', value=False, elem_id=self.elem_id("different_seeds"))
+        put_at_start = gr.Checkbox(label='Put variable parts at start of prompt',
+                                   value=False, elem_id=self.elem_id("put_at_start"))
+        different_seeds = gr.Checkbox(
+            label='Use different seed for each picture', value=False, elem_id=self.elem_id("different_seeds"))
         # Radio buttons for selecting the prompt between positive and negative
-        prompt_type = gr.Radio(["positive", "negative"], label="Select prompt", elem_id=self.elem_id("prompt_type"), value="positive")
+        prompt_type = gr.Radio(["positive", "negative"], label="Select prompt",
+                               elem_id=self.elem_id("prompt_type"), value="positive")
+        # Radio buttons for selecting the delimiter to use in the resulting prompt
+        variations_delimiter = gr.Radio(["comma", "space"], label="Select delimiter", elem_id=self.elem_id(
+            "variations_delimiter"), value="comma")
+        return [put_at_start, different_seeds, prompt_type, variations_delimiter]
 
-        return [put_at_start, different_seeds, prompt_type]
-
-    def run(self, p, put_at_start, different_seeds, prompt_type):
+    def run(self, p, put_at_start, different_seeds, prompt_type, variations_delimiter):
         modules.processing.fix_seed(p)
         # Raise error if promp type is not positive or negative
         if prompt_type not in ["positive", "negative"]:
             raise ValueError(f"Unknown prompt type {prompt_type}")
+        # Raise error if variations delimiter is not comma or space
+        if variations_delimiter not in ["comma", "space"]:
+            raise ValueError(
+                f"Unknown variations delimiter {variations_delimiter}")
 
         prompt = p.prompt if prompt_type == "positive" else p.negative_prompt
         original_prompt = prompt[0] if type(prompt) == list else prompt
         positive_prompt = p.prompt[0] if type(p.prompt) == list else p.prompt
 
+        delimiter = ", " if variations_delimiter == "comma" else " "
+
         all_prompts = []
         prompt_matrix_parts = original_prompt.split("|")
         combination_count = 2 ** (len(prompt_matrix_parts) - 1)
         for combination_num in range(combination_count):
-            selected_prompts = [text.strip().strip(',') for n, text in enumerate(prompt_matrix_parts[1:]) if combination_num & (1 << n)]
+            selected_prompts = [text.strip().strip(',') for n, text in enumerate(
+                prompt_matrix_parts[1:]) if combination_num & (1 << n)]
 
             if put_at_start:
                 selected_prompts = selected_prompts + [prompt_matrix_parts[0]]
             else:
                 selected_prompts = [prompt_matrix_parts[0]] + selected_prompts
 
-            all_prompts.append(", ".join(selected_prompts))
+            all_prompts.append(delimiter.join(selected_prompts))
 
         p.n_iter = math.ceil(len(all_prompts) / p.batch_size)
         p.do_not_save_grid = True
 
-        print(f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches.")
+        print(
+            f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches.")
 
         if prompt_type == "positive":
             p.prompt = all_prompts
         else:
             p.negative_prompt = all_prompts
-        p.seed = [p.seed + (i if different_seeds else 0) for i in range(len(all_prompts))]
+        p.seed = [p.seed + (i if different_seeds else 0)
+                  for i in range(len(all_prompts))]
         p.prompt_for_display = positive_prompt
         processed = process_images(p)
 
-        grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2))
-        grid = images.draw_prompt_matrix(grid, p.width, p.height, prompt_matrix_parts)
+        grid = images.image_grid(processed.images, p.batch_size, rows=1 << (
+            (len(prompt_matrix_parts) - 1) // 2))
+        grid = images.draw_prompt_matrix(
+            grid, p.width, p.height, prompt_matrix_parts)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])
 
         if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
+            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix",
+                              extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
 
         return processed

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -47,16 +47,23 @@ class Script(scripts.Script):
         return "Prompt matrix"
 
     def ui(self, is_img2img):
-        put_at_start = gr.Checkbox(label='Put variable parts at start of prompt',
-                                   value=False, elem_id=self.elem_id("put_at_start"))
-        different_seeds = gr.Checkbox(
-            label='Use different seed for each picture', value=False, elem_id=self.elem_id("different_seeds"))
-        # Radio buttons for selecting the prompt between positive and negative
-        prompt_type = gr.Radio(["positive", "negative"], label="Select prompt",
-                               elem_id=self.elem_id("prompt_type"), value="positive")
-        # Radio buttons for selecting the delimiter to use in the resulting prompt
-        variations_delimiter = gr.Radio(["comma", "space"], label="Select delimiter", elem_id=self.elem_id(
-            "variations_delimiter"), value="comma")
+        gr.HTML('<br />')
+        with gr.Row():
+            with gr.Column():
+                put_at_start = gr.Checkbox(label='Put variable parts at start of prompt',
+                                           value=False, elem_id=self.elem_id("put_at_start"))
+            with gr.Column():
+                # Radio buttons for selecting the prompt between positive and negative
+                prompt_type = gr.Radio(["positive", "negative"], label="Select prompt",
+                                       elem_id=self.elem_id("prompt_type"), value="positive")
+        with gr.Row():
+            with gr.Column():
+                different_seeds = gr.Checkbox(
+                    label='Use different seed for each picture', value=False, elem_id=self.elem_id("different_seeds"))
+            with gr.Column():
+                # Radio buttons for selecting the delimiter to use in the resulting prompt
+                variations_delimiter = gr.Radio(["comma", "space"], label="Select delimiter", elem_id=self.elem_id(
+                    "variations_delimiter"), value="comma")
         return [put_at_start, different_seeds, prompt_type, variations_delimiter]
 
     def run(self, p, put_at_start, different_seeds, prompt_type, variations_delimiter):

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -10,7 +10,6 @@ from modules import images
 from modules.processing import process_images, Processed
 from modules.shared import opts, cmd_opts, state
 import modules.sd_samplers
-from pprint import pprint
 
 
 def draw_xy_grid(xs, ys, x_label, y_label, cell):
@@ -34,8 +33,7 @@ def draw_xy_grid(xs, ys, x_label, y_label, cell):
             res.append(processed.images[0])
 
     grid = images.image_grid(res, rows=len(ys))
-    grid = images.draw_grid_annotations(
-        grid, res[0].width, res[0].height, hor_texts, ver_texts)
+    grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
 
     first_processed.images = [grid]
 
@@ -73,8 +71,7 @@ class Script(scripts.Script):
             raise ValueError(f"Unknown prompt type {prompt_type}")
         # Raise error if variations delimiter is not comma or space
         if variations_delimiter not in ["comma", "space"]:
-            raise ValueError(
-                f"Unknown variations delimiter {variations_delimiter}")
+            raise ValueError(f"Unknown variations delimiter {variations_delimiter}")
 
         prompt = p.prompt if prompt_type == "positive" else p.negative_prompt
         original_prompt = prompt[0] if type(prompt) == list else prompt
@@ -86,8 +83,7 @@ class Script(scripts.Script):
         prompt_matrix_parts = original_prompt.split("|")
         combination_count = 2 ** (len(prompt_matrix_parts) - 1)
         for combination_num in range(combination_count):
-            selected_prompts = [text.strip().strip(',') for n, text in enumerate(
-                prompt_matrix_parts[1:]) if combination_num & (1 << n)]
+            selected_prompts = [text.strip().strip(',') for n, text in enumerate(prompt_matrix_parts[1:]) if combination_num & (1 << n)]
 
             if put_at_start:
                 selected_prompts = selected_prompts + [prompt_matrix_parts[0]]
@@ -99,28 +95,23 @@ class Script(scripts.Script):
         p.n_iter = math.ceil(len(all_prompts) / p.batch_size)
         p.do_not_save_grid = True
 
-        print(
-            f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches.")
+        print(f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches.")
 
         if prompt_type == "positive":
             p.prompt = all_prompts
         else:
             p.negative_prompt = all_prompts
-        p.seed = [p.seed + (i if different_seeds else 0)
-                  for i in range(len(all_prompts))]
+        p.seed = [p.seed + (i if different_seeds else 0) for i in range(len(all_prompts))]
         p.prompt_for_display = positive_prompt
         processed = process_images(p)
 
-        grid = images.image_grid(processed.images, p.batch_size, rows=1 << (
-            (len(prompt_matrix_parts) - 1) // 2))
-        grid = images.draw_prompt_matrix(
-            grid, p.width, p.height, prompt_matrix_parts)
+        grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2))
+        grid = images.draw_prompt_matrix(grid, p.width, p.height, prompt_matrix_parts)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])
 
         if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix",
-                              extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
+            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
 
         return processed


### PR DESCRIPTION

Prompt Matrix is a great script but it lacks two important features:
- the ability to test negative prompt
- the ability to change the delimiter between variable strings for those who don't want commas in prompt

**Additional notes and description of your changes**

Added two Radio blocks for prompt type selection and delimiter.
Formated options with `gr.Row` and `gr.Column`

**Environment this was tested in**

 - OS: Windows
 - Browser: tested on Chrome, Mac Safari, and iOS Safari
 - Graphics card: n/a for the changes

**Screenshots or videos of your changes**
Desktop large:
![image](https://user-images.githubusercontent.com/28090/215335036-aa1fdd2c-40a7-4f52-9504-b61f309ebd4a.png)
Desktop medium:
![image](https://user-images.githubusercontent.com/28090/215335115-7b1908f8-c165-4e48-a761-856bd0f37e87.png)
Mobile:
![image](https://user-images.githubusercontent.com/28090/215335196-684226f4-a1fd-488d-a4a7-37264d596272.png)
