### PR TITLE
Fix xformers installation error on Linux

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -290,7 +290,7 @@ def prepare_environment():
                 if not is_installed("xformers"):
                     exit(0)
         elif platform.system() == "Linux":
-            run_pip(f"install xformers=={xformers_package}", "xformers")
+            run_pip(f"install {xformers_package}", "xformers")
 
     if not is_installed("pyngrok") and ngrok:
         run_pip("install pyngrok", "ngrok")


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fix xformers installation error on Linux (bug in 19de2a626b92bcfe83a97477f20d0faf9b3204c0)
```
Installing xformers
Traceback (most recent call last):
  File "/content/stable-diffusion-webui/launch.py", line 360, in <module>
    prepare_environment()
  File "/content/stable-diffusion-webui/launch.py", line 293, in prepare_environment
    run_pip(f"install xformers=={xformers_package}", "xformers")
  File "/content/stable-diffusion-webui/launch.py", line 137, in run_pip
    return run(f'"{python}" -m pip {args} --prefer-binary{index_url_line}', desc=f"Installing {desc}", errdesc=f"Couldn't install {desc}")
  File "/content/stable-diffusion-webui/launch.py", line 105, in run
    raise RuntimeError(message)
RuntimeError: Couldn't install xformers.
Command: "/content/stable-diffusion-webui/.venv/bin/python" -m pip install xformers==xformers==0.0.16rc425 --prefer-binary
Error code: 1
stdout: Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/

stderr: ERROR: Could not find a version that satisfies the requirement xformers==xformers==0.0.16rc425 (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 0.0.9, 0.0.10, 0.0.11, 0.0.12, 0.0.13, 0.0.16.dev424, 0.0.16.dev425, 0.0.16.dev426, 0.0.16.dev430, 0.0.16.dev432, 0.0.16rc424, 0.0.16rc425)
ERROR: No matching distribution found for xformers==xformers==0.0.16rc425
```

**Additional notes and description of your changes**

Remove duplicate `xformers==`

**Environment this was tested in**

 - OS: Linux