### PR TITLE
feat: add cloudflared option

### DIFF
--- a/modules/cloudflared.py
+++ b/modules/cloudflared.py
@@ -1,0 +1,199 @@
+import atexit
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tarfile
+import time
+from pathlib import Path
+from typing import Union
+
+import requests
+from tqdm import tqdm
+
+from modules import paths
+
+
+def _get_command() -> str:
+    system = platform.system()
+    machine = platform.machine()
+    if system == "Windows":
+        if machine == "AMD64":
+            command = "cloudflared-windows-amd64.exe"
+        elif machine == "x86":
+            command = "cloudflared-windows-386.exe"
+        else:
+            raise SystemError(f"{machine} is not supported on Windows")
+    elif system == "Linux":
+        if machine == "x86_64":
+            command = "cloudflared-linux-amd64"
+        elif machine == "i386":
+            command = "cloudflared-linux-386"
+        elif machine == "arm":
+            command = "cloudflared-linux-arm"
+        elif machine == "arm64":
+            command = "cloudflared-linux-arm64"
+        elif machine == "aarch":
+            command = "cloudflared-linux-arm64"
+        else:
+            raise SystemError(f"{machine} is not supported on Linux")
+    elif system == "Darwin":
+        if machine == "x86_64":
+            command = "cloudflared"
+        elif machine == "arm64":
+            print(
+                "* On a MacOS system with an Apple Silicon chip, Rosetta 2 needs to be installed, refer to this guide to learn more: https://support.apple.com/en-us/HT211861"
+            )
+            command = "cloudflared"
+        else:
+            raise SystemError(f"{machine} is not supported on Darwin")
+    else:
+        raise SystemError(f"{system} is not supported")
+    return command
+
+
+# Needed for the darwin package
+def _extract_tarball(tar_path: str, filename: str):
+    tar = tarfile.open(tar_path + "/" + filename, "r")
+    for item in tar:
+        tar.extract(item, tar_path)
+
+
+def _run_cloudflared(port: Union[int, str]):
+    system = platform.system()
+    machine = platform.machine()
+    command = _get_command()
+    cloudflared_path = os.path.join(paths.data_path, "tmp")
+    if not os.path.exists(cloudflared_path):
+        os.mkdir(cloudflared_path)
+
+    # Untar on Darwin, as there is an exclusive binary.
+    if system == "Darwin":
+        _download_cloudflared(cloudflared_path, "cloudflared-darwin-amd64.tgz")
+        _extract_tarball(cloudflared_path, "cloudflared-darwin-amd64.tgz")
+        executable = str(Path(cloudflared_path, command))
+    else:
+        _download_cloudflared(cloudflared_path, command)
+        executable = str(Path(cloudflared_path, command))
+    os.chmod(executable, 0o777)
+
+    if system == "Darwin" and machine == "arm64":
+        cloudflared = subprocess.Popen(
+            [
+                "arch",
+                "-x86_64",
+                executable,
+                "tunnel",
+                "--url",
+                f"http://127.0.0.1:{port}",
+                "--metrics",
+                "127.0.0.1:8099",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+    else:
+        cloudflared = subprocess.Popen(
+            [
+                executable,
+                "tunnel",
+                "--url",
+                f"http://127.0.0.1:{port}",
+                "--metrics",
+                "127.0.0.1:8099",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+    atexit.register(cloudflared.terminate)
+    localhost_url = "http://127.0.0.1:8099/metrics"
+    attempts = 0
+    while attempts < 10:
+        try:
+            tunnel_url = requests.get(localhost_url).text
+            tunnel_url = re.search(r"(?P<url>https?://\S+.trycloudflare.com)", tunnel_url).group("url")
+            break
+        except Exception:
+            attempts += 1
+            time.sleep(3)
+            continue
+    if attempts == 10:
+        raise RuntimeError("Can't connect to Cloudflare Edge")
+    return tunnel_url
+
+
+def _download_cloudflared(cloudflared_path: str, command: str):
+    system = platform.system()
+    machine = platform.machine()
+    if Path(cloudflared_path, command).exists():
+        if system == "Darwin" and machine == "arm64":
+            update_cloudflared = subprocess.Popen(
+                ["arch", "-x86_64", cloudflared_path + "/" + "cloudflared", "update"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
+        elif system == "Darwin" and machine == "x86_64":
+            update_cloudflared = subprocess.Popen(
+                [cloudflared_path + "/" + "cloudflared", "update"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
+        else:
+            update_cloudflared = subprocess.Popen(
+                [cloudflared_path + "/" + command, "update"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
+        return
+
+    url = None
+    if system == "Windows":
+        if machine == "AMD64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe"
+        elif machine == "x86":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-386.exe"
+
+    elif system == "Linux":
+        if machine == "x86_64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64"
+        elif machine == "i386":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-386"
+        elif machine == "arm":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm"
+        elif machine == "arm64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64"
+        elif machine == "aarch64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64"
+
+    elif system == "Darwin":
+        if machine == "x86_64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz"
+        if machine == "arm64":
+            url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz"
+
+    if url is None:
+        raise SystemError(f"cloudflared: {system} {machine} is not supported")
+    _download_file(cloudflared_path, url)
+
+
+def _download_file(cloudflared_path: str, url: str) -> str:
+    local_filename = url.split("/")[-1]
+    r = requests.get(url, stream=True)
+    download_path = str(Path(cloudflared_path, local_filename))
+    with tqdm.wrapattr(
+        r.raw,
+        "read",
+        total=int(r.headers.get("content-length", 0)),
+        desc="Downloading cloudflared...",
+        leave=False,
+    ) as src:
+        with open(download_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+    return download_path
+
+
+def start_cloudflared(port: Union[int, str]):
+    cloudflared_address = _run_cloudflared(port)
+    print(f" * Running on {cloudflared_address}")
+    print(" * Traffic stats available on http://127.0.0.1:8099/metrics")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -51,6 +51,7 @@ parser.add_argument("--upcast-sampling", action='store_true', help="upcast sampl
 parser.add_argument("--share", action='store_true', help="use share=True for gradio and make the UI accessible through their site")
 parser.add_argument("--ngrok", type=str, help="ngrok authtoken, alternative to gradio --share", default=None)
 parser.add_argument("--ngrok-region", type=str, help="The region in which ngrok should start.", default="us")
+parser.add_argument("--cloudflared", action='store_true', help="use cloudflared, alternative to gradio --share")
 parser.add_argument("--enable-insecure-extension-access", action='store_true', help="enable extensions tab regardless of other options")
 parser.add_argument("--codeformer-models-path", type=str, help="Path to directory with codeformer model file(s).", default=os.path.join(models_path, 'Codeformer'))
 parser.add_argument("--gfpgan-models-path", type=str, help="Path to directory with GFPGAN model file(s).", default=os.path.join(models_path, 'GFPGAN'))

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -62,6 +62,12 @@ if cmd_opts.ngrok is not None:
         cmd_opts.ngrok_region
         )
 
+if cmd_opts.cloudflared:
+    import modules.cloudflared as cloudflared
+    print('cloudflared detected, trying to connect...')
+    port = cmd_opts.port if cmd_opts.port is not None else 7860
+    cloudflared.start_cloudflared(port)
+
 
 def gr_show(visible=True):
     return {"visible": visible, "__type__": "update"}


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Add `--cloudflared` option, an alternative of ngrok. Most of the code was taken from <https://github.com/UWUplus/flask-cloudflared>.

**Additional notes and description of your changes**

The mechanism is simple.

1. Download cloudflared excutable from <https://github.com/cloudflare/cloudflared>, save it in `{data_path}/tmp`.
2. `cloudflared` runs at the same stage as ngrok runs.

Most of the code is to run differently depending on the os and architecture.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: RTX 3070 8GB

**Screenshots or videos of your changes**

```sh
stable-diffusion-webui on  cloudflared via  v18.12.1 via 🐍 v3.10.8 via 🅒 torch
❯ python launch.py --xformers --cloudflared
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:16:33) [MSC v.1929 64 bit (AMD64)]
Commit hash: 15cbda0e17d67875612926d62e000a7846d0140a
Installing requirements for Web UI
Launching Web UI with arguments: --xformers --cloudflared
cloudflared detected, trying to connect...
 * Running on https://annually-madagascar-strength-efficiency.trycloudflare.com
 * Traffic stats available on http://127.0.0.1:8099/metrics
Loading weights [2fdf5bea9a] from D:\stable-diffusion-webui\models\Stable-diffusion\AbyssOrangeMix2_hard-pruned.safetensors
Creating model from config: D:\stable-diffusion-webui\configs\v1-inference.yaml
LatentDiffusion: Running in eps-prediction mode
DiffusionWrapper has 859.52 M params.
Loading VAE weights specified in settings: D:\stable-diffusion-webui\models\VAE\BerrysMix.vae.safetensors
Applying xformers cross attention optimization.
Textual inversion embeddings loaded(1): bad_prompt
Model loaded in 3.0s (create model: 0.3s, apply weights to model: 0.5s, apply half(): 0.6s, load VAE: 0.1s, move model to device: 0.7s, load textual inversion embeddings: 0.8s).
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
```

Concurrent execution with ngrok is also possible.

```sh
❯ python launch.py --xformers --cloudflared --ngrok=TokenTokenTokenTokenTokenToken
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:16:33) [MSC v.1929 64 bit (AMD64)]
Commit hash: 15cbda0e17d67875612926d62e000a7846d0140a
Installing requirements for Web UI
Launching Web UI with arguments: --xformers --cloudflared --ngrok=TokenTokenTokenTokenTokenToken
ngrok authtoken detected, trying to connect...
ngrok connected to localhost:7860! URL: https://8ec1-2a09-bac1-3f40-00-252-4a.ngrok.io
You can use this link after the launch is complete.
cloudflared detected, trying to connect...
 * Running on https://resume-aka-exclusive-tours.trycloudflare.com
 * Traffic stats available on http://127.0.0.1:8099/metrics
Loading weights [2fdf5bea9a] from D:\stable-diffusion-webui\models\Stable-diffusion\AbyssOrangeMix2_hard-pruned.safetensors
Creating model from config: D:\stable-diffusion-webui\configs\v1-inference.yaml
LatentDiffusion: Running in eps-prediction mode
DiffusionWrapper has 859.52 M params.
Loading VAE weights specified in settings: D:\stable-diffusion-webui\models\VAE\BerrysMix.vae.safetensors
Applying xformers cross attention optimization.
Textual inversion embeddings loaded(1): bad_prompt
Model loaded in 3.6s (create model: 0.3s, apply weights to model: 0.5s, apply half(): 0.6s, load VAE: 0.1s, move model to device: 0.6s, load textual inversion embeddings: 1.4s).
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
```