### PR TITLE
Fix missing tooltip for 'Clear prompt' button

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -17,7 +17,7 @@ titles = {
     "\u2199\ufe0f": "Read generation parameters from prompt or last generation if prompt is empty into user interface.",
     "\u{1f4c2}": "Open images output directory",
     "\u{1f4be}": "Save style",
-    "\U0001F5D1": "Clear prompt",
+    "\u{1f5d1}": "Clear prompt",
     "\u{1f4cb}": "Apply selected styles to current prompt",
     "\u{1f4d2}": "Paste available values into the field",
     "\u{1f3b4}": "Show extra networks",


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes missing tooltip for 'Clear prompt' button

**Additional notes and description of your changes**

Currently used `\U0001F5D1` key doesn't match button with "🗑"  as `textContent`

```js
const obj = {
    "🗑": "Tooltip text"
}

obj['\U0001F5D1'] --> undefined
obj['\u{1f5d1}'] --> 'Tooltip text'
```
**Environment this was tested in**

List the environment you have developed / tested this on. 
 - OS: Windows
 - Browser: Chrome, Edge
 - Graphics card: not related

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/70658299/215632604-93d00281-a434-4ba2-9325-45a287c86029.png)
