### PR TITLE
Changes use_original_name_batch to default to True

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -327,7 +327,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "jpeg_quality": OptionInfo(80, "Quality for saved jpeg images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),
     "export_for_4chan": OptionInfo(True, "If PNG image is larger than 4MB or any dimension is larger than 4000, downscale and save copy as JPG"),
 
-    "use_original_name_batch": OptionInfo(False, "Use original name for output filename during batch process in extras tab"),
+    "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process in extras tab"),
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),


### PR DESCRIPTION
Adding default true to use_original_name_batch as images should by default hold the same name to help keep sequenced images in their correct order.

Tested in Ubuntu, Mac


[relevant reddit thread](https://www.reddit.com/r/StableDiffusion/comments/10pejra/adjusting_generation_order_and_organizing_outputs/)

