### PR TITLE
Fix prompt matrix #rows/#cols when using hires

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -171,8 +171,8 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts):
 
     pad_left = 0 if sum([sum([len(line.text) for line in lines]) for lines in ver_texts]) == 0 else width * 3 // 4
 
-    cols = round(im.width / width)
-    rows = round(im.height / height)
+    cols = im.width // width
+    rows = im.height // height
 
     assert cols == len(hor_texts), f'bad number of horizontal texts: {len(hor_texts)}; must be {cols}'
     assert rows == len(ver_texts), f'bad number of vertical texts: {len(ver_texts)}; must be {rows}'

--- a/modules/images.py
+++ b/modules/images.py
@@ -171,8 +171,8 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts):
 
     pad_left = 0 if sum([sum([len(line.text) for line in lines]) for lines in ver_texts]) == 0 else width * 3 // 4
 
-    cols = im.width // width
-    rows = im.height // height
+    cols = round(im.width / width)
+    rows = round(im.height / height)
 
     assert cols == len(hor_texts), f'bad number of horizontal texts: {len(hor_texts)}; must be {cols}'
     assert rows == len(ver_texts), f'bad number of vertical texts: {len(ver_texts)}; must be {rows}'

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -79,7 +79,7 @@ class Script(scripts.Script):
         processed = process_images(p)
 
         grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2))
-        grid = images.draw_prompt_matrix(grid, p.width, p.height, prompt_matrix_parts)
+        grid = images.draw_prompt_matrix(grid, max(p.width, p.hr_upscale_to_x), max(p.height, p.hr_upscale_to_y), prompt_matrix_parts)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -78,8 +78,8 @@ class Script(scripts.Script):
         p.prompt_for_display = original_prompt
         processed = process_images(p)
 
-        grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2))
-        grid = images.draw_prompt_matrix(grid, max(p.width, p.hr_upscale_to_x), max(p.height, p.hr_upscale_to_y), prompt_matrix_parts)
+        grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2)) 
+        grid = images.draw_prompt_matrix(grid, processed.images[0].width, processed.images[1].height, prompt_matrix_parts)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])


### PR DESCRIPTION



**Describe what this pull request is trying to achieve.**

Close #6866

**Additional notes and description of your changes**

See [my comment](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6866#issuecomment-1409488473) in the issue. 

- `images.draw_prompt_matrix()` should be called with the final width/height of the generated images, after upscaling. Otherwise, the number of rows/cols computed in images.draw_grid_annotations will increase by the upscaling factor.
- Round the number of cols/rows in `images.draw_grid_annotations`, since the final images width may be a bit less than the required hr_upscale_to_x/y

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 11
 - Browser: Firefox 109.0 (64 bit)
 - Graphics card: NVIDIA RTX 3090 24GB

**Screenshots or videos of your changes**

No change to the user interface whatsoever, but now the prompt matrix is working with hires:
![immagine](https://user-images.githubusercontent.com/24481570/215848886-b6945aed-19a8-403f-aa53-e5b2d1e51c92.png)
