### PR TITLE
Add .jpg to allowed thumb formats

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -29,8 +29,9 @@ def add_pages_to_demo(app):
         if not any([Path(x).resolve() in Path(filename).resolve().parents for x in allowed_dirs]):
             raise ValueError(f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages.")
 
-        if os.path.splitext(filename)[1].lower() != ".png":
-            raise ValueError(f"File cannot be fetched: {filename}. Only png.")
+        ext = os.path.splitext(filename)[1].lower()
+        if ext not in (".png", ".jpg"):
+            raise ValueError(f"File cannot be fetched: {filename}. Only png and jpg.")
 
         # would profit from returning 304
         return FileResponse(filename, headers={"Accept-Ranges": "bytes"})


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Allow for fetching .jpg preview files. Serves as an optimization for animated PNG previews.

**Additional notes and description of your changes**

This is needed for our extension to work. We just released a library of over 500 embeddings. Currently we have animated PNGs for embedding previews but we want to have it animate on hover.

Initially I tried to load it with https://github.com/davidmz/apng-canvas and it works but turns out injecting over 500 canvas elements into a web page is not good for performance.

Right now I plan to inject JS like this in our extension:

```
// get started and search for .card elements once stuff loads and we enter gradio's shadow root
window.onload = () => {
    const interval = setInterval(() => {
        const root = document.getElementsByTagName('gradio-app')?.[0]?.shadowRoot;
        if (root) {
            clearInterval(interval);
            
            const cards = root.querySelectorAll('.card');
            for (let card of cards) {
                const bgPNG = card.style.backgroundImage;
                
                if (bgPNG && bgPNG !== '' && bgPNG.includes('extensions')) {
                    const bgJPG = bgPNG.replace('.png', '.jpg');
                    // check if we actually have a JPG preview, method: HEAD does not work
                    fetch(bgJPG.replace('url("', '').replace('")', '')).then(res => {
                        if (!res.ok) return;
                        card.style.backgroundImage = bgJPG;
                        // ideally this would be done with CSS :hover but it's not possible to do inline and .card elements don't have IDs to allow us to build a style block with :hover's
                        card.addEventListener('mouseover', () => {
                            card.style.backgroundImage = bgPNG;
                        });
                        card.addEventListener('mouseout', () => {
                            card.style.backgroundImage = bgJPG;
                        });
                    });
                }
            }
        }
    }, 100);
}
```

One issue this fetch poses is that we gen a lot of exception noise in console output on each missed hit.

Ideally to solve this right I would scan for .jpg's and use them as default if found, then store the png in a data-style-hover data attr with `background-image: url(...` and have similar JS as above to toggle if that data attr is found.

In case of questions post here or DM me on Discord at catwars#8894.

**Environment this was tested in**

 - Windows
 - Browser: Brave
 - Graphics card: not relevant

**Screenshots or videos of your changes**

https://user-images.githubusercontent.com/116893749/216166750-7e454be3-cd9c-4d4e-987e-015c77345305.mp4
