### PR TITLE
Implementation of some unused command line arguments

### DIFF
--- a/modules/codeformer_model.py
+++ b/modules/codeformer_model.py
@@ -9,12 +9,15 @@ import modules.face_restoration
 import modules.shared
 from modules import shared, devices, modelloader
 from modules.paths import models_path
+from modules.shared import cmd_opts
 
 # codeformer people made a choice to include modified basicsr library to their project which makes
 # it utterly impossible to use it alongside with other libraries that also use basicsr, like GFPGAN.
 # I am making a choice to include some files from codeformer to work around this issue.
 model_dir = "Codeformer"
 model_path = os.path.join(models_path, model_dir)
+if cmd_opts.codeformer_models_path is not None and os.path.isdir(cmd_opts.codeformer_models_path):
+    model_path = cmd_opts.codeformer_models_path
 model_url = 'https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth'
 
 have_codeformer = False

--- a/modules/gfpgan_model.py
+++ b/modules/gfpgan_model.py
@@ -7,10 +7,13 @@ import gfpgan
 
 import modules.face_restoration
 from modules import paths, shared, devices, modelloader
+from modules.shared import cmd_opts
 
 model_dir = "GFPGAN"
 user_path = None
 model_path = os.path.join(paths.models_path, model_dir)
+if cmd_opts.gfpgan_models_path is not None and os.path.isdir(cmd_opts.gfpgan_models_path):
+    model_path = cmd_opts.gfpgan_models_path
 model_url = "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth"
 have_gfpgan = False
 loaded_gfpgan_model = None

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -39,6 +39,22 @@ class Upscaler:
 
         if self.model_path is None and self.name:
             self.model_path = os.path.join(shared.models_path, self.name)
+            match self.name:
+                case "ESRGAN":
+                    if modules.shared.cmd_opts.esrgan_models_path is not None and os.path.isdir(modules.shared.cmd_opts.esrgan_models_path):
+                        self.model_path = modules.shared.cmd_opts.esrgan_models_path
+                case "LDSR":
+                    if modules.shared.cmd_opts.ldsr_models_path is not None and os.path.isdir(modules.shared.cmd_opts.ldsr_models_path):
+                        self.model_path = modules.shared.cmd_opts.ldsr_models_path
+                case "RealESRGAN":
+                    if modules.shared.cmd_opts.realesrgan_models_path is not None and os.path.isdir(modules.shared.cmd_opts.realesrgan_models_path):
+                        self.model_path = modules.shared.cmd_opts.realesrgan_models_path
+                case "ScuNET":
+                    if modules.shared.cmd_opts.scunet_models_path is not None and os.path.isdir(modules.shared.cmd_opts.scunet_models_path):
+                        self.model_path = modules.shared.cmd_opts.scunet_models_path
+                case "SwinIR":
+                    if modules.shared.cmd_opts.swinir_models_path is not None and os.path.isdir(modules.shared.cmd_opts.swinir_models_path):
+                        self.model_path = modules.shared.cmd_opts.swinir_models_path
         if self.model_path and create_dirs:
             os.makedirs(self.model_path, exist_ok=True)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Models take a lot of space! And I'd like to share them between multiple instances of Stable Diffusion. So I placed my models in different directories than the ones in the models subdirectory of Automatic1111 webui. I saw that when I specified the new directory in the command line, those paths were ignored and it still downloaded the models in the original location. As it turns out, there was simply no use yet for those arguments.

So I implemented support for the following pre-existing command line arguments (who had no effect previously): `--gfpgan-models-path`, `--codeformer-models-path`, `--esrgan-models-path`, `--realesrgan-models-path`, `--scunet-models-path`, `--swinir-models-path`, `--ldsr-models-path`

**Additional notes and description of your changes**

It's only a matter of setting some model paths with the paths passed in the command line arguments if present.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 11 21H2
 - Browser: Firefox 109.0.1
 - Graphics card: NVIDIA RTX 3080 Ti 12GB

No modifications of the UI.
All tests passed.