### PR TITLE
Add optional argument --no-hashing to bypass sha256 hashing for loading speed benefits on low RAM/HDD systems

### DIFF
--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os.path
+from modules import shared
 
 import filelock
 
@@ -65,11 +66,23 @@ def sha256(filename, title):
     hashes = cache("hashes")
 
     sha256_value = sha256_from_cache(filename, title)
-    if sha256_value is not None:
-        return sha256_value
+    
+    if sha256_value != "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF":
+        if sha256_value is not None:
+            return sha256_value
 
     print(f"Calculating sha256 for {filename}: ", end='')
-    sha256_value = calculate_sha256(filename)
+  
+    # Check if --no-hashing parameter was supplied, if yes then set bogus hash to save time
+    if shared.cmd_opts.no_hashing:
+        sha256_value = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    # Is this parameter not there but such a bogus hash exists, now calculate a real one
+    elif sha256_value == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF":
+        sha256_value = calculate_sha256(filename)
+    # Else just proceed normally and calculate
+    else:
+        sha256_value = calculate_sha256(filename)
+    
     print(f"{sha256_value}")
 
     hashes[title] = {

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -147,7 +147,7 @@ def model_hash(filename):
 def select_checkpoint():
     model_checkpoint = shared.opts.sd_model_checkpoint
         
-    checkpoint_info = checkpoint_alisases.get(model_checkpoint, None)
+    checkpoint_info = checkpoints_list.get(model_checkpoint, None)
     if checkpoint_info is not None:
         return checkpoint_info
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -147,7 +147,7 @@ def model_hash(filename):
 def select_checkpoint():
     model_checkpoint = shared.opts.sd_model_checkpoint
         
-    checkpoint_info = checkpoints_list.get(model_checkpoint, None)
+    checkpoint_info = checkpoint_alisases.get(model_checkpoint, None)
     if checkpoint_info is not None:
         return checkpoint_info
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -86,6 +86,7 @@ parser.add_argument("--gradio-inpaint-tool", type=str, help="does not do anythin
 parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
 parser.add_argument("--styles-file", type=str, help="filename to use for styles", default=os.path.join(data_path, 'styles.csv'))
 parser.add_argument("--autolaunch", action='store_true', help="open the webui URL in the system's default browser upon launch", default=False)
+parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--theme", type=str, help="launches the UI with light or dark theme", default=None)
 parser.add_argument("--use-textbox-seed", action='store_true', help="use textbox for seeds in UI (no up/down, but possible to input long seeds)", default=False)
 parser.add_argument("--disable-console-progressbars", action='store_true', help="do not output progressbars to console", default=False)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This commit is meant to offer a long-term workaround for the disk loading time regression introduced by the sha256 calculation in [this commit](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/a95f1353089bdeaccd7c266b40cdd79efedfe632).

Explanation: Stable Diffusion models are typically 2 - 4+ GB in size. When assuming an average disk speed of 80 MB/s, this results in 50 seconds of waiting time _for each_ 4 GB model. This does not include the initializing time of the model itself. This takes further time in low RAM paging scenarios.

While I understand the result of this is saved in cache.json, the current implementation has overlooked cloud computing scenarios. Many people (including me) access the web UI in cloud environments such as Google Colab. The disk contents are temporary, meaning that each session the sha256 calculation would be done anew. Additionally, on low RAM systems, the hashing process does _**double**_ the loading time. As low RAM systems do not have enough standby memory to keep the file cached from the hashing operation. This is further worsened if the model is stored on a HDD.

Also, some people simply prefer looking at the model name itself in "parameters" instead of the hash, where this could be entirely ignored - with the exception of the option `"When reading generation parameters from text into UI (from PNG info or pasted text), do not change the selected model/checkpoint."` When choosing to use this new commandline switch, this option would be affected if it's not ticked.

**Additional notes and description of your changes**

Technical explanation: What the code is that it first checks if such a bogus string was already calculated before:

`if sha256_value != "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF":`

if it's not a bogus string, we can assume the sha256 value was calculated previously and is a valid one. It then just proceeds as the code normally would before in:
```
if sha256_value is not None:
            return sha256_value
```

Further on, the code edit check if `--no-hashing` was given as a startup argument. If yes, it will set the bogus hash

        `sha256_value = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"`

By the next `elif`, we are at the stage where no argument was given and checks for the existence of the bogus string. This happens if you used the command before, but you aren't anymore. In that case, it will calculate the real hash and replace the bogus string:

```
    elif sha256_value == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF":
        sha256_value = calculate_sha256(filename)
```

Finally, if nothing of this was ever used, it just proceeds normally as usual, calculating the sha256:

```
    else:
        sha256_value = calculate_sha256(filename)
```

It's really not complicated, I only felt like explaining this in case my intentions are unclear.

Overall I feel like that a cleaner approach would be to simply not store a hash at all. This is however where I'm reluctant to make further or complex changes, as more complexity in commits has shown to reduce more regressions in the past weeks. So to make the best of my limited abilities and keep things simple, I chose this approach with a bogus string. If you can implement this in a better fashion, please consider doing so! For the time being, having such an optional option would be just great for those of us who need it. I was able to confirm that it tremendously helps model loading times in environments like Google Colab and Kaggle (e.g. 22 seconds versus 50 seconds)

**Environment this was tested in**

Google Colab Linux Python 3.8, Windows 10 Python 3.8

Thank you for reading!

Edit: sd_models.py was not changed for this, I had to revert something to make the pull request less annoying to create on Github