### PR TITLE
Fix: show correct help message on --help

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -242,7 +242,7 @@ def prepare_environment():
 
     sys.argv += shlex.split(commandline_args)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui settings", default='config.json')
     args, _ = parser.parse_known_args(sys.argv)
 


### PR DESCRIPTION
this fix show correct help message on --help

currently due to the `argparse` in `prepare_environment` use for `run_extensions_installers`
the main `shared` help message will not be shown when passing `--help` arg
instead it only shows the short of help like so
```
usage: launch.py [-h] [--ui-settings-file UI_SETTINGS_FILE]

options:
  -h, --help            show this help message and exit
  --ui-settings-file UI_SETTINGS_FILE
                        filename to use for ui settings
```

`add_help=False` removes the help message trigger form the `argparse` in `prepare_environment`
allowing the execution to continue preaching the main `shared` `argparse` and showing the Four help message correctly
https://docs.python.org/3/library/argparse.html#argumentparser-objects

ideally there should only be one argparse at the beginning of the script
and when passing the `--help` the help message should be shown in immediately
not require waiting for all the things to be completed before parsing

but in order to do so the `shared` arg parser and other whings will need to be moved / restructured
which requires more work than it's worth

