### PR TITLE
fix symlinks in extra networks ui

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -26,7 +26,7 @@ def add_pages_to_demo(app):
     def fetch_file(filename: str = ""):
         from starlette.responses import FileResponse
 
-        if not any([Path(x).resolve() in Path(filename).resolve().parents for x in allowed_dirs]):
+        if not any([Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs]):
             raise ValueError(f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages.")
 
         ext = os.path.splitext(filename)[1].lower()


### PR DESCRIPTION
Issue tldr: using a symlinked folder under models/embeddings prevents you from adding previews in the "Extra Networks" UI with an error message of `Must be in one of directories registered by extra pages.`
Issue is present on both Linux and Windows.

This commit fixes that by swapping `resolve` to `absolute`.

`absolute` and `resolve` are equivalent, but `resolve` resolves symlinks (which is an obscure specialty behavior usually not wanted) whereas `absolute` treats symlinks as folders (which is the expected behavior).

With this commit, preview images load as expected.
I've confirmed the fix works on both Windows and Linux.

I'm not aware of any negative side effects this would cause.
I tested and couldn't find any paths that led to being able to access any data outside the intended folders, not even with using other symlinks in the filesystem or anything like that.

While researching this I found a lot of arguments about those two methods, including very strong opinions that one or the other is better and the other is awful (but inconsistent on which one is the one true good method). As far as I can tell the actual fact of the matter is just that they treat symlinks differently, and `absolute` is the one that treats them the way you'd expect within this context.