### PR TITLE
rudimentary aspect ratios

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -139,6 +139,15 @@ ui_reorder_categories = [
     "scripts",
 ]
 
+aspect_ratio_defaults = [
+    "1:1",
+    "1:2",
+    "3:2",
+    "4:3",
+    "16:9",
+]
+
+
 cmd_opts.disable_extension_access = (cmd_opts.share or cmd_opts.listen or cmd_opts.server_name) and not cmd_opts.enable_insecure_extension_access
 
 devices.device, devices.device_interrogate, devices.device_gfpgan, devices.device_esrgan, devices.device_codeformer = \
@@ -456,6 +465,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "quicksettings": OptionInfo("sd_model_checkpoint", "Quicksettings list"),
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order"),
+    "aspect_ratios": OptionInfo(", ".join(aspect_ratio_defaults), "txt2img/img2img aspect ratios"),
     "ui_extra_networks_tab_reorder": OptionInfo("", "Extra networks tab order"),
     "localization": OptionInfo("None", "Localization (requires restart)", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)),
 }))

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -466,6 +466,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "quicksettings": OptionInfo("sd_model_checkpoint", "Quicksettings list"),
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order"),
     "aspect_ratios": OptionInfo(", ".join(aspect_ratio_defaults), "txt2img/img2img aspect ratios"),
+    "aspect_ratio_base": OptionInfo("width", "aspect ratio base dimension (width or height)"),
     "ui_extra_networks_tab_reorder": OptionInfo("", "Extra networks tab order"),
     "localization": OptionInfo("None", "Localization (requires restart)", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)),
 }))

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -424,6 +424,20 @@ def ordered_ui_categories():
         yield category
 
 
+def aspect_ratio_list():
+    return [ratio.strip() for ratio in shared.opts.aspect_ratios.split(",")]
+
+
+def aspect_ratio_resize(w, h, bttn_val):
+    ratio = reduce(lambda bttn_val_width, bttn_val_height: int(bttn_val_width) / int(bttn_val_height), bttn_val.split(":"))
+    if ratio < 1:
+        return (round(h * ratio), h)
+    elif ratio > 1:
+        return (w, round(w * ratio))
+    else:
+        return [min(w,h)] * 2
+
+
 def get_value_for_setting(key):
     value = getattr(opts, key)
 
@@ -478,6 +492,10 @@ def create_ui():
                             with gr.Column(elem_id="txt2img_column_size", scale=4):
                                 width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="txt2img_width")
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="txt2img_height")
+                                with gr.Row():
+                                    for aspect_ratio in aspect_ratio_list():
+                                        aspect_ratio_bttn = ToolButton(value=aspect_ratio, elem_id=f"txt2img_ratio_{aspect_ratio.replace(':', '_')}")
+                                        aspect_ratio_bttn.click(aspect_ratio_resize, inputs=[width, height, aspect_ratio_bttn], outputs=[width, height])
 
                             res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn")
                             if opts.dimensions_and_batch_together:
@@ -756,6 +774,11 @@ def create_ui():
                             with gr.Column(elem_id="img2img_column_size", scale=4):
                                 width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="img2img_width")
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="img2img_height")
+                                with gr.Row():
+                                    for aspect_ratio in aspect_ratio_list():
+                                        aspect_ratio_bttn = ToolButton(value=aspect_ratio, elem_id=f"img2img_ratio_{aspect_ratio.replace(':', '_')}")
+                                        aspect_ratio_bttn.click(aspect_ratio_resize, inputs=[width, height, aspect_ratio_bttn], outputs=[width, height])
+
 
                             res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="img2img_res_switch_btn")
                             if opts.dimensions_and_batch_together:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -428,9 +428,9 @@ def aspect_ratio_list():
     return [ratio.strip() for ratio in shared.opts.aspect_ratios.split(",")]
 
 
-def aspect_ratio_resize(w, h, bttn_val):
+def aspect_ratio_resize(w, h, ratio_string):
     dimension = shared.opts.aspect_ratio_base
-    width, height = map(int, bttn_val.split(":"))
+    width, height = map(int, ratio_string.split(":"))
     ratio = width / height
     if dimension == 'width':
         return (w, round(w / ratio))
@@ -492,12 +492,9 @@ def create_ui():
                             with gr.Column(elem_id="txt2img_column_size", scale=4):
                                 width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="txt2img_width")
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="txt2img_height")
-                                with gr.Row():
-                                    for aspect_ratio in aspect_ratio_list():
-                                        aspect_ratio_bttn = ToolButton(value=aspect_ratio, elem_id=f"txt2img_ratio_{aspect_ratio.replace(':', '_')}")
-                                        aspect_ratio_bttn.click(aspect_ratio_resize, inputs=[width, height, aspect_ratio_bttn], outputs=[width, height])
 
                             res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn")
+                            aspect_ratio_dropdown = gr.Dropdown(value="1:1", choices=aspect_ratio_list(), type="value", elem_id="txt2img_ratio", show_label=False, label="Aspect Ratio")
                             if opts.dimensions_and_batch_together:
                                 with gr.Column(elem_id="txt2img_column_batch"):
                                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="txt2img_batch_count")
@@ -605,6 +602,7 @@ def create_ui():
             submit.click(**txt2img_args)
 
             res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height])
+            aspect_ratio_dropdown.change(aspect_ratio_resize, inputs=[width, height, aspect_ratio_dropdown], outputs=[width, height])
 
             txt_prompt_img.change(
                 fn=modules.images.image_data,
@@ -774,13 +772,9 @@ def create_ui():
                             with gr.Column(elem_id="img2img_column_size", scale=4):
                                 width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="img2img_width")
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="img2img_height")
-                                with gr.Row():
-                                    for aspect_ratio in aspect_ratio_list():
-                                        aspect_ratio_bttn = ToolButton(value=aspect_ratio, elem_id=f"img2img_ratio_{aspect_ratio.replace(':', '_')}")
-                                        aspect_ratio_bttn.click(aspect_ratio_resize, inputs=[width, height, aspect_ratio_bttn], outputs=[width, height])
-
 
                             res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="img2img_res_switch_btn")
+                            aspect_ratio_dropdown = gr.Dropdown(value="1:1", choices=aspect_ratio_list(), type="value", elem_id="img2img_ratio", show_label=False, label="Aspect Ratio")
                             if opts.dimensions_and_batch_together:
                                 with gr.Column(elem_id="img2img_column_batch"):
                                     batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="img2img_batch_count")
@@ -928,6 +922,7 @@ def create_ui():
             img2img_prompt.submit(**img2img_args)
             submit.click(**img2img_args)
             res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height])
+            aspect_ratio_dropdown.change(aspect_ratio_resize, inputs=[width, height, aspect_ratio_dropdown], outputs=[width, height])
 
             img2img_interrogate.click(
                 fn=lambda *args: process_interrogate(interrogate, *args),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -429,13 +429,13 @@ def aspect_ratio_list():
 
 
 def aspect_ratio_resize(w, h, bttn_val):
+    dimension = shared.opts.aspect_ratio_base
     width, height = map(int, bttn_val.split(":"))
     ratio = width / height
-    if w / ratio > h:
-        return (round(h * ratio), h)
-    else:
+    if dimension == 'width':
         return (w, round(w / ratio))
-
+    elif dimension == 'height':
+        return (round(h * ratio), h)
 
 
 def get_value_for_setting(key):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -429,13 +429,13 @@ def aspect_ratio_list():
 
 
 def aspect_ratio_resize(w, h, bttn_val):
-    ratio = reduce(lambda bttn_val_width, bttn_val_height: int(bttn_val_width) / int(bttn_val_height), bttn_val.split(":"))
-    if ratio < 1:
+    width, height = map(int, bttn_val.split(":"))
+    ratio = width / height
+    if w / ratio > h:
         return (round(h * ratio), h)
-    elif ratio > 1:
-        return (w, round(w * ratio))
     else:
-        return [min(w,h)] * 2
+        return (w, round(w / ratio))
+
 
 
 def get_value_for_setting(key):


### PR DESCRIPTION
Adds a ui setting where a user can specify their
preferred aspect ratios.  

Adds a ui setting where a user can specify the base
dimension (the one to keep the same, affects other).

~~Uses this to generate the buttons for txt2img &
img2img, with element ids.~~

To keep the user experience intuitive, the ratio uses colon format ":" to separate width and height.
This value is used as the ~~button~~ dropdown value, parsed as ints for the ratio value, ~~and used in the element id.~~

I did not update the stylesheets. I think there may need to be an update for ~~these buttons~~ this dropdown. ~~perhaps using `"button[id*=ratio]"` to target them, maybe even the row, so it can become size/ratio row.~~


**Environment this was tested in**

 - OS: Windows
 - Browser: chrome, firefox
 - Graphics card: not relevant

![image](https://user-images.githubusercontent.com/9631031/216793001-dd59a3ef-86ae-4859-86f0-2d06cab337c8.png)

Added user setting for specifying dimension to keep, so the other adjusts.
![image](https://user-images.githubusercontent.com/9631031/216795043-43c61f13-f37e-4045-8fe8-0399bf1f4e0b.png)

![image](https://user-images.githubusercontent.com/9631031/216796183-9f5cb64f-4ac1-4451-83dd-065fc16545ee.png)
