### PR TITLE
Add prompt_hash option for file/dir name pattern

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -66,8 +66,8 @@ titles = {
 
     "Interrogate": "Reconstruct prompt from existing image and put it into the prompt field.",
 
-    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [model_name], [prompt_words], [date], [datetime], [datetime<Format>], [datetime<Format><Time Zone>], [job_timestamp]; leave empty for default.",
-    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [model_name], [prompt_words], [date], [datetime], [datetime<Format>], [datetime<Format><Time Zone>], [job_timestamp]; leave empty for default.",
+    "Images filename pattern": "Use following tags to define how filenames for images are chosen: [steps], [cfg], [prompt_hash], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [model_name], [prompt_words], [date], [datetime], [datetime<Format>], [datetime<Format><Time Zone>], [job_timestamp]; leave empty for default.",
+    "Directory name pattern": "Use following tags to define how subdirectories for images and grids are chosen: [steps], [cfg],[prompt_hash], [prompt], [prompt_no_styles], [prompt_spaces], [width], [height], [styles], [sampler], [seed], [model_hash], [model_name], [prompt_words], [date], [datetime], [datetime<Format>], [datetime<Format><Time Zone>], [job_timestamp]; leave empty for default.",
     "Max prompt words": "Set the maximum number of words to be used in the [prompt_words] option; ATTENTION: If the words are too long, they may exceed the maximum length of the file path that the system can handle",
 
     "Loopback": "Process an image, use it as an input, repeat.",

--- a/modules/images.py
+++ b/modules/images.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageFont, ImageDraw, PngImagePlugin
 from fonts.ttf import Roboto
 import string
 import json
+import hashlib
 
 from modules import sd_samplers, shared, script_callbacks
 from modules.shared import opts, cmd_opts
@@ -343,6 +344,7 @@ class FilenameGenerator:
         'date': lambda self: datetime.datetime.now().strftime('%Y-%m-%d'),
         'datetime': lambda self, *args: self.datetime(*args),  # accepts formats: [datetime], [datetime<Format>], [datetime<Format><Time Zone>]
         'job_timestamp': lambda self: getattr(self.p, "job_timestamp", shared.state.job_timestamp),
+        'prompt_hash': lambda self: hashlib.sha256(self.prompt.encode()).hexdigest()[0:8],
         'prompt': lambda self: sanitize_filename_part(self.prompt),
         'prompt_no_styles': lambda self: self.prompt_no_style(),
         'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),


### PR DESCRIPTION
## [prompt_hash] option for file name

This PR enables users to write `[prompt_hash]` option for the image file/directory name.
ex)  `2864e2c6.png`
(same as model_hash, hash is the first 8 letters of sha256)

Similar goal can be achieved by inserting `[prompt]` to the file name,
but prompt is generally too long, so users would not be able to look at them
and see the difference at a glance. Even worse, often times prompts are cut 
if it does not fit in the maximum file name length.
`[prompt_hash]` option brings us easier way to search, group, and diff images by filename.

**Notes**

Need a small update to the wiki page after merge.
(Add `[prompt_hash]` row to the [file patterns table](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory#patterns)  )

**Environment this was tested in**

 - OS: Ubuntu 22.04.1 LTS / Windows 11
 - Browser: chrome
 - Graphics card: NVIDIA RTX 2070

**Screenshots or videos of your changes**

- can be set to the followin UI 
![image](https://user-images.githubusercontent.com/13178976/216806889-b16600ae-a1b9-42c1-9c79-d65d4d6d2584.png)
  resulting filename: `00177-2023-02-05-16-21-55_2864e2c6.png`

- can also be set to the directory name
![image](https://user-images.githubusercontent.com/13178976/216806934-9e39050e-d50a-43ac-ae21-a259cb9bb605.png)
  resulting directory name: `2023-02-05_2864e2c6`