### PR TITLE
Configurable JPG downscale threshold

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -575,9 +575,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     image.already_saved_as = fullfn
 
-    target_side_length = 4000
+    target_side_length = int(opts.target_side_length)
     oversize = image.width > target_side_length or image.height > target_side_length
-    if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > 4 * 1024 * 1024):
+    if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > opts.img_downscale_threshold * 1024 * 1024):
         ratio = image.width / image.height
 
         if oversize and ratio > 1:

--- a/modules/images.py
+++ b/modules/images.py
@@ -575,9 +575,17 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     image.already_saved_as = fullfn
 
-    target_side_length = int(opts.target_side_length)
+    try:
+        target_side_length = int(opts.target_side_length)
+    except ValueError:
+        target_side_length = 4000
+    try:
+        img_downscale_threshold = float(opts.img_downscale_threshold)
+    except ValueError:
+        img_downscale_threshold = 4
+    
     oversize = image.width > target_side_length or image.height > target_side_length
-    if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > opts.img_downscale_threshold * 1024 * 1024):
+    if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > img_downscale_threshold * 1024 * 1024):
         ratio = image.width / image.height
 
         if oversize and ratio > 1:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -325,7 +325,9 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_images_before_highres_fix": OptionInfo(False, "Save a copy of image before applying highres fix."),
     "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
     "jpeg_quality": OptionInfo(80, "Quality for saved jpeg images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),
-    "export_for_4chan": OptionInfo(True, "If PNG image is larger than 4MB or any dimension is larger than 4000, downscale and save copy as JPG"),
+    "export_for_4chan": OptionInfo(True, "If PNG image is larger than Downscale threshold or any dimension is larger than Target length, downscale the image to dimensions and save a copy as JPG"),
+    "img_downscale_threshold": OptionInfo(4, "Downscale threshold (MB)"),
+    "target_side_length": OptionInfo(4000, "Target length"),
 
     "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process in extras tab"),
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),


### PR DESCRIPTION
## Allowing the user to configure the image downscale parameters in setting

### this PR is a alternative solution to the issue describe by PR [#7549 Changed flag for 4chan from 4MB to 2MB. Real limit](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7549)

this exposes the image downscale parameters in settings
allowing the user to configure downscale size to their specific needs

### changes

- added 2 new settings entries

1. `target_side_length` defalut to 4000 (same as original)
2. `img_downscale_threshold`  defalut to 4 MB (same as original)

- changes to the description of `export_for_4chan`

### backwards compatibility
no issue
as this change uses the default values the current behavior is not changed