### PR TITLE
Update ui_extra_networks.py to fix div id's that have spaces in them

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -94,11 +94,13 @@ class ExtraNetworksPage:
             dirs = "".join([f"<li>{x}</li>" for x in self.allowed_directories_for_previews()])
             items_html = shared.html("extra-networks-no-cards.html").format(dirs=dirs)
 
+        self_name_id = self.name.replace(" ", "_")
+
         res = f"""
-<div id='{tabname}_{self.name}_subdirs' class='extra-network-subdirs extra-network-subdirs-{view}'>
+<div id='{tabname}_{self_name_id}_subdirs' class='extra-network-subdirs extra-network-subdirs-{view}'>
 {subdirs_html}
 </div>
-<div id='{tabname}_{self.name}_cards' class='extra-network-{view}'>
+<div id='{tabname}_{self_name_id}_cards' class='extra-network-{view}'>
 {items_html}
 </div>
 """


### PR DESCRIPTION
Update the string used to build the ID handle to replace spaces with underscore

**Ex**: instead of `txt2img_textual inversion_subdirs` it will now be `txt2img_textual_inversion_subdirs`

So that you can more easily target the element with CSS instead of having to do `div[id="txt2img_textual inversion_subdirs"]` you can just target it normally: `#txt2img_textual_inversion_subdirs`

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3080 TI

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/20732674/216847862-171fa150-aa30-438b-bacd-f4008f30d2f3.png)