### PR TITLE
Calls modules.sd_vae.refresh_vae_list(), fixes VAE list not updating

### DIFF
--- a/modules/shared_items.py
+++ b/modules/shared_items.py
@@ -20,4 +20,4 @@ def sd_vae_items():
 def refresh_vae_list():
     import modules.sd_vae
 
-    return modules.sd_vae.refresh_vae_list
+    return modules.sd_vae.refresh_vae_list()


### PR DESCRIPTION
Closes #7553.

We should be calling the method to actually update the list. Just returning it does not update the list.
It is used here https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ea9bd9fc7409109adcd61b897abc2c8881161256/modules/shared.py#L399

If we look at the other ones such as `sd_model_checkpoint`, it uses `refresh_checkpoints`, whose definition is also shown below
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ea9bd9fc7409109adcd61b897abc2c8881161256/modules/shared.py#L396 https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ea9bd9fc7409109adcd61b897abc2c8881161256/modules/shared.py#L295-L297