### PR TITLE
Fix hypernetworks and instruct pix2pix not working with `--upcast-sampling`

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -380,8 +380,8 @@ def apply_single_hypernetwork(hypernetwork, context_k, context_v, layer=None):
         layer.hyper_k = hypernetwork_layers[0]
         layer.hyper_v = hypernetwork_layers[1]
 
-    context_k = hypernetwork_layers[0](context_k)
-    context_v = hypernetwork_layers[1](context_v)
+    context_k = devices.cond_cast_unet(hypernetwork_layers[0](devices.cond_cast_float(context_k)))
+    context_v = devices.cond_cast_unet(hypernetwork_layers[1](devices.cond_cast_float(context_v)))
     return context_k, context_v
 
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -104,6 +104,9 @@ class StableDiffusionModelHijack:
             m.cond_stage_model.model.token_embedding = EmbeddingsWithFixes(m.cond_stage_model.model.token_embedding, self)
             m.cond_stage_model = sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(m.cond_stage_model, self)
 
+        if m.cond_stage_key == "edit":
+            sd_hijack_unet.hijack_ddpm_edit()
+
         self.optimization_method = apply_optimizations()
 
         self.clip = m.cond_stage_model


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Currently hypernetworks and instruct pix2pix crash or throw an exception when using `--upcast-sampling` (without autocast) with errors related to incorrect dtypes.

For hypernetworks, this changes two lines in `apply_single_hypernetwork()` to do the needed casting for hypernetworks to function when `--upcast-sampling` is used.

For instruct pix2pix the function hijack can't be done when `sd_hijack_unet.py` is loaded due to it resulting in import errors, so a function (`hijack_ddpm_edit()`) is added to check if the hijack has been already applied and to apply it if it has not. That function is then called in `hijack()` after an instruct pix2pix model loads.

**Environment this was tested in**
 - OS: macOS
 - Browser: Safari
 - Graphics card: M1 Max 64 GB