### PR TITLE
Convert image from RGBA to RGB before saving

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -73,6 +73,8 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
 
             if not save_normally:
                 os.makedirs(output_dir, exist_ok=True)
+                if processed_image.mode == 'RGBA':
+                    processed_image = processed_image.convert("RGB")
                 processed_image.save(os.path.join(output_dir, filename))
 
 


### PR DESCRIPTION
some image format (e.g. jpg) do not support rgba  
similar fix is already in place for `images.py`, this adds it to `img2img.py`  

closes #7641