### PR TITLE
Convert 16-bit greyscale to 8-bit when saving as JPEG

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -553,6 +553,8 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         elif extension.lower() in (".jpg", ".jpeg", ".webp"):
             if image_to_save.mode == 'RGBA':
                 image_to_save = image_to_save.convert("RGB")
+            elif image_to_save.mode == 'I;16':
+                image_to_save = image_to_save.point(lambda p: p * 0.0038910505836576).convert("L")
 
             image_to_save.save(temp_file_path, format=image_format, quality=opts.jpeg_quality)
 

--- a/modules/images.py
+++ b/modules/images.py
@@ -554,7 +554,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             if image_to_save.mode == 'RGBA':
                 image_to_save = image_to_save.convert("RGB")
             elif image_to_save.mode == 'I;16':
-                image_to_save = image_to_save.point(lambda p: p * 0.0038910505836576).convert("L")
+                image_to_save = image_to_save.point(lambda p: p * 0.0038910505836576).convert("RGB" if extension.lower() == ".webp" else "L")
 
             image_to_save.save(temp_file_path, format=image_format, quality=opts.jpeg_quality)
 


### PR DESCRIPTION
`stable-diffusion-webui-depthmap-script` (possibly others?) returns 16-bit greyscale images, which causes an error when saving as JPEG. This converts such images to 8-bit.

8-bit greyscale JPEG derived from #6065
![depthmap-0001-L](https://user-images.githubusercontent.com/4073789/217963969-84d6f788-9f07-4232-ab97-e68d218eef9f.jpg)

Fixes #6065, closes #7616 (alternate solution)