### PR TITLE
fix arg for train_hypernetwork api

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -498,7 +498,7 @@ class Api:
             if not apply_optimizations:
                 sd_hijack.undo_optimizations()
             try:
-                hypernetwork, filename = train_hypernetwork(*args)
+                hypernetwork, filename = train_hypernetwork(**args)
             except Exception as e:
                 error = e
             finally:


### PR DESCRIPTION
Very small modification.
The argument of `train_hypernetworks` in api.py is `args: dict`, so it is needed to pass `**args` to `train_hypernetworks` in `modules.hypernetworks.hypernetwork`. Since `*args` passes only the dict key, it is necessary to change to `**args`.