### PR TITLE
Fix: v0.91.0 of fastapi Cannot add middleware after an application ha…

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -27,3 +27,4 @@ GitPython==3.1.27
 torchsde==0.2.5
 safetensors==0.2.7
 httpcore<=0.15
+fastapi==0.90.1


### PR DESCRIPTION
…s started

fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7714

```
Traceback (most recent call last):
  File "launch.py", line 361, in <module>
    start()
  File "launch.py", line 356, in start
    webui.webui()
  File "/content/stable-diffusion-webui/webui.py", line 232, in webui
    app.add_middleware(GZipMiddleware, minimum_size=1000)
  File "/usr/local/lib/python3.8/dist-packages/starlette/applications.py", line 135, in add_middleware
    raise RuntimeError("Cannot add middleware after an application has started")
RuntimeError: Cannot add middleware after an application has started
```
v0.91.0 of fastapi Cannot add middleware after an application has started
https://github.com/tiangolo/fastapi/releases/tag/0.91.0