### PR TITLE
Fix face restorers setting

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -364,7 +364,7 @@ options_templates.update(options_section(('upscaling', "Upscaling"), {
 }))
 
 options_templates.update(options_section(('face-restoration', "Face restoration"), {
-    "face_restoration_model": OptionInfo(None, "Face restoration model", gr.Radio, lambda: {"choices": [x.name() for x in face_restorers]}),
+    "face_restoration_model": OptionInfo("CodeFormer", "Face restoration model", gr.Radio, lambda: {"choices": [x.name() for x in face_restorers]}),
     "code_former_weight": OptionInfo(0.5, "CodeFormer weight parameter; 0 = maximum effect; 1 = minimum effect", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}),
     "face_restoration_unload": OptionInfo(False, "Move face restoration model from VRAM into RAM after processing"),
 }))

--- a/webui.py
+++ b/webui.py
@@ -97,7 +97,6 @@ def initialize():
     modules.sd_models.setup_model()
     codeformer.setup_model(cmd_opts.codeformer_models_path)
     gfpgan.setup_model(cmd_opts.gfpgan_models_path)
-    shared.face_restorers.append(modules.face_restoration.FaceRestoration())
 
     modelloader.list_builtin_upscalers()
     modules.scripts.load_scripts()


### PR DESCRIPTION
The `Face restoration model` setting is currently unset by default, and CodeFormer is used. However, since the option isn't set, this doesn't get saved to image info.

I've changed the default to CodeFormer and removed the None option, as it did the same thing as unchecking `Restore faces`.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Edge
 - Graphics card: GTX 1080