### PR TITLE
add version to extensions table

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -2,6 +2,7 @@ import os
 import sys
 import traceback
 
+import time
 import git
 
 from modules import paths, shared
@@ -25,6 +26,7 @@ class Extension:
         self.status = ''
         self.can_update = False
         self.is_builtin = is_builtin
+        self.version = ''
 
         repo = None
         try:
@@ -40,6 +42,10 @@ class Extension:
             try:
                 self.remote = next(repo.remote().urls, None)
                 self.status = 'unknown'
+                head = repo.head.commit
+                ts = time.asctime(time.gmtime(repo.head.commit.committed_date))
+                self.version = f'{head.hexsha[:7]} ({ts})'
+
             except Exception:
                 self.remote = None
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -80,6 +80,7 @@ def extension_table():
             <tr>
                 <th><abbr title="Use checkbox to enable the extension; it will be enabled or disabled when you click apply button">Extension</abbr></th>
                 <th>URL</th>
+                <th><abbr title="Extension version">Version</abbr></th>
                 <th><abbr title="Use checkbox to mark the extension for update; it will be updated when you click apply button">Update</abbr></th>
             </tr>
         </thead>
@@ -87,11 +88,7 @@ def extension_table():
     """
 
     for ext in extensions.extensions:
-        remote = ""
-        if ext.is_builtin:
-            remote = "built-in"
-        elif ext.remote:
-            remote = f"""<a href="{html.escape(ext.remote or '')}" target="_blank">{html.escape("built-in" if ext.is_builtin else ext.remote or '')}</a>"""
+        remote = f"""<a href="{html.escape(ext.remote or '')}" target="_blank">{html.escape("built-in" if ext.is_builtin else ext.remote or '')}</a>"""
 
         if ext.can_update:
             ext_status = f"""<label><input class="gr-check-radio gr-checkbox" name="update_{html.escape(ext.name)}" checked="checked" type="checkbox">{html.escape(ext.status)}</label>"""
@@ -102,6 +99,7 @@ def extension_table():
             <tr>
                 <td><label><input class="gr-check-radio gr-checkbox" name="enable_{html.escape(ext.name)}" type="checkbox" {'checked="checked"' if ext.enabled else ''}>{html.escape(ext.name)}</label></td>
                 <td>{remote}</td>
+                <td>{ext.version}</td>
                 <td{' class="extension_status"' if ext.remote is not None else ''}>{ext_status}</td>
             </tr>
     """


### PR DESCRIPTION
adds version and timestamp to extensions table in ui.
main reason is if there is issue with an extension, its important to report correct version, just like with webui itself.

closes #7693

![image](https://user-images.githubusercontent.com/57876960/218509713-fb1fe9e7-6c7b-4162-a27f-5b4a84e7efe6.png)
