### PR TITLE
Torso-autocrop

### DIFF
--- a/modules/textual_inversion/autocrop.py
+++ b/modules/textual_inversion/autocrop.py
@@ -109,13 +109,12 @@ def focal_point(im, settings):
     if len(face_points) > 0 and (settings.torso_points_weight > 0):
       torso_centroid = centroid(face_points)
       torso_centroid.weight = settings.torso_points_weight / weight_pref_total 
-      if settings.torso_points_weight > 0:
-        face_x_distance = torso_centroid.x - im.width / 2
-        face_y_distance = torso_centroid.y - im.height / 2
-        face_direction = atan2(face_y_distance, face_x_distance)
-        torso_centroid.x -= (settings.crop_width / 2) * cos(face_direction)
-        torso_centroid.y -= (settings.crop_height / 2) * sin(face_direction)
-        pois.append(torso_centroid)
+      face_x_distance = torso_centroid.x - im.width / 2
+      face_y_distance = torso_centroid.y - im.height / 2
+      face_direction = atan2(face_y_distance, face_x_distance)
+      torso_centroid.x -= (settings.crop_width / 2) * cos(face_direction)
+      torso_centroid.y -= (settings.crop_height / 2) * sin(face_direction)
+      pois.append(torso_centroid)
 
     average_point = poi_average(pois, settings)
 

--- a/modules/textual_inversion/autocrop.py
+++ b/modules/textual_inversion/autocrop.py
@@ -113,8 +113,8 @@ def focal_point(im, settings):
         face_x_distance = torso_centroid.x - im.width / 2
         face_y_distance = torso_centroid.y - im.height / 2
         face_direction = atan2(face_y_distance, face_x_distance)
-        torso_centroid.x -= (im.width / 2) * cos(face_direction)
-        torso_centroid.y -= (im.height / 2) * sin(face_direction)
+        torso_centroid.x -= (settings.crop_width / 2) * cos(face_direction)
+        torso_centroid.y -= (settings.crop_height / 2) * sin(face_direction)
         pois.append(torso_centroid)
 
     average_point = poi_average(pois, settings)

--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -11,7 +11,7 @@ from modules.shared import opts, cmd_opts
 from modules.textual_inversion import autocrop
 
 
-def preprocess(id_task, process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
+def preprocess(id_task, process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_torso_weight=0.1, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
     try:
         if process_caption:
             shared.interrogator.load()
@@ -19,7 +19,7 @@ def preprocess(id_task, process_src, process_dst, process_width, process_height,
         if process_caption_deepbooru:
             deepbooru.model.start()
 
-        preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru, split_threshold, overlap_ratio, process_focal_crop, process_focal_crop_face_weight, process_focal_crop_entropy_weight, process_focal_crop_edges_weight, process_focal_crop_debug, process_multicrop, process_multicrop_mindim, process_multicrop_maxdim, process_multicrop_minarea, process_multicrop_maxarea, process_multicrop_objective, process_multicrop_threshold)
+        preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru, split_threshold, overlap_ratio, process_focal_crop, process_focal_crop_face_weight, process_focal_crop_torso_weight, process_focal_crop_entropy_weight, process_focal_crop_edges_weight, process_focal_crop_debug, process_multicrop, process_multicrop_mindim, process_multicrop_maxdim, process_multicrop_minarea, process_multicrop_maxarea, process_multicrop_objective, process_multicrop_threshold)
 
     finally:
 
@@ -131,7 +131,7 @@ def multicrop_pic(image: Image, mindim, maxdim, minarea, maxarea, objective, thr
     return wh and center_crop(image, *wh)
     
 
-def preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
+def preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_torso_weight=0.1, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
     width = process_width
     height = process_height
     src = os.path.abspath(process_src)
@@ -206,6 +206,7 @@ def preprocess_work(process_src, process_dst, process_width, process_height, pre
                 crop_width = width,
                 crop_height = height,
                 face_points_weight = process_focal_crop_face_weight,
+                torso_points_weight = process_focal_crop_torso_weight,
                 entropy_points_weight = process_focal_crop_entropy_weight,
                 corner_points_weight = process_focal_crop_edges_weight,
                 annotate_image = process_focal_crop_debug,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1107,9 +1107,10 @@ def create_ui():
                         process_overlap_ratio = gr.Slider(label='Split image overlap ratio', value=0.2, minimum=0.0, maximum=0.9, step=0.05, elem_id="train_process_overlap_ratio")
 
                     with gr.Row(visible=False) as process_focal_crop_row:
-                        process_focal_crop_face_weight = gr.Slider(label='Focal point face weight', value=0.9, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_face_weight")
-                        process_focal_crop_entropy_weight = gr.Slider(label='Focal point entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_entropy_weight")
-                        process_focal_crop_edges_weight = gr.Slider(label='Focal point edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_edges_weight")
+                        process_focal_crop_face_weight = gr.Slider(label='Face weight', value=0.9, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_face_weight")
+                        process_focal_crop_face_weight = gr.Slider(label='Torso weight', value=0.1, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_torso_weight")
+                        process_focal_crop_entropy_weight = gr.Slider(label='Entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_entropy_weight")
+                        process_focal_crop_edges_weight = gr.Slider(label='Edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_edges_weight")
                         process_focal_crop_debug = gr.Checkbox(label='Create debug image', elem_id="train_process_focal_crop_debug")
                     
                     with gr.Column(visible=False) as process_multicrop_col:
@@ -1267,6 +1268,7 @@ def create_ui():
                 process_overlap_ratio,
                 process_focal_crop,
                 process_focal_crop_face_weight,
+                process_focal_crop_torso_weight,
                 process_focal_crop_entropy_weight,
                 process_focal_crop_edges_weight,
                 process_focal_crop_debug,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1108,7 +1108,7 @@ def create_ui():
 
                     with gr.Row(visible=False) as process_focal_crop_row:
                         process_focal_crop_face_weight = gr.Slider(label='Face weight', value=0.9, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_face_weight")
-                        process_focal_crop_face_weight = gr.Slider(label='Torso weight', value=0.1, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_torso_weight")
+                        process_focal_crop_torso_weight = gr.Slider(label='Torso weight', value=0.1, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_torso_weight")
                         process_focal_crop_entropy_weight = gr.Slider(label='Entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_entropy_weight")
                         process_focal_crop_edges_weight = gr.Slider(label='Edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_edges_weight")
                         process_focal_crop_debug = gr.Checkbox(label='Create debug image', elem_id="train_process_focal_crop_debug")


### PR DESCRIPTION
I added a method of estimating where the torso of the subject may be based on the location of the face in the image.

It just finds the direction of the face relative to the center, then assumes the torso will be in the opposite direction.
This works very well in most cases. An edge case would be if the person is at the edge of a very wide image and they are standing straight up.

```python
torso_centroid = None
    if len(face_points) > 0 and settings.torso_points_weight > 0:
      torso_centroid = centroid(face_points)
      torso_centroid.weight = settings.torso_points_weight / weight_pref_total 
      face_x_distance = torso_centroid.x - im.width / 2
      face_y_distance = torso_centroid.y - im.height / 2
      face_direction = atan2(face_y_distance, face_x_distance)
      torso_centroid.x -= (settings.crop_width / 2) * cos(face_direction)
      torso_centroid.y -= (settings.crop_height / 2) * sin(face_direction)
      pois.append(torso_centroid)
```

I have tested this on: 
-windows 10 OS
-chrome browser
-NVIDA RTX A6000 48GB

Old:
![Screenshot 2023-02-14 174045](https://user-images.githubusercontent.com/64293310/218887936-6e3e8c03-4d37-4b1b-a1b3-bb6a335405cc.png)
New: Removed the redundant "Focal point" before each variable.
![Screenshot 2023-02-14 171809](https://user-images.githubusercontent.com/64293310/218887964-8b0f670b-1e52-459c-be87-bdf831d6d5c9.png)
Examples:
![00000-1-221](https://user-images.githubusercontent.com/64293310/218892609-7db849de-2485-4c43-9b00-1eb8163364fc.png)
![00001-1-291](https://user-images.githubusercontent.com/64293310/218892612-804900a8-f936-4826-8e28-4b680c2cbf2a.png)
![00002-1-387](https://user-images.githubusercontent.com/64293310/218892613-6f53115e-3a66-4aae-8f4b-d95d06458910.png)
![00003-1-5](https://user-images.githubusercontent.com/64293310/218892614-a72a8149-1834-4584-ade7-19d553c8d311.png)
