### PR TITLE
Fix pnginfo sendto, #7339

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -23,9 +23,10 @@ registered_param_bindings = []
 
 
 class ParamBinding:
-    def __init__(self, paste_button, tabname, source_text_component=None, source_image_component=None, source_tabname=None, override_settings_component=None):
+    def __init__(self, paste_button, tabname, tab_subname=None, source_text_component=None, source_image_component=None, source_tabname=None, override_settings_component=None):
         self.paste_button = paste_button
         self.tabname = tabname
+        self.tab_subname = tab_subname
         self.source_text_component = source_text_component
         self.source_image_component = source_image_component
         self.source_tabname = source_tabname
@@ -108,8 +109,13 @@ def register_paste_params_button(binding: ParamBinding):
 def connect_paste_params_buttons():
     binding: ParamBinding
     for binding in registered_param_bindings:
-        destination_image_component = paste_fields[binding.tabname]["init_img"]
-        fields = paste_fields[binding.tabname]["fields"]
+        if binding.tab_subname is None:
+            destination_tab = binding.tabname
+        else:
+            destination_tab = binding.tab_subname
+
+        destination_image_component = paste_fields[destination_tab]["init_img"]
+        fields = paste_fields[destination_tab]["fields"]
 
         destination_width_component = next(iter([field for field, name in fields if name == "Size-1"] if fields else []), None)
         destination_height_component = next(iter([field for field, name in fields if name == "Size-2"] if fields else []), None)
@@ -142,7 +148,7 @@ def connect_paste_params_buttons():
 
         binding.paste_button.click(
             fn=None,
-            _js=f"switch_to_{binding.tabname}",
+            _js=f"switch_to_{destination_tab}",
             inputs=None,
             outputs=None,
         )

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -445,6 +445,7 @@ def create_override_settings_dropdown(tabname, row):
 
     return dropdown
 
+override_settings_dict = {}
 
 def create_ui():
     import modules.img2img
@@ -539,6 +540,8 @@ def create_ui():
                     outputs=[],
                     show_progress=False,
                 )
+
+            override_settings_dict["txt2img"] = override_settings
 
             txt2img_gallery, generation_info, html_info, html_log = create_output_panel("txt2img", opts.outdir_txt2img_samples)
 
@@ -823,6 +826,8 @@ def create_ui():
 
             img2img_gallery, generation_info, html_info, html_log = create_output_panel("img2img", opts.outdir_img2img_samples)
 
+            override_settings_dict["img2img"] = override_settings
+
             connect_reuse_seed(seed, reuse_seed, generation_info, dummy_component, is_subseed=False)
             connect_reuse_seed(subseed, reuse_subseed, generation_info, dummy_component, is_subseed=True)
 
@@ -987,8 +992,13 @@ def create_ui():
                     buttons = parameters_copypaste.create_buttons(["txt2img", "img2img", "inpaint", "extras"])
 
                 for tabname, button in buttons.items():
+                    if tabname == "inpaint":
+                        tab_subname = tabname
+                        tabname = "img2img"
+                    else:
+                        tab_subname = None
                     parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                        paste_button=button, tabname=tabname, source_text_component=generation_info, source_image_component=image,
+                        paste_button=button, tabname=tabname, tab_subname=tab_subname, source_text_component=generation_info, source_image_component=image, override_settings_component=override_settings_dict.get(tabname),
                     ))
 
         image.change(


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Ever since the introduction of overrides, pnginfo sendto has not been working as expected. The model only sometimes received an override. Things like Clip Skip are always missing.

This PR aims to fix that, by always applying overrides when using pnginfo.

**Additional notes and description of your changes**
A problem I had run into when developing this was that the way register_paste_params_button was not able to send overrides to inpaint. This was because parts of it are of course part of img2img. But when treating it like img2img, it wouldn't use the correct img2img sub-tab.

I solved this by introducing a new attribute tab_subname for ParamBinding, that when used, will do only very specific things with "inpaint", while everything else is done with "img2img".

I also defined override_settings_dict in such a way, that extensions will be able to use it (for example the image browser).

There are no changes to the visible UI.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Firefox, Chrome
 - Graphics card: NVIDIA RTX 2060 6GB