### PR TITLE
Fixed missing part in the Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ sudo pacman -S wget git python3
 ```bash
 bash <(wget -qO- https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh)
 ```
-
+3. Place stable diffusion checkpoint (`model.ckpt`) in the `models/Stable-diffusion` directory (see [dependencies](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Dependencies) for where to get it).
+4. Run `webui.sh`.
 ### Installation on Apple Silicon
 
 Find the instructions [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Installation-on-Apple-Silicon).


### PR DESCRIPTION

**Describe what this pull request is trying to achieve.**

This is just a readme.md change, there was a mistake, the Windows instruction contained the stuff about putting in the stable diffusion checkpoint but the Linux one was missing it.

**Environment this was tested in**
No need to test, since its just readme.md, I checked the preview and it looks fine.
