### PR TITLE
Fix "Send seed/size to other tab" options

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -58,6 +58,14 @@ class ImageGridLoopParams:
         self.rows = rows
 
 
+class InfotextPastedParams:
+    def __init__(self, infotext, params, tabname=None, source_tabname=None):
+        self.infotext = infotext
+        self.params = params
+        self.tabname = tabname
+        self.source_tabname = source_tabname
+
+
 ScriptCallback = namedtuple("ScriptCallback", ["script", "callback"])
 callback_map = dict(
     callbacks_app_started=[],
@@ -174,10 +182,10 @@ def image_grid_callback(params: ImageGridLoopParams):
             report_exception(c, 'image_grid')
 
 
-def infotext_pasted_callback(infotext: str, params: Dict[str, Any]):
+def infotext_pasted_callback(params: InfotextPastedParams):
     for c in callback_map['callbacks_infotext_pasted']:
         try:
-            c.callback(infotext, params)
+            c.callback(params)
         except Exception:
             report_exception(c, 'infotext_pasted')
 
@@ -310,9 +318,8 @@ def on_image_grid(callback):
 
 def on_infotext_pasted(callback):
     """register a function to be called before applying an infotext.
-    The callback is called with two arguments:
-       - infotext: str - raw infotext.
-       - result: Dict[str, any] - parsed infotext parameters.
+    The callback is called with one argument:
+       - params: InfotextPastedParams - parameters to be used for infotext pasted. Can be modified.
     """
     add_callback(callback_map['callbacks_infotext_pasted'], callback)
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -988,7 +988,7 @@ def create_ui():
 
                 for tabname, button in buttons.items():
                     parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                        paste_button=button, tabname=tabname, source_text_component=generation_info, source_image_component=image,
+                        paste_button=button, tabname=tabname, source_text_component=generation_info, source_image_component=image, source_tabname="pnginfo",
                     ))
 
         image.change(


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I found out that the "Send size/seed to other tab" options were not being respected when sending from txt2img to img2img. Turns out that the paste function was ignoring the image data in the gallery, but *not* the infotext parameters. To remedy this I made two changes:

1. Check the tabname when parsing the infotext, and remove seed/size if sending from another tab unless the tab was pnginfo
2. Update the `on_infotext_pasted` script callback to include the source and destination tabname in the params, setting up for a potential extension that greatly improves the filter on what gets passed between tabs (like disabling sending width/height, but only if the destination tab is img2img)

**Additional notes and description of your changes**

N/A

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

N/A