### PR TITLE
Fix params.txt saving for infotexts modified by process_batch

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -585,10 +585,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if not p.disable_extra_networks:
                 extra_networks.activate(p, extra_network_data)
 
-        with open(os.path.join(paths.data_path, "params.txt"), "w", encoding="utf8") as file:
-            processed = Processed(p, [], p.seed, "")
-            file.write(processed.infotext(p, 0))
-
         if state.job_count == -1:
             state.job_count = p.n_iter
 
@@ -613,6 +609,15 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             if p.scripts is not None:
                 p.scripts.process_batch(p, batch_number=n, prompts=prompts, seeds=seeds, subseeds=subseeds)
+
+            # params.txt should be saved after scripts.process_batch, since the
+            # infotext could be modified by that callback
+            # Example: a wildcard processed by process_batch sets an extra model
+            # strength, which is saved as "Model Strength: 1.0" in the infotext
+            if n == 0:
+                with open(os.path.join(paths.data_path, "params.txt"), "w", encoding="utf8") as file:
+                    processed = Processed(p, [], p.seed, "")
+                    file.write(processed.infotext(p, 0))
 
             uc = get_conds_with_caching(prompt_parser.get_learned_conditioning, negative_prompts, p.steps, cached_uc)
             c = get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, prompts, p.steps, cached_c)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

If something in a `process_batch` callback modifies the infotext, the changes will not be reflected in `params.txt`, so they will not be restored if it's recalled later. So I made `params.txt` be written as late as possible, after all script callbacks have finished running.

**Additional notes and description of your changes**

N/A

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

N/A