### PR TITLE
Better Inpainting UI

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -664,7 +664,7 @@ def create_ui():
             from modules import ui_extra_networks
             extra_networks_ui_img2img = ui_extra_networks.create_ui(extra_networks, extra_networks_button, 'img2img')
 
-        with FormColumn:
+        with FormColumn():
             with gr.Column(variant='compact', elem_id="img2img_settings"):
                 copy_image_buttons = []
                 copy_image_destinations = {}

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -20,7 +20,7 @@ from PIL import Image, PngImagePlugin
 from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, wrap_gradio_call
 
 from modules import sd_hijack, sd_models, localization, script_callbacks, ui_extensions, deepbooru, sd_vae, extra_networks, postprocessing, ui_components, ui_common, ui_postprocessing
-from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML
+from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML, FormColumn
 from modules.paths import script_path, data_path
 
 from modules.shared import opts, cmd_opts, restricted_opts
@@ -664,7 +664,7 @@ def create_ui():
             from modules import ui_extra_networks
             extra_networks_ui_img2img = ui_extra_networks.create_ui(extra_networks, extra_networks_button, 'img2img')
 
-        with FormRow().style(equal_height=False):
+        with FormColumn:
             with gr.Column(variant='compact', elem_id="img2img_settings"):
                 copy_image_buttons = []
                 copy_image_destinations = {}

--- a/modules/ui_components.py
+++ b/modules/ui_components.py
@@ -28,6 +28,13 @@ class FormRow(gr.Row, gr.components.FormComponent):
         return "row"
 
 
+class FormColumn(gr.Column, gr.components.FormComponent):
+    """For better inpainting responsiveness"""
+
+    def get_block_name(self):
+        return "column"
+
+
 class FormGroup(gr.Group, gr.components.FormComponent):
     """Same as gr.Row but fits inside gradio forms"""
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Change the inpainting (and img2img) UI to utilize the full width of the screen.

**Additional notes and description of your changes**

See #7831 for additional screenshots and video demonstration of the changes (concept - before I did it in the actual ui scripts)

**Environment this was tested in**

 - OS: Windows
 - Browser: Edge
 - Graphics card: lol `--skip-torch-cuda-test --precision full --no-half --no-half-vae --use-cpu all`

**Screenshots or videos of your changes**

Before: #7831 

Actively Changing to Show the Difference: https://files.catbox.moe/44666n.mp4

After: More usable on portrait screens in a dual monitor setup, on 16:10 screens, on <1080p screens, etc.
![localhost(5)](https://user-images.githubusercontent.com/81622808/219690266-5f26e375-5d50-4ecb-b796-ea9eb138a861.png)

That screenshot wasn't with a DevTools change, it was using the changes proposed to ui.py and ui_components.py

Zoom to 150%, inpainting canvas is now even larger:
![150zoom_ (5)](https://user-images.githubusercontent.com/81622808/219690900-67218f89-e155-4321-ba99-278273f156a3.png)

Adding some more dynamic resizing, (or if Gradio supports it, making it outright user resizable) to the inpainting canvas would be ideal, but that's above my skill level.