### PR TITLE
Fix info alignment in XYZ Grid script

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -214,6 +214,8 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
     # Will be filled with empty images for any individual step that fails to process properly
     image_cache = [None] * (len(xs) * len(ys) * len(zs))
 
+    grid_info = {'prompts':[None] * len(zs), 'seeds':[None] * len(zs), 'infotexts':[None] * len(zs)}
+
     processed_result = None
     cell_mode = "P"
     cell_size = (1, 1)
@@ -241,6 +243,15 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
                 cell_mode = processed_image.mode
                 cell_size = processed_image.size
                 processed_result.images = [Image.new(cell_mode, cell_size)]
+                processed_result.all_prompts = [processed.prompt]
+                processed_result.all_seeds = [processed.seed]
+                processed_result.infotexts = [processed.infotexts[0]]
+
+            if include_sub_grids and grid_info['seeds'][iz] is None:
+                #Placeholder data for grids is a copy of the data for its first image:
+                grid_info['prompts'][iz] = processed.prompt
+                grid_info['seeds'][iz] = processed.seed
+                grid_info['infotexts'][iz] = processed.infotexts[0]
 
             image_cache[index(ix, iy, iz)] = processed_image
             if include_lone_images:
@@ -296,6 +307,10 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
         sub_grids[i] = grid
         if include_sub_grids and len(zs) > 1:
             processed_result.images.insert(i+1, grid)
+            processed_result.all_prompts.insert(i+1, grid_info['prompts'][i])
+            processed_result.all_seeds.insert(i+1, grid_info['seeds'][i])
+            processed_result.infotexts.insert(i+1, grid_info['infotexts'][i])
+
 
     sub_grid_size = sub_grids[0].size
     z_grid = images.image_grid(sub_grids, rows=1)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Resolve #7804
Fixes issue where the generation data in XYZ Grid does not align with the actual image; due to this, saved images did not have the correct metadata to re-generate them.

**Additional notes and description of your changes**

XYZ grid script was previously only culling the `images` property of its base Processed object, but not the related `all_prompts`, `all_seeds`, and `infotexts` lists, causing them to become misaligned. In a separate issue, sub-grids were later injecting into the `images` list, likewise without adjusting the data lists. I've just made it affect all lists the same way at the same time, and added a dict of lists for sub-grid data. (Oddly, `all_prompts` seems to include negative prompts as well, despite a separate list existing for that?)

Caveat: Sub-grids will copy the data of the first image _generated_ in them (not always top left!) but for now it's better than just... not.

It's also kind of ugly, but I plan on making more significant changes to this script soon to improve efficiency. For now this fix should stand on its own, and does not seem to have conflict with any other current PR's for the file.

**Environment this was tested in**

 - OS: Linux
 - Browser: Firefox
 - Graphics card: GeForce 1660 SUPER 6GB