### PR TITLE
store and print real torch version

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1779,10 +1779,15 @@ def versions_html():
     else:
         xformers_version = "N/A"
 
+    try:
+        torch_version = torch.__long_version__
+    except:
+        torch_version = torch.__version__
+
     return f"""
 python: <span title="{sys.version}">{python_version}</span>
  • 
-torch: {torch.__version__}
+torch: {torch_version}
  • 
 xformers: {xformers_version}
  • 

--- a/webui.py
+++ b/webui.py
@@ -20,6 +20,7 @@ import torch
 
 # Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
 if ".dev" in torch.__version__ or "+git" in torch.__version__:
+    torch.__long_version__ = torch.__version__
     torch.__version__ = re.search(r'[\d.]+[\d]', torch.__version__).group(0)
 
 from modules import shared, devices, sd_samplers, upscaler, extensions, localization, ui_tempdir, ui_extra_networks


### PR DESCRIPTION
some modules cannot parse dev version of torch so previous pr modifes torch version string - but this prevents collection of correct diagnostic data. plus some modules may actually want to know REAL version of torch.

this PR stores original torch version in `torch.__original_version__` and uses it to print in webui footer.