### PR TITLE
Added optional "Lock controls" button

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -191,6 +191,15 @@ function confirm_clear_prompt(prompt, negative_prompt) {
     return [prompt, negative_prompt]
 }
 
+function confirm_lock_controls() {
+    var lock_bg = gradioApp().querySelector("#tabs");
+    lock_bg.classList.toggle('bg-gray-100');
+
+    var all_ui_inputs = gradioApp().querySelectorAll('input, select, button:not(#ui_lock_controls):not(.gr-button-primary):not(.gr-button-secondary)');
+    all_ui_inputs.forEach(el => {
+        el.disabled = !el.disabled;
+    });
+}
 
 promptTokecountUpdateFuncs = {}
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -440,6 +440,7 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
 
 options_templates.update(options_section(('ui', "User interface"), {
     "return_grid": OptionInfo(True, "Show grid in results for web"),
+    "show_lock_controls": OptionInfo(False, "Show a lock button that disables UI controls"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),
     "add_model_hash_to_info": OptionInfo(True, "Add model hash to generation information"),
     "add_model_name_to_info": OptionInfo(True, "Add model name to generation information"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -88,6 +88,7 @@ reuse_symbol = '\u267b\ufe0f'  # ♻️
 paste_symbol = '\u2199\ufe0f'  # ↙
 refresh_symbol = '\U0001f504'  # 🔄
 save_style_symbol = '\U0001f4be'  # 💾
+lock_style_symbol = '\U0001F512'  # 🔒
 apply_style_symbol = '\U0001f4cb'  # 📋
 clear_prompt_symbol = '\U0001F5D1'  # 🗑️
 extra_networks_symbol = '\U0001F3B4'  # 🎴

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -337,6 +337,15 @@ def create_toprow(is_img2img):
                     outputs=[prompt, negative_prompt],
                 )
 
+                if opts.show_lock_controls:
+                    lock_controls_button = ToolButton(value=lock_style_symbol, elem_id=f"ui_lock_controls")
+                    lock_controls_button.click(
+                        fn=None,
+                        _js="confirm_lock_controls",
+                        inputs=None,
+                        outputs=None
+                    )
+
             with gr.Row(elem_id=f"{id_part}_styles_row"):
                 prompt_styles = gr.Dropdown(label="Styles", elem_id=f"{id_part}_styles", choices=[k for k, v in shared.prompt_styles.styles.items()], value=[], multiselect=True)
                 create_refresh_button(prompt_styles, shared.prompt_styles.reload, lambda: {"choices": [k for k, v in shared.prompt_styles.styles.items()]}, f"refresh_{id_part}_styles")


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Solution based on request:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7835

**Additional notes and description of your changes**
Added an optional UI settings checkbox: "Show a lock button that disables UI controls"
When activated, an additional button is added to the toolbar
When the "Lock" button is pressed, the main window changes the background. 
Buttons and Inputs are locked. Only text fields, primary and secondary buttons remain available.

_With this button appears small problem which I can't solve.. After clicking console throws error:
"TypeError: Cannot read properties of undefined (reading 'forEach')"_

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: GTX1060 ..

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/9393153/219882071-6555c7d9-4467-44df-938e-3a72bf41ea47.png)
![image](https://user-images.githubusercontent.com/9393153/219882099-41ac4c84-877c-45ae-8f25-38acb710c6e6.png)
