### PR TITLE
Add `Upscale by` and `Upscaler` options to img2img

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -8,8 +8,8 @@ function set_theme(theme){
 }
 
 function selected_gallery_index(){
-    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery] .gallery-item')
-    var button = gradioApp().querySelector('[style="display: block;"].tabitem div[id$=_gallery] .gallery-item.\\!ring-2')
+    var buttons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery] .thumbnails > .thumbnail-item')
+    var button = gradioApp().querySelector('[style="display: block;"].tabitem div[id$=_gallery] .thumbnails > .thumbnail-item.selected')
 
     var result = -1
     buttons.forEach(function(v, i){ if(v==button) { result = i } })
@@ -108,6 +108,14 @@ function get_img2img_tab_index() {
     let res = args_to_array(arguments)
     res.splice(-2)
     res[0] = get_tab_index('mode_img2img')
+    return res
+}
+
+function get_img2img_tab_index_for_res_preview() {
+    let res = args_to_array(arguments)
+    res.splice(-1) // gradio also sends outputs to the arguments, pop them off
+    res[0] = get_tab_index('mode_img2img')
+    debugger;
     return res
 }
 
@@ -334,4 +342,17 @@ var desiredCheckpointName = null;
 function selectCheckpoint(name){
     desiredCheckpointName = name;
     gradioApp().getElementById('change_checkpoint').click()
+}
+
+
+function onCalcResolutionImg2Img(init_img, scale, width, height, resize_mode){
+    i2iScale = gradioApp().getElementById('img2img_scale')
+    i2iWidth = gradioApp().getElementById('img2img_width')
+    i2iHeight = gradioApp().getElementById('img2img_height')
+
+    setInactive(i2iScale, scale == 1)
+    setInactive(i2iWidth, scale > 1)
+    setInactive(i2iHeight, scale > 1)
+
+    return [init_img, width, height, scale, resize_mode]
 }

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -118,14 +118,6 @@ function get_img2img_tab_index_for_res_preview() {
     return res
 }
 
-function get_img2img_tab_index_for_res_preview() {
-    let res = args_to_array(arguments)
-    res.splice(-1) // gradio also sends outputs to the arguments, pop them off
-    res[0] = get_tab_index('mode_img2img')
-    debugger;
-    return res
-}
-
 function create_submit_args(args){
     res = []
     for(var i=0;i<args.length;i++){

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -106,7 +106,14 @@ function create_tab_index_args(tabId, args){
 
 function get_img2img_tab_index() {
     let res = args_to_array(arguments)
-    res.splice(-2)
+    res.splice(-2) // gradio also sends outputs to the arguments, pop them off
+    res[0] = get_tab_index('mode_img2img')
+    return res
+}
+
+function get_img2img_tab_index_for_res_preview() {
+    let res = args_to_array(arguments)
+    res.splice(-1) // gradio also sends outputs to the arguments, pop them off
     res[0] = get_tab_index('mode_img2img')
     return res
 }
@@ -345,7 +352,7 @@ function selectCheckpoint(name){
 }
 
 
-function onCalcResolutionImg2Img(init_img, scale, width, height, resize_mode){
+function onCalcResolutionImg2Img(mode, scale, width, height, resize_mode, init_img, sketch, init_img_with_mask, inpaint_color_sketch, init_img_inpaint){
     i2iScale = gradioApp().getElementById('img2img_scale')
     i2iWidth = gradioApp().getElementById('img2img_width')
     i2iHeight = gradioApp().getElementById('img2img_height')
@@ -354,5 +361,5 @@ function onCalcResolutionImg2Img(init_img, scale, width, height, resize_mode){
     setInactive(i2iWidth, scale > 1)
     setInactive(i2iHeight, scale > 1)
 
-    return [init_img, width, height, scale, resize_mode]
+    return [];
 }

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -282,6 +282,9 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         res["Hires resize-1"] = 0
         res["Hires resize-2"] = 0
 
+    if "Img2Img Upscale" not in res:
+        res["Img2Img Upscale"] = 1
+
     restore_old_hires_fix_params(res)
 
     return res

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -282,8 +282,8 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         res["Hires resize-1"] = 0
         res["Hires resize-2"] = 0
 
-    if "Img2Img Upscale" not in res:
-        res["Img2Img Upscale"] = 1
+    if "Img2Img upscale" not in res:
+        res["Img2Img upscale"] = 1
 
     restore_old_hires_fix_params(res)
 

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -78,7 +78,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
+def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, scale: float, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     is_batch = mode == 5
@@ -149,6 +149,7 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         inpaint_full_res_padding=inpaint_full_res_padding,
         inpainting_mask_invert=inpainting_mask_invert,
         override_settings=override_settings,
+        scale=scale,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -78,7 +78,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, scale: float, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
+def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, scale: float, upscaler: str, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     is_batch = mode == 5
@@ -150,6 +150,7 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         inpainting_mask_invert=inpainting_mask_invert,
         override_settings=override_settings,
         scale=scale,
+        upscaler=upscaler,
     )
 
     p.scripts = modules.scripts.scripts_txt2img

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -929,7 +929,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     sampler = None
 
-    def __init__(self, init_images: list = None, resize_mode: int = 0, denoising_strength: float = 0.75, image_cfg_scale: float = None, mask: Any = None, mask_blur: int = 4, inpainting_fill: int = 0, inpaint_full_res: bool = True, inpaint_full_res_padding: int = 0, inpainting_mask_invert: int = 0, initial_noise_multiplier: float = None, **kwargs):
+    def __init__(self, init_images: Optional[list] = None, resize_mode: int = 0, denoising_strength: float = 0.75, image_cfg_scale: Optional[float] = None, mask: Any = None, mask_blur: int = 4, inpainting_fill: int = 0, inpaint_full_res: bool = True, inpaint_full_res_padding: int = 0, inpainting_mask_invert: int = 0, initial_noise_multiplier: Optional[float] = None, scale: float = 0, **kwargs):
         super().__init__(**kwargs)
 
         self.init_images = init_images
@@ -949,10 +949,26 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.mask = None
         self.nmask = None
         self.image_conditioning = None
+        self.scale = scale
+
+    def get_final_size(self):
+        if self.scale > 1:
+            img = self.init_images[0]
+            width = int(img.width * self.scale)
+            height = int(img.height * self.scale)
+            return width, height
+        else:
+            return self.width, self.height
+
 
     def init(self, all_prompts, all_seeds, all_subseeds):
         self.sampler = sd_samplers.create_sampler(self.sampler_name, self.sd_model)
         crop_region = None
+
+        if self.scale > 1:
+            self.extra_generation_params["Img2Img Upscale"] = self.scale
+
+        self.width, self.height = self.get_final_size()
 
         image_mask = self.image_mask
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -929,7 +929,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     sampler = None
 
-    def __init__(self, init_images: Optional[list] = None, resize_mode: int = 0, denoising_strength: float = 0.75, image_cfg_scale: Optional[float] = None, mask: Any = None, mask_blur: int = 4, inpainting_fill: int = 0, inpaint_full_res: bool = True, inpaint_full_res_padding: int = 0, inpainting_mask_invert: int = 0, initial_noise_multiplier: Optional[float] = None, scale: float = 0, **kwargs):
+    def __init__(self, init_images: Optional[list] = None, resize_mode: int = 0, denoising_strength: float = 0.75, image_cfg_scale: Optional[float] = None, mask: Any = None, mask_blur: int = 4, inpainting_fill: int = 0, inpaint_full_res: bool = True, inpaint_full_res_padding: int = 0, inpainting_mask_invert: int = 0, initial_noise_multiplier: Optional[float] = None, scale: float = 0, upscaler: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
 
         self.init_images = init_images
@@ -950,6 +950,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.nmask = None
         self.image_conditioning = None
         self.scale = scale
+        self.upscaler = upscaler
 
     def get_final_size(self):
         if self.scale > 1:
@@ -966,7 +967,16 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         crop_region = None
 
         if self.scale > 1:
-            self.extra_generation_params["Img2Img Upscale"] = self.scale
+            self.extra_generation_params["Img2Img upscale"] = self.scale
+
+        # Non-latent upscalers are run before sampling
+        # Latent upscalers are run during sampling
+        init_upscaler = None
+        if self.upscaler is not None:
+            self.extra_generation_params["Img2Img upscaler"] = self.upscaler
+            if self.upscaler not in shared.latent_upscale_modes:
+                assert len([x for x in shared.sd_upscalers if x.name == self.upscaler]) > 0, f"could not find upscaler named {self.upscaler}"
+                init_upscaler = self.upscaler
 
         self.width, self.height = self.get_final_size()
 
@@ -992,7 +1002,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 image_mask = images.resize_image(2, mask, self.width, self.height)
                 self.paste_to = (x1, y1, x2-x1, y2-y1)
             else:
-                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
+                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height, init_upscaler)
                 np_mask = np.array(image_mask)
                 np_mask = np.clip((np_mask.astype(np.float32)) * 2, 0, 255).astype(np.uint8)
                 self.mask_for_overlay = Image.fromarray(np_mask)
@@ -1009,7 +1019,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             image = images.flatten(img, opts.img2img_background_color)
 
             if crop_region is None and self.resize_mode != 3:
-                image = images.resize_image(self.resize_mode, image, self.width, self.height)
+                image = images.resize_image(self.resize_mode, image, self.width, self.height, init_upscaler)
 
             if image_mask is not None:
                 image_masked = Image.new('RGBa', (image.width, image.height))
@@ -1054,8 +1064,9 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
         self.init_latent = self.sd_model.get_first_stage_encoding(self.sd_model.encode_first_stage(image))
 
-        if self.resize_mode == 3:
-            self.init_latent = torch.nn.functional.interpolate(self.init_latent, size=(self.height // opt_f, self.width // opt_f), mode="bilinear")
+        latent_scale_mode = shared.latent_upscale_modes.get(self.upscaler, None) if self.upscaler is not None else shared.latent_upscale_modes.get(shared.latent_upscale_default_mode, "nearest")
+        if latent_scale_mode is not None:
+            self.init_latent = torch.nn.functional.interpolate(self.init_latent, size=(self.height // opt_f, self.width // opt_f), mode=latent_scale_mode["mode"], antialias=latent_scale_mode["antialias"])
 
         if image_mask is not None:
             init_mask = latent_mask

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -855,7 +855,7 @@ def create_ui():
             img2img_resolution_preview_inputs = [dummy_component, # filled in by selected img2img tab index in _js
                                                  scale, width, height, resize_mode,
                                                  init_img, sketch, init_img_with_mask, inpaint_color_sketch, init_img_inpaint]
-            for input in img2img_resolution_preview_inputs:
+            for input in img2img_resolution_preview_inputs[1:]:
                 if isinstance(input, Releaseable):
                     input.release(
                         fn=calc_resolution_img2img,
@@ -863,8 +863,7 @@ def create_ui():
                         inputs=img2img_resolution_preview_inputs,
                         outputs=[final_resolution],
                         show_progress=False,
-                    )
-                    input.release(
+                    ).success(
                         None,
                         _js="onCalcResolutionImg2Img",
                         inputs=img2img_resolution_preview_inputs,
@@ -878,8 +877,7 @@ def create_ui():
                         inputs=img2img_resolution_preview_inputs,
                         outputs=[final_resolution],
                         show_progress=False,
-                    )
-                    input.change(
+                    ).success(
                         None,
                         _js="onCalcResolutionImg2Img",
                         inputs=img2img_resolution_preview_inputs,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -767,7 +767,7 @@ def create_ui():
                     )
 
                 with FormRow():
-                    resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", choices=["Just resize", "Crop and resize", "Resize and fill", "Just resize (latent upscale)"], type="index", value="Just resize")
+                    resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", choices=["Just resize", "Crop and resize", "Resize and fill"], type="index", value="Just resize")
 
                 for category in ordered_ui_categories():
                     if category == "sampler":
@@ -797,7 +797,9 @@ def create_ui():
                             with FormRow():
                                 cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="img2img_cfg_scale")
                                 image_cfg_scale = gr.Slider(minimum=0, maximum=3.0, step=0.05, label='Image CFG Scale', value=1.5, elem_id="img2img_image_cfg_scale", visible=shared.sd_model and shared.sd_model.cond_stage_key == "edit")
-                            denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.75, elem_id="img2img_denoising_strength")
+                            with FormRow():
+                                upscaler = gr.Dropdown(label="Upscaler", elem_id="img2img_upscaler", choices=[*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]], value=shared.latent_upscale_default_mode)
+                                denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.75, elem_id="img2img_denoising_strength")
 
                     elif category == "seed":
                         seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox = create_seed_inputs('img2img')
@@ -934,6 +936,7 @@ def create_ui():
                     height,
                     width,
                     scale,
+                    upscaler,
                     resize_mode,
                     inpaint_full_res,
                     inpaint_full_res_padding,
@@ -1019,7 +1022,8 @@ def create_ui():
                 (seed, "Seed"),
                 (width, "Size-1"),
                 (height, "Size-2"),
-                (scale, "Img2Img Upscale"),
+                (scale, "Img2Img upscale"),
+                (upscaler, "Img2Img upscaler"),
                 (batch_size, "Batch size"),
                 (subseed, "Variation seed"),
                 (subseed_strength, "Variation seed strength"),

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -220,6 +220,7 @@ axis_options = [
     AxisOption("Clip skip", int, apply_clip_skip),
     AxisOption("Denoising", float, apply_field("denoising_strength")),
     AxisOptionTxt2Img("Hires upscaler", str, apply_field("hr_upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
+    AxisOptionImg2Img("Upscaler", str, apply_field("upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
     AxisOptionImg2Img("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")),
     AxisOption("VAE", str, apply_vae, cost=0.7, choices=lambda: list(sd_vae.vae_dict)),
     AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),

--- a/style.css
+++ b/style.css
@@ -1,48 +1,196 @@
-.container {
-    max-width: 100%;
+
+/* general gradio fixes */
+
+:root, .dark{
+    --checkbox-label-gap: 0.25em 0.1em;
+    --section-header-text-size: 12pt;
+    --block-background-fill: transparent;
 }
 
-.token-counter{
+.block.padded{
+    padding: 0 !important;
+}
+
+div.gradio-container{
+    max-width: unset !important;
+}
+
+.hidden{
+    display: none;
+}
+
+.compact{
+    background: transparent !important;
+    padding: 0 !important;
+}
+
+div.form{
+    border-width: 0;
+    box-shadow: none;
+    background: transparent;
+    overflow: visible;
+    gap: 0.5em;
+}
+
+.block.gradio-dropdown,
+.block.gradio-slider,
+.block.gradio-checkbox,
+.block.gradio-textbox,
+.block.gradio-radio,
+.block.gradio-checkboxgroup,
+.block.gradio-number,
+.block.gradio-colorpicker
+{
+    border-width: 0 !important;
+    box-shadow: none !important;
+}
+
+.gap.compact{
+    padding: 0;
+    gap: 0.2em 0;
+}
+
+div.compact{
+    gap: 1em;
+}
+
+.gradio-dropdown ul.options{
+    z-index: 3000;
+}
+
+.gradio-dropdown label span:not(.has-info),
+.gradio-textbox label span:not(.has-info),
+.gradio-number label span:not(.has-info)
+{
+    margin-bottom: 0;
+}
+
+.gradio-dropdown div.wrap.wrap.wrap.wrap{
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+
+.gradio-dropdown .wrap-inner.wrap-inner.wrap-inner{
+    flex-wrap: unset;
+}
+
+.gradio-dropdown .single-select{
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.gradio-dropdown .token-remove.remove-all.remove-all{
+    display: none;
+}
+
+.gradio-dropdown.multiselect .token-remove.remove-all.remove-all{
+    display: flex;
+}
+
+.gradio-slider input[type="number"]{
+    width: 6em;
+}
+
+.block.gradio-checkbox {
+    margin: 0.75em 1.5em 0 0;
+}
+
+.gradio-html div.wrap{
+    height: 100%;
+}
+div.gradio-html.min{
+    min-height: 0;
+}
+
+.block.gradio-gallery{
+    background: var(--input-background-fill);
+}
+
+.gradio-container .prose a, .gradio-container .prose a:visited{
+    color: unset;
+    text-decoration: none;
+}
+
+
+
+/* general styled components */
+
+.gradio-button.tool{
+    max-width: 2.2em;
+    min-width: 2.2em !important;
+    height: 2.4em;
+    align-self: end;
+    line-height: 1em;
+    border-radius: 0.5em;
+}
+
+.checkboxes-row{
+    margin-bottom: 0.5em;
+    margin-left: 0em;
+}
+.checkboxes-row > div{
+    flex: 0;
+    white-space: nowrap;
+    min-width: auto;
+}
+
+button.custom-button{
+    border-radius: var(--button-large-radius);
+    padding: var(--button-large-padding);
+    font-weight: var(--button-large-text-weight);
+    border: var(--button-border-width) solid var(--button-secondary-border-color);
+    background: var(--button-secondary-background-fill);
+    color: var(--button-secondary-text-color);
+    font-size: var(--button-large-text-size);
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    transition: var(--button-transition);
+    box-shadow: var(--button-shadow);
+    text-align: center;
+}
+
+
+/* txt2img/img2img specific */
+
+.block.token-counter{
     position: absolute;
     display: inline-block;
-    right: 2em;
+    right: 1em;
     min-width: 0 !important;
     width: auto;
     z-index: 100;
+    top: -0.75em;
 }
 
-.token-counter.error span{
+.block.token-counter span{
+    background: var(--input-background-fill) !important;
+    box-shadow: 0 0 0.0 0.3em rgba(192,192,192,0.15), inset 0 0 0.6em rgba(192,192,192,0.075);
+    border: 2px solid rgba(192,192,192,0.4) !important;
+    border-radius: 0.4em;
+}
+
+.block.token-counter.error span{
     box-shadow: 0 0 0.0 0.3em rgba(255,0,0,0.15), inset 0 0 0.6em rgba(255,0,0,0.075);
     border: 2px solid rgba(255,0,0,0.4) !important;
 }
 
-.token-counter div{
+.block.token-counter div{
     display: inline;
 }
 
-.token-counter span{
+.block.token-counter span{
     padding: 0.1em 0.75em;
 }
 
-#sh{
-    min-width: 2em;
-    min-height: 2em;
-    max-width: 2em;
-    max-height: 2em;
-    flex-grow: 0;
-    padding-left: 0.25em;
-    padding-right: 0.25em;
-    margin: 0.1em 0;
-    opacity: 0%;
-    cursor: default;
+[id$=_subseed_show]{
+    min-width: auto !important;
+    flex-grow: 0 !important;
+    display: flex;
 }
 
-.output-html p {margin: 0 0.5em;}
-
-.row > *,
-.row > .gr-form > * {
-    min-width: min(120px, 100%);
-    flex: 1 1 0%;
+[id$=_subseed_show] label{
+    margin-bottom: 0.5em;
+    align-self: end;
 }
 
 .performance {
@@ -75,196 +223,94 @@
     object-fit: scale-down;
 }
 #txt2img_actions_column, #img2img_actions_column {
-	margin: 0.35rem 0.75rem 0.35rem 0;	
+    gap: 0.5em;
 }
-#script_list {
-    padding: .625rem .75rem 0 .625rem;
-}
-.justify-center.overflow-x-scroll {
-    justify-content: left;
-}
-
-.justify-center.overflow-x-scroll button:first-of-type {
-    margin-left: auto;
-}
-
-.justify-center.overflow-x-scroll button:last-of-type {
-    margin-right: auto;
-}
-
-[id$=_random_seed], [id$=_random_subseed], [id$=_reuse_seed], [id$=_reuse_subseed], #open_folder{
-    min-width: 2.3em;
-    height: 2.5em;
-    flex-grow: 0;
-    padding-left: 0.25em;
-    padding-right: 0.25em;
-}
-
-#hidden_element{
-    display: none;
-}
-
-[id$=_seed_row], [id$=_subseed_row]{
-    gap: 0.5rem;
-    padding: 0.6em;
-}
-
-[id$=_subseed_show_box]{
-    min-width: auto;
-    flex-grow: 0;
-}
-
-[id$=_subseed_show_box] > div{
-    border: 0;
-    height: 100%;
-}
-
-[id$=_subseed_show]{
-    min-width: auto;
-    flex-grow: 0;
-    padding: 0;
-}
-
-[id$=_subseed_show] label{
-    height: 100%;
-}
-
-#txt2img_actions_column, #img2img_actions_column{
-    gap: 0;
-    margin-right: .75rem;
-}
-
 #txt2img_tools, #img2img_tools{
     gap: 0.4em;
 }
 
-#interrogate_col{
+.interrogate-col{
     min-width: 0 !important;
-    max-width: 8em !important;
-    margin-right: 1em;
-    gap: 0;
+    max-width: fit-content;
+    gap: 0.5em;
 }
-#interrogate, #deepbooru{
-    margin: 0em 0.25em 0.5em 0.25em;
-    min-width: 8em;
-    max-width: 8em;
+.interrogate-col > button{
+    flex: 1;
 }
 
-#style_pos_col, #style_neg_col{
-    min-width: 8em !important;
+.generate-box{
+    position: relative;
 }
-
-#txt2img_styles_row, #img2img_styles_row{
-    gap: 0.25em;
-    margin-top: 0.3em;
-}
-
-#txt2img_styles_row > button, #img2img_styles_row > button{
-    margin: 0;
-}
-
-#txt2img_styles, #img2img_styles{
-    padding: 0;
-}
-
-#txt2img_styles > label > div, #img2img_styles > label > div{
-    min-height: 3.2em;
-}
-
-ul.list-none{
-    max-height: 35em;
-    z-index: 2000;
-}
-
-.gr-form{
-    background: transparent;
-}
-
-.my-4{
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-#resize_mode{
-    flex: 1.5;
-}
-
-button{
-    align-self: stretch !important;
-}
-
-.overflow-hidden, .gr-panel{
-    overflow: visible !important;
-}
-
-#x_type, #y_type{
-    max-width: 10em;
-}
-
-#txt2img_preview, #img2img_preview, #ti_preview{
+.gradio-button.generate-box-skip, .gradio-button.generate-box-interrupt{
     position: absolute;
-    width: 320px;
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 34px;
-    z-index: 100;
-    border: none;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-}
-
-@media screen and (min-width: 768px) {
-    #txt2img_preview, #img2img_preview, #ti_preview {
-        position: absolute;
-    }
-}
-
-@media screen and (max-width: 767px) {
-    #txt2img_preview, #img2img_preview, #ti_preview {
-        position: relative;
-    }
-}
-
-#txt2img_preview div.left-0.top-0, #img2img_preview div.left-0.top-0, #ti_preview div.left-0.top-0{
+    width: 50%;
+    height: 100%;
     display: none;
+    background: #b4c0cc;
+}
+.gradio-button.generate-box-skip:hover, .gradio-button.generate-box-interrupt:hover{
+    background: #c2cfdb;
+}
+.gradio-button.generate-box-interrupt{
+    left: 0;
+    border-radius: 0.5rem 0 0 0.5rem;
+}
+.gradio-button.generate-box-skip{
+    right: 0;
+    border-radius: 0 0.5rem 0.5rem 0;
 }
 
-fieldset span.text-gray-500, .gr-block.gr-box span.text-gray-500,  label.block span{
-    position: absolute;
-    top: -0.7em;
-    line-height: 1.2em;
-    padding: 0;
-    margin: 0 0.5em;
-
-    background-color: white;
-    box-shadow:  6px 0 6px 0px white, -6px 0 6px 0px white;
-
-    z-index: 300;
+#txtimg_hr_finalres, #img2img_finalres {
+    min-height: 0 !important;
+    padding: .625rem .75rem;
+    margin-left: -0.75em
 }
 
-.dark fieldset span.text-gray-500, .dark .gr-block.gr-box span.text-gray-500, .dark label.block span{
-    background-color: rgb(31, 41, 55);
-    box-shadow: none;
-    border: 1px solid rgba(128, 128, 128, 0.1);
-    border-radius: 6px;
-    padding: 0.1em 0.5em;
+#txtimg_hr_finalres .resolution, #img2img_finalres .resolution{
+    font-weight: bold;
 }
 
-#txt2img_column_batch, #img2img_column_batch{
+.inactive{
+    opacity: 0.5;
+}
+
+[id$=_column_batch]{
     min-width: min(13.5em, 100%) !important;
 }
 
-#settings fieldset span.text-gray-500, #settings .gr-block.gr-box span.text-gray-500, #settings label.block span{
-    position: relative;
-    border: none;
-    margin-right: 8em;
+div.dimensions-tools{
+    min-width: 0 !important;
+    max-width: fit-content;
+    flex-direction: row;
+    align-content: center;
 }
 
-#settings .gr-panel div.flex-col div.justify-between div{
-    position: relative;
-    z-index: 200;
+#mode_img2img .gradio-image > div.fixed-height, #mode_img2img .gradio-image > div.fixed-height img{
+    height: 480px !important;
+    max-height: 480px !important;
+    min-height: 480px !important;
+}
+
+.image-buttons button{
+    min-width: auto;
+}
+
+.infotext {
+    overflow-wrap: break-word;
+}
+
+/* settings */
+#quicksettings {
+    width: fit-content;
+}
+
+#quicksettings > div, #quicksettings > fieldset{
+    max-width: 24em;
+    min-width: 24em;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: none;
 }
 
 #settings{
@@ -276,17 +322,18 @@ fieldset span.text-gray-500, .gr-block.gr-box span.text-gray-500,  label.block s
     margin-left: 10em;
 }
 
-#settings > div.flex-wrap{
+#settings > div.tab-nav{
     float: left;
     display: block;
     margin-left: 0;
     width: 10em;
 }
 
-#settings > div.flex-wrap button{
+#settings > div.tab-nav button{
     display: block;
     border: none;
     text-align: left;
+    white-space: initial;
 }
 
 #settings_result{
@@ -294,29 +341,8 @@ fieldset span.text-gray-500, .gr-block.gr-box span.text-gray-500,  label.block s
     margin: 0 1.2em;
 }
 
-input[type="range"]{
-    margin: 0.5em 0 -0.3em 0;
-}
 
-#mask_bug_info {
-  text-align: center;
-  display: block;
-  margin-top: -0.75em;
-  margin-bottom: -0.75em;
-}
-
-#txt2img_negative_prompt, #img2img_negative_prompt{
-}
-
-/* gradio 3.8 adds opacity to progressbar which makes it blink; disable it here */
-.transition.opacity-20 {
-  opacity: 1 !important;
-}
-
-/* more gradio's garbage cleanup */
-.min-h-\[4rem\] { min-height: unset !important; }
-.min-h-\[6rem\] { min-height: unset !important; }
-
+/* live preview */
 .progressDiv{
     position: relative;
     height: 20px;
@@ -362,6 +388,8 @@ input[type="range"]{
     height: 100%;
 }
 
+/* fullscreen popup (ie in Lora's (i) button) */
+
 .popup-metadata{
     color: black;
     background: white;
@@ -402,87 +430,54 @@ input[type="range"]{
     padding: 2em;
 }
 
+/* fullpage image viewer */
+
 #lightboxModal{
-  display: none;
-  position: fixed;
-  z-index: 1001;
-  padding-top: 100px;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgba(20, 20, 20, 0.95);
-  user-select: none;
-  -webkit-user-select: none;
+    display: none;
+    position: fixed;
+    z-index: 1001;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(20, 20, 20, 0.95);
+    user-select: none;
+    -webkit-user-select: none;
+    flex-direction: column;
 }
 
 .modalControls {
-    display: grid;
-    grid-template-columns: 32px 32px 32px 1fr 32px;
-    grid-template-areas: "zoom tile save space close";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    padding: 16px;
-    gap: 16px;
+    display: flex;
+    gap: 1em;
+    padding: 1em;
     background-color: rgba(0,0,0,0.2);
 }
-
 .modalClose {
-    grid-area: close;
+    margin-left: auto;
 }
-
-.modalZoom {
-    grid-area: zoom;
-}
-
-.modalSave {
-    grid-area: save;
-}
-
-.modalTileImage {
-    grid-area: tile;
-}
-
-.modalClose,
-.modalZoom,
-.modalTileImage {
-  color: white;
-  font-size: 35px;
-  font-weight: bold;
-  cursor: pointer;
-}
-
-.modalSave {
+.modalControls span{
     color: white;
-    font-size: 28px;
-    margin-top: 8px;
+    font-size: 35px;
     font-weight: bold;
     cursor: pointer;
+    width: 1em;
 }
 
-.modalClose:hover,
-.modalClose:focus,
-.modalSave:hover,
-.modalSave:focus,
-.modalZoom:hover,
-.modalZoom:focus {
-  color: #999;
-  text-decoration: none;
-  cursor: pointer;
+.modalControls span:hover, .modalControls span:focus{
+    color: #999;
+    text-decoration: none;
 }
 
-#modalImage {
+#lightboxModal > img {
     display: block;
     margin: auto;
     width: auto;
 }
 
-.modalImageFullscreen {
+#lightboxModal > img.modalImageFullscreen{
     object-fit: contain;
-    height: 90%;
+    height: 100%;
 }
 
 .modalPrev,
@@ -512,45 +507,7 @@ input[type="range"]{
   background-color: rgba(0, 0, 0, 0.8);
 }
 
-#imageARPreview{
-    position:absolute;
-    top:0px;
-    left:0px;
-    border:2px solid red;
-    background:rgba(255, 0, 0, 0.3);
-    z-index: 900;
-    pointer-events:none;
-    display:none
-}
-
-#txt2img_generate_box, #img2img_generate_box{
-    position: relative;
-}
-
-#txt2img_interrupt, #img2img_interrupt, #txt2img_skip, #img2img_skip{
-    position: absolute;
-    width: 50%;
-    height: 100%;
-    background: #b4c0cc;
-    display: none;
-}
-
-#txt2img_interrupt, #img2img_interrupt{
-    left: 0;
-    border-radius: 0.5rem 0 0 0.5rem;
-}
-#txt2img_skip, #img2img_skip{
-    right: 0;
-    border-radius: 0 0.5rem 0.5rem 0;
-}
-
-.red {
-	color: red;
-}
-
-.gallery-item {
-    --tw-bg-opacity: 0 !important;
-}
+/* context menu (ie for the generate button) */
 
 #context-menu{
     z-index:9999;
@@ -579,61 +536,8 @@ input[type="range"]{
     background: #a55000;
 }
 
-#quicksettings {
-    width: fit-content;
-}
 
-#quicksettings > div, #quicksettings > fieldset{
-    max-width: 24em;
-    min-width: 24em;
-    padding: 0;
-    border: none;
-    box-shadow: none;
-    background: none;
-    margin-right: 10px;
-}
-
-#quicksettings > div > div > div > label > span {
-    position: relative;
-    margin-right: 9em;
-    margin-bottom: -1em;
-}
-
-canvas[key="mask"] {
-    z-index: 12 !important;
-    filter: invert();
-    mix-blend-mode: multiply;
-    pointer-events: none;
-}
-
-
-/* gradio 3.4.1 stuff for editable scrollbar values */
-.gr-box > div > div > input.gr-text-input{
-    position: absolute;
-    right: 0.5em;
-    top: -0.6em;
-    z-index: 400;
-    width: 6em;
-}
-#quicksettings .gr-box > div > div > input.gr-text-input {
-  top: -1.12em;
-}
-
-.row.gr-compact{
-    overflow: visible;
-}
-
-#img2img_image, #img2img_image > .h-60, #img2img_image > .h-60 > div, #img2img_image > .h-60 > div > img,
-#img2img_sketch, #img2img_sketch > .h-60, #img2img_sketch > .h-60 > div, #img2img_sketch > .h-60 > div > img,
-#img2maskimg, #img2maskimg > .h-60, #img2maskimg > .h-60 > div, #img2maskimg > .h-60 > div > img,
-#inpaint_sketch, #inpaint_sketch > .h-60, #inpaint_sketch > .h-60 > div, #inpaint_sketch > .h-60 > div > img
-{
-    height: 480px !important;
-    max-height: 480px !important;
-    min-height: 480px !important;
-}
-
-/* Extensions */
+/* extensions */
 
 #tab_extensions table{
     border-collapse: collapse;
@@ -646,6 +550,7 @@ canvas[key="mask"] {
 
 #tab_extensions table input[type="checkbox"]{
     margin-right: 0.5em;
+    appearance: checkbox;
 }
 
 #tab_extensions button{
@@ -670,74 +575,7 @@ canvas[key="mask"] {
     font-size: 90%;
 }
 
-#image_buttons_txt2img button, #image_buttons_img2img button, #image_buttons_extras button{
-    min-width: auto;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-}
-
-.gr-form{
-    background-color: white;
-}
-
-.dark .gr-form{
-    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-}
-
-.gr-button-tool, .gr-button-tool-top{
-    max-width: 2.5em;
-    min-width: 2.5em !important;
-    height: 2.4em;
-}
-
-.gr-button-tool{
-    margin: 0.6em 0em 0.55em 0;
-}
-
-.gr-button-tool-top, #settings .gr-button-tool{
-    margin: 1.6em 0.7em 0.55em 0;
-}
-
-
-#modelmerger_results_container{
-    margin-top: 1em;
-    overflow: visible;
-}
-
-#modelmerger_models{
-    gap: 0;
-}
-
-
-#quicksettings .gr-button-tool{
-    margin: 0;
-    border-color: unset;
-	background-color: unset;
-}
-
-#modelmerger_interp_description>p {
-    margin: 0!important;
-    text-align: center;
-}
-#modelmerger_interp_description {
-    margin: 0.35rem 0.75rem 1.23rem;
-}
-#img2img_settings > div.gr-form, #txt2img_settings > div.gr-form {
-    padding-top: 0.9em;
-    padding-bottom: 0.9em;
-}
-#txt2img_settings {
-    padding-top: 1.16em;
-    padding-bottom: 0.9em;
-}
-#img2img_settings {
-    padding-bottom: 0.9em;
-}
-
-#img2img_settings div.gr-form .gr-form, #txt2img_settings div.gr-form .gr-form, #train_tabs div.gr-form .gr-form{
-    border: none;
-    padding-bottom: 0.5em;
-}
+/* replace original footer with ours */
 
 footer {
     display: none !important;
@@ -756,99 +594,7 @@ footer {
     opacity: 0.85;
 }
 
-#txtimg_hr_finalres{
-    min-height: 0 !important;
-    padding: .625rem .75rem;
-    margin-left: -0.75em
-}
-
-#txtimg_hr_finalres .resolution{
-    font-weight: bold;
-}
-
-#txt2img_checkboxes, #img2img_checkboxes{
-    margin-bottom: 0.5em;
-    margin-left: 0em;
-}
-#txt2img_checkboxes > div, #img2img_checkboxes > div{
-    flex: 0;
-    white-space: nowrap;
-    min-width: auto;
-}
-
-#img2img_finalres{
-    min-height: 0 !important;
-    padding: .625rem .75rem;
-    margin-left: 0.25em
-}
-
-#img2img_finalres .resolution{
-    font-weight: bold;
-}
-
-#img2img_copy_to_img2img, #img2img_copy_to_sketch, #img2img_copy_to_inpaint, #img2img_copy_to_inpaint_sketch{
-    margin-left: 0em;
-}
-
-#axis_options {
-    margin-left: 0em;
-}
-
-.inactive{
-    opacity: 0.5;
-}
-
-[id*='_prompt_container']{
-    gap: 0;
-}
-
-[id*='_prompt_container'] > div{
-    margin: -0.4em 0 0 0;
-}
-
-.gr-compact {
-    border: none;
-}
-
-.dark .gr-compact{
-    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-	margin-left: 0;
-}
-
-.gr-compact{
-    overflow: visible;
-}
-
-.gr-compact > *{
-}
-
-.gr-compact .gr-block, .gr-compact .gr-form{
-    border: none;
-    box-shadow: none;
-}
-
-.gr-compact .gr-box{
-    border-radius: .5rem !important;
-    border-width: 1px !important;
-}
-
-#mode_img2img > div > div{
-    gap: 0 !important;
-}
-
-[id*='img2img_copy_to_'] {
-    border: none;
-}
-
-[id*='img2img_copy_to_'] > button {
-}
-
-[id*='img2img_label_copy_to_'] {
-    font-size: 1.0em;
-    font-weight: bold;
-    text-align: center;
-    line-height: 2.4em;
-}
+/* extra networks UI */
 
 .extra-networks > div > [id *= '_extra_']{
     margin: 0.3em;
@@ -861,12 +607,12 @@ footer {
 .extra-network-subdirs button{
     margin: 0 0.15em;
 }
-
-#txt2img_extra_networks .search, #img2img_extra_networks .search{
+.extra-networks .tab-nav .search{
     display: inline-block;
     max-width: 16em;
     margin: 0.3em;
     align-self: center;
+    width: 16em;
 }
 
 #txt2img_extra_view, #img2img_extra_view {
@@ -898,6 +644,7 @@ footer {
     text-shadow: 2px 2px 3px black;
     padding: 0.25em;
     font-size: 22pt;
+    width: 1.5em;
 }
 .extra-network-cards .card:hover .metadata-button, .extra-network-thumbs .card:hover .metadata-button{
     display: inline-block;
@@ -991,10 +738,13 @@ footer {
     left: 0;
     right: 0;
     padding: 0.5em;
-    color: white;
     background: rgba(0,0,0,0.5);
     box-shadow: 0 0 0.25em 0.25em rgba(0,0,0,0.5);
     text-shadow: 0 0 0.2em black;
+}
+
+.extra-network-cards .card .actions *{
+    color: white;
 }
 
 .extra-network-cards .card .actions:hover{
@@ -1033,8 +783,4 @@ footer {
 
 .extra-network-cards .card ul a:hover{
     color: red;
-}
-
-[id*='_prompt_container'] > div {
-	margin: 0!important;
 }

--- a/style.css
+++ b/style.css
@@ -1,196 +1,48 @@
-
-/* general gradio fixes */
-
-:root, .dark{
-    --checkbox-label-gap: 0.25em 0.1em;
-    --section-header-text-size: 12pt;
-    --block-background-fill: transparent;
+.container {
+    max-width: 100%;
 }
 
-.block.padded{
-    padding: 0 !important;
-}
-
-div.gradio-container{
-    max-width: unset !important;
-}
-
-.hidden{
-    display: none;
-}
-
-.compact{
-    background: transparent !important;
-    padding: 0 !important;
-}
-
-div.form{
-    border-width: 0;
-    box-shadow: none;
-    background: transparent;
-    overflow: visible;
-    gap: 0.5em;
-}
-
-.block.gradio-dropdown,
-.block.gradio-slider,
-.block.gradio-checkbox,
-.block.gradio-textbox,
-.block.gradio-radio,
-.block.gradio-checkboxgroup,
-.block.gradio-number,
-.block.gradio-colorpicker
-{
-    border-width: 0 !important;
-    box-shadow: none !important;
-}
-
-.gap.compact{
-    padding: 0;
-    gap: 0.2em 0;
-}
-
-div.compact{
-    gap: 1em;
-}
-
-.gradio-dropdown ul.options{
-    z-index: 3000;
-}
-
-.gradio-dropdown label span:not(.has-info),
-.gradio-textbox label span:not(.has-info),
-.gradio-number label span:not(.has-info)
-{
-    margin-bottom: 0;
-}
-
-.gradio-dropdown div.wrap.wrap.wrap.wrap{
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-}
-
-.gradio-dropdown .wrap-inner.wrap-inner.wrap-inner{
-    flex-wrap: unset;
-}
-
-.gradio-dropdown .single-select{
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.gradio-dropdown .token-remove.remove-all.remove-all{
-    display: none;
-}
-
-.gradio-dropdown.multiselect .token-remove.remove-all.remove-all{
-    display: flex;
-}
-
-.gradio-slider input[type="number"]{
-    width: 6em;
-}
-
-.block.gradio-checkbox {
-    margin: 0.75em 1.5em 0 0;
-}
-
-.gradio-html div.wrap{
-    height: 100%;
-}
-div.gradio-html.min{
-    min-height: 0;
-}
-
-.block.gradio-gallery{
-    background: var(--input-background-fill);
-}
-
-.gradio-container .prose a, .gradio-container .prose a:visited{
-    color: unset;
-    text-decoration: none;
-}
-
-
-
-/* general styled components */
-
-.gradio-button.tool{
-    max-width: 2.2em;
-    min-width: 2.2em !important;
-    height: 2.4em;
-    align-self: end;
-    line-height: 1em;
-    border-radius: 0.5em;
-}
-
-.checkboxes-row{
-    margin-bottom: 0.5em;
-    margin-left: 0em;
-}
-.checkboxes-row > div{
-    flex: 0;
-    white-space: nowrap;
-    min-width: auto;
-}
-
-button.custom-button{
-    border-radius: var(--button-large-radius);
-    padding: var(--button-large-padding);
-    font-weight: var(--button-large-text-weight);
-    border: var(--button-border-width) solid var(--button-secondary-border-color);
-    background: var(--button-secondary-background-fill);
-    color: var(--button-secondary-text-color);
-    font-size: var(--button-large-text-size);
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    transition: var(--button-transition);
-    box-shadow: var(--button-shadow);
-    text-align: center;
-}
-
-
-/* txt2img/img2img specific */
-
-.block.token-counter{
+.token-counter{
     position: absolute;
     display: inline-block;
-    right: 1em;
+    right: 2em;
     min-width: 0 !important;
     width: auto;
     z-index: 100;
-    top: -0.75em;
 }
 
-.block.token-counter span{
-    background: var(--input-background-fill) !important;
-    box-shadow: 0 0 0.0 0.3em rgba(192,192,192,0.15), inset 0 0 0.6em rgba(192,192,192,0.075);
-    border: 2px solid rgba(192,192,192,0.4) !important;
-    border-radius: 0.4em;
-}
-
-.block.token-counter.error span{
+.token-counter.error span{
     box-shadow: 0 0 0.0 0.3em rgba(255,0,0,0.15), inset 0 0 0.6em rgba(255,0,0,0.075);
     border: 2px solid rgba(255,0,0,0.4) !important;
 }
 
-.block.token-counter div{
+.token-counter div{
     display: inline;
 }
 
-.block.token-counter span{
+.token-counter span{
     padding: 0.1em 0.75em;
 }
 
-[id$=_subseed_show]{
-    min-width: auto !important;
-    flex-grow: 0 !important;
-    display: flex;
+#sh{
+    min-width: 2em;
+    min-height: 2em;
+    max-width: 2em;
+    max-height: 2em;
+    flex-grow: 0;
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+    margin: 0.1em 0;
+    opacity: 0%;
+    cursor: default;
 }
 
-[id$=_subseed_show] label{
-    margin-bottom: 0.5em;
-    align-self: end;
+.output-html p {margin: 0 0.5em;}
+
+.row > *,
+.row > .gr-form > * {
+    min-width: min(120px, 100%);
+    flex: 1 1 0%;
 }
 
 .performance {
@@ -223,94 +75,196 @@ button.custom-button{
     object-fit: scale-down;
 }
 #txt2img_actions_column, #img2img_actions_column {
-    gap: 0.5em;
+	margin: 0.35rem 0.75rem 0.35rem 0;	
 }
+#script_list {
+    padding: .625rem .75rem 0 .625rem;
+}
+.justify-center.overflow-x-scroll {
+    justify-content: left;
+}
+
+.justify-center.overflow-x-scroll button:first-of-type {
+    margin-left: auto;
+}
+
+.justify-center.overflow-x-scroll button:last-of-type {
+    margin-right: auto;
+}
+
+[id$=_random_seed], [id$=_random_subseed], [id$=_reuse_seed], [id$=_reuse_subseed], #open_folder{
+    min-width: 2.3em;
+    height: 2.5em;
+    flex-grow: 0;
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+}
+
+#hidden_element{
+    display: none;
+}
+
+[id$=_seed_row], [id$=_subseed_row]{
+    gap: 0.5rem;
+    padding: 0.6em;
+}
+
+[id$=_subseed_show_box]{
+    min-width: auto;
+    flex-grow: 0;
+}
+
+[id$=_subseed_show_box] > div{
+    border: 0;
+    height: 100%;
+}
+
+[id$=_subseed_show]{
+    min-width: auto;
+    flex-grow: 0;
+    padding: 0;
+}
+
+[id$=_subseed_show] label{
+    height: 100%;
+}
+
+#txt2img_actions_column, #img2img_actions_column{
+    gap: 0;
+    margin-right: .75rem;
+}
+
 #txt2img_tools, #img2img_tools{
     gap: 0.4em;
 }
 
-.interrogate-col{
+#interrogate_col{
     min-width: 0 !important;
-    max-width: fit-content;
-    gap: 0.5em;
+    max-width: 8em !important;
+    margin-right: 1em;
+    gap: 0;
 }
-.interrogate-col > button{
-    flex: 1;
+#interrogate, #deepbooru{
+    margin: 0em 0.25em 0.5em 0.25em;
+    min-width: 8em;
+    max-width: 8em;
 }
 
-.generate-box{
-    position: relative;
+#style_pos_col, #style_neg_col{
+    min-width: 8em !important;
 }
-.gradio-button.generate-box-skip, .gradio-button.generate-box-interrupt{
+
+#txt2img_styles_row, #img2img_styles_row{
+    gap: 0.25em;
+    margin-top: 0.3em;
+}
+
+#txt2img_styles_row > button, #img2img_styles_row > button{
+    margin: 0;
+}
+
+#txt2img_styles, #img2img_styles{
+    padding: 0;
+}
+
+#txt2img_styles > label > div, #img2img_styles > label > div{
+    min-height: 3.2em;
+}
+
+ul.list-none{
+    max-height: 35em;
+    z-index: 2000;
+}
+
+.gr-form{
+    background: transparent;
+}
+
+.my-4{
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#resize_mode{
+    flex: 1.5;
+}
+
+button{
+    align-self: stretch !important;
+}
+
+.overflow-hidden, .gr-panel{
+    overflow: visible !important;
+}
+
+#x_type, #y_type{
+    max-width: 10em;
+}
+
+#txt2img_preview, #img2img_preview, #ti_preview{
     position: absolute;
-    width: 50%;
-    height: 100%;
-    display: none;
-    background: #b4c0cc;
-}
-.gradio-button.generate-box-skip:hover, .gradio-button.generate-box-interrupt:hover{
-    background: #c2cfdb;
-}
-.gradio-button.generate-box-interrupt{
+    width: 320px;
     left: 0;
-    border-radius: 0.5rem 0 0 0.5rem;
-}
-.gradio-button.generate-box-skip{
     right: 0;
-    border-radius: 0 0.5rem 0.5rem 0;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 34px;
+    z-index: 100;
+    border: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
 }
 
-#txtimg_hr_finalres{
-    min-height: 0 !important;
-    padding: .625rem .75rem;
-    margin-left: -0.75em
+@media screen and (min-width: 768px) {
+    #txt2img_preview, #img2img_preview, #ti_preview {
+        position: absolute;
+    }
 }
 
-#txtimg_hr_finalres .resolution{
-    font-weight: bold;
+@media screen and (max-width: 767px) {
+    #txt2img_preview, #img2img_preview, #ti_preview {
+        position: relative;
+    }
 }
 
-.inactive{
-    opacity: 0.5;
+#txt2img_preview div.left-0.top-0, #img2img_preview div.left-0.top-0, #ti_preview div.left-0.top-0{
+    display: none;
 }
 
-[id$=_column_batch]{
+fieldset span.text-gray-500, .gr-block.gr-box span.text-gray-500,  label.block span{
+    position: absolute;
+    top: -0.7em;
+    line-height: 1.2em;
+    padding: 0;
+    margin: 0 0.5em;
+
+    background-color: white;
+    box-shadow:  6px 0 6px 0px white, -6px 0 6px 0px white;
+
+    z-index: 300;
+}
+
+.dark fieldset span.text-gray-500, .dark .gr-block.gr-box span.text-gray-500, .dark label.block span{
+    background-color: rgb(31, 41, 55);
+    box-shadow: none;
+    border: 1px solid rgba(128, 128, 128, 0.1);
+    border-radius: 6px;
+    padding: 0.1em 0.5em;
+}
+
+#txt2img_column_batch, #img2img_column_batch{
     min-width: min(13.5em, 100%) !important;
 }
 
-div.dimensions-tools{
-    min-width: 0 !important;
-    max-width: fit-content;
-    flex-direction: row;
-    align-content: center;
-}
-
-#mode_img2img .gradio-image > div.fixed-height, #mode_img2img .gradio-image > div.fixed-height img{
-    height: 480px !important;
-    max-height: 480px !important;
-    min-height: 480px !important;
-}
-
-.image-buttons button{
-    min-width: auto;
-}
-
-.infotext {
-    overflow-wrap: break-word;
-}
-
-/* settings */
-#quicksettings {
-    width: fit-content;
-}
-
-#quicksettings > div, #quicksettings > fieldset{
-    max-width: 24em;
-    min-width: 24em;
-    padding: 0;
+#settings fieldset span.text-gray-500, #settings .gr-block.gr-box span.text-gray-500, #settings label.block span{
+    position: relative;
     border: none;
-    box-shadow: none;
-    background: none;
+    margin-right: 8em;
+}
+
+#settings .gr-panel div.flex-col div.justify-between div{
+    position: relative;
+    z-index: 200;
 }
 
 #settings{
@@ -322,18 +276,17 @@ div.dimensions-tools{
     margin-left: 10em;
 }
 
-#settings > div.tab-nav{
+#settings > div.flex-wrap{
     float: left;
     display: block;
     margin-left: 0;
     width: 10em;
 }
 
-#settings > div.tab-nav button{
+#settings > div.flex-wrap button{
     display: block;
     border: none;
     text-align: left;
-    white-space: initial;
 }
 
 #settings_result{
@@ -341,8 +294,29 @@ div.dimensions-tools{
     margin: 0 1.2em;
 }
 
+input[type="range"]{
+    margin: 0.5em 0 -0.3em 0;
+}
 
-/* live preview */
+#mask_bug_info {
+  text-align: center;
+  display: block;
+  margin-top: -0.75em;
+  margin-bottom: -0.75em;
+}
+
+#txt2img_negative_prompt, #img2img_negative_prompt{
+}
+
+/* gradio 3.8 adds opacity to progressbar which makes it blink; disable it here */
+.transition.opacity-20 {
+  opacity: 1 !important;
+}
+
+/* more gradio's garbage cleanup */
+.min-h-\[4rem\] { min-height: unset !important; }
+.min-h-\[6rem\] { min-height: unset !important; }
+
 .progressDiv{
     position: relative;
     height: 20px;
@@ -388,8 +362,6 @@ div.dimensions-tools{
     height: 100%;
 }
 
-/* fullscreen popup (ie in Lora's (i) button) */
-
 .popup-metadata{
     color: black;
     background: white;
@@ -430,54 +402,87 @@ div.dimensions-tools{
     padding: 2em;
 }
 
-/* fullpage image viewer */
-
 #lightboxModal{
-    display: none;
-    position: fixed;
-    z-index: 1001;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(20, 20, 20, 0.95);
-    user-select: none;
-    -webkit-user-select: none;
-    flex-direction: column;
+  display: none;
+  position: fixed;
+  z-index: 1001;
+  padding-top: 100px;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(20, 20, 20, 0.95);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .modalControls {
-    display: flex;
-    gap: 1em;
-    padding: 1em;
+    display: grid;
+    grid-template-columns: 32px 32px 32px 1fr 32px;
+    grid-template-areas: "zoom tile save space close";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 16px;
+    gap: 16px;
     background-color: rgba(0,0,0,0.2);
 }
+
 .modalClose {
-    margin-left: auto;
+    grid-area: close;
 }
-.modalControls span{
+
+.modalZoom {
+    grid-area: zoom;
+}
+
+.modalSave {
+    grid-area: save;
+}
+
+.modalTileImage {
+    grid-area: tile;
+}
+
+.modalClose,
+.modalZoom,
+.modalTileImage {
+  color: white;
+  font-size: 35px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.modalSave {
     color: white;
-    font-size: 35px;
+    font-size: 28px;
+    margin-top: 8px;
     font-weight: bold;
     cursor: pointer;
-    width: 1em;
 }
 
-.modalControls span:hover, .modalControls span:focus{
-    color: #999;
-    text-decoration: none;
+.modalClose:hover,
+.modalClose:focus,
+.modalSave:hover,
+.modalSave:focus,
+.modalZoom:hover,
+.modalZoom:focus {
+  color: #999;
+  text-decoration: none;
+  cursor: pointer;
 }
 
-#lightboxModal > img {
+#modalImage {
     display: block;
     margin: auto;
     width: auto;
 }
 
-#lightboxModal > img.modalImageFullscreen{
+.modalImageFullscreen {
     object-fit: contain;
-    height: 100%;
+    height: 90%;
 }
 
 .modalPrev,
@@ -507,7 +512,45 @@ div.dimensions-tools{
   background-color: rgba(0, 0, 0, 0.8);
 }
 
-/* context menu (ie for the generate button) */
+#imageARPreview{
+    position:absolute;
+    top:0px;
+    left:0px;
+    border:2px solid red;
+    background:rgba(255, 0, 0, 0.3);
+    z-index: 900;
+    pointer-events:none;
+    display:none
+}
+
+#txt2img_generate_box, #img2img_generate_box{
+    position: relative;
+}
+
+#txt2img_interrupt, #img2img_interrupt, #txt2img_skip, #img2img_skip{
+    position: absolute;
+    width: 50%;
+    height: 100%;
+    background: #b4c0cc;
+    display: none;
+}
+
+#txt2img_interrupt, #img2img_interrupt{
+    left: 0;
+    border-radius: 0.5rem 0 0 0.5rem;
+}
+#txt2img_skip, #img2img_skip{
+    right: 0;
+    border-radius: 0 0.5rem 0.5rem 0;
+}
+
+.red {
+	color: red;
+}
+
+.gallery-item {
+    --tw-bg-opacity: 0 !important;
+}
 
 #context-menu{
     z-index:9999;
@@ -536,8 +579,61 @@ div.dimensions-tools{
     background: #a55000;
 }
 
+#quicksettings {
+    width: fit-content;
+}
 
-/* extensions */
+#quicksettings > div, #quicksettings > fieldset{
+    max-width: 24em;
+    min-width: 24em;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: none;
+    margin-right: 10px;
+}
+
+#quicksettings > div > div > div > label > span {
+    position: relative;
+    margin-right: 9em;
+    margin-bottom: -1em;
+}
+
+canvas[key="mask"] {
+    z-index: 12 !important;
+    filter: invert();
+    mix-blend-mode: multiply;
+    pointer-events: none;
+}
+
+
+/* gradio 3.4.1 stuff for editable scrollbar values */
+.gr-box > div > div > input.gr-text-input{
+    position: absolute;
+    right: 0.5em;
+    top: -0.6em;
+    z-index: 400;
+    width: 6em;
+}
+#quicksettings .gr-box > div > div > input.gr-text-input {
+  top: -1.12em;
+}
+
+.row.gr-compact{
+    overflow: visible;
+}
+
+#img2img_image, #img2img_image > .h-60, #img2img_image > .h-60 > div, #img2img_image > .h-60 > div > img,
+#img2img_sketch, #img2img_sketch > .h-60, #img2img_sketch > .h-60 > div, #img2img_sketch > .h-60 > div > img,
+#img2maskimg, #img2maskimg > .h-60, #img2maskimg > .h-60 > div, #img2maskimg > .h-60 > div > img,
+#inpaint_sketch, #inpaint_sketch > .h-60, #inpaint_sketch > .h-60 > div, #inpaint_sketch > .h-60 > div > img
+{
+    height: 480px !important;
+    max-height: 480px !important;
+    min-height: 480px !important;
+}
+
+/* Extensions */
 
 #tab_extensions table{
     border-collapse: collapse;
@@ -550,7 +646,6 @@ div.dimensions-tools{
 
 #tab_extensions table input[type="checkbox"]{
     margin-right: 0.5em;
-    appearance: checkbox;
 }
 
 #tab_extensions button{
@@ -575,7 +670,74 @@ div.dimensions-tools{
     font-size: 90%;
 }
 
-/* replace original footer with ours */
+#image_buttons_txt2img button, #image_buttons_img2img button, #image_buttons_extras button{
+    min-width: auto;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+}
+
+.gr-form{
+    background-color: white;
+}
+
+.dark .gr-form{
+    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+.gr-button-tool, .gr-button-tool-top{
+    max-width: 2.5em;
+    min-width: 2.5em !important;
+    height: 2.4em;
+}
+
+.gr-button-tool{
+    margin: 0.6em 0em 0.55em 0;
+}
+
+.gr-button-tool-top, #settings .gr-button-tool{
+    margin: 1.6em 0.7em 0.55em 0;
+}
+
+
+#modelmerger_results_container{
+    margin-top: 1em;
+    overflow: visible;
+}
+
+#modelmerger_models{
+    gap: 0;
+}
+
+
+#quicksettings .gr-button-tool{
+    margin: 0;
+    border-color: unset;
+	background-color: unset;
+}
+
+#modelmerger_interp_description>p {
+    margin: 0!important;
+    text-align: center;
+}
+#modelmerger_interp_description {
+    margin: 0.35rem 0.75rem 1.23rem;
+}
+#img2img_settings > div.gr-form, #txt2img_settings > div.gr-form {
+    padding-top: 0.9em;
+    padding-bottom: 0.9em;
+}
+#txt2img_settings {
+    padding-top: 1.16em;
+    padding-bottom: 0.9em;
+}
+#img2img_settings {
+    padding-bottom: 0.9em;
+}
+
+#img2img_settings div.gr-form .gr-form, #txt2img_settings div.gr-form .gr-form, #train_tabs div.gr-form .gr-form{
+    border: none;
+    padding-bottom: 0.5em;
+}
 
 footer {
     display: none !important;
@@ -594,7 +756,99 @@ footer {
     opacity: 0.85;
 }
 
-/* extra networks UI */
+#txtimg_hr_finalres{
+    min-height: 0 !important;
+    padding: .625rem .75rem;
+    margin-left: -0.75em
+}
+
+#txtimg_hr_finalres .resolution{
+    font-weight: bold;
+}
+
+#txt2img_checkboxes, #img2img_checkboxes{
+    margin-bottom: 0.5em;
+    margin-left: 0em;
+}
+#txt2img_checkboxes > div, #img2img_checkboxes > div{
+    flex: 0;
+    white-space: nowrap;
+    min-width: auto;
+}
+
+#img2img_finalres{
+    min-height: 0 !important;
+    padding: .625rem .75rem;
+    margin-left: -0.75em
+}
+
+#img2img_finalres .resolution{
+    font-weight: bold;
+}
+
+#img2img_copy_to_img2img, #img2img_copy_to_sketch, #img2img_copy_to_inpaint, #img2img_copy_to_inpaint_sketch{
+    margin-left: 0em;
+}
+
+#axis_options {
+    margin-left: 0em;
+}
+
+.inactive{
+    opacity: 0.5;
+}
+
+[id*='_prompt_container']{
+    gap: 0;
+}
+
+[id*='_prompt_container'] > div{
+    margin: -0.4em 0 0 0;
+}
+
+.gr-compact {
+    border: none;
+}
+
+.dark .gr-compact{
+    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+	margin-left: 0;
+}
+
+.gr-compact{
+    overflow: visible;
+}
+
+.gr-compact > *{
+}
+
+.gr-compact .gr-block, .gr-compact .gr-form{
+    border: none;
+    box-shadow: none;
+}
+
+.gr-compact .gr-box{
+    border-radius: .5rem !important;
+    border-width: 1px !important;
+}
+
+#mode_img2img > div > div{
+    gap: 0 !important;
+}
+
+[id*='img2img_copy_to_'] {
+    border: none;
+}
+
+[id*='img2img_copy_to_'] > button {
+}
+
+[id*='img2img_label_copy_to_'] {
+    font-size: 1.0em;
+    font-weight: bold;
+    text-align: center;
+    line-height: 2.4em;
+}
 
 .extra-networks > div > [id *= '_extra_']{
     margin: 0.3em;
@@ -607,12 +861,12 @@ footer {
 .extra-network-subdirs button{
     margin: 0 0.15em;
 }
-.extra-networks .tab-nav .search{
+
+#txt2img_extra_networks .search, #img2img_extra_networks .search{
     display: inline-block;
     max-width: 16em;
     margin: 0.3em;
     align-self: center;
-    width: 16em;
 }
 
 #txt2img_extra_view, #img2img_extra_view {
@@ -644,7 +898,6 @@ footer {
     text-shadow: 2px 2px 3px black;
     padding: 0.25em;
     font-size: 22pt;
-    width: 1.5em;
 }
 .extra-network-cards .card:hover .metadata-button, .extra-network-thumbs .card:hover .metadata-button{
     display: inline-block;
@@ -738,13 +991,10 @@ footer {
     left: 0;
     right: 0;
     padding: 0.5em;
+    color: white;
     background: rgba(0,0,0,0.5);
     box-shadow: 0 0 0.25em 0.25em rgba(0,0,0,0.5);
     text-shadow: 0 0 0.2em black;
-}
-
-.extra-network-cards .card .actions *{
-    color: white;
 }
 
 .extra-network-cards .card .actions:hover{
@@ -783,4 +1033,8 @@ footer {
 
 .extra-network-cards .card ul a:hover{
     color: red;
+}
+
+[id*='_prompt_container'] > div {
+	margin: 0!important;
 }

--- a/style.css
+++ b/style.css
@@ -779,7 +779,7 @@ footer {
 #img2img_finalres{
     min-height: 0 !important;
     padding: .625rem .75rem;
-    margin-left: -0.75em
+    margin-left: 0.25em
 }
 
 #img2img_finalres .resolution{


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adds "upscale by" and "upscaler" options to img2img, with the same functionality as Hires. fix

Closes #7422

**Additional notes and description of your changes**

"Upscale by" is disabled by default, it only takes effect if the slider's value is > 1. Otherwise the old behavior is used

Infotext and XYZ Grid support was also added

The "Just Resize (latent upscale)" resize mode was removed since it's now redundant

Non-latent upscalers are run before sampling, latent upscalers are run later during sampling

~~Sadly performance is bad because the event callbacks are run every time the sliders update and not when they're released, this is the corresponding gradio issue: https://github.com/gradio-app/gradio/issues/3204~~ No longer an issue since webui uses Gradio 3.23.0, can use their `.release()` callback now

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

![2023-02-19 03_49_47-Stable Diffusion - Chromium](https://user-images.githubusercontent.com/24979496/219946087-5861eebc-d6d1-488a-94cd-4e487e775972.png)