### PR TITLE
Custom height and width settings for Extra Networks cards

### DIFF
--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -1,4 +1,4 @@
-<div class='card' {preview_html} onclick={card_clicked}>
+<div class='card' style={style} onclick={card_clicked}>
 	<div class='actions'>
 		<div class='additional'>
 			<ul>

--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -1,4 +1,6 @@
 <div class='card' style={style} onclick={card_clicked}>
+	{metadata_button}
+
 	<div class='actions'>
 		<div class='additional'>
 			<ul>

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -438,6 +438,8 @@ options_templates.update(options_section(('interrogate', "Interrogate Options"),
 options_templates.update(options_section(('extra_networks', "Extra Networks"), {
     "extra_networks_default_view": OptionInfo("cards", "Default view for Extra Networks", gr.Dropdown, {"choices": ["cards", "thumbs"]}),
     "extra_networks_default_multiplier": OptionInfo(1.0, "Multiplier for extra networks", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+    "extra_networks_card_width": OptionInfo(0, "Card width for Extra Networks (em)"),
+    "extra_networks_card_height": OptionInfo(0, "Card height for Extra Networks (em)"),
     "sd_hypernetwork": OptionInfo("None", "Add hypernetwork to prompt", gr.Dropdown, lambda: {"choices": [""] + [x for x in hypernetworks.keys()]}, refresh=reload_hypernetworks),
 }))
 

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -124,8 +124,12 @@ class ExtraNetworksPage:
         if onclick is None:
             onclick = '"' + html.escape(f"""return cardClicked({json.dumps(tabname)}, {item["prompt"]}, {"true" if self.allow_negative_prompt else "false"})""") + '"'
 
+        height = f"height: {shared.opts.extra_networks_card_height}em;" if shared.opts.extra_networks_card_height else ''
+        width = f"width: {shared.opts.extra_networks_card_width}em;" if shared.opts.extra_networks_card_width else ''
+        background_image = f"background-image: url(\"{html.escape(preview)}\");" if preview else ''
+
         args = {
-            "preview_html": "style='background-image: url(\"" + html.escape(preview) + "\")'" if preview else '',
+            "style": f"'{height}{width}{background_image}'",
             "prompt": item.get("prompt", None),
             "tabname": json.dumps(tabname),
             "local_preview": json.dumps(item["local_preview"]),


### PR DESCRIPTION
I like the thumbs view for the cards because it is smaller, but the aspect ratio annoyed me a bit as it was square, while most images I generate are not so they get cut off. This allows the user to set their own custom width and height so it can be whatever.

The default setting is 0, as that evals to false so it will use whatever the extra_networks_default_view css is then,

Closes #7874

## Screenshot (thumbs view with custom height/width)
![image](https://user-images.githubusercontent.com/23466035/219971347-4fabab34-1c7b-407f-9a59-3985cb49447d.png)

