### PR TITLE
Fix broken image downscale TypeError

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -582,9 +582,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         ratio = image.width / image.height
 
         if oversize and ratio > 1:
-            image = image.resize((opts.target_side_length, image.height * opts.target_side_length // image.width), LANCZOS)
+            image = image.resize((round(opts.target_side_length), round(image.height * opts.target_side_length / image.width)), LANCZOS)
         elif oversize:
-            image = image.resize((image.width * opts.target_side_length // image.height, opts.target_side_length), LANCZOS)
+            image = image.resize((round(image.width * opts.target_side_length / image.height), round(opts.target_side_length)), LANCZOS)
 
         try:
             _atomically_save_image(image, fullfn_without_extension, ".jpg")


### PR DESCRIPTION
Fx broken image downscale caused by [reword settings for 4chan export, remove unneded try/excepts, add try/except for actually saving JPG](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/fb2354cb2ae47f9e9b70f0e04f34925bbb31b1ac#diff-7035c0b11c034183a4d5570fccaf498d0e1ceea6f1a70efffab2bf963703739aL579) which also remove the float to int casting of `opts.target_side_length`
as resize size can only be integer tuple this raises an error causing the downscale to fail

```py
Error completing request
Arguments: (0, <PIL.Image.Image image mode=RGB size=768x1024 at 0x20703F08250>, None, '', '', True, 0, 4, 512, 512, True, 'R-ESRGAN 4x+ Anime6B', 'None', 0, 0, 0, 0) {}
Traceback (most recent call last):
  File "B:\Documents\GitHub\stable-diffusion-webui\modules\call_queue.py", line 56, in f
    res = list(func(*args, **kwargs))
  File "B:\Documents\GitHub\stable-diffusion-webui\modules\call_queue.py", line 37, in f
    res = func(*args, **kwargs)
  File "B:\Documents\GitHub\stable-diffusion-webui\modules\postprocessing.py", line 70, in run_postprocessing
    images.save_image(pp.image, path=outpath, basename=basename, seed=None, prompt=None, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=None)
  File "B:\Documents\GitHub\stable-diffusion-webui\modules\images.py", line 587, in save_image
    image = image.resize((image.width * opts.target_side_length // image.height, opts.target_side_length), LANCZOS)
  File "B:\Documents\GitHub\stable-diffusion-webui\venv\lib\site-packages\PIL\Image.py", line 2192, in resize
    return self._new(self.im.resize(size, resample, box))
TypeError: 'float' object cannot be interpreted as an integer
```
This PR fixes the issue
yes I could just typed casted as I did before
but since I'm bored I used round() for more accurate approximation

note: the round() functions will returns int type 
[Return number rounded to ndigits precision after the decimal point. If ndigits is omitted or is None, it returns the nearest integer to its input.](https://docs.python.org/3/library/functions.html?highlight=round#round)


why also use round() on `opts.target_side_length`  and not int()?
for those thick headed people that decides to use a non integer value