### PR TITLE
Add description support for extra networks

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -16,6 +16,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         for name, lora_on_disk in lora.available_loras.items():
             path, ext = os.path.splitext(lora_on_disk.filename)
             previews = [path + ".png", path + ".preview.png"]
+            descriptions = [path + ".txt", path + ".description.txt"]
 
             preview = None
             for file in previews:
@@ -23,10 +24,19 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
                     preview = self.link_preview(file)
                     break
 
+            description = None
+            for file in descriptions:
+                if os.path.isfile(file):
+                    with open(file, "r") as description_file:
+                        description = description_file.read()
+
+                    break
+
             yield {
                 "name": name,
                 "filename": path,
                 "preview": preview,
+                "description": description,
                 "search_term": self.search_terms_from_path(lora_on_disk.filename),
                 "prompt": json.dumps(f"<lora:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -1,4 +1,4 @@
-<div class='card' {preview_html} onclick={card_clicked}>
+<div class='card' {preview_html} onclick={card_clicked} title={description}>
 	<div class='actions'>
 		<div class='additional'>
 			<ul>

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -119,6 +119,7 @@ class ExtraNetworksPage:
 
     def create_html_for_item(self, item, tabname):
         preview = item.get("preview", None)
+        description = item.get("description", None)
 
         onclick = item.get("onclick", None)
         if onclick is None:
@@ -126,6 +127,7 @@ class ExtraNetworksPage:
 
         args = {
             "preview_html": "style='background-image: url(\"" + html.escape(preview) + "\")'" if preview else '',
+            "description": '"' + html.escape(description) + '"' if description else '',
             "prompt": item.get("prompt", None),
             "tabname": json.dumps(tabname),
             "local_preview": json.dumps(item["local_preview"]),

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -18,6 +18,7 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         for name, checkpoint in sd_models.checkpoints_list.items():
             path, ext = os.path.splitext(checkpoint.filename)
             previews = [path + ".png", path + ".preview.png"]
+            descriptions = [path + ".txt", path + ".description.txt"]
 
             preview = None
             for file in previews:
@@ -25,10 +26,19 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
                     preview = self.link_preview(file)
                     break
 
+            description = None
+            for file in descriptions:
+                if os.path.isfile(file):
+                    with open(file, "r") as description_file:
+                        description = description_file.read()
+
+                    break
+
             yield {
                 "name": checkpoint.name_for_extra,
                 "filename": path,
                 "preview": preview,
+                "description": description,
                 "search_term": self.search_terms_from_path(checkpoint.filename) + " " + (checkpoint.sha256 or ""),
                 "onclick": '"' + html.escape(f"""return selectCheckpoint({json.dumps(name)})""") + '"',
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -15,6 +15,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         for name, path in shared.hypernetworks.items():
             path, ext = os.path.splitext(path)
             previews = [path + ".png", path + ".preview.png"]
+            descriptions = [path + ".txt", path + ".description.txt"]
 
             preview = None
             for file in previews:
@@ -22,10 +23,19 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
                     preview = self.link_preview(file)
                     break
 
+            description = None
+            for file in descriptions:
+                if os.path.isfile(file):
+                    with open(file, "r") as description_file:
+                        description = description_file.read()
+
+                    break
+
             yield {
                 "name": name,
                 "filename": path,
                 "preview": preview,
+                "description": description,
                 "search_term": self.search_terms_from_path(path),
                 "prompt": json.dumps(f"<hypernet:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -15,16 +15,28 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         for embedding in sd_hijack.model_hijack.embedding_db.word_embeddings.values():
             path, ext = os.path.splitext(embedding.filename)
-            preview_file = path + ".preview.png"
+            previews = [path + ".png", path + ".preview.png"]
+            descriptions = [path + ".txt", path + ".description.txt"]
 
             preview = None
-            if os.path.isfile(preview_file):
-                preview = self.link_preview(preview_file)
+            for file in previews:
+                if os.path.isfile(file):
+                    preview = self.link_preview(file)
+                    break
+
+            description = None
+            for file in descriptions:
+                if os.path.isfile(file):
+                    with open(file, "r") as description_file:
+                        description = description_file.read()
+
+                    break
 
             yield {
                 "name": embedding.name,
                 "filename": embedding.filename,
                 "preview": preview,
+                "description": description,
                 "search_term": self.search_terms_from_path(embedding.filename),
                 "prompt": json.dumps(embedding.name),
                 "local_preview": path + ".preview.png",


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adds support for descriptions in the Extra Networks section, shown as a tooltip when hovering the model. These live alongside the `model.preview.png` files and follow generally the same idea, except they're named `model.description.txt`.

The goal is to allow users to keep easily visible notes alongside their models, for example related prompts.

Models without a description will simply omit the tooltip.

For consistency, I also unified the way preview images are handled, in regards to filenames (Textual Inversions had a slightly different behavior, which could be confusing for users)

**Additional notes and description of your changes**

None, it's pretty straightforward.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox 110
 - Graphics card: NVIDIA RTX2070

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/19396809/220144396-04fa64f6-7c49-4985-b602-58cf45168685.png)
