### PR TITLE
Fixes newlines within checkpoints being detected as its own entry

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -418,7 +418,7 @@ class Script(scripts.Script):
             if opt.label == 'Nothing':
                 return [0]
 
-            valslist = [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals)))]
+            valslist = [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals))) if x]
 
             if opt.type == int:
                 valslist_ext = []


### PR DESCRIPTION
Closes #7951, Closes #7621.

When using newlines after commas, they get detected as their own entry (specifically as the empty string), and since we lookup the closest model, the empty string is allowed. 

We fix this by just not allowing empty strings.
This does not break anything else, multiline Prompt S/R will still work

Best shown through examples

```
>>> vals = """
... AbyssHellHero,
... AbyssOrangeMix2_hard,
... AbyssOrangeMix2_nsfw,
... AbyssOrangeMix2_sfw,
... """
>>> [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals)))]
['AbyssHellHero', '', 'AbyssOrangeMix2_hard', '', 'AbyssOrangeMix2_nsfw', '', 'AbyssOrangeMix2_sfw', '']
>>> [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals))) if x] 
['AbyssHellHero', 'AbyssOrangeMix2_hard', 'AbyssOrangeMix2_nsfw', 'AbyssOrangeMix2_sfw']
```

Still parses multilines as before

```
>>> vals = """
... pizza,"misato
... penguin
... ","cheese
...  lain",geass
... """
>>> [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals)))]      
['pizza', 'misato\npenguin', 'cheese\n lain', 'geass']
>>> [x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals))) if x] 
['pizza', 'misato\npenguin', 'cheese\n lain', 'geass']
```
