### PR TITLE
ENH: sort list in "extra networks"

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -1,5 +1,6 @@
 import json
 import os
+from operator import itemgetter
 import lora
 
 from modules import shared, ui_extra_networks
@@ -13,7 +14,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         lora.list_available_loras()
 
     def list_items(self):
-        for name, lora_on_disk in lora.available_loras.items():
+        for name, lora_on_disk in sorted(lora.available_loras.items(), key=itemgetter(0)):
             path, ext = os.path.splitext(lora_on_disk.filename)
             previews = [path + ".png", path + ".preview.png"]
 

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -1,7 +1,7 @@
 import html
 import json
 import os
-import urllib.parse
+from operator import itemgetter
 
 from modules import shared, ui_extra_networks, sd_models
 
@@ -15,7 +15,7 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
 
     def list_items(self):
         checkpoint: sd_models.CheckpointInfo
-        for name, checkpoint in sd_models.checkpoints_list.items():
+        for name, checkpoint in sorted(sd_models.checkpoints_list.items(), key=itemgetter(0)):
             path, ext = os.path.splitext(checkpoint.filename)
             previews = [path + ".png", path + ".preview.png"]
 

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -1,5 +1,6 @@
 import json
 import os
+from operator import itemgetter
 
 from modules import shared, ui_extra_networks
 
@@ -12,7 +13,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         shared.reload_hypernetworks()
 
     def list_items(self):
-        for name, path in shared.hypernetworks.items():
+        for name, path in sorted(shared.hypernetworks.items(), key=itemgetter(0)):
             path, ext = os.path.splitext(path)
             previews = [path + ".png", path + ".preview.png"]
 

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -1,5 +1,6 @@
 import json
 import os
+from operator import attrgetter
 
 from modules import ui_extra_networks, sd_hijack
 
@@ -13,7 +14,7 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
         sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)
 
     def list_items(self):
-        for embedding in sd_hijack.model_hijack.embedding_db.word_embeddings.values():
+        for embedding in sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.values(), key=attrgetter('name')):
             path, ext = os.path.splitext(embedding.filename)
             preview_file = path + ".preview.png"
 


### PR DESCRIPTION
# Rationale

The cards in the "extra networks" lists are not sorted (unless the underlying filesystem already returns a sorted list).
This PR fixes this, by sorting all 4 kinds of extra networks by name.

# Environment this was tested in

OS: Debian GNU/Linux 12 (Bookworm)
Browser: Brave
GPU: AMD Radeon RX 6800 XT

# Demo

## Before:
![without sorting](http://images.isja.org/wo_sort.png)

## After:
![with sorting](http://images.isja.org/with_sort.png)
