### PR TITLE
Use emojis for extra network buttons

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -5,12 +5,10 @@ function setupExtraNetworksForTab(tabname){
     var tabs = gradioApp().querySelector('#'+tabname+'_extra_tabs > div')
     var search = gradioApp().querySelector('#'+tabname+'_extra_search textarea')
     var refresh = gradioApp().getElementById(tabname+'_extra_refresh')
-    var close = gradioApp().getElementById(tabname+'_extra_close')
 
     search.classList.add('search')
     tabs.appendChild(search)
     tabs.appendChild(refresh)
-    tabs.appendChild(close)
 
     search.addEventListener("input", function(evt){
         searchTerm = search.value.toLowerCase()

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -13,6 +13,10 @@ from modules.generation_parameters_copypaste import image_from_url_text
 extra_pages = []
 allowed_dirs = set()
 
+# Using constants for these since the variation selector isn't visible.
+# Important that they exactly match script.js for tooltip to work.
+refresh_symbol = '\U0001f504'  # 🔄
+close_symbol = '\U0000274C'  # ❌
 
 def register_page(page):
     """registers extra networks page for the UI; recommend doing it in on_before_ui() callback for extensions"""
@@ -182,8 +186,8 @@ def create_ui(container, button, tabname):
                 ui.pages.append(page_elem)
 
     filter = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", placeholder="Search...", visible=False)
-    button_refresh = gr.Button('Refresh', elem_id=tabname+"_extra_refresh")
-    button_close = gr.Button('Close', elem_id=tabname+"_extra_close")
+    button_refresh = gr.Button(refresh_symbol, elem_id=tabname+"_extra_refresh")
+    button_close = gr.Button(close_symbol, elem_id=tabname+"_extra_close")
 
     ui.button_save_preview = gr.Button('Save preview', elem_id=tabname+"_save_preview", visible=False)
     ui.preview_target_filename = gr.Textbox('Preview save filename', elem_id=tabname+"_preview_filename", visible=False)

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -13,10 +13,6 @@ from modules.generation_parameters_copypaste import image_from_url_text
 extra_pages = []
 allowed_dirs = set()
 
-# Using constants for these since the variation selector isn't visible.
-# Important that they exactly match script.js for tooltip to work.
-refresh_symbol = '\U0001f504'  # 🔄
-close_symbol = '\U0000274C'  # ❌
 
 def register_page(page):
     """registers extra networks page for the UI; recommend doing it in on_before_ui() callback for extensions"""
@@ -186,8 +182,7 @@ def create_ui(container, button, tabname):
                 ui.pages.append(page_elem)
 
     filter = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", placeholder="Search...", visible=False)
-    button_refresh = gr.Button(refresh_symbol, elem_id=tabname+"_extra_refresh")
-    button_close = gr.Button(close_symbol, elem_id=tabname+"_extra_close")
+    button_refresh = gr.Button('Refresh', elem_id=tabname+"_extra_refresh")
 
     ui.button_save_preview = gr.Button('Save preview', elem_id=tabname+"_save_preview", visible=False)
     ui.preview_target_filename = gr.Textbox('Preview save filename', elem_id=tabname+"_preview_filename", visible=False)
@@ -198,7 +193,6 @@ def create_ui(container, button, tabname):
 
     state_visible = gr.State(value=False)
     button.click(fn=toggle_visibility, inputs=[state_visible], outputs=[state_visible, container])
-    button_close.click(fn=toggle_visibility, inputs=[state_visible], outputs=[state_visible, container])
 
     def refresh():
         res = []


### PR DESCRIPTION


**Describe what this pull request is trying to achieve.**

Use emojis for the extra network UI buttons, so they take up less space:
🔄 for refresh - this emoji is chosen as it's consistent with other usages of refresh in Web UI
❌ for close - this emoji is chosen because it seems intuitive

**Additional notes and description of your changes**

The emojis are declared and assigned similarly to how it's done in ui.py

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Chrome, Firefox

**Screenshots or videos of your changes**

Before and after:
![image](https://user-images.githubusercontent.com/2993060/220202093-43fc5869-98a5-4e12-9793-07f0a2ce8aa9.png)
![image](https://user-images.githubusercontent.com/2993060/220202171-fd6fa79c-df34-4fdf-955a-52997420930a.png)

Mobile UI before and after:
![image](https://user-images.githubusercontent.com/2993060/220202396-67722a93-d4fb-4b87-8a6a-a38329fe562a.png)
![image](https://user-images.githubusercontent.com/2993060/220202539-1e984a83-419e-49de-a0ad-295dd7aeb805.png)
