### PR TITLE
Add a message displaying total launch time

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -180,6 +180,7 @@ def wait_on_server(demo=None):
 
 
 def api_only():
+    time_a = time.perf_counter()
     initialize()
 
     app = FastAPI()
@@ -190,12 +191,17 @@ def api_only():
     modules.script_callbacks.app_started_callback(None, app)
 
     api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
+    time_b = time.perf_counter()
+    launch_time = time_b - time_a
+    print(f"Total launch time: {launch_time:.20f} seconds")
 
 
 def webui():
+    time_a = time.perf_counter()
     launch_api = cmd_opts.api
     initialize()
 
+    launched = False
     while 1:
         if shared.opts.clean_temp_dir_at_start:
             ui_tempdir.cleanup_tmpdr()
@@ -226,6 +232,14 @@ def webui():
             inbrowser=cmd_opts.autolaunch,
             prevent_thread_lock=True
         )
+
+        if not launched:
+            launched = True
+            time_b = time.perf_counter()
+            launch_time = time_b - time_a
+            print(f"Total launch time: {launch_time:.20f} seconds")
+
+
         # after initial launch, disable --autolaunch for subsequent restarts
         cmd_opts.autolaunch = False
 

--- a/webui.py
+++ b/webui.py
@@ -193,7 +193,7 @@ def api_only():
     api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
     time_b = time.perf_counter()
     launch_time = time_b - time_a
-    print(f"Total launch time: {launch_time:nf} seconds")
+    print(f"Total launch time: {launch_time:.20f} seconds")
 
 
 def webui():
@@ -237,7 +237,7 @@ def webui():
             launched = True
             time_b = time.perf_counter()
             launch_time = time_b - time_a
-            print(f"Total launch time: {launch_time:nf} seconds")
+            print(f"Total launch time: {launch_time:.20f} seconds")
 
 
         # after initial launch, disable --autolaunch for subsequent restarts

--- a/webui.py
+++ b/webui.py
@@ -193,7 +193,7 @@ def api_only():
     api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
     time_b = time.perf_counter()
     launch_time = time_b - time_a
-    print(f"Total launch time: {launch_time:.20f} seconds")
+    print(f"Total launch time: {launch_time:nf} seconds")
 
 
 def webui():
@@ -237,7 +237,7 @@ def webui():
             launched = True
             time_b = time.perf_counter()
             launch_time = time_b - time_a
-            print(f"Total launch time: {launch_time:.20f} seconds")
+            print(f"Total launch time: {launch_time:nf} seconds")
 
 
         # after initial launch, disable --autolaunch for subsequent restarts


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

allow you and your friend to measure your..... webui launch time

**Additional notes and description of your changes**

I developed a complex update to the program, which uses exposed built-in high-level Operating System public API (which interacts with the low-level CPU instructions for acquiring current cycle number and frequence and doing math to get seconds since system launch) via Python's wrapper around C code, which helps to make even more high-level interaction, also it uses Python's built-in API which wraps around window API and OS' text engine to display UTF-16 characters along with the time taken to launch WebUI. Also by utilizing boolean data type and the view level, it is possible to display that message only once, during start up.

**Environment this was tested in**

trust me bro

**Screenshots or videos of your changes**

![omg, look at that precision bro](https://user-images.githubusercontent.com/97038786/220424540-704daf4a-ef52-4e2d-902f-1409b325ff97.png)

p.s. yes, this is cringe, but the whole idea is also dumb + idc ~~+ ratio~~. "why?", you ask? huh, better fight with this question: "why not?"