### PR TITLE
continue fix prompt_matrix.py when high-res

### DIFF
--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -100,7 +100,7 @@ class Script(scripts.Script):
         processed = process_images(p)
 
         grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2)) 
-        grid = images.draw_prompt_matrix(grid, processed.images[0].width, processed.images[1].height, prompt_matrix_parts, margin_size)
+        grid = images.draw_prompt_matrix(grid, p.hr_upscale_to_x, p.hr_upscale_to_y,, prompt_matrix_parts, margin_size)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -100,7 +100,7 @@ class Script(scripts.Script):
         processed = process_images(p)
 
         grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2)) 
-        grid = images.draw_prompt_matrix(grid, p.hr_upscale_to_x, p.hr_upscale_to_y,, prompt_matrix_parts, margin_size)
+        grid = images.draw_prompt_matrix(grid, processed.images[0].width, processed.images[0].height, prompt_matrix_parts, margin_size)
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])


### PR DESCRIPTION
this file last commit fixed common situation when using both prompts matrix and high-res。 
but if we just open matrix option，and prompts forgot using ‘|’,like`1girl ……`，we will only get one pic，and `processed.images[1].height` will cause a index out of bounds exception.
i think maybe use `hr_upscale_to_x/y` value is better? it's more robust

