### PR TITLE
Bug fix: Added results selector for notifications

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -15,7 +15,7 @@ onUiUpdate(function(){
         }
     }
 
-    const galleryPreviews = gradioApp().querySelectorAll('div[id^="tab_"][style*="display: block"] img.h-full.w-full.overflow-hidden');
+    const galleryPreviews = gradioApp().querySelectorAll('div[id^="tab_"][style*="display: block"] div[id$="_results"] img.h-full.w-full.overflow-hidden');
 
     if (galleryPreviews == null) return;
 


### PR DESCRIPTION
This causes the querySelectorAll function to only select images in a results div, ignoring images that might be in an extension's gallery.

**Describe what this pull request is trying to achieve.**

Fixes #8030 by making the selector for galleryPreviews more specific.

**Additional notes and description of your changes**

Currently, notifications.js checks if the first gallery image in the currently-selected tab has changed. If so, it generates a notification. However, if an extension has its own gallery (such as that in [StylePile](https://github.com/some9000/StylePile)), notifications will never trigger since extension galleries are loaded before the results gallery.

This change to the selector query causes it to only include results within a div ending in "_results", which should mean that it now ignores any galleries created by extensions.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox and Edge
 - Graphics card: Nvidia GeForce RTX 3060 Ti

**Screenshots or videos of your changes**

This commit does not alter the UI. This is a screenshot of the StylePile extension's gallery that is causing the issue:

![image](https://user-images.githubusercontent.com/35073576/220770064-c0911953-81bf-4d42-8d2a-1efd0df11b56.png)