### PR TITLE
Add .mjs support for extensions

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1754,6 +1754,9 @@ def reload_javascript():
     for script in modules.scripts.list_scripts("javascript", ".js"):
         head += f'<script type="text/javascript" src="file={script.path}?{os.path.getmtime(script.path)}"></script>\n'
 
+    for script in modules.scripts.list_scripts("javascript", ".mjs"):
+        head += f'<script type="module" src="file={script.path}?{os.path.getmtime(script.path)}"></script>\n'
+
     head += f'<script type="text/javascript">{inline}</script>\n'
 
     def template_response(*args, **kwargs):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

If the `.mjs` file is in the `extension/javascript` folder add `type="module"` instead of `type="text/javascript"`

**Environment this was tested in**

  - OS: Linux
  - Browser: Chrome
  - Graphics card: NVIDIA RTX 2060 6GB