### PR TITLE
Bugfix: Filter out temporary files that will be generated if the download fails.

### DIFF
--- a/modules/codeformer_model.py
+++ b/modules/codeformer_model.py
@@ -55,7 +55,7 @@ def setup_model(dirname):
                 if self.net is not None and self.face_helper is not None:
                     self.net.to(devices.device_codeformer)
                     return self.net, self.face_helper
-                model_paths = modelloader.load_models(model_path, model_url, self.cmd_dir, download_name='codeformer-v0.1.0.pth')
+                model_paths = modelloader.load_models(model_path, model_url, self.cmd_dir, download_name='codeformer-v0.1.0.pth', ext_filter=['.pth'])
                 if len(model_paths) != 0:
                     ckpt_path = model_paths[0]
                 else:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
If a codeformer model is not download totally, it will remain a broken model file. This file will crash the program on the next call.
There is an existential issue here, who has same problem like me.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7593

**Additional notes and description of your changes**
I see download_name is already specified explicitly, so i think filter file extension name is work enough.

**Environment this was tested in**
 - OS: Ubuntu 20.04 [WSL]
 - Browser: Edge
 - Graphics card: RTX 3060Ti

**Screenshots or videos of your changes**
![image](https://user-images.githubusercontent.com/27395365/220977769-dd44601b-8677-439b-ad87-8295155b7fe5.png)

This is **required** for anything that touches the user interface.