### PR TITLE
Bump pytorch_lightning from 1.7.6 to 1.7.7

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -9,7 +9,7 @@ Pillow==9.4.0
 realesrgan==0.3.0
 torch
 omegaconf==2.2.3
-pytorch_lightning==1.7.6
+pytorch_lightning==1.7.7
 scikit-image==0.19.2
 fonts
 font-roboto


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This fixes https://github.com/Lightning-AI/lightning/issues/14765

**Additional notes and description of your changes**

https://github.com/Lightning-AI/lightning/pull/14809

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Ubuntu 20.04.5
 - Browser: N/A
 - Graphics card: N/A

**Screenshots or videos of your changes**

N/A