### PR TITLE
Use parse_known_args in modules/shared.py for better WSGI support.

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -114,7 +114,7 @@ parser.add_argument("--no-download-sd-model", action='store_true', help="don't d
 script_loading.preload_extensions(extensions.extensions_dir, parser)
 script_loading.preload_extensions(extensions.extensions_builtin_dir, parser)
 
-cmd_opts = parser.parse_args()
+cmd_opts, _ = parser.parse_known_args()
 
 restricted_opts = {
     "samples_filename_pattern",


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

When running in a WSGI environment (e.g. with `gunicorn`) there will often be additional, unknown command line args in scope. Without this change, unknown command line args will fail at initialization time.

**Additional notes and description of your changes**

Using `parse_known_args()` instead of `parse_args()` allows broader usage with standard hosting patterns such as `gunicorn`.

**Environment this was tested in**

OS: Linux