### PR TITLE
sort upscalers by name

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from basicsr.utils.download_util import load_file_from_url
 from modules import shared
-from modules.upscaler import Upscaler
+from modules.upscaler import Upscaler, UpscalerNone
 from modules.paths import script_path, models_path
 
 
@@ -169,4 +169,8 @@ def load_upscalers():
         scaler = cls(commandline_options.get(cmd_name, None))
         datas += scaler.scalers
 
-    shared.sd_upscalers = datas
+    shared.sd_upscalers = sorted(
+        datas,
+        # Special case for UpscalerNone keeps it at the beginning of the list.
+        key=lambda x: x.name if not isinstance(x.scaler, UpscalerNone) else ""
+    )

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from basicsr.utils.download_util import load_file_from_url
 from modules import shared
-from modules.upscaler import Upscaler, UpscalerNone
+from modules.upscaler import Upscaler, UpscalerLanczos, UpscalerNearest, UpscalerNone
 from modules.paths import script_path, models_path
 
 
@@ -172,5 +172,5 @@ def load_upscalers():
     shared.sd_upscalers = sorted(
         datas,
         # Special case for UpscalerNone keeps it at the beginning of the list.
-        key=lambda x: x.name if not isinstance(x.scaler, UpscalerNone) else ""
+        key=lambda x: x.name.lower() if not isinstance(x.scaler, (UpscalerNone, UpscalerLanczos, UpscalerNearest)) else ""
     )


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I have several upscalers installed, but whenever I wanted to use them in the UI, they've been listed in an unsorted mess. This simple PR implements sorting by name so that it's much easier to find which specific upscaler I want to use.

**Additional notes and description of your changes**

This simply changes the order of the underlying Python list that the upscalers are imported into, and it preserves the "None" `UpscalerNone` as a special case at the beginning of the list.

_update 2023-03-06:_ I've added `UpscalerLanczos` and `UpscalerNearest` to the special sorting treatment per [catboxanon](https://github.com/catboxanon)'s suggestion, effectively moving them to the top of the list.

**Environment this was tested in**

 - OS: Linux (Pop_OS 22.04)
 - Browser: Firefox 108
 - Graphics card: NVIDIA RTX 3060 Ti 8GB

**Screenshots or videos of your changes**

See this before/after screenshot of the upscaler menu in the web UI:

![before-after-04](https://user-images.githubusercontent.com/1472326/221278453-8c675d9d-63e8-4272-a6a0-5cc9f539fefd.png)

Since the underlying list is sorted, this has the happy side-effect of sorting the other upscaler menus as well, but I didn't bother adding screenshots for each of them. I can add more screenshots if needed.

Of course, I also verified with several manual tests that the UI is actually using the correct upscaler when selected.