### PR TITLE
Add lossless webp option

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -556,7 +556,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             elif image_to_save.mode == 'I;16':
                 image_to_save = image_to_save.point(lambda p: p * 0.0038910505836576).convert("RGB" if extension.lower() == ".webp" else "L")
 
-            image_to_save.save(temp_file_path, format=image_format, quality=opts.jpeg_quality)
+            image_to_save.save(temp_file_path, format=image_format, quality=opts.jpeg_quality, lossless=opts.webp_lossless)
 
             if opts.enable_pnginfo and info is not None:
                 exif_bytes = piexif.dump({

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -327,6 +327,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_images_before_highres_fix": OptionInfo(False, "Save a copy of image before applying highres fix."),
     "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
     "jpeg_quality": OptionInfo(80, "Quality for saved jpeg images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),
+    "webp_lossless": OptionInfo(False, "Use lossless compression for webp images"),
     "export_for_4chan": OptionInfo(True, "If the saved image file size is above the limit, or its either width or height are above the limit, save a downscaled copy as JPG"),
     "img_downscale_threshold": OptionInfo(4.0, "File size limit for the above option, MB", gr.Number),
     "target_side_length": OptionInfo(4000, "Width/height limit for the above option, in pixels", gr.Number),


### PR DESCRIPTION
This adds an option under `Saving images/grids` to save webp images losslessly. Default `False`.

Closes #8086

**Environment this was tested in**
 - OS: Windows 10
 - Browser: Edge 110.0.1587.56
 - Graphics card: GTX 1080

**Screenshots or videos of your changes**
(These are renamed to png. Can't upload webp files here.)

Default lossy webp
![00049-3512473112](https://user-images.githubusercontent.com/4073789/221335074-78a38d77-6f50-4490-bbcb-4b9cb62f89da.png)

Lossless webp
![00050-3512473112](https://user-images.githubusercontent.com/4073789/221335130-63a3eb10-30b0-4120-b907-d9ce4dbd514f.png)
