### PR TITLE
Fix modal image height

### DIFF
--- a/style.css
+++ b/style.css
@@ -444,7 +444,7 @@ input[type="range"]{
 
 .modalImageFullscreen {
     object-fit: contain;
-    height: 90%;
+    max-height: 90%;
 }
 
 .modalPrev,


### PR DESCRIPTION
Show the real height of small images in modal. The scaling made it look muddy and blurry.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox, Chrome

**Screenshots of changes**

![Stable-Diffusion-modal](https://user-images.githubusercontent.com/40300551/221341014-a3e4f031-87e8-48ec-961f-0c9253c4d458.jpg)
