### PR TITLE
update to ignore escape (\) brackets

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -9,14 +9,14 @@ function checkBrackets(evt, textArea, counterElt) {
   errorStringSquare = '[...] - Different number of opening and closing square brackets detected.\n';
   errorStringCurly  = '{...} - Different number of opening and closing curly brackets detected.\n';
 
-  openBracketRegExp = /\(/g;
-  closeBracketRegExp = /\)/g;
+  openBracketRegExp = /(?<!\\)\(/g;
+  closeBracketRegExp = /(?<!\\)\)/g;
 
-  openSquareBracketRegExp = /\[/g;
-  closeSquareBracketRegExp = /\]/g;
+  openSquareBracketRegExp = /(?<!\\)\[/g;
+  closeSquareBracketRegExp = /(?<!\\)\]/g;
 
-  openCurlyBracketRegExp = /\{/g;
-  closeCurlyBracketRegExp = /\}/g;
+  openCurlyBracketRegExp = /(?<!\\)\{/g;
+  closeCurlyBracketRegExp = /(?<!\\)\}/g;
 
   totalOpenBracketMatches = 0;
   totalCloseBracketMatches = 0;


### PR DESCRIPTION
## Changes:

* Added (?<!\\) negative lookbehind assertion to the open and close bracket regular expressions to ensure that only unescaped brackets are matched.

![изображение](https://user-images.githubusercontent.com/53343081/221346620-7e410bf4-49b1-4505-8c11-5345bc2598e9.png)
