### PR TITLE
git 3.1.30 api change, issue #8116

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -66,7 +66,7 @@ class Extension:
 
     def check_updates(self):
         repo = git.Repo(self.path)
-        for fetch in repo.remote().fetch("--dry-run"):
+        for fetch in repo.remote().fetch(dry_run=True):
             if fetch.flags != fetch.HEAD_UPTODATE:
                 self.can_update = True
                 self.status = "behind"
@@ -79,8 +79,8 @@ class Extension:
         repo = git.Repo(self.path)
         # Fix: `error: Your local changes to the following files would be overwritten by merge`,
         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
-        repo.git.fetch('--all')
-        repo.git.reset('--hard', 'origin')
+        repo.git.fetch(all=True)
+        repo.git.reset('origin', hard=True)
 
 
 def list_extensions():

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -23,7 +23,7 @@ torchdiffeq==0.2.3
 kornia==0.6.7
 lark==1.1.2
 inflection==0.5.1
-GitPython==3.1.27
+GitPython==3.1.30
 torchsde==0.2.5
 safetensors==0.2.7
 httpcore<=0.15

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -23,7 +23,7 @@ torchdiffeq==0.2.3
 kornia==0.6.7
 lark==1.1.2
 inflection==0.5.1
-GitPython==3.1.30
+GitPython==3.1.27
 torchsde==0.2.5
 safetensors==0.2.7
 httpcore<=0.15


### PR DESCRIPTION
this is a fix for #8116 , where gitpython made a breaking api change:

> [per this](https://github.com/gitpython-developers/GitPython/pull/1518) and [this changelog](https://github.com/gitpython-developers/GitPython/pull/1518) you can no longer feed arbitrary arguments to prevent remote code execution.

Running on ubuntu 22 wsl

Tested with installs/updates, works as expected

<sup>edited to reference and auto-close:</sup> fixes #8116, fixes #8199, fixes #8116