### PR TITLE
Enable ControlNet batch support

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -718,12 +718,14 @@ def create_ui():
                         gr.HTML(
                             f"<p style='padding-bottom: 1em;' class=\"text-gray-500\">Process images in a directory on the same machine where the server is running." +
                             f"<br>Use an empty output directory to save pictures normally instead of writing to the output directory." +
-                            f"<br>Add inpaint batch mask directory to enable inpaint batch processing."
+                            f"<br>Add inpaint batch mask directory to enable inpaint batch processing." +
+                            f"<br>Add control batch images directory to enable ControlNet batch processing."
                             f"{hidden}</p>"
                         )
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs, elem_id="img2img_batch_input_dir")
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs, elem_id="img2img_batch_output_dir")
                         img2img_batch_inpaint_mask_dir = gr.Textbox(label="Inpaint batch mask directory (required for inpaint batch processing only)", **shared.hide_dirs, elem_id="img2img_batch_inpaint_mask_dir")
+                        img2img_batch_control_input_dir = gr.Textbox(label="Control batch images directory (required for control batch processing only)", **shared.hide_dirs, elem_id="img2img_batch_control_input_dir")
 
                 def copy_image(img):
                     if isinstance(img, dict) and 'image' in img:
@@ -876,6 +878,7 @@ def create_ui():
                     img2img_batch_input_dir,
                     img2img_batch_output_dir,
                     img2img_batch_inpaint_mask_dir,
+                    img2img_batch_control_input_dir,
                     override_settings,
                 ] + custom_inputs,
                 outputs=[


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Enable ControlNet extension batch support for control images.

**Additional notes and description of your changes**

Currently there's only batch support for inpainting masks. I simply adapted the following inpainting batch support pull request (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7295/files), but for ControlNet control images instead.

This enables using 1 control image per 1 img2img input image, which helps to create videos combining different techniques.

This is to add support to the ControlNet extension Mikubill/sd-webui-controlnet

This change can only be usable after the following Pull Request is approved in the extension repo: https://github.com/Mikubill/sd-webui-controlnet/pull/383

UPDATE: extension pull request has been approved and merged.

**Environment this was tested in**

 - OS: Linux
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3090 24GB
 - Extension used: https://github.com/Mikubill/sd-webui-controlnet

**Screenshots or videos of your changes**

<img width="871" alt="Screen Shot 2023-02-25 at 22 28 19 1" src="https://user-images.githubusercontent.com/20116813/221387467-7e2c1aed-3d41-48c4-8738-97aa2eed08c5.png">

