### PR TITLE
adds checks for resulting image size to avoid memory issues

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -330,6 +330,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "export_for_4chan": OptionInfo(True, "If the saved image file size is above the limit, or its either width or height are above the limit, save a downscaled copy as JPG"),
     "img_downscale_threshold": OptionInfo(4.0, "File size limit for the above option, MB", gr.Number),
     "target_side_length": OptionInfo(4000, "Width/height limit for the above option, in pixels", gr.Number),
+    "img_max_size_mp": OptionInfo(200, "Maximum image size, in megapixels", gr.Number),
 
     "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process in extras tab"),
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -485,10 +485,9 @@ class Script(scripts.Script):
         zs = process_axis(z_opt, z_values)
 
         # this could be moved to common code, but unlikely to be ever triggered anywhere else
-        Image.MAX_IMAGE_PIXELS = opts.img_max_size_mp * 1000000 * 1.1 # allow 10% overhead for margins and legend
+        Image.MAX_IMAGE_PIXELS = opts.img_max_size_mp * 1.1 # allow 10% overhead for margins and legend
         grid_mp = round(len(xs) * len(ys) * len(zs) * p.width * p.height / 1000000)
-        if grid_mp > opts.img_max_size_mp:
-            return Processed(p, [], p.seed, info=f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)')
+        assert grid_mp < opts.img_max_size_mp, f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)'
 
         def fix_axis_seeds(axis_opt, axis_list):
             if axis_opt.label in ['Seed', 'Var. seed']:

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -485,7 +485,7 @@ class Script(scripts.Script):
         zs = process_axis(z_opt, z_values)
 
         # this could be moved to common code, but unlikely to be ever triggered anywhere else
-        Image.MAX_IMAGE_PIXELS = opts.img_max_size_mp * 1.1 # allow 10% overhead for margins and legend
+        Image.MAX_IMAGE_PIXELS = opts.img_max_size_mp * 1000000 * 1.1 # allow 10% overhead for margins and legend
         grid_mp = round(len(xs) * len(ys) * len(zs) * p.width * p.height / 1000000)
         if grid_mp > opts.img_max_size_mp:
             return Processed(p, [], p.seed, info=f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)')

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -484,6 +484,12 @@ class Script(scripts.Script):
         z_opt = self.current_axis_options[z_type]
         zs = process_axis(z_opt, z_values)
 
+        # this could be moved to common code, but unlikely to be ever triggered anywhere else
+        Image.MAX_IMAGE_PIXELS = opts.img_max_size_mp * 1.1 # allow 10% overhead for margins and legend
+        grid_mp = round(len(xs) * len(ys) * len(zs) * p.width * p.height / 1000000)
+        if grid_mp > opts.img_max_size_mp:
+            return Processed(p, [], p.seed, info=f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)')
+
         def fix_axis_seeds(axis_opt, axis_list):
             if axis_opt.label in ['Seed', 'Var. seed']:
                 return [int(random.randrange(4294967294)) if val is None or val == '' or val == -1 else val for val in axis_list]


### PR DESCRIPTION
adds field in **Settings** -> **Saving Images/Grids** -> **Maximum image size, in megapixels**
(implemented as `shared.opts.img_max_size_mp`)

enforces a check inside xyz grid script as that is common place where this issue occurs.
on error, results will be none and error will be printed in webui (using infotext).

closes #8051 
closes #8164
