### PR TITLE
replace image metadata parser and allow safe parsing of all image metadata

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -603,32 +603,57 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     return fullfn, txt_fullfn
 
 
+def safe_decode_string(s: bytes):
+    remove_prefix = lambda text, prefix: text[len(prefix):] if text.startswith(prefix) else text
+    for encoding in ['utf-8', 'utf-16', 'ascii', 'latin_1', 'cp1252', 'cp437']: # try different encodings
+        try:
+            decoded = s.decode(encoding, errors="strict")
+            val = remove_prefix(decoded, 'UNICODE') # remove silly prefix added by old pnginfo/exif encoding
+            val = remove_prefix(val, 'ASCII')
+            val = re.sub(r'[\x00-\x09]', '', val).strip() # remove remaining special characters
+            if len(val) > 1024: # limit string length
+                val = val[:1024]
+            if len(val) == 0: # remove empty strings
+                val = None
+            # if not all(ord(c) < 128 for c in decoded): # only allow 7-bit ascii characters
+            #    val = None
+            return val 
+        except:
+            pass
+    return None
+
+
 def read_info_from_image(image):
     items = image.info or {}
-
     geninfo = items.pop('parameters', None)
 
     if "exif" in items:
         exif = piexif.load(items["exif"])
-        exif_comment = (exif or {}).get("Exif", {}).get(piexif.ExifIFD.UserComment, b'')
-        try:
-            exif_comment = piexif.helper.UserComment.load(exif_comment)
-        except ValueError:
-            exif_comment = exif_comment.decode('utf8', errors="ignore")
+        for _key, subkey in exif.items():
+            if isinstance(subkey, dict):
+                for key, val in subkey.items():
+                    if isinstance(val, bytes): # decode bytestring
+                        val = safe_decode_string(val)
+                    if isinstance(val, tuple) and isinstance(val[0], int) and isinstance(val[1], int): # convert camera ratios
+                        val = round(val[0] / val[1], 2)
+                    if val is not None and key in ExifTags.TAGS: # add known tags
+                        items[ExifTags.TAGS[key]] = val
+                        if ExifTags.TAGS[key] == 'UserComment': # add geninfo from UserComment
+                            geninfo = val
+                    elif val is not None and key in ExifTags.GPSTAGS:
+                        items[ExifTags.GPSTAGS[key]] = val
 
-        if exif_comment:
-            items['exif comment'] = exif_comment
-            geninfo = exif_comment
+    for key, val in items.items():
+        if isinstance(val, bytes): # decode bytestring
+            items[key] = safe_decode_string(val)
 
-        for field in ['jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
-                      'loop', 'background', 'timestamp', 'duration']:
-            items.pop(field, None)
+    for key in ['exif', 'ExifOffset', 'JpegIFOffset', 'JpegIFByteCount', 'ExifVersion', 'icc_profile', 'jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'adobe', 'photoshop', 'loop', 'duration']: # remove unwanted tags
+        items.pop(key, None)
 
     if items.get("Software", None) == "NovelAI":
         try:
             json_info = json.loads(items["Comment"])
             sampler = sd_samplers.samplers_map.get(json_info["sampler"], "Euler a")
-
             geninfo = f"""{items["Description"]}
 Negative prompt: {json_info["uc"]}
 Steps: {json_info["steps"]}, Sampler: {sampler}, CFG scale: {json_info["scale"]}, Seed: {json_info["seed"]}, Size: {image.width}x{image.height}, Clip skip: 2, ENSD: 31337"""


### PR DESCRIPTION
This PR replaces existing `read_info_from_image` image metadata parser.  

Old parser based on `piexif.decode` is perfectly fine for parsing images created by WebUI, but its prone to overflows/crashes when handling foreign images.

And with common use case of loading image via **PNG Info** tab and then sending it to other tabs, this results in unhandled situations.

Additionally, there is large value to show other EXIF/PNGinfo fields, not just `UserComment` where WebUI generation infotext is stored. So now **PNGInfo** tab can show *all* metadata, not just generation info.

I've tested with WebUI generated images, NovelAI sample and while loading different 3rd party images.  
Goal is no change in behavior for WebUI/NovelAI images but overall safer operations.
