### PR TITLE
Add a way for API txt2img and img2img requests to pass args to always on scripts

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -191,7 +191,7 @@ class Api:
             script_args[selectable_scripts.args_from:selectable_scripts.args_to] = request.script_args
             script_args[0] = selectable_idx + 1
         else:
-            # if 0 then none
+            # when [0] = 0 no selectable script to run
             script_args[0] = 0
 
         # Now check for always on scripts

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -172,17 +172,53 @@ class Api:
         return script, script_idx
 
     def get_script(self, script_name, script_runner):
+        if script_name is None or script_name == "":
+            return None, None
+        
+        script_idx = script_name_to_index(script_name, script_runner.scripts)
+        return script_runner.scripts[script_idx]
+
+    def init_script_args(self, request, selectable_scripts, selectable_idx, script_runner):
+        #find max idx from the scripts in runner and generate a none array to init script_args
+        last_arg_index = 1
         for script in script_runner.scripts:
-            if script_name.lower() == script.title().lower():
-                return script
-        return None
+            if last_arg_index < script.args_to:
+                last_arg_index = script.args_to
+        # None everywhere except position 0 to initialize script args
+        script_args = [None]*last_arg_index
+        # position 0 in script_arg is the idx+1 of the selectable script that is going to be run when using scripts.scripts_*2img.run()
+        if selectable_scripts:
+            script_args[selectable_scripts.args_from:selectable_scripts.args_to] = request.script_args
+            script_args[0] = selectable_idx + 1
+        else:
+            # if 0 then none
+            script_args[0] = 0
+
+        # Now check for always on scripts
+        if request.alwayson_script_name and (len(request.alwayson_script_name) > 0):
+            # always on script with no arg should always run, but if you include their name in the api request, send an empty list for there args
+            if not request.alwayson_script_args:
+                raise HTTPException(status_code=422, detail=f"Script {request.alwayson_script_name} has no arg list")
+            if len(request.alwayson_script_name) != len(request.alwayson_script_args):
+                raise HTTPException(status_code=422, detail=f"Number of script names and number of script arg lists doesn't match")
+
+            for alwayson_script_name, alwayson_script_args in zip(request.alwayson_script_name, request.alwayson_script_args):
+                alwayson_script = self.get_script(alwayson_script_name, script_runner)
+                if alwayson_script == None:
+                    raise HTTPException(status_code=422, detail=f"always on script {alwayson_script_name} not found")
+                # Selectable script in always on script param check
+                if alwayson_script.alwayson == False:
+                    raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
+                if alwayson_script_args != []:
+                    script_args[alwayson_script.args_from:alwayson_script.args_to] = alwayson_script_args
+        return script_args
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):
         script_runner = scripts.scripts_txt2img
         if not script_runner.scripts:
             script_runner.initialize_scripts(False)
             ui.create_ui()
-        api_selectable_scripts, api_selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
+        selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
 
         populate = txt2imgreq.copy(update={ # Override __init__ params
             "sampler_name": validate_sampler_name(txt2imgreq.sampler_name or txt2imgreq.sampler_index),
@@ -196,53 +232,24 @@ class Api:
 
         args = vars(populate)
         args.pop('script_name', None)
-        args.pop('script_args', None) # will refeed them later with script_args
+        args.pop('script_args', None) # will refeed them to the pipeline directly after initializing them
         args.pop('alwayson_script_name', None)
         args.pop('alwayson_script_args', None)
 
-        #find max idx from the scripts in runner and generate a none array to init script_args
-        last_arg_index = 1
-        for script in script_runner.scripts:
-            if last_arg_index < script.args_to:
-                last_arg_index = script.args_to
-        # None everywhere exepct position 0 to initialize script args
-        script_args = [None]*last_arg_index
-        # position 0 in script_arg is the idx+1 of the selectable script that is going to be run
-        if api_selectable_scripts:
-            script_args[api_selectable_scripts.args_from:api_selectable_scripts.args_to] = txt2imgreq.script_args
-            script_args[0] = api_selectable_script_idx + 1
-        else:
-            # if 0 then none
-            script_args[0] = 0
-
-        # Now check for always on scripts
-        if len(txt2imgreq.alwayson_script_name) > 0:
-            # always on script with no arg should always run, but if you include their name in the api request, send an empty list for there args
-            if len(txt2imgreq.alwayson_script_name) != len(txt2imgreq.alwayson_script_args):
-                raise HTTPException(status_code=422, detail=f"Number of script names and number of script arg lists doesn't match")
-
-            for alwayson_script_name, alwayson_script_args in zip(txt2imgreq.alwayson_script_name, txt2imgreq.alwayson_script_args):
-                alwayson_script = self.get_script(alwayson_script_name, script_runner)
-                if alwayson_script == None:
-                    raise HTTPException(status_code=422, detail=f"always on script {alwayson_script_name} not found")
-                # Selectable script in always on script param check
-                if alwayson_script.alwayson == False:
-                    raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
-                if alwayson_script_args != []:
-                    script_args[alwayson_script.args_from:alwayson_script.args_to] = alwayson_script_args
+        script_args = self.init_script_args(txt2imgreq, selectable_scripts, selectable_script_idx, script_runner)
 
         with self.queue_lock:
             p = StableDiffusionProcessingTxt2Img(sd_model=shared.sd_model, **args)
             p.scripts = script_runner
 
             shared.state.begin()
-            if api_selectable_scripts != None:
+            if selectable_scripts != None:
                 p.script_args = script_args
                 p.outpath_grids = opts.outdir_txt2img_grids
                 p.outpath_samples = opts.outdir_txt2img_samples
-                processed = scripts.scripts_txt2img.run(p, *p.script_args)
+                processed = scripts.scripts_txt2img.run(p, *p.script_args) # Need to pass args as list here
             else:
-                p.script_args = tuple(script_args)
+                p.script_args = tuple(script_args) # Need to pass args as tuple here
                 processed = process_images(p)
             shared.state.end()
 
@@ -263,7 +270,7 @@ class Api:
         if not script_runner.scripts:
             script_runner.initialize_scripts(True)
             ui.create_ui()
-        api_selectable_scripts, api_selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
+        selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
 
         populate = img2imgreq.copy(update={ # Override __init__ params
             "sampler_name": validate_sampler_name(img2imgreq.sampler_name or img2imgreq.sampler_index),
@@ -279,41 +286,11 @@ class Api:
         args = vars(populate)
         args.pop('include_init_images', None)  # this is meant to be done by "exclude": True in model, but it's for a reason that I cannot determine.
         args.pop('script_name', None)
-        args.pop('script_args', None) # will refeed them later with script_args
+        args.pop('script_args', None)  # will refeed them to the pipeline directly after initializing them
         args.pop('alwayson_script_name', None)
         args.pop('alwayson_script_args', None)
 
-        #find max idx from the scripts in runner and generate a none array to init script_args
-        last_arg_index = 1
-        for script in script_runner.scripts:
-            if last_arg_index < script.args_to:
-                last_arg_index = script.args_to
-        # None everywhere exepct position 0 to initialize script args
-        script_args = [None]*last_arg_index
-        # position 0 in script_arg is the idx+1 of the selectable script that is going to be run
-        if api_selectable_scripts:
-            script_args[api_selectable_scripts.args_from:api_selectable_scripts.args_to] = img2imgreq.script_args
-            script_args[0] = api_selectable_script_idx + 1
-        else:
-            # if 0 then none
-            script_args[0] = 0
-
-        # Now check for always on scripts
-        if len(img2imgreq.alwayson_script_name) > 0:
-            # always on script with no arg should always run, but if you include their name in the api request, send an empty list for there args
-            if len(img2imgreq.alwayson_script_name) != len(img2imgreq.alwayson_script_args):
-                raise HTTPException(status_code=422, detail=f"Number of script names and number of script arg lists doesn't match")
-
-            for alwayson_script_name, alwayson_script_args in zip(img2imgreq.alwayson_script_name, img2imgreq.alwayson_script_args):
-                alwayson_script = self.get_script(alwayson_script_name, script_runner)
-                if alwayson_script == None:
-                    raise HTTPException(status_code=422, detail=f"always on script {alwayson_script_name} not found")
-                # Selectable script in always on script param check
-                if alwayson_script.alwayson == False:
-                    raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
-                if alwayson_script_args != []:
-                    script_args[alwayson_script.args_from:alwayson_script.args_to] = alwayson_script_args
-
+        script_args = self.init_script_args(img2imgreq, selectable_scripts, selectable_script_idx, script_runner)
 
         with self.queue_lock:
             p = StableDiffusionProcessingImg2Img(sd_model=shared.sd_model, **args)
@@ -321,13 +298,13 @@ class Api:
             p.scripts = script_runner
 
             shared.state.begin()
-            if api_selectable_scripts != None:
+            if selectable_scripts != None:
                 p.script_args = script_args
                 p.outpath_grids = opts.outdir_img2img_grids
                 p.outpath_samples = opts.outdir_img2img_samples
-                processed = scripts.scripts_img2img.run(p, *p.script_args)
+                processed = scripts.scripts_img2img.run(p, *p.script_args) # Need to pass args as list here
             else:
-                p.script_args = tuple(script_args)
+                p.script_args = tuple(script_args) # Need to pass args as tuple here
                 processed = process_images(p)
             shared.state.end()
 

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -274,7 +274,7 @@ class Api:
             ui.create_ui()
         selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
 
-        populate = img2imgreq.copy(update={ # Override __init__ params
+        populate = img2imgreq.copy(update={  # Override __init__ params
             "sampler_name": validate_sampler_name(img2imgreq.sampler_name or img2imgreq.sampler_index),
             "do_not_save_samples": not img2imgreq.save_images,
             "do_not_save_grid": not img2imgreq.save_images,

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -113,7 +113,6 @@ StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingImg2Img",
     StableDiffusionProcessingImg2Img,
-
     [
         {"key": "sampler_index", "type": str, "default": "Euler"},
         {"key": "init_images", "type": list, "default": None},

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -100,13 +100,13 @@ class PydanticModelGenerator:
 StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingTxt2Img",
     StableDiffusionProcessingTxt2Img,
-    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}]
+    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_script_name", "type": list, "default": []}, {"key": "alwayson_script_args", "type": list, "default": []}]
 ).generate_model()
 
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingImg2Img",
     StableDiffusionProcessingImg2Img,
-    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}]
+    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_script_name", "type": list, "default": []}, {"key": "alwayson_script_args", "type": list, "default": []}]
 ).generate_model()
 
 class TextToImageResponse(BaseModel):

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -100,13 +100,13 @@ class PydanticModelGenerator:
 StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingTxt2Img",
     StableDiffusionProcessingTxt2Img,
-    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_script_name", "type": list, "default": []}, {"key": "alwayson_script_args", "type": list, "default": []}]
+    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_scripts", "type": dict, "default": {}}]
 ).generate_model()
 
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingImg2Img",
     StableDiffusionProcessingImg2Img,
-    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_script_name", "type": list, "default": []}, {"key": "alwayson_script_args", "type": list, "default": []}]
+    [{"key": "sampler_index", "type": str, "default": "Euler"}, {"key": "init_images", "type": list, "default": None}, {"key": "denoising_strength", "type": float, "default": 0.75}, {"key": "mask", "type": str, "default": None}, {"key": "include_init_images", "type": bool, "default": False, "exclude" : True}, {"key": "script_name", "type": str, "default": None}, {"key": "script_args", "type": list, "default": []}, {"key": "alwayson_scripts", "type": dict, "default": {}}]
 ).generate_model()
 
 class TextToImageResponse(BaseModel):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

UPDATE:
Changed to add 1 param, a dictionary, to the api for txt2img and img2img (alwayson_scripts) in the format proposed in the comment below.

~~These changes add 2 params to the api for txt2img and img2img (alwayson_script_name, alwayson_script_args).~~

~~`alwayson_script_name` is a list of string containing the name of the always on scripts you want to pass args to 
exemple: ["Additional networks for generating", "ControlNet"]~~

~~`alwayson_script_args` is a list of lists containing args for script mentioned in alwayson_script_name 
exemple: "alwayson_script_args": [[true, false, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "Refresh models"] , [!Controlnet args here!]]~~

The goal is to pass args to always on scripts like controlnet or additional-networks without them having to duplicate or hijack parts of the API just to have access to them. Some adjustment on the part of the extensions might be needed if they want to support it. For exemple, controlnet might have to detect that the images are a base64 string instead of an Image but it shouldn't require much work. 
To test this, I had to do a small change to additional_network because it would throw an error. I believe it was checking the 0 index of a possibly empty tuple to see if it existed.
These changes should not affect how the api works currently, selectable scripts should be working exactly like before.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card:  NVIDIA RTX 2080 8GB

Exemple txt2img request with additional network as an alwayson_script:
```
{
	"enable_hr": false,
	"denoising_strength": 0,
	"firstphase_width": 0,
	"firstphase_height": 0,
	"hr_scale": 1,
	"hr_upscaler": false,
	"hr_second_pass_steps": 0,
	"hr_resize_x": 0,
	"hr_resize_y": 0,
	"prompt": "a prompt",
	"styles": [],
	"seed": -1,
	"subseed": -1,
	"subseed_strength": 0,
	"seed_resize_from_h": -1,
	"seed_resize_from_w": -1,
	"sampler_name": "DPM++ 2S a",
	"batch_size": 1,
	"n_iter": 1,
	"steps": 10,
	"cfg_scale": 7,
	"width": 512,
	"height": 512,
	"restore_faces": false,
	"tiling": false,
	"negative_prompt": "",
	"s_churn": 0,
	"s_tmax": 0,
	"s_tmin": 0,
	"s_noise": 1,
	"override_settings": {},
	"override_settings_restore_afterwards": true,
	"script_name": "",
	"script_args": [],
	"alwayson_scripts": {
		"Additional networks for generating": {
			"args": [true, false, "LoRA", "<!!!!!A lora model here!!!!>", 0.3, 0.3, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "Refresh models"]
		}
	}
}
```
closes #8253