### PR TITLE
Gradio auth logic fix - Handle empty/newlines

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -214,7 +214,6 @@ def webui():
             with open(cmd_opts.gradio_auth_path, 'r', encoding="utf8") as file:
                 for line in file.readlines():
                     gradio_auth_creds += [x.strip() for x in line.split(',') if x.strip()]
-            file.close()
 
         app, local_url, share_url = shared.demo.launch(
             share=cmd_opts.share,

--- a/webui.py
+++ b/webui.py
@@ -209,11 +209,12 @@ def webui():
 
         gradio_auth_creds = []
         if cmd_opts.gradio_auth:
-            gradio_auth_creds += cmd_opts.gradio_auth.strip('"').replace('\n', '').split(',')
+            gradio_auth_creds += [x.strip() for x in cmd_opts.gradio_auth.strip('"').replace('/n', '').split(',') if x.strip()]
         if cmd_opts.gradio_auth_path:
             with open(cmd_opts.gradio_auth_path, 'r', encoding="utf8") as file:
                 for line in file.readlines():
-                    gradio_auth_creds += [x.strip() for x in line.split(',')]
+                    gradio_auth_creds += [x.strip() for x in line.split(',') if x.strip()]
+            file.close()
 
         app, local_url, share_url = shared.demo.launch(
             share=cmd_opts.share,

--- a/webui.py
+++ b/webui.py
@@ -209,7 +209,7 @@ def webui():
 
         gradio_auth_creds = []
         if cmd_opts.gradio_auth:
-            gradio_auth_creds += [x.strip() for x in cmd_opts.gradio_auth.strip('"').replace('/n', '').split(',') if x.strip()]
+            gradio_auth_creds += [x.strip() for x in cmd_opts.gradio_auth.strip('"').replace('\n', '').split(',') if x.strip()]
         if cmd_opts.gradio_auth_path:
             with open(cmd_opts.gradio_auth_path, 'r', encoding="utf8") as file:
                 for line in file.readlines():


### PR DESCRIPTION
When the massive one-liner was split into multiple lines, it lost the ability to handle new lines.
This removes empty strings & newline characters from the logins.
It also closes the file so it's more robust if the garbage collection function ever changes.

**Environment this was tested in**
 - OS: Windows
 - Browser: Brave - Chromium-based