### PR TITLE
fix [Bug]: Extension update check issue #6447

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -66,7 +66,7 @@ class Extension:
 
     def check_updates(self):
         repo = git.Repo(self.path)
-        for fetch in repo.remote().fetch("--dry-run"):
+        for fetch in repo.remote().fetch(dry_run=True):
             if fetch.flags != fetch.HEAD_UPTODATE:
                 self.can_update = True
                 self.status = "behind"


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

One line patch to fix a bug that has recurred: Extension update check issue #6447

**Additional notes and description of your changes**

This code: `repo.remote().fetch("--dry-run")`
produces this git command: `git fetch -v -- origin --dry-run`
Gives an error: `fatal: couldn't find remote ref --dry-run`

The corrected code: `repo.remote().fetch(dry_run=True)`
produces this git command: `git fetch -v --dry-run -- origin`
Which does not cause an error.

This seems to be due to a change in GitPython 3.1.31 vs 3.1.27, but the correction using a kwarg is a better way to do it I guess.

We can reproduce the bug outside the webui, like this:

```
# pip install GitPython==3.1.31
```

Old code, causes an error:
```
# python -c 'import git; git.Repo(".").remote().fetch("--dry-run")'
...
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin --dry-run
  stderr: 'fatal: couldn't find remote ref --dry-run'
```

New code, no error:
```
# python -c 'import git; git.Repo(".").remote().fetch(dry_run=True)
```

Showing that kwarg options are passed through to the git command line:
```
# python -c 'import git; git.Repo(".").remote().fetch(bogus=True)'
...
git.exc.GitCommandError: Cmd('git') failed due to: exit code(129)
  cmdline: git fetch -v --bogus -- origin
  stderr: 'error: unknown option `bogus''
```

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Debian Linux
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090
 - Python 3.10.10
 - git version 2.39.2
 - GitPython 3.1.31

I also tested it with the older GitPython that is specified in requirements_versions.txt:
 - GitPython 3.1.27
 
I didn't test it on Windows, but I don't think that it can break anything on Windows.