### PR TITLE
add: /sdapi/v1/scripts in API

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -150,6 +150,7 @@ class Api:
         self.add_api_route("/sdapi/v1/train/embedding", self.train_embedding, methods=["POST"], response_model=TrainResponse)
         self.add_api_route("/sdapi/v1/train/hypernetwork", self.train_hypernetwork, methods=["POST"], response_model=TrainResponse)
         self.add_api_route("/sdapi/v1/memory", self.get_memory, methods=["GET"], response_model=MemoryResponse)
+        self.add_api_route("/sdapi/v1/scripts", self.get_scripts_list, methods=["GET"], response_model=ScriptsList)
 
     def add_api_route(self, path: str, endpoint, **kwargs):
         if shared.cmd_opts.api_auth:
@@ -174,6 +175,18 @@ class Api:
         script_idx = script_name_to_index(script_name, script_runner.selectable_scripts)
         script = script_runner.selectable_scripts[script_idx]
         return script, script_idx
+    
+    def get_scripts_list(self):
+        t2ilist = []
+        i2ilist = []
+   
+        for a in scripts.scripts_txt2img.titles:
+            t2ilist.append(str(a.lower()))
+
+        for b in scripts.scripts_img2img.titles:
+            i2ilist.append(str(b.lower()))
+
+        return ScriptsList(txt2img = t2ilist, img2img = i2ilist)  
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):
         script, script_idx = self.get_script(txt2imgreq.script_name, scripts.scripts_txt2img)

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -177,14 +177,8 @@ class Api:
         return script, script_idx
     
     def get_scripts_list(self):
-        t2ilist = []
-        i2ilist = []
-   
-        for a in scripts.scripts_txt2img.titles:
-            t2ilist.append(str(a.lower()))
-
-        for b in scripts.scripts_img2img.titles:
-            i2ilist.append(str(b.lower()))
+        t2ilist = [str(title.lower()) for title in scripts.scripts_txt2img.titles]
+        i2ilist = [str(title.lower()) for title in scripts.scripts_img2img.titles]
 
         return ScriptsList(txt2img = t2ilist, img2img = i2ilist)  
 

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -267,3 +267,7 @@ class EmbeddingsResponse(BaseModel):
 class MemoryResponse(BaseModel):
     ram: dict = Field(title="RAM", description="System memory stats")
     cuda: dict = Field(title="CUDA", description="nVidia CUDA memory stats")
+
+class ScriptsList(BaseModel):
+    txt2img: list = Field(default=None,title="Txt2img", description="Titles of scripts (txt2img)")
+    img2img: list = Field(default=None,title="Img2img", description="Titles of scripts (img2img)")


### PR DESCRIPTION


**Describe what this pull request is trying to achieve.**

Added an API interface to get the current Scripts list.

**Additional notes and description of your changes**

- FastAPI : `GET` **/sdapi/v1/scripts** Get Scripts List

- Parameters : No parameters

- Responses example : 

Response body
```json
{
  "txt2img": [
    "animator v6",
    "animator v6",
    "animator v6",
    "prompt matrix",
    "prompts from file or textbox",
    "lanczos quick upscale",
    "x/y/z plot",
    "controlnet m2m",
    "depthmap v0.3.8"
  ],
  "img2img": [
    "advanced loopback",
    "animator v6",
    "animator v6",
    "animator v6",
    "img2img alternative test",
    "interpolate",
    "loopback",
    "loopback and superimpose",
    "alpha canvas",
    "outpainting mk2",
    "sd parseq v0.01",
    "poor man's outpainting",
    "prompt matrix",
    "prompts from file or textbox",
    "lanczos quick upscale",
    "sd upscale",
    "vid2vid",
    "videos",
    "x/y/z plot",
    "controlnet m2m",
    "depthmap v0.3.8"
  ]
}
```

Response headers
```Headers
 content-length: 554 
 content-type: application/json 
 date: Sat,04 Mar 2023 18:15:20 GMT 
 server: uvicorn 
 x-process-time: 0.0009 
 ```


**Environment this was tested in**

 - OS: Windows
 - Browser: chrome
 - Graphics card:  NVIDIA RTX A5000

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/13723054/222922475-b39e8c7b-1f37-4c93-af13-8bea4b6e0c7d.png)