### PR TITLE
Extra network description files

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -15,18 +15,10 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         for name, lora_on_disk in lora.available_loras.items():
             path, ext = os.path.splitext(lora_on_disk.filename)
-            previews = [path + ".png", path + ".preview.png"]
-
-            preview = None
-            for file in previews:
-                if os.path.isfile(file):
-                    preview = self.link_preview(file)
-                    break
-
             yield {
                 "name": name,
                 "filename": path,
-                "preview": preview,
+                "preview": self._find_preview(path),
                 "search_term": self.search_terms_from_path(lora_on_disk.filename),
                 "prompt": json.dumps(f"<lora:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -19,6 +19,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
                 "name": name,
                 "filename": path,
                 "preview": self._find_preview(path),
+                "description": self._find_description(path),
                 "search_term": self.search_terms_from_path(lora_on_disk.filename),
                 "prompt": json.dumps(f"<lora:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -7,6 +7,7 @@
 			<span style="display:none" class='search_term'>{search_term}</span>
 		</div>
 		<span class='name'>{name}</span>
+		<span class='description'>{description}</span>
 	</div>
 </div>
 

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -2,6 +2,7 @@ import glob
 import os.path
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 
 from modules import shared
 import gradio as gr
@@ -136,6 +137,15 @@ class ExtraNetworksPage:
         }
 
         return self.card_page.format(**args)
+
+    def _find_preview(self, path: str) -> Optional[str]:
+        """
+        Find a preview PNG for a given path (without extension) and call link_preview on it.
+        """
+        for file in [path + ".png", path + ".preview.png"]:
+            if os.path.isfile(file):
+                return self.link_preview(file)
+        return None
 
 
 def intialize():

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -1,6 +1,7 @@
 import glob
 import os.path
 import urllib.parse
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -131,6 +132,7 @@ class ExtraNetworksPage:
             "tabname": json.dumps(tabname),
             "local_preview": json.dumps(item["local_preview"]),
             "name": item["name"],
+            "description": (item.get("description") or ""),
             "card_clicked": onclick,
             "save_card_preview": '"' + html.escape(f"""return saveCardPreview(event, {json.dumps(tabname)}, {json.dumps(item["local_preview"])})""") + '"',
             "search_term": item.get("search_term", ""),
@@ -145,6 +147,19 @@ class ExtraNetworksPage:
         for file in [path + ".png", path + ".preview.png"]:
             if os.path.isfile(file):
                 return self.link_preview(file)
+        return None
+
+    @lru_cache(maxsize=512)
+    def _find_description(self, path: str) -> Optional[str]:
+        """
+        Find and read a description file for a given path (without extension).
+        """
+        for file in [f"{path}.txt", f"{path}.description.txt"]:
+            try:
+                with open(file, "r", encoding="utf-8", errors="replace") as f:
+                    return f.read()
+            except OSError:
+                pass
         return None
 
 

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -20,6 +20,7 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
                 "name": checkpoint.name_for_extra,
                 "filename": path,
                 "preview": self._find_preview(path),
+                "description": self._find_description(path),
                 "search_term": self.search_terms_from_path(checkpoint.filename) + " " + (checkpoint.sha256 or ""),
                 "onclick": '"' + html.escape(f"""return selectCheckpoint({json.dumps(name)})""") + '"',
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -1,7 +1,6 @@
 import html
 import json
 import os
-import urllib.parse
 
 from modules import shared, ui_extra_networks, sd_models
 
@@ -17,18 +16,10 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         checkpoint: sd_models.CheckpointInfo
         for name, checkpoint in sd_models.checkpoints_list.items():
             path, ext = os.path.splitext(checkpoint.filename)
-            previews = [path + ".png", path + ".preview.png"]
-
-            preview = None
-            for file in previews:
-                if os.path.isfile(file):
-                    preview = self.link_preview(file)
-                    break
-
             yield {
                 "name": checkpoint.name_for_extra,
                 "filename": path,
-                "preview": preview,
+                "preview": self._find_preview(path),
                 "search_term": self.search_terms_from_path(checkpoint.filename) + " " + (checkpoint.sha256 or ""),
                 "onclick": '"' + html.escape(f"""return selectCheckpoint({json.dumps(name)})""") + '"',
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -14,18 +14,11 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         for name, path in shared.hypernetworks.items():
             path, ext = os.path.splitext(path)
-            previews = [path + ".png", path + ".preview.png"]
-
-            preview = None
-            for file in previews:
-                if os.path.isfile(file):
-                    preview = self.link_preview(file)
-                    break
 
             yield {
                 "name": name,
                 "filename": path,
-                "preview": preview,
+                "preview": self._find_preview(path),
                 "search_term": self.search_terms_from_path(path),
                 "prompt": json.dumps(f"<hypernet:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -19,6 +19,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
                 "name": name,
                 "filename": path,
                 "preview": self._find_preview(path),
+                "description": self._find_description(path),
                 "search_term": self.search_terms_from_path(path),
                 "prompt": json.dumps(f"<hypernet:{name}:") + " + opts.extra_networks_default_multiplier + " + json.dumps(">"),
                 "local_preview": path + ".png",

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -15,16 +15,10 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         for embedding in sd_hijack.model_hijack.embedding_db.word_embeddings.values():
             path, ext = os.path.splitext(embedding.filename)
-            preview_file = path + ".preview.png"
-
-            preview = None
-            if os.path.isfile(preview_file):
-                preview = self.link_preview(preview_file)
-
             yield {
                 "name": embedding.name,
                 "filename": embedding.filename,
-                "preview": preview,
+                "preview": self._find_preview(path),
                 "search_term": self.search_terms_from_path(embedding.filename),
                 "prompt": json.dumps(embedding.name),
                 "local_preview": path + ".preview.png",

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -19,6 +19,7 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
                 "name": embedding.name,
                 "filename": embedding.filename,
                 "preview": self._find_preview(path),
+                "description": self._find_description(path),
                 "search_term": self.search_terms_from_path(embedding.filename),
                 "prompt": json.dumps(embedding.name),
                 "local_preview": path + ".preview.png",

--- a/style.css
+++ b/style.css
@@ -939,6 +939,17 @@ footer {
     line-break: anywhere;
 }
 
+.extra-network-cards .card .actions .description {
+    display: block;
+    max-height: 3em;
+    white-space: pre-wrap;
+    line-height: 1.1;
+}
+
+.extra-network-cards .card .actions .description:hover {
+    max-height: none;
+}
+
 .extra-network-cards .card .actions:hover .additional{
     display: block;
 }


### PR DESCRIPTION
This pull request adds support for _description files_ for extra networks; for example, some LoRAs activate (better) with a given keyword, which may not be obvious from the LoRA's filename, so this allows for jotting notes down into a `.txt` (or `.description.txt`) file next to the model file, following how preview PNGs work.

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: Irrelevant

**Screenshots or videos of your changes**

The UI shows up to three lines of the file to begin with, and all of it when hovering over the description.

Default:
![card-desc](https://user-images.githubusercontent.com/58669/223208950-6d6a9043-bfdd-49ef-b579-90daf3f9facf.png)

Hover:
![card-hover](https://user-images.githubusercontent.com/58669/223208953-fb5a4597-2fa9-4874-a643-84dc4fafab77.png)

No description (as before):
![image](https://user-images.githubusercontent.com/58669/223209188-789f430a-8428-4d26-ad15-2087fabe4201.png)
