### PR TITLE
Add mac binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ notification.mp3
 /test/stdout.txt
 /test/stderr.txt
 /cache.json
+*.DS_Store


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This commit adds [Desktop Services Store](https://en.wikipedia.org/wiki/.DS_Store) files to gitignore (mac meta file for directories, icon positions, etc.)

**Environment this was tested in** [irrelevant, no change in behavior]

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: macOS Big Sur
 - Browser: chrome
 - Graphics card: Intel Iris Plus Graphics 650 1536 MB

( Don't judge my Graphics Card :,] )

**Comment of PR Author regarding the changed file**

I would recommend to sort the gitignore file in a later pull request and categorise the contents by clearly separated `# Categories` such as IDE specific, OS specific and so on, perhaps even alphabetically sorted for better readability over the gitignore file. This however needs a deeper dive and more opinions on the file organisation.