### PR TITLE
update "replace preview" link button's css

### DIFF
--- a/style.css
+++ b/style.css
@@ -856,7 +856,7 @@ footer {
 }
 
 .extra-network-thumbs .card:hover .additional a {
-    display: block;
+    display: inline-block;
 }
 
 .extra-network-thumbs .actions .additional a {


### PR DESCRIPTION
modify css

**Describe what this pull request is trying to achieve.**
Only modified extra network's thumbnail card's a tag button's css. 

In the past, It has a hove css to all button, and set display to Block.
```javascript
.extra-network-thumbs .card:hover .additional a {
    display: block;
}
```

That means every button on this card, will take a whole single line. Which means there is no way other extensions can add more buttons on this extra network's thumbnail preview card any more. The thumbnail is too small for many lines.

This pull request, just change it to "inline-block". Which breaks nothing, and now other extensions can add more button to extra network's thumbnail card.

