### PR TITLE
Add correction file filename length limits on *nix systems

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -577,6 +577,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         max_name_len = os.statvfs(path).f_namemax
         fullfn_without_extension = fullfn_without_extension[:max_name_len - max(4, len(extension))]
         params.filename = fullfn_without_extension + extension
+        fullfn = params.filename
     _atomically_save_image(image, fullfn_without_extension, extension)
 
     image.already_saved_as = fullfn

--- a/modules/images.py
+++ b/modules/images.py
@@ -512,6 +512,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             file_decoration = "-" + file_decoration
 
         file_decoration = namegen.apply(file_decoration) + suffix
+        if hasattr(os, 'statvfs'):
+            max_name_len = os.statvfs(path).f_namemax
+            file_decoration = file_decoration[:max_name_len - 5]
 
         if add_number:
             basecount = get_next_sequence_number(path, basename)

--- a/modules/images.py
+++ b/modules/images.py
@@ -575,7 +575,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     fullfn_without_extension, extension = os.path.splitext(params.filename)
     if hasattr(os, 'statvfs'):
         max_name_len = os.statvfs(path).f_namemax
-        fullfn_without_extension = fullfn_without_extension[:max_name_len - len(extension)]
+        fullfn_without_extension = fullfn_without_extension[:max_name_len - max(4, len(extension))]
         params.filename = fullfn_without_extension + extension
     _atomically_save_image(image, fullfn_without_extension, extension)
 

--- a/modules/images.py
+++ b/modules/images.py
@@ -512,9 +512,6 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             file_decoration = "-" + file_decoration
 
         file_decoration = namegen.apply(file_decoration) + suffix
-        if hasattr(os, 'statvfs'):
-            max_name_len = os.statvfs(path).f_namemax
-            file_decoration = file_decoration[:max_name_len - 5]
 
         if add_number:
             basecount = get_next_sequence_number(path, basename)
@@ -576,6 +573,10 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         os.replace(temp_file_path, filename_without_extension + extension)
 
     fullfn_without_extension, extension = os.path.splitext(params.filename)
+    if hasattr(os, 'statvfs'):
+        max_name_len = os.statvfs(path).f_namemax
+        fullfn_without_extension = fullfn_without_extension[:max_name_len - len(extension)]
+        params.filename = fullfn_without_extension + extension
     _atomically_save_image(image, fullfn_without_extension, extension)
 
     image.already_saved_as = fullfn


### PR DESCRIPTION
**TLDR:** Linux sometimes limits filename length, long prompts break, this fixes that.

-------------


The issue: on Linux (and other *nix systems) it's possible for filename length limits to exist that apply to some directories and not others. No I cannot explain why, that seems pretty stupid, but for some reason that's actually a thing. It's triggered by LUKS among other tools.
SD image gens with eg `[prompt_words]` or `[model_name]` can exceed this limit with sufficiently long prompts and/or model names.
The result is images fail to save or display in the WebUI if a prompt is too long.

---------

The solutions to this are either (A) implement a user-configurable setting for max file length, or (B) just detect it and cap it.

The setting is redundant for the majority of users, and has a predictable value for the remaining few, so probably not wanted.

The way to detect this is via `os.statvfs`, which in python dev's infinite wisdom not only doesn't work but _doesn't exist_ on Windows for some reason, thus the `hasattr` check - that block never runs on Windows, does run on Linux (and any other applicable OS).
When ran it just quietly caps file name length to the length, minus five characters to leave room for any extension (eg `.webp` would be 5, `.jpg` or `.png` would be 4)

Side effect of this appears to be that when it triggers, the WebUI embeds a link to a `tmp` file rather than the final output file. It's the full image file, minus the metadata. The output file itself is stored properly with name and all.
I... honestly don't know why that happens, and it's not majorly breaking, but it might be good to correct that issue.

------

If you want to test replication: use a Linux install, with anything that has random filename length limits - eg Ubuntu 22 and checkmark the 'encrypt home directory' option during install (LUKS home dir encryption is one such provider of random inexplicable filename length limits), and install the webui in the affected directory (eg within your encrypted home directory), then set your `Images filename pattern` to something like `[prompt_spaces] [seed] [sampler] idk whatever else you weant [model_name]` and then generate an image with a prompt of `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` (ie make really really long words, so the word count limit doesn't save you)
Without this fix, it will fail to save the image and fail to load the image in the UI. With this fix, it will save and load as expected.