### PR TITLE
allow usage of latest pytorch_lighning

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -9,7 +9,7 @@ Pillow==9.4.0
 realesrgan==0.3.0
 torch
 omegaconf==2.2.3
-pytorch_lightning==1.7.6
+pytorch_lightning==1.9.4
 scikit-image==0.19.2
 fonts
 font-roboto

--- a/webui.py
+++ b/webui.py
@@ -4,6 +4,7 @@ import time
 import importlib
 import signal
 import re
+import warnings
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware

--- a/webui.py
+++ b/webui.py
@@ -19,7 +19,7 @@ startup_timer = timer.Timer()
 
 import torch
 import pytorch_lightning # pytorch_lightning should be imported after torch, but it re-enables warnings on import so import once to disable them
-warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="pytorch_lightning")
 startup_timer.record("import torch")
 
 import gradio

--- a/webui.py
+++ b/webui.py
@@ -17,6 +17,8 @@ from modules import paths, timer, import_hook, errors
 startup_timer = timer.Timer()
 
 import torch
+import pytorch_lightning # pytorch_lightning should be imported after torch, but it re-enables warnings on import so import once to disable them
+warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 startup_timer.record("import torch")
 
 import gradio


### PR DESCRIPTION
this is **optional** PR for people that want to use newer version of `pytorch_lightning`.

there are number of PRs that tried to update it from 1.7.6 to 1.7.7, but this PR allows usage all the way to newest 1.9.4.
basically, new package is fully compatible except for a future deprecation warning (will be in effect in version 2.0).
to fully address deprecation warning would require changes to imports in several upstream libs as well, so easiest (and safe) for now is to ignore it.
