### PR TITLE
allow usage of latest fastapi

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -27,4 +27,4 @@ GitPython==3.1.30
 torchsde==0.2.5
 safetensors==0.2.7
 httpcore<=0.15
-fastapi==0.90.1
+fastapi==0.94.0


### PR DESCRIPTION
this is an **optional** PR for people that want to use latest version of `fastapi`  
(tested with 0.94.0 which is latest version)

a bit of background:
`gradio` uses `fastapi` which uses `starlette`  
but `starlette` introduced a change in feb that disallows modifying middleware once app has been started  
on the other side `gradio` creates and starts app internally, so there is no way to create->modify->start  
however, `webui` tries to modify **cors** and **gzip** middleware (both for a very good reason)  
*and thus the conflict*  

this caused a lot of issues (*too many to count*) where `fastapi` was updated causing startup issues for `webui` and resolution is always to downgrade to `fastapi==0.90.1` which is latest version that does not enforce middleware modification restriction  

but since `starlette` enforcement is purely a choice and not a functional requirement, it can be bypassed...

for reference, this is the error message if `fastapi` is upgraded before this change:

```error
RuntimeError: Cannot add middleware after an application has started
```
