### PR TITLE
clarify to user that only one optimizer can be used when multiple are specified

### DIFF
--- a/modules/import_hook.py
+++ b/modules/import_hook.py
@@ -3,3 +3,4 @@ import sys
 # this will break any attempt to import xformers which will prevent stability diffusion repo from trying to use it
 if "--xformers" not in "".join(sys.argv):
     sys.modules["xformers"] = None
+    print('Note: not using xformers. To enable xformers install it and pass --xformers flag')

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -40,7 +40,6 @@ def apply_optimizations():
     can_use_sdp = hasattr(torch.nn.functional, "scaled_dot_product_attention") and callable(getattr(torch.nn.functional, "scaled_dot_product_attention")) # not everyone has torch 2.x to use sdp
 
     if cmd_opts.force_enable_xformers or (cmd_opts.xformers and shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)):
-        print("Applying xformers cross attention optimization.")
         ldm.modules.attention.CrossAttention.forward = sd_hijack_optimizations.xformers_attention_forward
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sd_hijack_optimizations.xformers_attnblock_forward
         methods.append('xformers')
@@ -82,7 +81,7 @@ def apply_optimizations():
         optimization_method = methods[0]
         print("Applying cross attention optimization: %s" % optimization_method)
         if len(methods) > 1:
-            print('Warning: multiple optimization methods specified, ignoring: %s' % ', '.join(methods[1:]))
+            print('Warning: multiple cross attention optimization methods specified, ignoring: %s' % ', '.join(methods[1:]))
 
     return optimization_method
 


### PR DESCRIPTION
only up to one cross attention optimization can be used, but currently there is no warning to the user when multiple are specified.
this change aims to fix that so that users are aware they passed conflicting parameters.
