### PR TITLE
disable pil checks

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -515,6 +515,7 @@ class Script(scripts.Script):
         zs = process_axis(z_opt, z_values)
 
         # this could be moved to common code, but unlikely to be ever triggered anywhere else
+        Image.MAX_IMAGE_PIXELS = None # disable check in Pillow and rely on check below to allow large custom image sizes
         grid_mp = round(len(xs) * len(ys) * len(zs) * p.width * p.height / 1000000)
         assert grid_mp < opts.img_max_size_mp, f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)'
 


### PR DESCRIPTION
follow-up pr to #8175

disables pil checks now that we rely on internal ones and allows larger images to be created.
without disabling pil check, maximum image size is limited to around 200mp (which is pil default).
*(i had to create a new pr since underlying file was heavily modified in the meantime by other prs).*
