### PR TITLE
force refresh tqdm before close

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -714,6 +714,7 @@ class TotalTQDM:
 
     def clear(self):
         if self._tqdm is not None:
+            self._tqdm.refresh()
             self._tqdm.close()
             self._tqdm = None
 


### PR DESCRIPTION
trivial pr to fix a bug where console tqdm total progress bar can be left ~90% upon completion of all operations.