### PR TITLE
initialize extra_network_data before use

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -583,6 +583,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         if state.job_count == -1:
             state.job_count = p.n_iter
 
+        extra_network_data = None
         for n in range(p.n_iter):
             p.iteration = n
 
@@ -712,7 +713,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if opts.grid_save:
                 images.save_image(grid, p.outpath_grids, "grid", p.all_seeds[0], p.all_prompts[0], opts.grid_format, info=infotext(), short_filename=not opts.grid_extended_filename, p=p, grid=True)
 
-    if not p.disable_extra_networks:
+    if not p.disable_extra_networks and extra_network_data:
         extra_networks.deactivate(p, extra_network_data)
 
     devices.torch_gc()


### PR DESCRIPTION
Fixes this error:
`UnboundLocalError: local variable 'extra_network_data' referenced before assignment`

`extra_network_data` is defined inside a loop but accessed outside it. if `n_iter` is 0 then the loop is never entered and `extra_network_data` is never initialized.

also a thing to consider is `extra_networks.activate()` is called in each loop but `extra_networks.deactivate()` is only called once outside. perhaps this could have undesired side effects? for example if the last `extra_network_data` in the loop is different from previous ones, only this `extra_network_data` will be deactivated.