### PR TITLE
Allow configuring behavior for generated files if interrupted

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -667,3 +667,11 @@ def flatten(img, bgcolor):
         img = background
 
     return img.convert('RGB')
+
+def get_output_path(save_path, was_interrupted):
+    if was_interrupted:
+        if opts.interrupted_save_action == "Delete":
+            save_path = None
+        elif opts.interrupted_save_action == "Save to Subfolder":
+            save_path = os.path.join(save_path, "interrupted")
+    return save_path

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -71,11 +71,13 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
                 left, right = os.path.splitext(filename)
                 filename = f"{left}-{n}{right}"
 
-            if not save_normally:
-                os.makedirs(output_dir, exist_ok=True)
+            true_output_dir = images.get_output_path(output_dir, proc.interrupted[n])
+
+            if not save_normally and true_output_dir is not None:
+                os.makedirs(true_output_dir, exist_ok=True)
                 if processed_image.mode == 'RGBA':
                     processed_image = processed_image.convert("RGB")
-                processed_image.save(os.path.join(output_dir, filename))
+                processed_image.save(os.path.join(true_output_dir, filename))
 
 
 def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -366,6 +366,7 @@ options_templates.update(options_section(('saving-to-dirs', "Saving to a directo
     "use_save_to_dirs_for_ui": OptionInfo(False, "When using \"Save\" button, save images to a subdirectory"),
     "directories_filename_pattern": OptionInfo("[date]", "Directory name pattern", component_args=hide_dirs),
     "directories_max_prompt_words": OptionInfo(8, "Max prompt words for [prompt_words] pattern", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1, **hide_dirs}),
+    "interrupted_save_action": OptionInfo("Save", "Action for output when generation interrupted", gr.Radio, {"choices": ["Save", "Save to Subfolder", "Delete"]}),
 }))
 
 options_templates.update(options_section(('upscaling', "Upscaling"), {

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -2,6 +2,7 @@ import math
 from collections import namedtuple
 from copy import copy
 import random
+import os.path
 
 import modules.scripts as scripts
 import gradio as gr
@@ -105,7 +106,10 @@ class Script(scripts.Script):
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])
 
-        if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
+        was_interrupted = any(x for x in processed.interrupted)
+        save_path = images.get_output_path(p.outpath_grids, was_interrupted)
+
+        if opts.grid_save and save_path is not None:
+            images.save_image(processed.images[0], save_path, "prompt_matrix", extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
 
         return processed

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -654,13 +654,16 @@ class Script(scripts.Script):
             # Don't need sub-images anymore, drop from list:
             processed.images = processed.images[:z_count+1]
 
-        if opts.grid_save:
+        was_interrupted = any(x for x in processed.interrupted)
+        save_path = images.get_output_path(p.outpath_grids, was_interrupted)
+
+        if opts.grid_save and save_path is not None:
             # Auto-save main and sub-grids:
             grid_count = z_count + 1 if z_count > 1 else 1
             for g in range(grid_count):
                 #TODO: See previous comment about intentional data misalignment.
                 adj_g = g-1 if g > 0 else g
-                images.save_image(processed.images[g], p.outpath_grids, "xyz_grid", info=processed.infotexts[g], extension=opts.grid_format, prompt=processed.all_prompts[adj_g], seed=processed.all_seeds[adj_g], grid=True, p=processed)
+                images.save_image(processed.images[g], save_path, "xyz_grid", info=processed.infotexts[g], extension=opts.grid_format, prompt=processed.all_prompts[adj_g], seed=processed.all_seeds[adj_g], grid=True, p=processed)
 
         if not include_sub_grids:
             # Done with sub-grids, drop all related information:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Allows the user to configure the behavior applied to interrupted/skipped generations.

- `Save`: default behavior
- `Save to Subdirectory`: images are saved to an `interrupted` subdirectory of the normal output directory
- `Delete`: the interrupted gens are deleted

Also marks interrupted gens with `Generation state: Interrupted` in PNG info

Closes #8456, closes #7577

**Additional notes and description of your changes**

Some work was done to adjust the output path/saving logic dependent on interrupted/skipped state.

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: RTX 3090