### PR TITLE
some loras fail to load on error

### DIFF
--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -86,6 +86,10 @@ def load_lora(name, filename):
 
     for key_diffusers, weight in sd.items():
         fullkey = convert_diffusers_name_to_compvis(key_diffusers)
+        if '.' not in fullkey:
+            print('invalid extension for lora file:', fullkey)
+            continue
+
         key, lora_key = fullkey.split(".", 1)
 
         sd_module = shared.sd_model.lora_layer_mapping.get(key, None)


### PR DESCRIPTION
if someone puts the wrong file in the lora directory, as I have put a .pt file there, then an exception is thrown and all loras after processing this file will not be loaded

(sorry for the wrong commit message, it was intended for another pull request)