### PR TITLE
early return on bad args rather than waiting for entire app to load

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import shlex
 import platform
 import argparse
 import json
+import modules.shared
 
 dir_repos = "repositories"
 dir_extensions = "extensions"
@@ -213,9 +214,10 @@ def list_extensions(settings_file):
     except Exception as e:
         print(e, file=sys.stderr)
 
+    extensions = set(settings.get('extensions_order', []) + os.listdir(dir_extensions))
     disabled_extensions = set(settings.get('disabled_extensions', []))
 
-    return [x for x in os.listdir(dir_extensions) if x not in disabled_extensions]
+    return [x for x in extensions if x not in disabled_extensions]
 
 
 def run_extensions_installers(settings_file):

--- a/launch.py
+++ b/launch.py
@@ -7,7 +7,6 @@ import shlex
 import platform
 import argparse
 import json
-import modules.shared
 
 dir_repos = "repositories"
 dir_extensions = "extensions"
@@ -214,10 +213,9 @@ def list_extensions(settings_file):
     except Exception as e:
         print(e, file=sys.stderr)
 
-    extensions = set(settings.get('extensions_order', []) + os.listdir(dir_extensions))
     disabled_extensions = set(settings.get('disabled_extensions', []))
 
-    return [x for x in extensions if x not in disabled_extensions]
+    return [x for x in os.listdir(dir_extensions) if x not in disabled_extensions]
 
 
 def run_extensions_installers(settings_file):

--- a/launch.py
+++ b/launch.py
@@ -7,8 +7,7 @@ import shlex
 import platform
 import argparse
 import json
-import modules.shared
-fix_modules_shared_lint = modules.shared # fix linting error
+import modules.shared # pylint: disable=unused-import
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import shlex
 import platform
 import argparse
 import json
+import modules.shared
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/launch.py
+++ b/launch.py
@@ -8,6 +8,7 @@ import platform
 import argparse
 import json
 import modules.shared
+fix_modules_shared_lint = modules.shared # fix linting error
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -5,7 +5,6 @@ import os
 import sys
 import time
 
-from PIL import Image
 import gradio as gr
 import tqdm
 


### PR DESCRIPTION
a minor annoyance I mistyped an argument and the entire app tries to load before failing on the bad arg.

a simple one liner fixed the issue by parsing arguments before anything else.