### PR TITLE
early return on bad args rather than waiting for entire app to load

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -7,7 +7,11 @@ import shlex
 import platform
 import argparse
 import json
-import modules.shared # pylint: disable=unused-import
+try:
+    import modules.shared # pylint: disable=unused-import
+except:
+    # import fails on first execution before pip installed all the modules
+    pass
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import shlex
 import platform
 import argparse
 import json
+import modules.shared # pylint: disable=unused-import
 
 dir_repos = "repositories"
 dir_extensions = "extensions"

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -5,7 +5,6 @@ import os
 import sys
 import time
 
-from PIL import Image
 import gradio as gr
 import tqdm
 


### PR DESCRIPTION
a minor annoyance I mistyped an argument and the entire app tries to load before failing on the bad arg and crashing.

a simple one liner fixed the issue by parsing arguments before anything else.