### PR TITLE
add --skip-torch-cuda-test to argparser

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -109,6 +109,7 @@ parser.add_argument("--tls-certfile", type=str, help="Partially enables TLS, req
 parser.add_argument("--server-name", type=str, help="Sets hostname of server", default=None)
 parser.add_argument("--gradio-queue", action='store_true', help="Uses gradio queue; experimental option; breaks restart UI button")
 parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
+parser.add_argument("--skip-torch-cuda-test", action='store_true', help="Do not check for cuda available")
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
 


### PR DESCRIPTION
### Describe what this pull request is trying to achieve

Allows other extensions to import `modules.scripts` for example in extension-specific tests.

### Additional notes and description of your changes

When trying to import `modules.scripts` and `modules.shared` (to name a few) inside the webui tests, the argument parser raises an error because it does not recognize the `--skip-torch-cuda-test` argument. Adding this option to the argparser prevents the unintended unexpected-option error.

An alternative would be to set the `IGNORE_CMD_ARGS_ERRORS` env var when running tests. I assume adding the argument to the argparser is a better solution, feel free to close this if we don't want `--skip-torch-cuda-test` to be a public cli option.

### Environment this was tested in

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3080 10GB

### Screenshots or videos of your changes

See the failing pipeline in the controlnet extension: https://github.com/Mikubill/sd-webui-controlnet/actions/runs/4419188125/jobs/7747296275

This was encountered while trying to add more tests to the extension: https://github.com/Mikubill/sd-webui-controlnet/pull/587

Let me know if I should add more information.