### PR TITLE
disable gradio css transitions

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -262,6 +262,9 @@ def webui():
             inbrowser=cmd_opts.autolaunch,
             prevent_thread_lock=True
         )
+        for dep in shared.demo.dependencies:
+            dep['show_progress'] = False  # disable gradio css animation on component update
+
         # after initial launch, disable --autolaunch for subsequent restarts
         cmd_opts.autolaunch = False
 


### PR DESCRIPTION
gradio components by default go through css transition on every update.
typically this is short and invisible, but if component update takes more than 50ms, then visible flickering becomes apparent.
(this is most commonly visible on large text boxes as smaller components are hardly noticeable)

this also wastes gpu resources up to a point where there are many stories how disabling hw acceleration in browser increases generation performance.

there is no upside of having css transition on component update, so this component simply disables it.
note that this has no effect on manually handled transitions such as progress bars.
