### PR TITLE
preserve privacy by disabling gradio analytics globally

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -16,6 +16,7 @@ index_url = os.environ.get('INDEX_URL', "")
 stored_commit_hash = None
 skip_install = False
 
+os.environ['GRADIO_ANALYTICS_ENABLED'] = 'False'
 
 def check_python_version():
     is_windows = platform.system() == "Windows"


### PR DESCRIPTION
a1111 aims to disable gradio analytics everywhere in the code otherwise it defaults to true, but extensions don't adhere to this pattern at all.
to preserve privacy as originally intended I set gradio analytics to false globally.

it doesn't really matter if it's a string, as long as it's not the string "True", so the string "False" made sense.