### PR TITLE
api error handler

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -6,8 +6,11 @@ import uvicorn
 from threading import Lock
 from io import BytesIO
 from gradio.processing_utils import decode_base64_to_file
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, FastAPI, Request, Response
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from secrets import compare_digest
 
 import modules.shared as shared
@@ -90,6 +93,16 @@ def encode_pil_to_base64(image):
     return base64.b64encode(bytes_data)
 
 def api_middleware(app: FastAPI):
+    rich_available = True
+    try:
+        import anyio # importing just so it can be placed on silent list
+        import starlette # importing just so it can be placed on silent list
+        from rich.console import Console
+        console = Console()
+    except:
+        import traceback
+        rich_available = False
+
     @app.middleware("http")
     async def log_and_time(req: Request, call_next):
         ts = time.time()
@@ -109,6 +122,36 @@ def api_middleware(app: FastAPI):
                 duration = duration,
             ))
         return res
+
+    def handle_exception(request: Request, e: Exception):
+        err = {
+            "error": type(e).__name__,
+            "detail": vars(e).get('detail', ''),
+            "body": vars(e).get('body', ''),
+            "errors": str(e),
+        }
+        print(f"API error: {request.method}: {request.url} {err}")
+        if not isinstance(e, HTTPException): # do not print backtrace on known httpexceptions
+            if rich_available:
+                console.print_exception(show_locals=True, max_frames=2, extra_lines=1, suppress=[anyio, starlette], word_wrap=False, width=min([console.width, 200]))
+            else:
+                traceback.print_exc()
+        return JSONResponse(status_code=vars(e).get('status_code', 500), content=jsonable_encoder(err))
+
+    @app.middleware("http")
+    async def exception_handling(request: Request, call_next):
+        try:
+            return await call_next(request)
+        except Exception as e:
+            return handle_exception(request, e)
+
+    @app.exception_handler(Exception)
+    async def fastapi_exception_handler(request: Request, e: Exception):
+        return handle_exception(request, e)
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, e: HTTPException):
+        return handle_exception(request, e)
 
 
 class Api:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ GitPython
 torchsde
 safetensors
 psutil
+rich


### PR DESCRIPTION
with increased usage via api, there are quite a few issues where user has no idea what is the problem or how to troubleshoot it due to error messages coming from fastapi/starlette/anyio could not be more crtptic

this pr replaces fastapi exception handler with a custom one (both using pretty-printed version or normal python traceback are supported)

*note*: pretty-print uses `rich` as formatter which is same as `accelerate`, so its no a new requirement, i just wanted to be explicit about loading it and have a fallback if its not available

## global handler?

if there is interest, i can extend this same exception handler to cover entire webui  
(api always needs a separate handler anyhow due to how fastapi works internally)

## new api error handling

**clear error message and source**

    API error: GET: http://127.0.0.1:7860/sdapi/v1/progress {'error': 'NameError', 'detail': '', 'body': '', 'errors': "name 'unknown' is not defined"}

    ╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
    │ /home/vlado/dev/automatic/modules/api/api.py:136 in exception_handling                           │
    │                                                                                                  │
    │   135 │   │   try:                                                                               │
    │ ❱ 136 │   │   │   return await call_next(request)                                                │
    │   137 │   │   except Exception as e:                                                             │
    │                                                                                                  │
    │ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
    │ │        call_next = <function BaseHTTPMiddleware.__call__.<locals>.call_next at               │ │
    │ │                    0x7f94a39ac280>                                                           │ │
    │ │                e = NameError("name 'uknown' is not defined")                                 │ │
    │ │ handle_exception = <function api_middleware.<locals>.handle_exception at 0x7f94a3919480>     │ │
    │ │          request = <starlette.requests.Request object at 0x7f94a39a2650>                     │ │
    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
    │                                                                                                  │
    │ /home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py:84 in call_next     │
    │                                                                                                  │
    │                                     ... 19 frames hidden ...                                     │
    │                                                                                                  │
    │ /home/vlado/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:867 in run           │
    │                                                                                                  │
    │ /home/vlado/dev/automatic/modules/api/api.py:403 in progressapi                                  │
    │                                                                                                  │
    │   402 │   │   if shared.state.job_count == 0:                                                    │
    │ ❱ 403 │   │   │   return ProgressResponse(uknown, progress=0, eta_relative=0, state=shared.sta   │
    │   404                                                                                            │
    │                                                                                                  │
    │ ╭────────────────────── locals ──────────────────────╮                                           │
    │ │  req = ProgressRequest(skip_current_image=False)   │                                           │
    │ │ self = <api.py.ApiHijack object at 0x7f94a3ab46a0> │                                           │
    │ ╰────────────────────────────────────────────────────╯                                           │
    ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
    NameError: name 'uknown' is not defined

## old api error handling

**unreadable and whats worse, it doesn't even show where error comes from**

    ERROR:    Exception in ASGI application
    Traceback (most recent call last):
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 94, in receive
        return self.receive_nowait()
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 89, in receive_nowait
        raise WouldBlock
    anyio.WouldBlock

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py", line 78, in call_next
        message = await recv_stream.receive()
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/streams/memory.py", line 114, in receive
        raise EndOfStream
    anyio.EndOfStream

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/vlado/.local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
        result = await app(  # type: ignore[func-returns-value]
      File "/home/vlado/.local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
        return await self.app(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/fastapi/applications.py", line 273, in __call__
        await super().__call__(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/applications.py", line 120, in __call__
        await self.middleware_stack(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
        raise exc
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
        await self.app(scope, receive, _send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py", line 108, in __call__
        response = await self.dispatch_func(request, call_next)
      File "/home/vlado/dev/automatic/modules/api/api.py", line 96, in log_and_time
        res: Response = await call_next(req)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py", line 84, in call_next
        raise app_exc
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/base.py", line 70, in coro
        await self.app(scope, receive_or_disconnect, send_no_error)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 84, in __call__
        await self.app(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/gzip.py", line 24, in __call__
        await responder(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/gzip.py", line 44, in __call__
        await self.app(scope, receive, self.send_with_gzip)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
        raise exc
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
        await self.app(scope, receive, sender)
      File "/home/vlado/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
        raise e
      File "/home/vlado/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
        await self.app(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/routing.py", line 716, in __call__
        await route.handle(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
        await self.app(scope, receive, send)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
        response = await func(request)
      File "/home/vlado/.local/lib/python3.10/site-packages/fastapi/routing.py", line 237, in app
        raw_response = await run_endpoint_function(
      File "/home/vlado/.local/lib/python3.10/site-packages/fastapi/routing.py", line 165, in run_endpoint_function
        return await run_in_threadpool(dependant.call, **values)
      File "/home/vlado/.local/lib/python3.10/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
        return await anyio.to_thread.run_sync(func, *args)
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/to_thread.py", line 31, in run_sync
        return await get_asynclib().run_sync_in_worker_thread(
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
        return await future
      File "/home/vlado/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 867, in run
        result = context.run(func, *args)
      File "/home/vlado/dev/automatic/modules/api/api.py", line 368, in progressapi
        return ProgressResponse(unknown, progress=0, eta_relative=0, state=shared.state.dict(), textinfo=shared.state.textinfo)
    NameError: name 'unknown' is not defined
