### PR TITLE
fix [Bug]: Changed gui's img2img p.scripts from scripts_txt2img to scripts_img2img

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -151,7 +151,7 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         override_settings=override_settings,
     )
 
-    p.scripts = modules.scripts.scripts_txt2img
+    p.scripts = modules.scripts.scripts_img2img
     p.script_args = args
 
     if shared.cmd_opts.enable_console_prompts:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Changes the `ScriptRunner` for img2img request from the gui from `scripts_txt2img` to `scripts_img2img`. At a glance this seems to be a small copy paste oversight but if it's a unorthodox way to fix something, feel free to close this PR. 

**Additional notes and description of your changes**

In an attempt to find a way to know reliably whether we were in an img2img request or a txt2img request for the controlnet webui, I stumbled upon this. The gui's img2img requests would be inconsistent when we were checking the `is_img2img` and `is_txt2img` script properties but with this change it seems to make it consistent again. This is essentially what the API sets when making an img2img request.

see discussion in https://github.com/Mikubill/sd-webui-controlnet/pull/587

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 2080 8GB