### PR TITLE
Fix for API running unwanted alwayson scripts

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -217,7 +217,7 @@ class Api:
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
                     script_args[alwayson_script.args_from:alwayson_script.args_to] = request.alwayson_scripts[alwayson_script_name]["args"]
 
-        # Remove always on scripts that were not included in the request by resetting the script list in our ScriptRunner
+        # Remove always on scripts that were not included in the request by resetting the script list in out ScriptRunner
         script_runner.alwayson_scripts.clear()
         script_runner.alwayson_scripts = alwayson_script_to_run
         script_runner.scripts.clear()

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -3,6 +3,7 @@ import io
 import time
 import datetime
 import uvicorn
+import gradio as gr
 from threading import Lock
 from io import BytesIO
 from gradio.processing_utils import decode_base64_to_file
@@ -152,6 +153,9 @@ class Api:
         self.add_api_route("/sdapi/v1/memory", self.get_memory, methods=["GET"], response_model=MemoryResponse)
         self.add_api_route("/sdapi/v1/scripts", self.get_scripts_list, methods=["GET"], response_model=ScriptsList)
 
+        self.default_script_arg_txt2img = []
+        self.default_script_arg_img2img = []
+
     def add_api_route(self, path: str, endpoint, **kwargs):
         if shared.cmd_opts.api_auth:
             return self.app.add_api_route(path, endpoint, dependencies=[Depends(self.auth)], **kwargs)
@@ -185,7 +189,7 @@ class Api:
         script_idx = script_name_to_index(script_name, script_runner.scripts)
         return script_runner.scripts[script_idx]
 
-    def init_script_args(self, request, selectable_scripts, selectable_idx, script_runner):
+    def init_default_script_args(self, script_runner):
         #find max idx from the scripts in runner and generate a none array to init script_args
         last_arg_index = 1
         for script in script_runner.scripts:
@@ -193,13 +197,24 @@ class Api:
                 last_arg_index = script.args_to
         # None everywhere except position 0 to initialize script args
         script_args = [None]*last_arg_index
+        script_args[0] = 0
+
+        # get default values
+        with gr.Blocks(): # will throw errors calling ui function without this
+            for script in script_runner.scripts:
+                if script.ui(script.is_img2img):
+                    ui_default_values = []
+                    for elem in script.ui(script.is_img2img):
+                        ui_default_values.append(elem.value)
+                    script_args[script.args_from:script.args_to] = ui_default_values
+        return script_args
+
+    def init_script_args(self, request, default_script_args, selectable_scripts, selectable_idx, script_runner):
+        script_args = default_script_args.copy()
         # position 0 in script_arg is the idx+1 of the selectable script that is going to be run when using scripts.scripts_*2img.run()
         if selectable_scripts:
             script_args[selectable_scripts.args_from:selectable_scripts.args_to] = request.script_args
             script_args[0] = selectable_idx + 1
-        else:
-            # when [0] = 0 no selectable script to run
-            script_args[0] = 0
 
         # Now check for always on scripts
         if request.alwayson_scripts and (len(request.alwayson_scripts) > 0):
@@ -220,6 +235,8 @@ class Api:
         if not script_runner.scripts:
             script_runner.initialize_scripts(False)
             ui.create_ui()
+        if not self.default_script_arg_txt2img:
+            self.default_script_arg_txt2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
 
         populate = txt2imgreq.copy(update={  # Override __init__ params
@@ -235,7 +252,7 @@ class Api:
         args.pop('script_args', None) # will refeed them to the pipeline directly after initializing them
         args.pop('alwayson_scripts', None)
 
-        script_args = self.init_script_args(txt2imgreq, selectable_scripts, selectable_script_idx, script_runner)
+        script_args = self.init_script_args(txt2imgreq, self.default_script_arg_txt2img, selectable_scripts, selectable_script_idx, script_runner)
 
         send_images = args.pop('send_images', True)
         args.pop('save_images', None)
@@ -272,6 +289,8 @@ class Api:
         if not script_runner.scripts:
             script_runner.initialize_scripts(True)
             ui.create_ui()
+        if not self.default_script_arg_img2img:
+            self.default_script_arg_img2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
 
         populate = img2imgreq.copy(update={  # Override __init__ params
@@ -289,7 +308,7 @@ class Api:
         args.pop('script_args', None)  # will refeed them to the pipeline directly after initializing them
         args.pop('alwayson_scripts', None)
 
-        script_args = self.init_script_args(img2imgreq, selectable_scripts, selectable_script_idx, script_runner)
+        script_args = self.init_script_args(img2imgreq, self.default_script_arg_img2img, selectable_scripts, selectable_script_idx, script_runner)
 
         send_images = args.pop('send_images', True)
         args.pop('save_images', None)

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -217,7 +217,7 @@ class Api:
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
                     script_args[alwayson_script.args_from:alwayson_script.args_to] = request.alwayson_scripts[alwayson_script_name]["args"]
 
-        # Remove always on scripts that were not included in the request by resetting the script list in out ScriptRunner
+        # Remove always on scripts that were not included in the request by resetting the script list in our ScriptRunner
         script_runner.alwayson_scripts.clear()
         script_runner.alwayson_scripts = alwayson_script_to_run
         script_runner.scripts.clear()

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -3,7 +3,6 @@ import io
 import time
 import datetime
 import uvicorn
-import copy
 from threading import Lock
 from io import BytesIO
 from gradio.processing_utils import decode_base64_to_file
@@ -203,7 +202,6 @@ class Api:
             script_args[0] = 0
 
         # Now check for always on scripts
-        alwayson_script_to_run = [] # list to replace the one from the global ScriptRunner we copied
         if request.alwayson_scripts and (len(request.alwayson_scripts) > 0):
             for alwayson_script_name in request.alwayson_scripts.keys():
                 alwayson_script = self.get_script(alwayson_script_name, script_runner)
@@ -212,21 +210,13 @@ class Api:
                 # Selectable script in always on script param check
                 if alwayson_script.alwayson == False:
                     raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
-                # all good, so add to run list and set its args if any
-                alwayson_script_to_run.append(alwayson_script)
+                # always on script with no arg should always run so you don't really need to add them to the requests
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
                     script_args[alwayson_script.args_from:alwayson_script.args_to] = request.alwayson_scripts[alwayson_script_name]["args"]
-
-        # Remove always on scripts that were not included in the request by resetting the script list in out ScriptRunner
-        script_runner.alwayson_scripts.clear()
-        script_runner.alwayson_scripts = alwayson_script_to_run
-        script_runner.scripts.clear()
-        script_runner.scripts = alwayson_script_to_run + script_runner.selectable_scripts
-
         return script_args
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):
-        script_runner = copy.copy(scripts.scripts_txt2img) # copy so we don't overwrite our globals
+        script_runner = scripts.scripts_txt2img
         if not script_runner.scripts:
             script_runner.initialize_scripts(False)
             ui.create_ui()
@@ -278,7 +268,7 @@ class Api:
         if mask:
             mask = decode_base64_to_image(mask)
 
-        script_runner = copy.copy(scripts.scripts_img2img) # copy so we don't overwrite our globals
+        script_runner = scripts.scripts_img2img
         if not script_runner.scripts:
             script_runner.initialize_scripts(True)
             ui.create_ui()


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

To avoid having scripts that don't handle None argument throw errors and scripts running when the requester doesn't want them to, I changed how the ScriptRunner is handled for api requests. Now it makes a copy of the global ScriptRunner it wants to run and strips this copy of unrequested scripts. This should prevent unwanted scripts from running but it means you need to include all script that you want to run, even if they don't take any args. 

For scripts that don't take args, an empty dict can be passed as their value instead of one with an args key like so:

```
"alwayson_scripts": {
		"Randomizer Keywords": {},
		"Additional networks for generating": {
			"args": [true, false, "LoRA", "<!!A lora model here!!>", 0.3, 0.3, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "LoRA", "None", 1, 1, "Refresh models"]
		}
	}
```

**Additional notes and description of your changes**

As a consequence of this change, if you look at the global ScriptRunners (`*2img_scripts`) while the processing is ongoing, they will not match what is in the processing class and so this should be avoided, instead you can look at the ScriptRunner that is passed to the processing class in `scripts` which will contain the ScriptRunner that has been copied and pruned.

closes #8666

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 2080 8GB
