### PR TITLE
fix output-html text overflow.

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,7 +37,10 @@
     cursor: default;
 }
 
-.output-html p {margin: 0 0.5em;}
+.output-html p {
+    margin: 0 0.5em;
+    overflow-wrap: break-word;
+}
 
 .row > *,
 .row > .gr-form > * {


### PR DESCRIPTION
if prompt is so long, will output-html > p has text overflow issue.