### PR TITLE
fixed typo in prompt-bracket-checker.js which leads to js error

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -105,6 +105,6 @@ var shadowRootLoaded = setInterval(function() {
 
     setupBracketChecking('txt2img_prompt', 'txt2img_token_counter')
     setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter')
-    setupBracketChecking('img2img_prompt', 'imgimg_token_counter')
+    setupBracketChecking('img2img_prompt', 'img2img_token_counter')
     setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter')
 }, 1000);


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixed a typo which leads to a js error, because the counter element doesn't get found.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Firefox/Chrome
 - Graphics card: NVIDIA RTX 2080 TI