### PR TITLE
Add comma to the list of invalid filename chars

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -308,7 +308,7 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
     return res
 
 
-invalid_filename_chars = '<>:"/\\|?*\n'
+invalid_filename_chars = '<>:"/\\|,?*\n'
 invalid_filename_prefix = ' '
 invalid_filename_postfix = ' .'
 re_nonletters = re.compile(r'[\s' + string.punctuation + ']+')


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adds comma `,` to the list of invalid filename characters because it breaks some external commandline scripts like `ffmpeg` when stitching videos made of SD-WebUI generated images (they include the prompts by default and that prompts often contain commas)

**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Linux
 - Browser: Firefox
 - Graphics card: Nvidia RTX 3050

**Screenshots or videos of your changes**

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.