### PR TITLE
Option to send parameters for individual gallery image to other tabs

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -57,6 +57,12 @@ function extract_image_from_gallery(gallery){
     return [gallery[index]];
 }
 
+function prepare_gallery_paste_params(){
+    gallery = arguments[0];
+    arguments[0] = extract_image_from_gallery(gallery)[0];
+    return args_to_array(arguments)
+}
+
 function args_to_array(args){
     res = []
     for(var i=0;i<args.length;i++){

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -374,6 +374,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "disable_weights_auto_swap": OptionInfo(True, "When reading generation parameters from text into UI (from PNG info or pasted text), do not change the selected model/checkpoint."),
     "send_seed": OptionInfo(True, "Send seed when sending prompt or image to other interface"),
     "send_size": OptionInfo(True, "Send size when sending prompt or image to another interface"),
+    "send_embedded_infotext": OptionInfo(True, "Send the infotext of the selected image when sending prompt or image to another interface"),
     "font": OptionInfo("", "Font for image grids that have text"),
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Allows the user to send an individual image's prompt (like randomized prompts generated by dynamic-prompts) instead of the UI's current state to another tab

The prompt sent depends on the currently selected gallery image, if no image is selected it defaults to the old behavior

Closes #7882

**Additional notes and description of your changes**

Required a refactor of the prompt copy/paste code for extracting/parsing image infotext

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090