### PR TITLE
Don't bubble when metadata_button is clicked

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -132,10 +132,12 @@ function popup(contents){
     globalPopup.style.display = "flex";
 }
 
-function extraNetworksShowMetadata(text){
+function extraNetworksShowMetadata(event, text){
     elem = document.createElement('pre')
     elem.classList.add('popup-metadata');
     elem.textContent = text;
 
     popup(elem);
+    
+    event.stopPropagation()
 }

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -127,7 +127,7 @@ class ExtraNetworksPage:
         metadata_button = ""
         metadata = item.get("metadata")
         if metadata:
-            metadata_onclick = '"' + html.escape(f"""extraNetworksShowMetadata({json.dumps(metadata)}); return false;""") + '"'
+            metadata_onclick = '"' + html.escape(f"""extraNetworksShowMetadata({json.dumps(metadata)}); event.stopPropagation(); return false;""") + '"'
             metadata_button = f"<div class='metadata-button' title='Show metadata' onclick={metadata_onclick}></div>"
 
         args = {

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -127,7 +127,7 @@ class ExtraNetworksPage:
         metadata_button = ""
         metadata = item.get("metadata")
         if metadata:
-            metadata_onclick = '"' + html.escape(f"""extraNetworksShowMetadata({json.dumps(metadata)}); event.stopPropagation(); return false;""") + '"'
+            metadata_onclick = '"' + html.escape(f"""return extraNetworksShowMetadata(event, {json.dumps(metadata)})""") + '"'
             metadata_button = f"<div class='metadata-button' title='Show metadata' onclick={metadata_onclick}></div>"
 
         args = {


### PR DESCRIPTION
Currently, clicking an extra network's metadata button also triggers the card's own onclick handler. This prevents that.
 
**Environment this was tested in**
 - OS: Windows 10
 - Browser: Edge 111.0.1661.44