### PR TITLE
Fix img2img-alternative-test script for SD v2.x

### DIFF
--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -6,17 +6,10 @@ from tqdm import trange
 import modules.scripts as scripts
 import gradio as gr
 
-from modules import processing, shared, sd_samplers, prompt_parser, sd_samplers_common
-from modules.processing import Processed
-from modules.shared import opts, cmd_opts, state
+from modules import processing, shared, sd_samplers, sd_samplers_common
 
 import torch
 import k_diffusion as K
-
-from PIL import Image
-from torch import autocast
-from einops import rearrange, repeat
-
 
 def find_noise_for_image(p, cond, uncond, cfg_scale, steps):
     x = p.init_latent
@@ -135,7 +128,7 @@ class Script(scripts.Script):
     def show(self, is_img2img):
         return is_img2img
 
-    def ui(self, is_img2img):     
+    def ui(self, is_img2img):
         info = gr.Markdown('''
         * `CFG Scale` should be 2 or lower.
         ''')
@@ -223,4 +216,3 @@ class Script(scripts.Script):
         processed = processing.process_images(p)
 
         return processed
-


### PR DESCRIPTION
It produced completely broken nonsense output on SD v2 previously.
Now it generates... relatively similar to SD v1. V1 in my tests makes slightly garbled outputs, and V2 seems to amplify contrast. Different output issues, but either way, it's gone from "not working" to "just kinda weird". V1 outputs shouldn't be changed at all by this PR.
Fix is straight forward - just use the v denoiser when v is needed, and skip the redundant var from `get_scalings` (it's literally named `c_skip` in external source, so...)

Tested and validated that it works the same on SD v1.x, and now works (ish) on SD v2.

I'm not here to clean up that whole script file, it's a mess, but I removed some of the stray spaces and unused imports as just a bit of tidiness while I'm touching the file anyway.

Followup work to clean up the code and/or just overall improve the quality/capability on either SD version might be worthwhile.