### PR TITLE
Unload and re-load checkpoint to VRAM on request (API & Manual)

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -18,7 +18,7 @@ from modules.textual_inversion.textual_inversion import create_embedding, train_
 from modules.textual_inversion.preprocess import preprocess
 from modules.hypernetworks.hypernetwork import create_hypernetwork, train_hypernetwork
 from PIL import PngImagePlugin,Image
-from modules.sd_models import checkpoints_list
+from modules.sd_models import checkpoints_list, unload_model_weights, reload_model_weights
 from modules.sd_models_config import find_checkpoint_config_near_filename
 from modules.realesrgan_model import get_realesrgan_models
 from modules import devices
@@ -150,6 +150,8 @@ class Api:
         self.add_api_route("/sdapi/v1/train/embedding", self.train_embedding, methods=["POST"], response_model=TrainResponse)
         self.add_api_route("/sdapi/v1/train/hypernetwork", self.train_hypernetwork, methods=["POST"], response_model=TrainResponse)
         self.add_api_route("/sdapi/v1/memory", self.get_memory, methods=["GET"], response_model=MemoryResponse)
+        self.add_api_route("/sdapi/v1/unload-checkpoint", self.unloadapi, methods=["POST"])
+        self.add_api_route("/sdapi/v1/reload-checkpoint", self.reloadapi, methods=["POST"])
         self.add_api_route("/sdapi/v1/scripts", self.get_scripts_list, methods=["GET"], response_model=ScriptsList)
 
     def add_api_route(self, path: str, endpoint, **kwargs):
@@ -409,6 +411,16 @@ class Api:
 
     def interruptapi(self):
         shared.state.interrupt()
+
+        return {}
+
+    def unloadapi(self):
+        unload_model_weights()
+
+        return {}
+
+    def reloadapi(self):
+        reload_model_weights()
 
         return {}
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -494,7 +494,7 @@ def reload_model_weights(sd_model=None, info=None):
     if sd_model is None or checkpoint_config != sd_model.used_config:
         del sd_model
         checkpoints_loaded.clear()
-        load_model(checkpoint_info, already_loaded_state_dict=state_dict, time_taken_to_load_state_dict=timer.records["load weights from disk"])
+        load_model(checkpoint_info, already_loaded_state_dict=state_dict)
         return shared.sd_model
 
     try:
@@ -515,5 +515,25 @@ def reload_model_weights(sd_model=None, info=None):
             timer.record("move model to device")
 
     print(f"Weights loaded in {timer.summary()}.")
+
+    return sd_model
+
+def unload_model_weights(sd_model=None, info=None):
+    from modules import lowvram, devices, sd_hijack
+    timer = Timer()
+
+    if shared.sd_model:
+
+        # shared.sd_model.cond_stage_model.to(devices.cpu)
+        # shared.sd_model.first_stage_model.to(devices.cpu)
+        shared.sd_model.to(devices.cpu)
+        sd_hijack.model_hijack.undo_hijack(shared.sd_model)
+        shared.sd_model = None
+        sd_model = None
+        gc.collect()
+        devices.torch_gc()
+        torch.cuda.empty_cache()
+
+    print(f"Unloaded weights {timer.summary()}.")
 
     return sd_model

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1491,11 +1491,33 @@ def create_ui():
                 request_notifications = gr.Button(value='Request browser notifications', elem_id="request_notifications")
                 download_localization = gr.Button(value='Download localization template', elem_id="download_localization")
                 reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies")
+                with gr.Row():
+                    unload_sd_model = gr.Button(value='Unload SD checkpoint to free VRAM', elem_id="sett_unload_sd_model")
+                    reload_sd_model = gr.Button(value='Reload the last SD checkpoint back into VRAM', elem_id="sett_reload_sd_model")
 
             with gr.TabItem("Licenses"):
                 gr.HTML(shared.html("licenses.html"), elem_id="licenses")
 
             gr.Button(value="Show all pages", elem_id="settings_show_all_pages")
+            
+
+        def unload_sd_weights():
+            modules.sd_models.unload_model_weights()
+
+        def reload_sd_weights():
+            modules.sd_models.reload_model_weights()
+
+        unload_sd_model.click(
+            fn=unload_sd_weights,
+            inputs=[],
+            outputs=[]
+        )
+
+        reload_sd_model.click(
+            fn=reload_sd_weights,
+            inputs=[],
+            outputs=[]
+        )
 
         request_notifications.click(
             fn=lambda: None,


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I'm introducing the ability to unload checkpoint from VRAM and back onto it by user request via API or UI.

**Additional context and use case**

I'm currently working on a chatbot extension which allows the bot to send images on request.
The images are generated via SD-webui API, but my card can only run LLaMA-7b-q4 and 512×512 image generation in parallel. I'm also planning to add voice generation — and one can see where this is going — 12 gigs of VRAM won't be enough.

Thus, one way to optimise the load is to _**juggle models around RAM and VRAM**_.


<details>
<summary>That chatbot screenshot for the curious</summary>

![EXA1](https://user-images.githubusercontent.com/42910943/224866564-939a3bcb-e7cf-4ac0-a33f-b3047b55054d.jpg)

</details>

**Additional notes and description of your changes**

The already present `reload_model_weights()` function is made available through the API and Actions UI button.
Additionally, `unload_model_weights()` is introduced for the purpose of unhooking the loaded model and triggering garbage collector. It is also made accessible via API and UI.

The API endpoints are
- `/sdapi/v1/unload-checkpoint` (POST)
- `/sdapi/v1/reload-checkpoint` (POST)

Possibly resolves #8244 if the user manually triggers `unload` → `reload last`.

**Environment this was tested in**
 - OS: Windows 10 x64
 - Browser: Firefox 110
 - Graphics card: NVIDIA RTX 3060 with 12 Gb VRAM

**Screenshots or videos of your changes**

The UI change consists of an addition of two new buttons grouped in the Actions sub-menu:

Old|New
-|-
![Actions before the change](https://user-images.githubusercontent.com/42910943/226540409-118e111c-aae0-40f1-a4f0-b6260fedb6b1.png)|![Actions after the change](https://user-images.githubusercontent.com/42910943/226540289-31a21d67-8849-4715-9437-653dec832565.png)

FastAPI UI automatically shows new endpoints:

<details>
<summary>API webpage screenshot</summary>

![FastAPI](https://user-images.githubusercontent.com/42910943/226541165-3f6c057c-6b7f-43e1-b36c-544fc99f80f5.png)

</details>

Triggering them (both through the settings and the API page) confirms VRAM control:

![MemGraph](https://user-images.githubusercontent.com/42910943/226541939-00ec323f-6b82-4a06-a9fb-56520dc9919f.png)
