### PR TITLE
input release dispatcher

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -291,7 +291,6 @@ onUiUpdate(function(){
 		let clone_num = elem.cloneNode();
 		active_clone_input.push(clone_num);
 		
-		
 		let label = parent.querySelector("label");
 		
 		clone_num.id = "num_clone";			

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -277,6 +277,92 @@ onUiUpdate(function(){
             })
         }
     }
+	
+	// input release component dispatcher
+	let active_clone_input = [];
+	function ui_input_release_component(elem){
+
+		if(active_clone_input.length > 0) return;
+		
+		let parent = elem.parentElement;
+		let comp_parent = parent.parentElement.parentElement;		
+		if(comp_parent.id == ("img2img_width" || "img2img_height" )) return;
+		
+		let clone_num = elem.cloneNode();
+		active_clone_input.push(clone_num);
+		
+		
+		let label = parent.querySelector("label");
+		
+		clone_num.id = "num_clone";			
+		clone_num.value = elem.value;	
+		parent.append(clone_num);		
+		elem.classList.add("hidden");
+		
+		clone_num.addEventListener('change', function (e) {			
+			elem.value = clone_num.value;
+			updateInput(elem);
+		})
+
+		if(label){				
+			let comp_range = comp_parent.querySelector("input[type='range']");
+			let clone_range = comp_range.cloneNode();
+			active_clone_input.push(clone_range);
+			
+			clone_range.id = comp_range.id+"_clone";
+			clone_range.value = comp_range.value;					
+			comp_range.parentElement.append(clone_range);				
+			comp_range.classList.add("hidden");
+			
+			clone_range.addEventListener('input', function (e) {								
+				clone_num.value = e.target.value;	
+			})
+			clone_range.addEventListener('change', function (e) {
+				elem.value = clone_range.value;
+				updateInput(elem);	
+			})				
+			clone_num.addEventListener('input', function (e) {								
+				clone_range.value = e.target.value;	
+			})								
+		}				
+	}
+	function ui_input_release_handler(e){
+		const len = active_clone_input.length;
+		console.log(e.target);
+		if(len > 0){
+			if(e.target.id.indexOf("_clone") == -1){
+				for(var i=len-1; i>=0; i--){
+					let relem = active_clone_input[i];
+					relem.previousElementSibling.classList.remove("hidden");
+					relem.remove();
+					active_clone_input.pop();
+				}
+			}
+		}
+	
+		let elem_type = e.target.tagName;
+		if(elem_type == "INPUT"){
+			let elem = e.target;			
+			if(elem.type == "number"){								
+				ui_input_release_component(elem);				
+			}else if(elem.type == "range"){
+				elem = e.target.parentElement.querySelector("input[type='number']");
+				ui_input_release_component(elem);				
+			}
+		}
+	}
+	function ui_dispatch_input_release(value){	
+		if(value){			
+			gradioApp().querySelector(".mx-auto.container").addEventListener('mouseover',  ui_input_release_handler);
+		}else{
+			gradioApp().querySelector(".mx-auto.container").removeEventListener('mouseover',  ui_input_release_handler);
+		}
+	}
+	gradioApp().querySelector("#setting_ui_dispatch_input_release input").addEventListener('click', function (e) {		
+		ui_dispatch_input_release(e.target.checked);
+	})
+	ui_dispatch_input_release(opts.ui_dispatch_input_release);
+	
 })
 
 onOptionsChanged(function(){

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -327,8 +327,7 @@ onUiUpdate(function(){
 		}				
 	}
 	function ui_input_release_handler(e){
-		const len = active_clone_input.length;
-		console.log(e.target);
+		const len = active_clone_input.length;		
 		if(len > 0){
 			if(e.target.id.indexOf("_clone") == -1){
 				for(var i=len-1; i>=0; i--){

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -472,6 +472,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "hidden_tabs": OptionInfo([], "Hidden UI tabs (requires restart)", ui_components.DropdownMulti, lambda: {"choices": [x for x in tab_names]}),
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order"),
     "ui_extra_networks_tab_reorder": OptionInfo("", "Extra networks tab order"),
+    "ui_dispatch_input_release": OptionInfo(True, "Dispatch event change on release, for slider and input number components"),    
     "localization": OptionInfo("None", "Localization (requires restart)", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)),
 }))
 

--- a/style.css
+++ b/style.css
@@ -1029,3 +1029,6 @@ footer {
 [id*='_prompt_container'] > div {
 	margin: 0!important;
 }
+.hidden{
+	display:none
+}


### PR DESCRIPTION
This PR is a universal fix for all input number fields and sliders of the UI including scripts and extensions to dispatch the change event on release of current action thus gaining better user experience, responsiveness and performance. It is optimized to work with total of 5 extra event listeners for all sliders and numeric input fields, achieving low overhead and minimum memory impact noted that gradio's current solution version 3.22 uses 3 extra event listeners for each slider without addressing the numeric input fields at all
you don't need to modify any of the source py files for this to work you can enable it or disable it globally through options

https://github.com/gradio-app/gradio/issues/3204

https://user-images.githubusercontent.com/124302297/226691694-6b5a4c4f-7e59-4e86-8dfb-4a9b28999d72.mp4


**Environment this was tested in**
 - OS: [Windows]
 - Browser: [chrome, Firefox]
 