### PR TITLE
Add polling and reload callback for extensions.

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -75,13 +75,13 @@ callback_map = dict(
     callbacks_script_unloaded=[],
     callbacks_before_ui=[],
     callbacks_on_polling=[],
+    callbacks_on_reload=[],
 )
 
 
 def clear_callbacks():
     for callback_list in callback_map.values():
         callback_list.clear()
-
 
 def app_started_callback(demo: Optional[Blocks], app: FastAPI):
     for c in callback_map['callbacks_app_started']:
@@ -96,6 +96,14 @@ def app_polling_callback(demo: Optional[Blocks], app: FastAPI):
             c.callback()
         except Exception:
             report_exception(c, 'callbacks_on_polling')
+
+def app_reload_callback(demo: Optional[Blocks], app: FastAPI):
+    for c in callback_map['callbacks_on_reload']:
+        try:
+            c.callback()
+        except Exception:
+            report_exception(c, 'callbacks_on_reload')
+
 
 def model_loaded_callback(sd_model):
     for c in callback_map['callbacks_model_loaded']:
@@ -238,6 +246,9 @@ def on_polling(callback):
     """register a function to be called on each polling of the server."""
     add_callback(callback_map['callbacks_on_polling'], callback)
 
+def on_before_reload(callback):
+    """register a function to be called just before the server reloads."""
+    add_callback(callback_map['callbacks_on_reload'], callback)
 
 def on_model_loaded(callback):
     """register a function to be called when the stable diffusion model is created; the model is

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -75,7 +75,6 @@ callback_map = dict(
     callbacks_script_unloaded=[],
     callbacks_before_ui=[],
     callbacks_on_reload=[],
-    callbacks_on_reload=[],
     callbacks_on_polling=[],
 )
 

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -63,6 +63,7 @@ callback_map = dict(
     callbacks_cfg_denoiser=[],
     callbacks_before_component=[],
     callbacks_after_component=[],
+    callbacks_on_polling=[],
 )
 
 
@@ -78,6 +79,12 @@ def app_started_callback(demo: Optional[Blocks], app: FastAPI):
         except Exception:
             report_exception(c, 'app_started_callback')
 
+def app_polling_callback(demo: Optional[Blocks], app: FastAPI):
+    for c in callback_map['callbacks_on_polling']:
+        try:
+            c.callback()
+        except Exception:
+            report_exception(c, 'callbacks_on_polling')
 
 def model_loaded_callback(sd_model):
     for c in callback_map['callbacks_model_loaded']:
@@ -182,6 +189,11 @@ def on_app_started(callback):
     """register a function to be called when the webui started, the gradio `Block` component and
     fastapi `FastAPI` object are passed as the arguments"""
     add_callback(callback_map['callbacks_app_started'], callback)
+
+
+def on_polling(callback):
+    """register a function to be called on each polling of the server."""
+    add_callback(callback_map['callbacks_on_polling'], callback)
 
 
 def on_model_loaded(callback):

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -64,13 +64,13 @@ callback_map = dict(
     callbacks_before_component=[],
     callbacks_after_component=[],
     callbacks_on_polling=[],
+    callbacks_on_reload=[],
 )
 
 
 def clear_callbacks():
     for callback_list in callback_map.values():
         callback_list.clear()
-
 
 def app_started_callback(demo: Optional[Blocks], app: FastAPI):
     for c in callback_map['callbacks_app_started']:
@@ -85,6 +85,14 @@ def app_polling_callback(demo: Optional[Blocks], app: FastAPI):
             c.callback()
         except Exception:
             report_exception(c, 'callbacks_on_polling')
+
+def app_reload_callback(demo: Optional[Blocks], app: FastAPI):
+    for c in callback_map['callbacks_on_reload']:
+        try:
+            c.callback()
+        except Exception:
+            report_exception(c, 'callbacks_on_reload')
+
 
 def model_loaded_callback(sd_model):
     for c in callback_map['callbacks_model_loaded']:
@@ -195,6 +203,9 @@ def on_polling(callback):
     """register a function to be called on each polling of the server."""
     add_callback(callback_map['callbacks_on_polling'], callback)
 
+def on_before_reload(callback):
+    """register a function to be called just before the server reloads."""
+    add_callback(callback_map['callbacks_on_reload'], callback)
 
 def on_model_loaded(callback):
     """register a function to be called when the stable diffusion model is created; the model is

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -74,6 +74,7 @@ callback_map = dict(
     callbacks_infotext_pasted=[],
     callbacks_script_unloaded=[],
     callbacks_before_ui=[],
+    callbacks_on_polling=[],
 )
 
 
@@ -89,6 +90,12 @@ def app_started_callback(demo: Optional[Blocks], app: FastAPI):
         except Exception:
             report_exception(c, 'app_started_callback')
 
+def app_polling_callback(demo: Optional[Blocks], app: FastAPI):
+    for c in callback_map['callbacks_on_polling']:
+        try:
+            c.callback()
+        except Exception:
+            report_exception(c, 'callbacks_on_polling')
 
 def model_loaded_callback(sd_model):
     for c in callback_map['callbacks_model_loaded']:
@@ -225,6 +232,11 @@ def on_app_started(callback):
     """register a function to be called when the webui started, the gradio `Block` component and
     fastapi `FastAPI` object are passed as the arguments"""
     add_callback(callback_map['callbacks_app_started'], callback)
+
+
+def on_polling(callback):
+    """register a function to be called on each polling of the server."""
+    add_callback(callback_map['callbacks_on_polling'], callback)
 
 
 def on_model_loaded(callback):

--- a/webui.py
+++ b/webui.py
@@ -171,6 +171,7 @@ def create_api(app):
 def wait_on_server(demo=None):
     while 1:
         time.sleep(0.5)
+        modules.script_callbacks.app_polling_callback(None, demo)
         if shared.state.need_restart:
             shared.state.need_restart = False
             time.sleep(0.5)

--- a/webui.py
+++ b/webui.py
@@ -106,6 +106,7 @@ def create_api(app):
 def wait_on_server(demo=None):
     while 1:
         time.sleep(0.5)
+        modules.script_callbacks.app_polling_callback(None, demo)
         if shared.state.need_restart:
             shared.state.need_restart = False
             time.sleep(0.5)

--- a/webui.py
+++ b/webui.py
@@ -173,6 +173,7 @@ def wait_on_server(demo=None):
         time.sleep(0.5)
         modules.script_callbacks.app_polling_callback(None, demo)
         if shared.state.need_restart:
+            modules.script_callbacks.app_reload_callback(None, demo)
             shared.state.need_restart = False
             time.sleep(0.5)
             demo.close()

--- a/webui.py
+++ b/webui.py
@@ -108,6 +108,7 @@ def wait_on_server(demo=None):
         time.sleep(0.5)
         modules.script_callbacks.app_polling_callback(None, demo)
         if shared.state.need_restart:
+            modules.script_callbacks.app_reload_callback(None, demo)
             shared.state.need_restart = False
             time.sleep(0.5)
             demo.close()


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Add a polling and reload callback that extensions can use.

**Additional notes and description of your changes**

I've made a telegram bot extension for Automatic1111 that uses this , I use the polling provided by this PR to poll telegram updates, which simplifies this kind of usage to all extensions.

**Environment this was tested in**

 - OS: Windows and Linux
 - Browser: Edgium
 - Graphics card:  NVIDIA RTX 2080 8GB

**Screenshots or videos of your changes**

Since it's a functionality to be used by extensions, no videos are provided.