### PR TITLE
speedup model loading

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -137,14 +137,14 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     if theta_func2:
         shared.state.textinfo = f"Loading B"
         print(f"Loading {secondary_model_info.filename}...")
-        theta_1 = sd_models.read_state_dict(secondary_model_info.filename, map_location='cpu')
+        theta_1 = sd_models.read_state_dict(secondary_model_info.filename)
     else:
         theta_1 = None
 
     if theta_func1:
         shared.state.textinfo = f"Loading C"
         print(f"Loading {tertiary_model_info.filename}...")
-        theta_2 = sd_models.read_state_dict(tertiary_model_info.filename, map_location='cpu')
+        theta_2 = sd_models.read_state_dict(tertiary_model_info.filename)
 
         shared.state.textinfo = 'Merging B and C'
         shared.state.sampling_steps = len(theta_1.keys())
@@ -166,7 +166,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     shared.state.textinfo = f"Loading {primary_model_info.filename}..."
     print(f"Loading {primary_model_info.filename}...")
-    theta_0 = sd_models.read_state_dict(primary_model_info.filename, map_location='cpu')
+    theta_0 = sd_models.read_state_dict(primary_model_info.filename)
 
     print("Merging...")
     shared.state.textinfo = 'Merging A and B'

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -1,6 +1,7 @@
 import collections
 import os.path
 import sys
+import io
 import gc
 import torch
 import re
@@ -234,7 +235,7 @@ def read_metadata_from_safetensors(filename):
         return res
 
 
-def read_state_dict(checkpoint_file, print_global_state=False, map_location=None):
+def read_state_dict(checkpoint_file):
     _, extension = os.path.splitext(checkpoint_file)
     with open(checkpoint_file, 'rb') as f:
         if extension.lower() == ".safetensors":

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -240,7 +240,7 @@ def read_state_dict(checkpoint_file, print_global_state=False, map_location=None
         if extension.lower() == ".safetensors":
             buffer = f.read()
             pl_sd = safetensors.torch.load(buffer)
-        elif extension.lower() == ".ckpt":
+        elif extension.lower() == ".ckpt" or extension.lower() == ".pt":
             buffer = io.BytesIO(f.read())
             pl_sd = torch.load(buffer, map_location)
         else:

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -120,7 +120,7 @@ def resolve_vae(checkpoint_file):
 
 
 def load_vae_dict(filename, map_location):
-    vae_ckpt = sd_models.read_state_dict(filename, map_location=map_location)
+    vae_ckpt = sd_models.read_state_dict(filename)
     vae_dict_1 = {k: v for k, v in vae_ckpt.items() if k[0:4] != "loss" and k not in vae_ignore_keys}
     return vae_dict_1
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -152,7 +152,6 @@ devices.device, devices.device_interrogate, devices.device_gfpgan, devices.devic
     (devices.cpu if any(y in cmd_opts.use_cpu for y in [x, 'all']) else devices.get_optimal_device() for x in ['sd', 'interrogate', 'gfpgan', 'esrgan', 'codeformer'])
 
 device = devices.device
-weight_load_location = None if cmd_opts.lowram else "cpu"
 
 batch_cond_uncond = cmd_opts.always_batch_cond_uncond or not (cmd_opts.lowvram or cmd_opts.medvram)
 parallel_processing_allowed = not cmd_opts.lowvram and not cmd_opts.medvram


### PR DESCRIPTION
this pr changes weights loading from implict file handling by `torch` or `safetensors` to explicit binary stream  

now my local storage where models are stored is getting fully saturated during model read (>600mb/sec while previously it was fluctuating between 180-500mb/sec)

pr also removes obsolete variables, `map_location` and `weight_load_location`

keeping in draft pending some testing for possible side-effects.

## results

- **ckpt**: ~30% (**1.5x**) faster using loading using `torch.load` from io stream is than from file
- **safetensors** ~50% (**2x**) faster loading using `safetensors.torch.load` from file stream than `safetensors.torch.load_file`  

*note*: those are my worst-case examples, i've seen even bigger speedups in some tests

and reported in console - not bad for a 4GB model:

> Model loaded in 7.6s (load weights: 5.3s, create model: 0.4s, apply weights: 0.6s, load vae: 0.5s, device move: 0.8s).

## notes

- `load_file` attempts to memory map the file, but does so quite inefficiently  
  (see my notes at <https://github.com/huggingface/safetensors/issues/200#issuecomment-1478326999> for details)
- `safetensors.torch.load` does not have `device` param (unlike `load_file`) and always loads to cpu anyhow and model gets moved as needed later

## follow-ups

1. this pr can be extended to wrap `open()` function with a progress bar:

simply replace:  
> with open(checkpoint_file, 'rb') as f:

with  
> import rich  
> with rich.progress.open(checkpoint_file, 'rb') as f:

and the console output becomes:

    Loading weights from /home/vlado/dev/automatic/models/Stable-diffusion/perfect-world-v20.safetensors
    Reading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 GB 0:00:00

2. what is the impact when loading model from non-local storage? e.g. mapped s3 bucket
