### PR TITLE
Move `load_file_from_url` import

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -4,7 +4,6 @@ import shutil
 import importlib
 from urllib.parse import urlparse
 
-from basicsr.utils.download_util import load_file_from_url
 from modules import shared
 from modules.upscaler import Upscaler, UpscalerLanczos, UpscalerNearest, UpscalerNone
 from modules.paths import script_path, models_path
@@ -59,6 +58,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
 
         if model_url is not None and len(output) == 0:
             if download_name is not None:
+                from basicsr.utils.download_util import load_file_from_url
                 dl = load_file_from_url(model_url, model_path, True, download_name)
                 output.append(dl)
             else:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
One of the internal calls of `load_file_from_url` imports cv2, locking the cv2 site-package, which may (and in our case, is) breaking the installation of some extension libraries. The base project should limit its import of unnecessary libraries during the installation phase.

**Environment this was tested in**
Windows, but this change has no environment-specific impact.