### PR TITLE
Fix scripts load order

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -239,7 +239,15 @@ def load_scripts():
             elif issubclass(script_class, scripts_postprocessing.ScriptPostprocessing):
                 postprocessing_scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir, module))
 
-    for scriptfile in sorted(scripts_list):
+    def orderby(basedir):
+        # 1st webui, 2nd extensions-builtin, 3rd extensions
+        priority = {os.path.join(paths.script_path, "extensions-builtin"):1, paths.script_path:0}
+        for key in priority:
+            if basedir.startswith(key):
+                return priority[key]
+        return 9999
+
+    for scriptfile in sorted(scripts_list, key=lambda x: [orderby(x.basedir), x.filename, x.path]):
         try:
             if scriptfile.basedir != paths.script_path:
                 sys.path = [scriptfile.basedir] + sys.path

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -247,7 +247,7 @@ def load_scripts():
                 return priority[key]
         return 9999
 
-    for scriptfile in sorted(scripts_list, key=lambda x: [orderby(x.basedir), x.filename, x.path]):
+    for scriptfile in sorted(scripts_list, key=lambda x: [orderby(x.basedir), x]):
         try:
             if scriptfile.basedir != paths.script_path:
                 sys.path = [scriptfile.basedir] + sys.path


### PR DESCRIPTION
 - 1st webui, 2nd extensions-builtin, 3rd extensions
 - to load scripts independent of --data-dir
 - change load order key [x.basedir, x.filename, x.path] to [orderby(x.basedir), x]

e.g., scripts/xyz_grid.py dependent extentions should loaded later extensions\sd-webui-controlnet\scripts\xyz_grid_support.py extensions\sd-webui-additional-networks\scripts\xyz_grid_support.py
