### PR TITLE
Add ability to display and/or save inpainting mask and masked composite

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -689,6 +689,22 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image.info["parameters"] = text
                 output_images.append(image)
 
+                if hasattr(p, 'mask_for_overlay') and p.mask_for_overlay:
+                    image_mask = p.mask_for_overlay.convert('RGB')
+                    image_mask_composite = Image.composite(image.convert('RGBA').convert('RGBa'), Image.new('RGBa', image.size), p.mask_for_overlay.convert('L')).convert('RGBA')
+
+                    if opts.save_mask:
+                        images.save_image(image_mask, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-mask")
+
+                    if opts.save_mask_composite:
+                        images.save_image(image_mask_composite, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-mask-composite")
+
+                    if opts.return_mask:
+                        output_images.append(image_mask)
+                    
+                    if opts.return_mask_composite:
+                        output_images.append(image_mask_composite)
+
             del x_samples_ddim
 
             devices.torch_gc()

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -332,6 +332,8 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_images_before_face_restoration": OptionInfo(False, "Save a copy of image before doing face restoration."),
     "save_images_before_highres_fix": OptionInfo(False, "Save a copy of image before applying highres fix."),
     "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
+    "save_mask": OptionInfo(False, "For inpainting, save a copy of the greyscale mask"),
+    "save_mask_composite": OptionInfo(False, "For inpainting, save a masked composite"),
     "jpeg_quality": OptionInfo(80, "Quality for saved jpeg images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),
     "webp_lossless": OptionInfo(False, "Use lossless compression for webp images"),
     "export_for_4chan": OptionInfo(True, "If the saved image file size is above the limit, or its either width or height are above the limit, save a downscaled copy as JPG"),
@@ -454,6 +456,8 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
 
 options_templates.update(options_section(('ui', "User interface"), {
     "return_grid": OptionInfo(True, "Show grid in results for web"),
+    "return_mask": OptionInfo(False, "For inpainting, include the greyscale mask in results for web"),
+    "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),
     "add_model_hash_to_info": OptionInfo(True, "Add model hash to generation information"),
     "add_model_name_to_info": OptionInfo(True, "Add model name to generation information"),


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This exposes the inpainting mask and masked composite to the user, and gives the choice to display these in the web UI, save them to disk, or both. This should make layering inpainting results easier in external software.

**Additional notes and description of your changes**

All these options are disabled by default, as majority of users will likely not benefit from this feature.

This takes into account the mask blur value. Masked composite is premultiplied. I've done a comparison of the final composited inpainting result vs. the original image + the masked composite, and results are identical, besides the edge expanding slightly less outward (I believe this is due to a minor difference in how the final composite is handled currently in the `apply_overlay` function, where the mask is inverted).

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

New behavior, when both the mask and masked composite are enabled to display in the web UI:
![image](https://user-images.githubusercontent.com/122327233/226996288-5d6a3c57-f987-49b7-bfba-67365cd83927.png)
