### PR TITLE
Add possibility to use subfolders inside the sd-models folder

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -28,6 +28,14 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
 
     try:
         places = []
+        
+        # searching for SD models subfolders inside the 'models/Stable-diffusion' directory:
+        custom_places_path = os.path.join(models_path, "Stable-diffusion")
+        custom_places = next(os.walk(custom_places_path))[1]
+        for custom_place in custom_places:
+            if os.path.exists(custom_place):
+                custom_place_path = os.path.join(custom_places_path, custom_place)
+                places.append(custom_place_path)
 
         if command_path is not None and command_path != model_path:
             pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')


### PR DESCRIPTION
### Description

With this small update you can create subfolders inside the "models/Stable-diffusion" directory and place there the models you want, and these models will appear in the list of SD checkpoints in the GUI.

So now you can organize your SD-models collection much better and separate your models into subfolders

### Demo
#### SD models folder:
<img src="https://lovemet.ru/www/img/a1111-sd-custom-folder-add1.png" alt="custom-subfolder-demo" width="50%"/>

#### Custom subfolder:
<img src="https://lovemet.ru/www/img/a1111-sd-custom-folder-add2.png" alt="custom-subfolder-demo" width="50%"/>

#### How it shows up in the GUI:
<img src="https://lovemet.ru/www/img/a1111-sd-custom-folder-add3.png" alt="custom-subfolder-demo" width="100%"/>

### Checkpoint Merger demo*
<img src="https://lovemet.ru/www/img/a1111-sd-custom-folder-add4.png" alt="custom-subfolder-demo" width="100%"/>

> *If you create a new subfolder while GUI is working, models from the subfolder will normally appear in the list. But if you want to use the Checkpoint Merger in this case and merge a model from the recently created subfolder, you must restart GUI at first or you will get an error. As you can see on the screenshot above the Checkpoint Merger works good after the GUI was restarted.