### PR TITLE
Use '--shallow-since' to reduce the size of cloned repos

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -149,7 +149,7 @@ def check_run_python(code):
     return check_run(f'"{python}" -c "{code}"')
 
 
-def git_clone(url, dir, name, commithash=None):
+def git_clone(url, dir, name, commithash=None, start_time=0):
     # TODO clone into temporary dir and move if successful
 
     if os.path.exists(dir):
@@ -160,11 +160,11 @@ def git_clone(url, dir, name, commithash=None):
         if current_hash == commithash:
             return
 
-        run(f'"{git}" -C "{dir}" fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
+        run(f'"{git}" -C "{dir}" fetch --shallow-since="{start_time}"', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
         run(f'"{git}" -C "{dir}" checkout {commithash}', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
         return
 
-    run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
+    run(f'"{git}" clone --shallow-since="{start_time}" "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
 
     if commithash is not None:
         run(f'"{git}" -C "{dir}" checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
@@ -174,7 +174,7 @@ def git_pull_recursive(dir):
     for subdir, _, _ in os.walk(dir):
         if os.path.exists(os.path.join(subdir, '.git')):
             try:
-                output = subprocess.check_output([git, '-C', subdir, 'pull', '--autostash'])
+                output = subprocess.check_output([git, '-C', subdir, 'pull ', '--autostash'])
                 print(f"Pulled changes for repository in '{subdir}':\n{output.decode('utf-8').strip()}\n")
             except subprocess.CalledProcessError as e:
                 print(f"Couldn't perform 'git pull' on repository in '{subdir}':\n{e.output.decode('utf-8').strip()}\n")
@@ -312,11 +312,11 @@ def prepare_environment():
 
     os.makedirs(os.path.join(script_path, dir_repos), exist_ok=True)
 
-    git_clone(stable_diffusion_repo, repo_dir('stable-diffusion-stability-ai'), "Stable Diffusion", stable_diffusion_commit_hash)
-    git_clone(taming_transformers_repo, repo_dir('taming-transformers'), "Taming Transformers", taming_transformers_commit_hash)
-    git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
-    git_clone(codeformer_repo, repo_dir('CodeFormer'), "CodeFormer", codeformer_commit_hash)
-    git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
+    git_clone(stable_diffusion_repo, repo_dir('stable-diffusion-stability-ai'), "Stable Diffusion", stable_diffusion_commit_hash, "1669305599")
+    git_clone(taming_transformers_repo, repo_dir('taming-transformers'), "Taming Transformers", taming_transformers_commit_hash, "1642089599")
+    git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash, "1669219199")
+    git_clone(codeformer_repo, repo_dir('CodeFormer'), "CodeFormer", codeformer_commit_hash, "1662652799")
+    git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash, "1641484799")
 
     if not is_installed("lpips"):
         run_pip(f"install -r \"{os.path.join(repo_dir('CodeFormer'), 'requirements.txt')}\"", "requirements for CodeFormer")

--- a/launch.py
+++ b/launch.py
@@ -149,7 +149,7 @@ def check_run_python(code):
     return check_run(f'"{python}" -c "{code}"')
 
 
-def git_clone(url, dir, name, commithash=None, start_time=0):
+def git_clone(url, dir, name, commithash=None, start_time="0"):
     # TODO clone into temporary dir and move if successful
 
     if os.path.exists(dir):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

As the title, use `git xxx --shallow-since=<timestamp>` to avoid cloning former useless commits, and reduce the time of preparing environment.

**Additional notes and description of your changes**

I found many repositories(e.g. taming-transformers) have a huge size of **commit history** to clone, but totally useless. We just need the specific version. 

Unlukily, git doesn't support us to clone a specific commit. So just clone repositories since the commit. 

I added a parameter `start_time` for the function `git_clone()` as the parameter of `--shallow-since=<para>`.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 1660Ti 6GB

**Screenshots or videos of your changes**

Here is the new size of the whole folder `repositories`:

![image](https://user-images.githubusercontent.com/101185502/227238981-b5372034-5c51-41a9-9c4c-47cad723f771.png)

And the origin size:

![image](https://user-images.githubusercontent.com/101185502/227506282-72d7484b-ddce-4dc1-a242-2142928557e4.png)
