### PR TITLE
Add patchmatch

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -99,5 +99,5 @@ def fill(image, mask):
 
 def pm(image: Image.Image, mask: Image.Image, patch_size=4):
     mask = mask.convert('L')
-    image_mod = patch_match.inpaint(image.convert('RGB'), mask.convert('L'), patch_size=patch_size)
+    image_mod = patch_match.inpaint(image.convert('RGB'), mask, patch_size=patch_size)
     return Image.fromarray(image_mod, mode='RGB')

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -1,5 +1,5 @@
 from PIL import Image, ImageFilter, ImageOps
-
+from patchmatch import patch_match
 
 def get_crop_region(mask, pad=0):
     """finds a rectangular region that contains all masked ares in an image. Returns (x1, y1, x2, y2) coordinates of the rectangle.
@@ -97,3 +97,7 @@ def fill(image, mask):
 
     return image_mod.convert("RGB")
 
+def pm(image: Image.Image, mask: Image.Image, patch_size=4):
+    mask = mask.convert('L')
+    image_mod = patch_match.inpaint(image.convert('RGB'), mask.convert('L'), patch_size=patch_size)
+    return Image.fromarray(image_mod, mode='RGB')

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -991,7 +991,9 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 image = images.resize_image(2, image, self.width, self.height)
 
             if image_mask is not None:
-                if self.inpainting_fill != 1:
+                if self.inpainting_fill == 4:
+                    image = masking.pm(image, latent_mask)
+                elif self.inpainting_fill != 1:
                     image = masking.fill(image, latent_mask)
 
             if add_color_corrections:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -802,7 +802,7 @@ def create_ui():
                                 inpainting_mask_invert = gr.Radio(label='Mask mode', choices=['Inpaint masked', 'Inpaint not masked'], value='Inpaint masked', type="index", elem_id="img2img_mask_mode")
 
                             with FormRow():
-                                inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing'], value='original', type="index", elem_id="img2img_inpainting_fill")
+                                inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing', 'patch match'], value='original', type="index", elem_id="img2img_inpainting_fill")
 
                             with FormRow():
                                 with gr.Column():


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This implements [patchmatch](https://github.com/invoke-ai/PyPatchMatch) which should allow for much better inpainting (and more notably outpainting) results.

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/4681

**Additional notes and description of your changes**

Requires `pypatchmatch` to be installed. This is currently only available on Windows via pip. [Further install instructions are here](https://invoke-ai.github.io/InvokeAI/installation/060_INSTALL_PATCHMATCH/).

`Mask blur` must be set to `0`, because blurring breaks the seams that patchmatch tries to recover. There's probably better ways to blend the final image but I'm not sure what the correct solution for this should be. If you want you can play around with the individual passes before the final composite with https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8814.

I've also hardcoded the `patch_size` parameter to `4`. Might want to expose this to the user, but increasing it also greatly increases computation time (the default is `15` which takes far too long to run for practical purposes).

Haven't tested with the [openOutpaint](https://github.com/zero01101/openOutpaint-webUI-extension) extension yet but I'm hoping this addition could make big gains for that extension. Needs `4: "patch match"` added after [this line](https://github.com/zero01101/openOutpaint/blob/e32dfc8891e4c3519e4712893d289022ee6efb79/js/ui/tool/dream.js#L1845). I think the extension does not currently expose the denoise parameter either, which probably needs to be done to yield good results.

Opening as a PR for now since the installation process should be smoothed out before merging, and to see if it even works well in practice. Feedback appreciated.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090