### PR TITLE
Allow extra networks to store infotext parameters

### DIFF
--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -26,7 +26,7 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
         pass
 
     def infotext_params(self, p, params_list):
-        infotext_params = {}
+        lora_hashes = []
 
         for params in params_list:
             assert len(params.items) > 0
@@ -34,6 +34,6 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
 
             lora_on_disk = lora.available_loras.get(name, None)
             if lora_on_disk:
-                infotext_params[f"lora/{name}"] = lora_on_disk.shorthash()
+                lora_hashes.append(f"lora/{name}:{lora_on_disk.shorthash()}")
 
-        return infotext_params
+        return {"Lora hashes": ", ".join(lora_hashes)}

--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -34,6 +34,6 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
 
             lora_on_disk = lora.available_loras.get(name, None)
             if lora_on_disk:
-                lora_hashes.append(f"lora/{name}:{lora_on_disk.shorthash()}")
+                lora_hashes.append(f"{name}:{lora_on_disk.shorthash()}")
 
         return {"Lora hashes": ", ".join(lora_hashes)}

--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -1,4 +1,4 @@
-from modules import extra_networks, shared
+from modules import extra_networks, shared, sd_models
 import lora
 
 class ExtraNetworkLora(extra_networks.ExtraNetwork):
@@ -24,3 +24,16 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
 
     def deactivate(self, p):
         pass
+
+    def infotext_params(self, p, params_list):
+        infotext_params = {}
+
+        for params in params_list:
+            assert len(params.items) > 0
+            name = params.items[0]
+
+            lora_on_disk = lora.available_loras.get(name, None)
+            if lora_on_disk:
+                infotext_params[f"lora/{name}"] = lora_on_disk.shorthash()
+
+        return infotext_params

--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -3,7 +3,7 @@ import os
 import re
 import torch
 
-from modules import shared, devices, sd_models, errors
+from modules import shared, devices, sd_models, errors, hashes
 
 metadata_tags_order = {"ss_sd_model_name": 1, "ss_resolution": 2, "ss_clip_skip": 3, "ss_num_train_images": 10, "ss_tag_frequency": 20}
 
@@ -62,6 +62,18 @@ class LoraOnDisk:
             self.metadata = m
 
         self.ssmd_cover_images = self.metadata.pop('ssmd_cover_images', None)  # those are cover images and they are too big to display in UI as text
+
+    def hash(self):
+        result = self.metadata.get("sshs_model_hash", None)
+        if not result:
+            if self.filename.endswith(".safetensors"):
+                result = sd_models.safetensors_hash(self.filename)
+            else:
+                result = hashes.sha256_from_cache(self.filename, "lora/" + self.name)
+        return result
+
+    def shorthash(self):
+        return self.hash()[0:12]
 
 
 class LoraModule:

--- a/modules/extra_networks.py
+++ b/modules/extra_networks.py
@@ -153,11 +153,7 @@ def get_infotext_params(p: StableDiffusionProcessing, extra_network_data: Dict[s
         except Exception as e:
             errors.display(e, f"getting unmentioned extra network params {extra_network_name}")
 
-    result = []
-    for k, v in params.items():
-        result.append(f"{k}: {v}".replace('"', '\\"'))
-
-    return ", ".join(result)
+    return dict(params)
 
 
 re_extra_net = re.compile(r"<(\w+):([^>]+)>")

--- a/modules/extra_networks.py
+++ b/modules/extra_networks.py
@@ -1,7 +1,9 @@
 import re
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
+from typing import Dict, List
 
 from modules import errors
+from modules.processing import StableDiffusionProcessing
 
 extra_network_registry = {}
 
@@ -15,15 +17,15 @@ def register_extra_network(extra_network):
 
 
 class ExtraNetworkParams:
-    def __init__(self, items=None):
+    def __init__(self, items: List[str] | None = None):
         self.items = items or []
 
 
 class ExtraNetwork:
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.name = name
 
-    def activate(self, p, params_list):
+    def activate(self, p: StableDiffusionProcessing, params_list: List[ExtraNetworkParams]):
         """
         Called by processing on every run. Whatever the extra network is meant to do should be activated here.
         Passes arguments related to this extra network in params_list.
@@ -53,15 +55,22 @@ class ExtraNetwork:
         """
         raise NotImplementedError
 
-    def deactivate(self, p):
+    def deactivate(self, p: StableDiffusionProcessing):
         """
         Called at the end of processing for housekeeping. No need to do anything here.
         """
 
         raise NotImplementedError
 
+    def infotext_params(self, p: StableDiffusionProcessing, params_list: List[ExtraNetworkParams]):
+        """
+        Returns a dict of extra infotext parameters, to be added inside the
+        "Extra networks" infotext field, for example model hashes
+        """
+        return {}
 
-def activate(p, extra_network_data):
+
+def activate(p: StableDiffusionProcessing, extra_network_data: Dict[str, List[ExtraNetworkParams]]):
     """call activate for extra networks in extra_network_data in specified order, then call
     activate for all remaining registered networks with an empty argument list"""
 
@@ -87,7 +96,7 @@ def activate(p, extra_network_data):
             errors.display(e, f"activating extra network {extra_network_name}")
 
 
-def deactivate(p, extra_network_data):
+def deactivate(p: StableDiffusionProcessing, extra_network_data: Dict[str, List[ExtraNetworkParams]]):
     """call deactivate for extra networks in extra_network_data in specified order, then call
     deactivate for all remaining registered networks"""
 
@@ -110,6 +119,45 @@ def deactivate(p, extra_network_data):
             extra_network.deactivate(p)
         except Exception as e:
             errors.display(e, f"deactivating unmentioned extra network {extra_network_name}")
+
+
+def get_infotext_params(p: StableDiffusionProcessing, extra_network_data: Dict[str, List[ExtraNetworkParams]]):
+    """
+    returns the infotext for extra networks
+    example output:
+    Extra networks: "lora|claude-monet: abcd1234, lora|vincent-van-gogh: 4321dcba"
+    """
+    params = OrderedDict()
+
+    for extra_network_name, extra_network_args in extra_network_data.items():
+        extra_network = extra_network_registry.get(extra_network_name, None)
+        if extra_network is None:
+            continue
+
+        try:
+            found = extra_network.infotext_params(p, extra_network_args)
+            if found:
+                params.update(found)
+        except Exception as e:
+            errors.display(e, f"getting extra network params {extra_network_name}")
+
+    for extra_network_name, extra_network in extra_network_registry.items():
+        args = extra_network_data.get(extra_network_name, None)
+        if args is not None:
+            continue
+
+        try:
+            found = extra_network.infotext_params(p, [])
+            if found:
+                params.update(found)
+        except Exception as e:
+            errors.display(e, f"getting unmentioned extra network params {extra_network_name}")
+
+    result = []
+    for k, v in params.items():
+        result.append(f"{k}: {v}".replace('"', '\\"'))
+
+    return ", ".join(result)
 
 
 re_extra_net = re.compile(r"<(\w+):([^>]+)>")

--- a/modules/extra_networks_hypernet.py
+++ b/modules/extra_networks_hypernet.py
@@ -38,6 +38,6 @@ class ExtraNetworkHypernet(extra_networks.ExtraNetwork):
                 sha256 = hashes.sha256(filename, f'hypernet/{name}')
                 if sha256:
                     shorthash = sha256[0:10]
-                    hypernet_hashes.append(f"hypernet/{name}:{shorthash}")
+                    hypernet_hashes.append(f"{name}:{shorthash}")
 
         return {"Hypernet hashes": ", ".join(hypernet_hashes)}

--- a/modules/extra_networks_hypernet.py
+++ b/modules/extra_networks_hypernet.py
@@ -27,7 +27,7 @@ class ExtraNetworkHypernet(extra_networks.ExtraNetwork):
         pass
 
     def infotext_params(self, p, params_list):
-        infotext_params = {}
+        hypernet_hashes = []
 
         for params in params_list:
             assert len(params.items) > 0
@@ -38,6 +38,6 @@ class ExtraNetworkHypernet(extra_networks.ExtraNetwork):
                 sha256 = hashes.sha256(filename, f'hypernet/{name}')
                 if sha256:
                     shorthash = sha256[0:10]
-                    infotext_params[f"hypernet/{name}"] = shorthash
+                    hypernet_hashes.append(f"hypernet/{name}:{shorthash}")
 
-        return infotext_params
+        return {"Hypernet hashes": ", ".join(hypernet_hashes)}

--- a/modules/extra_networks_hypernet.py
+++ b/modules/extra_networks_hypernet.py
@@ -1,4 +1,4 @@
-from modules import extra_networks, shared, extra_networks
+from modules import extra_networks, shared, extra_networks, hashes
 from modules.hypernetworks import hypernetwork
 
 
@@ -25,3 +25,19 @@ class ExtraNetworkHypernet(extra_networks.ExtraNetwork):
 
     def deactivate(self, p):
         pass
+
+    def infotext_params(self, p, params_list):
+        infotext_params = {}
+
+        for params in params_list:
+            assert len(params.items) > 0
+            name = params.items[0]
+
+            filename = shared.hypernetworks.get(name, None)
+            if filename:
+                sha256 = hashes.sha256(filename, f'hypernet/{name}')
+                if sha256:
+                    shorthash = sha256[0:10]
+                    infotext_params[f"hypernet/{name}"] = shorthash
+
+        return infotext_params

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -613,7 +613,9 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if p.scripts is not None:
                 p.scripts.process_batch(p, batch_number=n, prompts=prompts, seeds=seeds, subseeds=subseeds)
 
-            p.extra_generation_params["Extra networks"] = extra_networks.get_infotext_params(p, extra_network_data)
+            extra_networks_infotexts = extra_networks.get_infotext_params(p, extra_network_data)
+            for k, v in extra_networks_infotexts.items():
+                p.extra_generation_params[k] = v
 
             # params.txt should be saved after scripts.process_batch, since the
             # infotext could be modified by that callback

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -613,6 +613,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if p.scripts is not None:
                 p.scripts.process_batch(p, batch_number=n, prompts=prompts, seeds=seeds, subseeds=subseeds)
 
+            p.extra_generation_params["Extra networks"] = extra_networks.get_infotext_params(p, extra_network_data)
+
             # params.txt should be saved after scripts.process_batch, since the
             # infotext could be modified by that callback
             # Example: a wildcard processed by process_batch sets an extra model


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Provides an API for extra networks to save parameters to the infotext. Updates hypernetworks and LoRAs added to prompts to store this information.

Closes #8040

**Additional notes and description of your changes**

Example output:

```
Hypernet hashes: "waterElemental_10:be10c1cb8f", Lora hashes: "incaseStyle_incaseAnythingV3:e55f3380b6"
```

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090