### PR TITLE
Fix None type error for TI module

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -152,7 +152,11 @@ class EmbeddingDatabase:
                 name = data.get('name', name)
             else:
                 data = extract_image_data_embed(embed_image)
-                name = data.get('name', name)
+                if data:
+                    name = data.get('name', name)
+                else:
+                    # if data is None, means this is not an embeding, just a preview image
+                    return
         elif ext in ['.BIN', '.PT']:
             data = torch.load(path, map_location="cpu")
         elif ext in ['.SAFETENSORS']:


### PR DESCRIPTION
When user using model_name.png as a preview image for embeding, textural_inversion.py still treat it as an embeding, and didn't handle its error, just let python throw out an None type error like following:
```bash
  File "D:\Work\Dev\AI\stable-diffusion-webui\modules\textual_inversion\textual_inversion.py", line 155, in load_from_file
    name = data.get('name', name)
AttributeError: 'NoneType' object has no attribute 'get'
```

In this PR, with a simple `if data:` checking, there will be no error, breaks nothing, and now this module can works fine with user's preview images.
Old code:  
```python
                data = extract_image_data_embed(embed_image)
                name = data.get('name', name)
```
New code:  
```python
                data = extract_image_data_embed(embed_image)
                if data:
                    name = data.get('name', name)
                else:
                    # if data is None, means this is not an embeding, just a preview image
                    return
```

Also, since there is no more errors on textual inversion module, from now on, extra network can set "model_name.png" as preview image for embedings.