### PR TITLE
Fix 'modules.extensions' has no attribute 'extensions_dir'

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -130,7 +130,7 @@ def install_extension_from_url(dirname, url):
 
         dirname = last_part
 
-    target_dir = os.path.join(extensions.extensions_dir, dirname)
+    target_dir = os.path.join(paths.extensions_dir, dirname)
     assert not os.path.exists(target_dir), f'Extension directory already exists: {target_dir}'
 
     normalized_url = normalize_git_url(url)


### PR DESCRIPTION
No `extensions.extensions_dir` in extensions.py

Changed to `paths`

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Ubuntu
 - Browser: [e.g. chrome, safari]
 - Graphics card: a100
