### PR TITLE
fix overriding getElementById on document

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ function gradioApp() {
     const elems = document.getElementsByTagName('gradio-app')
     const elem = elems.length == 0 ? document : elems[0]
 
-    elem.getElementById = function(id){ return document.getElementById(id) }
+    if (elem !== document) elem.getElementById = function(id){ return document.getElementById(id) }
     return elem.shadowRoot ? elem.shadowRoot : elem
 }
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

fix infinite loop on frontend app

**Additional notes and description of your changes**

currently when gradioApp() is called and the target element appears to be "document", it is overriding default getElementById function, which causes errors like "Too much recursion" or "[Maximum call stack size exceeded](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/8895#issuecomment-1483772370)", this fixes it by checking the element

**Environment this was tested in**

 - OS: MacOS
 - Browser: Firefox, Safari
 - Graphics card: -
