### PR TITLE
Add Reload CSS button

### DIFF
--- a/html/footer.html
+++ b/html/footer.html
@@ -5,6 +5,8 @@
          • 
         <a href="https://gradio.app">Gradio</a>
          • 
+        <a href="/" onclick="javascript:gradioApp().getElementById('settings_reload_css').click(); return false">Reload CSS</a>
+         • 
         <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false">Reload UI</a>
 </div>
 <br />

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -335,3 +335,8 @@ function selectCheckpoint(name){
     desiredCheckpointName = name;
     gradioApp().getElementById('change_checkpoint').click()
 }
+
+function updateInlineStylesheet(css) {
+    document.querySelector("gradio-app > div > style").textContent = css;
+    return [];
+}

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1476,8 +1476,6 @@ def create_ui():
             with gr.Column(scale=6):
                 settings_submit = gr.Button(value="Apply settings", variant='primary', elem_id="settings_submit")
             with gr.Column():
-                reload_css = gr.Button(value='Reload CSS', elem_id="settings_reload_css")
-            with gr.Column():
                 restart_gradio = gr.Button(value='Reload UI', variant='primary', elem_id="settings_restart_gradio")
 
         result = gr.HTML(elem_id="settings_result")
@@ -1527,6 +1525,7 @@ def create_ui():
                 request_notifications = gr.Button(value='Request browser notifications', elem_id="request_notifications")
                 download_localization = gr.Button(value='Download localization template', elem_id="download_localization")
                 reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies")
+                reload_css = gr.Button(value='Reload CSS', variant='secondary', elem_id="settings_reload_css")
                 with gr.Row():
                     unload_sd_model = gr.Button(value='Unload SD checkpoint to free VRAM', elem_id="sett_unload_sd_model")
                     reload_sd_model = gr.Button(value='Reload the last SD checkpoint back into VRAM', elem_id="sett_reload_sd_model")


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adds a Reload CSS button to the settings page. Allows changing webui's `style.css` or extension CSS without needing to restart the entire webui

**Additional notes and description of your changes**

The CSS is saved in the backend too, so it will be preserved the page is reloaded

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**
<img width="489" alt="2023-03-27 13_09_25-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/228015394-564f8c01-b1af-4304-965a-faed2ae5066d.png">
<img width="935" alt="2023-03-27 13_09_39-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/228015401-4e726f08-15c0-48f8-9b17-1c84deca5964.png">
