### PR TITLE
Fix padding on accordion/dropdown list elements

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -553,3 +553,15 @@ def IOComponent_init(self, *args, **kwargs):
 
 original_IOComponent_init = gr.components.IOComponent.__init__
 gr.components.IOComponent.__init__ = IOComponent_init
+
+
+def BlockContext_init(self, *args, **kwargs):
+    res = original_BlockContext_init(self, *args, **kwargs)
+
+    add_classes_to_gradio_component(self)
+
+    return res
+
+
+original_BlockContext_init = gr.blocks.BlockContext.__init__
+gr.blocks.BlockContext.__init__ = BlockContext_init

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
     --block-background-fill: transparent;
 }
 
-.block.padded{
+.block.padded:not(.gradio-accordion) {
     padding: 0 !important;
 }
 
@@ -63,6 +63,19 @@ div.compact{
 .gradio-number label span:not(.has-info)
 {
     margin-bottom: 0;
+}
+
+.gradio-dropdown ul.options {
+  max-height: 35em;
+  z-index: 3000;
+}
+
+.gradio-dropdown ul.options li.item {
+  padding: 0.05em 0;
+}
+
+.gradio-dropdown ul.options li.item.selected {
+  background-color: var(--secondary-500);
 }
 
 .gradio-dropdown div.wrap.wrap.wrap.wrap{


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Makes accordions have the padding they did before, while removing padding on dropdown list elements and adding selected highlight. Makes both closer to their appearance in old Gradio

**Additional notes and description of your changes**

Just some CSS additions, plus blocks layout elements get CSS classes like with `IOComponent`s

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

Old:
<img width="931" alt="2023-03-25 15_19_55-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/227738689-24fdb3ed-e4b1-4972-b9de-543b6c717709.png">
<img width="227" alt="2023-03-19 23_51_32-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/227738709-dd0701e0-fa60-4350-a169-d3c6a50adc16.png">

New:
<img width="923" alt="2023-03-25 15_51_38-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/227738665-649f5ced-7ded-4be1-a9bb-f020277718a3.png">
<img width="471" alt="2023-03-25 15_51_54-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/227738668-48ba54cd-025b-4563-90bb-1a08da85696f.png">