### PR TITLE
Fix dropdown width

### DIFF
--- a/style.css
+++ b/style.css
@@ -56,6 +56,9 @@ div.compact{
 
 .gradio-dropdown ul.options{
     z-index: 3000;
+    min-width: fit-content;
+    max-width: inherit;
+    white-space: nowrap;
 }
 
 .gradio-dropdown label span:not(.has-info),


### PR DESCRIPTION
Makes gradio dropdowns fit their content width without wrapping or scrolling. Combined with #8943, they should mostly look how they did before.

Fixes #8955

**Environment this was tested in**
 - OS: Windows 10
 - Browser: Edge 111.0.1661.54

**Screenshots or videos of your changes**
Before
![before](https://user-images.githubusercontent.com/4073789/227752926-71d249c3-442c-4f76-9326-5a61dbba46bf.png)

After
![after](https://user-images.githubusercontent.com/4073789/227752929-0403042e-c628-4ce7-bb5a-b1b264eb5c15.png)
