### PR TITLE
Fix the style box dropdown not wrapping in txt2img and img2img

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,7 +69,7 @@ div.compact{
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
-.gradio-dropdown .wrap-inner.wrap-inner.wrap-inner{
+.gradio-dropdown:not(.multiselect) .wrap-inner.wrap-inner.wrap-inner{
     flex-wrap: unset;
 }
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9007

**Additional notes and description of your changes**

The latest update has disabled the txt2img and img2img style box wrap in CSS.

**Environment this was tested in**
 - OS: Windows
 - Browser: Chrome

**Screenshots or videos of your changes**

Before:
![Screenshot 2023-03-27 112907](https://user-images.githubusercontent.com/69743585/227834956-2ef89bf8-3bc3-47d3-be07-1328ace7bd76.png)
After:
![Screenshot 2023-03-27 112805](https://user-images.githubusercontent.com/69743585/227834977-9c61b41a-adf8-4820-a5b1-865a5ac300b2.png)