### PR TITLE
Temporary disable extensions option

### DIFF
--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -1,5 +1,5 @@
 
-function extensions_apply(_, _){
+function extensions_apply(_, _, disable_all){
     var disable = []
     var update = []
 
@@ -13,10 +13,10 @@ function extensions_apply(_, _){
 
     restart_reload()
 
-    return [JSON.stringify(disable), JSON.stringify(update)]
+    return [JSON.stringify(disable), JSON.stringify(update), disable_all]
 }
 
-function extensions_check(){
+function extensions_check(_, _){
     var disable = []
 
     gradioApp().querySelectorAll('#extensions input[type="checkbox"]').forEach(function(x){

--- a/launch.py
+++ b/launch.py
@@ -206,6 +206,10 @@ def list_extensions(settings_file):
         print(e, file=sys.stderr)
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
+    disable_all_extensions = settings.get('disable_all_extensions', False)
+
+    if disable_all_extensions:
+        return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]
 

--- a/launch.py
+++ b/launch.py
@@ -206,10 +206,6 @@ def list_extensions(settings_file):
         print(e, file=sys.stderr)
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
-    disable_all_extensions = settings.get('disable_all_extensions', False)
-
-    if disable_all_extensions:
-        return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]
 

--- a/launch.py
+++ b/launch.py
@@ -206,6 +206,10 @@ def list_extensions(settings_file):
         print(e, file=sys.stderr)
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
+    disable_all_extensions = settings.get('disable_all_extensions', 'none')
+
+    if disable_all_extensions != 'none':
+        return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]
 

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -97,6 +97,10 @@ def list_extensions():
     if not os.path.isdir(extensions_dir):
         return
 
+    if shared.opts.disable_all_extensions:
+        print("*** \"Disable all extensions\" option was set, will not load any extensions ***")
+        return
+
     extension_paths = []
     for dirname in [extensions_dir, extensions_builtin_dir]:
         if not os.path.isdir(dirname):

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -15,7 +15,12 @@ if not os.path.exists(extensions_dir):
 
 
 def active():
-    return [x for x in extensions if x.enabled]
+    if shared.opts.disable_all_extensions == "all":
+        return []
+    elif shared.opts.disable_all_extensions == "extra":
+        return [x for x in extensions if x.enabled and x.is_builtin]
+    else:
+        return [x for x in extensions if x.enabled]
 
 
 class Extension:
@@ -97,9 +102,10 @@ def list_extensions():
     if not os.path.isdir(extensions_dir):
         return
 
-    if shared.opts.disable_all_extensions:
+    if shared.opts.disable_all_extensions == "all":
         print("*** \"Disable all extensions\" option was set, will not load any extensions ***")
-        return
+    elif shared.opts.disable_all_extensions == "extra":
+        print("*** \"Disable all extensions\" option was set, will only load built-in extensions ***")
 
     extension_paths = []
     for dirname in [extensions_dir, extensions_builtin_dir]:
@@ -116,4 +122,3 @@ def list_extensions():
     for dirname, path, is_builtin in extension_paths:
         extension = Extension(name=dirname, path=path, enabled=dirname not in shared.opts.disabled_extensions, is_builtin=is_builtin)
         extensions.append(extension)
-

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -423,7 +423,7 @@ options_templates.update(options_section(('postprocessing', "Postprocessing"), {
 
 options_templates.update(options_section((None, "Hidden options"), {
     "disabled_extensions": OptionInfo([], "Disable these extensions"),
-    "disable_all_extensions": OptionInfo(False, "Disable all extensions (preserves the list of disabled extensions)"),
+    "disable_all_extensions": OptionInfo("none", "Disable all extensions (preserves the list of disabled extensions)", gr.Radio, {"choices": ["none", "extra", "all"]}),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
 }))
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -422,7 +422,8 @@ options_templates.update(options_section(('postprocessing', "Postprocessing"), {
 }))
 
 options_templates.update(options_section((None, "Hidden options"), {
-    "disabled_extensions": OptionInfo([], "Disable those extensions"),
+    "disabled_extensions": OptionInfo([], "Disable these extensions"),
+    "disable_all_extensions": OptionInfo(False, "Disable all extensions (preserves the list of disabled extensions)"),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
 }))
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Temporarily disable extensions for debugging/development purposes

Closes #9049

**Additional notes and description of your changes**

Extensions will be loaded but not count as active in the `extensions.active()` function

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

<img width="993" alt="2023-03-27 12_49_03-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/228010058-1f9261e7-22b5-45d5-9d3f-95515613d87d.png">