### PR TITLE
fix [Bug]: very wide image doesn't fit in inpaint. Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -318,6 +318,13 @@ div.dimensions-tools{
     min-height: 480px !important;
 }
 
+#img2img_sketch, #img2maskimg, #inpaint_sketch {
+    overflow: overlay !important;
+    resize: auto;
+    background: var(--panel-background-fill);
+    z-index: 5;
+}
+
 .image-buttons button{
     min-width: auto;
 }


### PR DESCRIPTION
Fix for wide width image in img2img_sketch, img2maskimg, inpaint_sketch

Without fix, very wide image doesn't fit in inpaint
![Screenshot 2023-03-27 211116](https://user-images.githubusercontent.com/17048169/228029767-148ac45a-de63-43e1-a050-b4651d145a22.jpg)
![Screenshot 2023-03-27 211032](https://user-images.githubusercontent.com/17048169/228029773-55380966-c6df-4519-8417-330f5b3be638.jpg)
