### PR TITLE
Fix quicksettings alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -329,6 +329,7 @@ div.dimensions-tools{
 /* settings */
 #quicksettings {
     width: fit-content;
+    align-items: end;
 }
 
 #quicksettings > div, #quicksettings > fieldset{


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/4073789/228082780-e2e46e46-cf33-4eca-9892-76f9b4205991.png)

After
![image](https://user-images.githubusercontent.com/4073789/228082861-0ba11914-7fbd-4173-8182-6a9d7fd0029b.png)

This is caused by taller items stretching it. Editing the slider's label so it doesn't wrap works too, but that would have to be done to every setting.

**Environment this was tested in**
 - OS: Windows 10
 - Browser: Edge