### PR TITLE
Interrupt/skip results like live preview settings

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -226,7 +226,7 @@ class KDiffusionSampler:
         try:
             return func()
         except sd_samplers_common.InterruptedException:
-            return self.last_latent
+            return state.current_latent
 
     def number_of_needed_noises(self, p):
         return p.steps


### PR DESCRIPTION
Makes interrupt/skip results respect live preview subject, regarding issue #9038.

Currently interrupted sampler returns `self.last_latent` which is the denoised (combined) latent, while `state.current_latent` is updated on every sampling step by the sampler, according to the *Live Preview Subject* setting, and can be used instead to keep output consistent with preview.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card:. NVIDIA RTX 2070 8GB

**Screenshots or videos of your changes**
![befaft](https://user-images.githubusercontent.com/48160881/228287215-049cbe73-d715-4aac-984b-e3f94a3068f9.jpg)

