### PR TITLE
Update ui.py - 8 -> 7 character short commit hash in footer

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1820,7 +1820,7 @@ def versions_html():
 
     python_version = ".".join([str(x) for x in sys.version_info[0:3]])
     commit = launch.commit_hash()
-    short_commit = commit[0:8]
+    short_commit = commit[0:7]
 
     if shared.xformers_available:
         import xformers


### PR DESCRIPTION
Reduce displayed length of commit hash from 8 characters to 7. 8 seems arbitrary. git itself uses 7 characters.

**Describe what this pull request is trying to achieve.**

`git` itself, github's website, etc. all display 7 character "short" commit hashes. webui displays 8 in the footer. This seems odd, just want to bring it inline with what someone might be expecting to see.

**Additional notes and description of your changes**

I changed an 8 to a 7

**Environment this was tested in**

 - OS: Windows
 - Browser: Edge
 - Graphics card: CPU

 - OS: Linux (Colab)
 - Browser: Edge
 - Graphics card: nVIDIA T4

**Screenshots or videos of your changes**

Before
![image](https://user-images.githubusercontent.com/81622808/228363800-6089f72b-b08b-4f4a-b9a8-b610921ddd93.png)

After
![image](https://user-images.githubusercontent.com/81622808/228363676-1fe4e333-157a-42ae-92d6-76b5442cd193.png)