### PR TITLE
xyz_grid.py: remove unnecessary batch_size designation

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -441,8 +441,6 @@ class Script(scripts.Script):
         if not no_fixed_seeds:
             modules.processing.fix_seed(p)
 
-        if not opts.return_grid:
-            p.batch_size = 1
 
         def process_axis(opt, vals):
             if opt.label == 'Nothing':


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I was trying to suppress showing image in web when running a xyz batch, but I found I could not adjust the batch size.  
The code block I touched will set batch_size to 1 if Settings->User interface->"Show grid in results for web" is unchecked (opts.return_grid=False). This preset does not make sense because the originating setting is for UI image visualization, not for the image production. 
I thus suggest deleting these two lines.

**Environment this was tested in**

Briefly tested for generating * batch_size number of images. I am not 100% certain for other parts of the program.
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA desktop

