### PR TITLE
CSS: Remove duplicate highlights in dropdowns

### DIFF
--- a/style.css
+++ b/style.css
@@ -72,11 +72,11 @@ div.compact{
     padding: 0.05em 0;
 }
 
-.gradio-dropdown ul.options li.item.selected {
+.gradio-dropdown ul.options li.item:not(:has(.hide)) {
     background-color: var(--neutral-100);
 }
 
-.dark .gradio-dropdown ul.options li.item.selected {
+.dark .gradio-dropdown ul.options li.item:not(:has(.hide)) {
     background-color: var(--neutral-900);
 }
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Highlighting of selected item in dropdowns is currently broken. Right now it's evident in the Sampling Method dropdown, but potentially it can happen in any dropdown, since a Gradio bug causes the `selected` class to be set incorrectly, when the selected list item's name is an extension of other items.

Meanwhile the `hide` class of the span children of each element (which is responsible for not displaying the check mark) is set correctly. So this workaround uses that instead of the incorrectly set `selected` class.

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 2070 8GB

**Screenshots or videos of your changes**
(highlight color is exaggerated in screenshots for demonstration, remains unchanged in actual PR) 
Before:
![bef](https://user-images.githubusercontent.com/48160881/228424751-1a5d6001-f0fe-4404-b7c5-89edab76ebc2.jpg)
After:
![bef2](https://user-images.githubusercontent.com/48160881/228424771-bcaf79d3-eb89-4808-be16-180be4c6317a.jpg)


