### PR TITLE
[Fix] Prevent alwayson_scripts args param resizing script_arg list when they are inserted in it

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -272,7 +272,9 @@ class Api:
                     raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
                 # always on script with no arg should always run so you don't really need to add them to the requests
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
-                    script_args[alwayson_script.args_from:alwayson_script.args_to] = request.alwayson_scripts[alwayson_script_name]["args"]
+                    # min between arg length in scriptrunner and arg length in the request
+                    for idx in range(0, min((alwayson_script.args_to - alwayson_script.args_from), len(request.alwayson_scripts[alwayson_script_name]["args"]))):
+                        script_args[alwayson_script.args_from + idx] = request.alwayson_scripts[alwayson_script_name]["args"][idx]
         return script_args
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

If the length of args in the alwayson_scripts request was smaller then the number of args that the script reserved in script_args, the insertion method would resize script_args. This was probably also a problem before the default_args commit, but since most script need all their args it most likely went under the radar. The only extension I know of that can work with a subset of it's args is controlnet, which was probably fine if you used it in isolation since there used to be Nones in almost every position. Now with default args, when accidently resizing the script_arg list, controlnet was getting values from the script that was next to it in the list which weren't, in some cases, Nones.

With this fix the behavior should be:
If the alwayson args are smaller then the length in the ScriptRunner, they will be put in place from the starting position of the script in script_args and you will have the default values for the rest of the length.
If they are equal, no change from before.
If the alwayson args are longer, they will be clipped to the length in the ScriptRunner.

**Additional notes and description of your changes**

closes #9107
closes https://github.com/Mikubill/sd-webui-controlnet/issues/675

Tested by hand with fastapi and with the controlnet tests, which needed a bit of clean up to bring it up to date with the lastest controlnet args, see https://github.com/Mikubill/sd-webui-controlnet/pull/678.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 2080 8GB