### PR TITLE
feat: use existing virtualenv if already active

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -152,24 +152,31 @@ else
     cd "${clone_dir}"/ || { printf "\e[1m\e[31mERROR: Can't cd to %s/%s/, aborting...\e[0m" "${install_dir}" "${clone_dir}"; exit 1; }
 fi
 
-printf "\n%s\n" "${delimiter}"
-printf "Create and activate python venv"
-printf "\n%s\n" "${delimiter}"
-cd "${install_dir}"/"${clone_dir}"/ || { printf "\e[1m\e[31mERROR: Can't cd to %s/%s/, aborting...\e[0m" "${install_dir}" "${clone_dir}"; exit 1; }
-if [[ ! -d "${venv_dir}" ]]
+if [[ -z "${VIRTUAL_ENV}" ]];
 then
-    "${python_cmd}" -m venv "${venv_dir}"
-    first_launch=1
-fi
-# shellcheck source=/dev/null
-if [[ -f "${venv_dir}"/bin/activate ]]
-then
-    source "${venv_dir}"/bin/activate
+    printf "\n%s\n" "${delimiter}"
+    printf "Create and activate python venv"
+    printf "\n%s\n" "${delimiter}"
+    cd "${install_dir}"/"${clone_dir}"/ || { printf "\e[1m\e[31mERROR: Can't cd to %s/%s/, aborting...\e[0m" "${install_dir}" "${clone_dir}"; exit 1; }
+    if [[ ! -d "${venv_dir}" ]]
+    then
+        "${python_cmd}" -m venv "${venv_dir}"
+        first_launch=1
+    fi
+    # shellcheck source=/dev/null
+    if [[ -f "${venv_dir}"/bin/activate ]]
+    then
+        source "${venv_dir}"/bin/activate
+    else
+        printf "\n%s\n" "${delimiter}"
+        printf "\e[1m\e[31mERROR: Cannot activate python venv, aborting...\e[0m"
+        printf "\n%s\n" "${delimiter}"
+        exit 1
+    fi
 else
     printf "\n%s\n" "${delimiter}"
-    printf "\e[1m\e[31mERROR: Cannot activate python venv, aborting...\e[0m"
+    printf "python venv already activate: ${VIRTUAL_ENV}"
     printf "\n%s\n" "${delimiter}"
-    exit 1
 fi
 
 if [[ ! -z "${ACCELERATE}" ]] && [ ${ACCELERATE}="True" ] && [ -x "$(command -v accelerate)" ]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

- this PR will take into consideration active virtualenv without attempting to create another one

- my use case: [pyenv](https://github.com/pyenv/pyenv/) handles Python versions (and venvs) separate from system-wide Python installations, so the default Python is not necessarily the one I would like to use


**Additional notes and description of your changes**

- check if `$VIRTUAL_ENV` variable and if not then do everything as before.

**Environment this was tested in**

 - OS: macOS 13.3, M1