### PR TITLE
[MacOS] Update torch version on macos script to works with extensions

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -11,7 +11,7 @@ fi
 
 export install_dir="$HOME"
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half-vae --use-cpu interrogate"
-export TORCH_COMMAND="pip install torch==1.12.1 torchvision==0.13.1"
+export TORCH_COMMAND="pip install torch==1.13.1 torchvision==0.14.1"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
 export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"
 export PYTORCH_ENABLE_MPS_FALLBACK=1


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

On macos the script 'webui-macos-env.sh` setting the pytorch version but the version outdated so some extensions doesn't work on macos. 

This PR update the torch version 1.13.1 from 1.12.1

This fix works [sd-dynamic-threshold](https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/issues/15) extentions on MacOS.

**Additional notes and description of your changes**

N/A

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [MacOs with M1 chip]
 - Browser: [chrome]
 - Graphics card: [MacOS M1]

**Screenshots or videos of your changes**

N/A