### PR TITLE
Fix "hasattr" to "in" method when querying a Dictionary

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -375,7 +375,7 @@ def enable_midas_autodownload():
 
 def repair_config(sd_config):
 
-    if not hasattr(sd_config.model.params, "use_ema"):
+    if not "use_ema" in sd_config.model.params:
         sd_config.model.params.use_ema = False
 
     if shared.cmd_opts.no_half:
@@ -387,7 +387,7 @@ def repair_config(sd_config):
         sd_config.model.params.first_stage_config.params.ddconfig.attn_type = "vanilla"
 
     # For UnCLIP-L, override the hardcoded karlo directory
-    if hasattr(sd_config.model.params, "noise_aug_config") and hasattr(sd_config.model.params.noise_aug_config.params, "clip_stats_path"):
+    if "noise_aug_config" in sd_config.model.params and "clip_stats_path" in sd_config.model.params.noise_aug_config.params:
         karlo_path = os.path.join(paths.models_path, 'karlo')
         sd_config.model.params.noise_aug_config.params.clip_stats_path = sd_config.model.params.noise_aug_config.params.clip_stats_path.replace("checkpoints/karlo_models", karlo_path)
 


### PR DESCRIPTION
When running this project on Linux, I noticed that there was always an AttributeError. I found that in the python file "modules/sd_models.py", the "hasattr" method was used to check whether an element exists in a dictionary, but "hasattr" function cannot be used to check for elements in a dictionary. This caused it to always return True, which resulted in the AttributeError being raised consistently.

My OS: Arch Linux x86_64
Environments: Python 3.10.10

![Screenshot from 2023-03-29 23-54-33-pen](https://user-images.githubusercontent.com/47492237/228608776-aba6a51e-0854-4682-bf8c-70760edeaf5c.png)
