### PR TITLE
Small update for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alternatively, use online services (like Google Colab):
 - [List of Online Services](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Online-Services)
 
 ### Automatic Installation on Windows
-1. Install [Python 3.10.6](https://www.python.org/downloads/windows/), checking "Add Python to PATH".
+1. Install [Python 3.10.9](https://www.python.org/downloads/release/python-3109/) (Newer version of Python does not support torch), checking "Add Python to PATH".
 2. Install [git](https://git-scm.com/download/win).
 3. Download the stable-diffusion-webui repository, for example by running `git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui.git`.
 4. Run `webui-user.bat` from Windows Explorer as normal, non-administrator, user.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alternatively, use online services (like Google Colab):
 - [List of Online Services](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Online-Services)
 
 ### Automatic Installation on Windows
-1. Install [Python 3.10.9](https://www.python.org/downloads/release/python-3109/) (Newer version of Python does not support torch), checking "Add Python to PATH".
+1. Install [Python 3.10.6](https://www.python.org/downloads/release/python-3106/) (Newer version of Python does not support torch), checking "Add Python to PATH".
 2. Install [git](https://git-scm.com/download/win).
 3. Download the stable-diffusion-webui repository, for example by running `git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui.git`.
 4. Run `webui-user.bat` from Windows Explorer as normal, non-administrator, user.

--- a/launch.py
+++ b/launch.py
@@ -49,7 +49,7 @@ or any other error regarding unsuccessful package (library) installation,
 please downgrade (or upgrade) to the latest version of 3.10 Python
 and delete current Python and "venv" folder in WebUI's directory.
 
-You can download 3.10 Python from here: https://www.python.org/downloads/release/python-3109/
+You can download 3.10 Python from here: https://www.python.org/downloads/release/python-3106/
 
 {"Alternatively, use a binary release of WebUI: https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases" if is_windows else ""}
 


### PR DESCRIPTION
Small update on readme to remain user that newest python is not compatible with torch. (Not really a issue but it is a life improvement for the audience)
Also update direct url for download as well for the notif info inside launch.py (url given was for 3.10.9)

OS: Windows 11

PS: I first lauch the batch using python 11 and got error, no matter how I change the env it keep searching for py 11 which is wrong, I am assuming the first launch store the path of env py somewhere. Maybe it is a good idea to check it everytime.