### PR TITLE
Extension settings backup/restore feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ notification.mp3
 /test/stdout.txt
 /test/stderr.txt
 /cache.json
+/config_states/

--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -50,7 +50,7 @@ function install_extension_from_index(button, url){
 
 function config_state_confirm_restore(_, config_state_name, config_restore_type) {
     if (config_state_name == "Current") {
-        return [false, config_state_name];
+        return [false, config_state_name, config_restore_type];
     }
     let restored = "";
     if (config_restore_type == "extensions") {
@@ -60,6 +60,12 @@ function config_state_confirm_restore(_, config_state_name, config_restore_type)
     } else {
         restored = "the webui version and all saved extension versions";
     }
-    let confirmed = confirm("Are you sure you want to restore from this state?\nThis will reset " + restored + ".\n(A backup of the current state will be made.)");
+    let confirmed = confirm("Are you sure you want to restore from this state?\nThis will reset " + restored + ".");
+    if (confirmed) {
+        restart_reload();
+        gradioApp().querySelectorAll('#extensions .extension_status').forEach(function(x){
+            x.innerHTML = "Loading..."
+        })
+    }
     return [confirmed, config_state_name, config_restore_type];
 }

--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -47,3 +47,19 @@ function install_extension_from_index(button, url){
 
     gradioApp().querySelector('#install_extension_button').click()
 }
+
+function config_state_confirm_restore(_, config_state_name, config_restore_type) {
+    if (config_state_name == "Current") {
+        return [false, config_state_name];
+    }
+    let restored = "";
+    if (config_restore_type == "extensions") {
+        restored = "all saved extension versions";
+    } else if (config_restore_type == "webui") {
+        restored = "the webui version";
+    } else {
+        restored = "the webui version and all saved extension versions";
+    }
+    let confirmed = confirm("Are you sure you want to restore from this state?\nThis will reset " + restored + ".\n(A backup of the current state will be made.)");
+    return [confirmed, config_state_name, config_restore_type];
+}

--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -1,0 +1,200 @@
+"""
+Supports saving and restoring webui and extensions from a known working set of commits
+"""
+
+import os
+import sys
+import traceback
+import json
+import time
+import tqdm
+
+from datetime import datetime
+from collections import OrderedDict
+import git
+
+from modules import shared, extensions
+from modules.paths_internal import extensions_dir, extensions_builtin_dir, script_path, config_states_dir
+
+
+all_config_states = OrderedDict()
+
+
+def list_config_states():
+    global all_config_states
+
+    all_config_states.clear()
+    os.makedirs(config_states_dir, exist_ok=True)
+
+    config_states = []
+    for filename in os.listdir(config_states_dir):
+        if filename.endswith(".json"):
+            path = os.path.join(config_states_dir, filename)
+            with open(path, "r", encoding="utf-8") as f:
+                j = json.load(f)
+                j["filepath"] = path
+                config_states.append(j)
+
+    config_states = list(sorted(config_states, key=lambda cs: cs["created_at"], reverse=True))
+
+    for cs in config_states:
+        timestamp = time.asctime(time.gmtime(cs["created_at"]))
+        name = cs.get("name", "Config")
+        full_name = f"{name}: {timestamp}"
+        all_config_states[full_name] = cs
+
+    return all_config_states
+
+
+def get_webui_config():
+    webui_repo = None
+
+    try:
+        if os.path.exists(os.path.join(script_path, ".git")):
+            webui_repo = git.Repo(script_path)
+    except Exception:
+        print(f"Error reading webui git info from {script_path}:", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
+
+    webui_remote = None
+    webui_commit_hash = None
+    webui_commit_date = None
+    webui_branch = None
+    if webui_repo and not webui_repo.bare:
+        try:
+            webui_remote = next(webui_repo.remote().urls, None)
+            head = webui_repo.head.commit
+            webui_commit_date = webui_repo.head.commit.committed_date
+            webui_commit_hash = head.hexsha
+            webui_branch = webui_repo.active_branch.name
+
+        except Exception:
+            webui_remote = None
+
+    return {
+        "remote": webui_remote,
+        "commit_hash": webui_commit_hash,
+        "commit_date": webui_commit_date,
+        "branch": webui_branch,
+    }
+
+
+def get_extension_config():
+    ext_config = {}
+
+    for ext in extensions.extensions:
+        entry = {
+            "name": ext.name,
+            "path": ext.path,
+            "enabled": ext.enabled,
+            "is_builtin": ext.is_builtin,
+            "remote": ext.remote,
+            "commit_hash": ext.commit_hash,
+            "commit_date": ext.commit_date,
+            "branch": ext.branch,
+            "have_info_from_repo": ext.have_info_from_repo
+        }
+
+        ext_config[ext.name] = entry
+
+    return ext_config
+
+
+def get_config():
+    creation_time = datetime.now().timestamp()
+    webui_config = get_webui_config()
+    ext_config = get_extension_config()
+
+    return {
+        "created_at": creation_time,
+        "webui": webui_config,
+        "extensions": ext_config
+    }
+
+
+def restore_webui_config(config):
+    print("* Restoring webui state...")
+
+    if "webui" not in config:
+        print("Error: No webui data saved to config")
+        return
+
+    webui_config = config["webui"]
+
+    if "commit_hash" not in webui_config:
+        print("Error: No commit saved to webui config")
+        return
+
+    webui_commit_hash = webui_config.get("commit_hash", None)
+    webui_repo = None
+
+    try:
+        if os.path.exists(os.path.join(script_path, ".git")):
+            webui_repo = git.Repo(script_path)
+    except Exception:
+        print(f"Error reading webui git info from {script_path}:", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
+        return
+
+    try:
+        webui_repo.git.fetch(all=True)
+        webui_repo.git.reset(webui_commit_hash, hard=True)
+        print(f"* Restored webui to commit {webui_commit_hash}.")
+    except Exception:
+        print(f"Error restoring webui to commit {webui_commit_hash}:", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
+
+
+def restore_extension_config(config):
+    print("* Restoring extension state...")
+
+    if "extensions" not in config:
+        print("Error: No extension data saved to config")
+        return
+
+    ext_config = config["extensions"]
+
+    results = []
+    disabled = []
+
+    for ext in tqdm.tqdm(extensions.extensions):
+        if ext.is_builtin:
+            continue
+
+        ext.read_info_from_repo()
+        current_commit = ext.commit_hash
+
+        if ext.name not in ext_config:
+            ext.disabled = True
+            disabled.append(ext.name)
+            results.append((ext, current_commit[:8], False, "Saved extension state not found in config, marking as disabled"))
+            continue
+
+        entry = ext_config[ext.name]
+
+        if "commit_hash" in entry and entry["commit_hash"]:
+            try:
+                ext.fetch_and_reset_hard(entry["commit_hash"])
+                ext.read_info_from_repo()
+                if current_commit != entry["commit_hash"]:
+                    results.append((ext, current_commit[:8], True, entry["commit_hash"][:8]))
+            except Exception as ex:
+                results.append((ext, current_commit[:8], False, ex))
+        else:
+            results.append((ext, current_commit[:8], False, "No commit hash found in config"))
+
+        if not entry.get("enabled", False):
+            ext.disabled = True
+            disabled.append(ext.name)
+        else:
+            ext.disabled = False
+
+    shared.opts.disabled_extensions = disabled
+    shared.opts.save(shared.config_filename)
+
+    print("* Finished restoring extensions. Results:")
+    for ext, prev_commit, success, result in results:
+        if success:
+            print(f"  + {ext.name}: {prev_commit} -> {result}")
+        else:
+            print(f"  ! {ext.name}: FAILURE ({result})")

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -3,10 +3,11 @@ import sys
 import traceback
 
 import time
+from datetime import datetime
 import git
 
 from modules import shared
-from modules.paths_internal import extensions_dir, extensions_builtin_dir
+from modules.paths_internal import extensions_dir, extensions_builtin_dir, script_path
 
 extensions = []
 
@@ -31,12 +32,15 @@ class Extension:
         self.status = ''
         self.can_update = False
         self.is_builtin = is_builtin
+        self.commit_hash = ''
+        self.commit_date = None
         self.version = ''
+        self.branch = None
         self.remote = None
         self.have_info_from_repo = False
 
     def read_info_from_repo(self):
-        if self.have_info_from_repo:
+        if self.is_builtin or self.have_info_from_repo:
             return
 
         self.have_info_from_repo = True
@@ -56,10 +60,15 @@ class Extension:
                 self.status = 'unknown'
                 self.remote = next(repo.remote().urls, None)
                 head = repo.head.commit
-                ts = time.asctime(time.gmtime(repo.head.commit.committed_date))
-                self.version = f'{head.hexsha[:8]} ({ts})'
+                self.commit_date = repo.head.commit.committed_date
+                ts = time.asctime(time.gmtime(self.commit_date))
+                if repo.active_branch:
+                    self.branch = repo.active_branch.name
+                self.commit_hash = head.hexsha
+                self.version = f'{self.commit_hash[:8]} ({ts})'
 
-            except Exception:
+            except Exception as ex:
+                print(f"Failed reading extension data from Git repository ({self.name}): {ex}", file=sys.stderr)
                 self.remote = None
 
     def list_files(self, subdir, extension):
@@ -88,12 +97,12 @@ class Extension:
         self.can_update = False
         self.status = "latest"
 
-    def fetch_and_reset_hard(self):
+    def fetch_and_reset_hard(self, commit='origin'):
         repo = git.Repo(self.path)
         # Fix: `error: Your local changes to the following files would be overwritten by merge`,
         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
         repo.git.fetch(all=True)
-        repo.git.reset('origin', hard=True)
+        repo.git.reset(commit, hard=True)
 
 
 def list_extensions():

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -91,8 +91,19 @@ class Extension:
         for fetch in repo.remote().fetch(dry_run=True):
             if fetch.flags != fetch.HEAD_UPTODATE:
                 self.can_update = True
-                self.status = "behind"
+                self.status = "new commits"
                 return
+
+        try:
+            origin = repo.rev_parse('origin')
+            if repo.head.commit != origin:
+                self.can_update = True
+                self.status = "behind HEAD"
+                return
+        except Exception:
+            self.can_update = False
+            self.status = "unknown (remote error)"
+            return
 
         self.can_update = False
         self.status = "latest"
@@ -103,6 +114,7 @@ class Extension:
         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
         repo.git.fetch(all=True)
         repo.git.reset(commit, hard=True)
+        self.have_info_from_repo = False
 
 
 def list_extensions():

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -20,3 +20,4 @@ data_path = cmd_opts_pre.data_dir
 models_path = os.path.join(data_path, "models")
 extensions_dir = os.path.join(data_path, "extensions")
 extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
+config_states_dir = os.path.join(script_path, "config_states")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -424,6 +424,7 @@ options_templates.update(options_section(('postprocessing', "Postprocessing"), {
 options_templates.update(options_section((None, "Hidden options"), {
     "disabled_extensions": OptionInfo([], "Disable these extensions"),
     "disable_all_extensions": OptionInfo("none", "Disable all extensions (preserves the list of disabled extensions)", gr.Radio, {"choices": ["none", "extra", "all"]}),
+    "restore_config_state_file": OptionInfo("", "Config state file to restore from, under 'config-states/' folder"),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
 }))
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -122,6 +122,16 @@ def check_updates(id_task, disable_list):
     return extension_table(), ""
 
 
+def make_commit_link(commit_hash, remote, text=None):
+    if text is None:
+        text = commit_hash[:8]
+    if remote.startswith("https://github.com/"):
+        href = os.path.join(remote, "commit", commit_hash)
+        return f'<a href="{href}" target="_blank">{text}</a>'
+    else:
+        return text
+
+
 def extension_table():
     code = f"""<!-- {time.time()} -->
     <table id="extensions">
@@ -150,11 +160,15 @@ def extension_table():
         if shared.opts.disable_all_extensions == "extra" and not ext.is_builtin or shared.opts.disable_all_extensions == "all":
             style = STYLE_PRIMARY
 
+        version_link = ext.version
+        if ext.commit_hash and ext.remote:
+            version_link = make_commit_link(ext.commit_hash, ext.remote, ext.version)
+
         code += f"""
             <tr>
                 <td><label{style}><input class="gr-check-radio gr-checkbox" name="enable_{html.escape(ext.name)}" type="checkbox" {'checked="checked"' if ext.enabled else ''}>{html.escape(ext.name)}</label></td>
                 <td>{remote}</td>
-                <td>{ext.version}</td>
+                <td>{version_link}</td>
                 <td{' class="extension_status"' if ext.remote is not None else ''}>{ext_status}</td>
             </tr>
     """
@@ -200,6 +214,9 @@ def update_config_states_table(state_name):
     if current_webui["commit_hash"] != webui_commit_hash:
         style_commit = STYLE_PRIMARY
 
+    commit_link = make_commit_link(webui_commit_hash, webui_remote)
+    date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
+
     code += f"""<h2>Config Backup: {config_name}</h2>
       <div><b>Filepath:</b> {filepath}</div>
       <div><b>Created at:</b> {created_date}</div>"""
@@ -218,8 +235,8 @@ def update_config_states_table(state_name):
             <tr>
                 <td><label{style_remote}>{webui_remote}</label></td>
                 <td><label{style_branch}>{webui_branch}</label></td>
-                <td><label{style_commit}>{webui_commit_hash[:8]}</label></td>
-                <td><label{style_commit}>{webui_commit_date}</label></td>
+                <td><label{style_commit}>{commit_link}</label></td>
+                <td><label{style_commit}>{date_link}</label></td>
             </tr>
         </tbody>
       </table>
@@ -270,13 +287,16 @@ def update_config_states_table(state_name):
             if current_ext.commit_hash != ext_commit_hash:
                 style_commit = STYLE_PRIMARY
 
+            commit_link = make_commit_link(ext_commit_hash, ext_remote)
+            date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
+
         code += f"""
             <tr>
                 <td><label{style_enabled}><input class="gr-check-radio gr-checkbox" type="checkbox" disabled="true" {'checked="checked"' if ext_enabled else ''}>{html.escape(ext_name)}</label></td>
                 <td><label{style_remote}>{remote}</label></td>
                 <td><label{style_branch}>{ext_branch}</label></td>
-                <td><label{style_commit}>{ext_commit_hash[:8]}</label></td>
-                <td><label{style_commit}>{ext_commit_date}</label></td>
+                <td><label{style_commit}>{commit_link}</label></td>
+                <td><label{style_commit}>{date_link}</label></td>
             </tr>
     """
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -201,8 +201,8 @@ def update_config_states_table(state_name):
         style_commit = STYLE_PRIMARY
 
     code += f"""<h2>Config Backup: {config_name}</h2>
-      <span>Filepath: {filepath}</span>
-      <span>Created at: {created_date}</span>"""
+      <div><b>Filepath:</b> {filepath}</div>
+      <div><b>Created at:</b> {created_date}</div>"""
 
     code += f"""<h2>WebUI State</h2>
       <table id="config_state_webui">

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -202,6 +202,10 @@ def update_config_states_table(state_name):
     else:
         webui_commit_date = "<unknown>"
 
+    remote = f"""<a href="{html.escape(webui_remote)}" target="_blank">{html.escape(webui_remote or '')}</a>"""
+    commit_link = make_commit_link(webui_commit_hash, webui_remote)
+    date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
+
     current_webui = config_states.get_webui_config()
 
     style_remote = ""
@@ -213,9 +217,6 @@ def update_config_states_table(state_name):
         style_branch = STYLE_PRIMARY
     if current_webui["commit_hash"] != webui_commit_hash:
         style_commit = STYLE_PRIMARY
-
-    commit_link = make_commit_link(webui_commit_hash, webui_remote)
-    date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
 
     code += f"""<h2>Config Backup: {config_name}</h2>
       <div><b>Filepath:</b> {filepath}</div>
@@ -233,7 +234,7 @@ def update_config_states_table(state_name):
         </thead>
         <tbody>
             <tr>
-                <td><label{style_remote}>{webui_remote}</label></td>
+                <td><label{style_remote}>{remote}</label></td>
                 <td><label{style_branch}>{webui_branch}</label></td>
                 <td><label{style_commit}>{commit_link}</label></td>
                 <td><label{style_commit}>{date_link}</label></td>
@@ -270,6 +271,8 @@ def update_config_states_table(state_name):
             ext_commit_date = "<unknown>"
 
         remote = f"""<a href="{html.escape(ext_remote)}" target="_blank">{html.escape(ext_remote or '')}</a>"""
+        commit_link = make_commit_link(ext_commit_hash, ext_remote)
+        date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
 
         style_enabled = ""
         style_remote = ""
@@ -286,9 +289,6 @@ def update_config_states_table(state_name):
                 style_branch = STYLE_PRIMARY
             if current_ext.commit_hash != ext_commit_hash:
                 style_commit = STYLE_PRIMARY
-
-            commit_link = make_commit_link(ext_commit_hash, ext_remote)
-            date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
 
         code += f"""
             <tr>

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -61,7 +61,7 @@ def save_config_state(name):
     if not name:
         name = "Config"
     current_config_state["name"] = name
-    filename = os.path.join(config_states_dir, datetime.now().strftime("%Y_%m_%d-%H_%M_%S") + ".json")
+    filename = os.path.join(config_states_dir, datetime.now().strftime("%Y_%m_%d-%H_%M_%S") + "_" + name + ".json")
     print(f"Saving backup of webui/extension state to {filename}.")
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(current_config_state, f)
@@ -175,6 +175,7 @@ def update_config_states_table(state_name):
 
     config_name = config_state.get("name", "Config")
     created_date = time.asctime(time.gmtime(config_state["created_at"]))
+    filepath = config_state.get("filepath", "<unknown>")
 
     code = f"""<!-- {time.time()} -->"""
 
@@ -200,6 +201,7 @@ def update_config_states_table(state_name):
         style_commit = STYLE_PRIMARY
 
     code += f"""<h2>Config Backup: {config_name}</h2>
+      <span>Filepath: {filepath}</span>
       <span>Created at: {created_date}</span>"""
 
     code += f"""<h2>WebUI State</h2>

--- a/webui.py
+++ b/webui.py
@@ -116,7 +116,7 @@ def initialize():
             config_state = json.load(f)
             config_states.restore_extension_config(config_state)
         startup_timer.record("restore extension config")
-    else:
+    elif config_state_file:
         print(f"!!! Config state backup not found: {config_state_file}")
 
     if cmd_opts.ui_debug_mode:
@@ -325,7 +325,7 @@ def webui():
                 config_state = json.load(f)
                 config_states.restore_extension_config(config_state)
             startup_timer.record("restore extension config")
-        else:
+        elif config_state_file:
             print(f"!!! Config state backup not found: {config_state_file}")
 
         localization.list_localizations(cmd_opts.localizations_dir)

--- a/webui.py
+++ b/webui.py
@@ -5,6 +5,7 @@ import importlib
 import signal
 import re
 import warnings
+import json
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -37,7 +38,7 @@ if ".dev" in torch.__version__ or "+git" in torch.__version__:
     torch.__long_version__ = torch.__version__
     torch.__version__ = re.search(r'[\d.]+[\d]', torch.__version__).group(0)
 
-from modules import shared, devices, sd_samplers, upscaler, extensions, localization, ui_tempdir, ui_extra_networks
+from modules import shared, devices, sd_samplers, upscaler, extensions, localization, ui_tempdir, ui_extra_networks, config_states
 import modules.codeformer_model as codeformer
 import modules.face_restoration
 import modules.gfpgan_model as gfpgan
@@ -104,6 +105,17 @@ def initialize():
     extensions.list_extensions()
     localization.list_localizations(cmd_opts.localizations_dir)
     startup_timer.record("list extensions")
+
+    config_state_file = shared.opts.restore_config_state_file
+    shared.opts.restore_config_state_file = ""
+    shared.opts.save(shared.config_filename)
+
+    if os.path.isfile(config_state_file):
+        print(f"*** About to restore extension state from file: {config_state_file}")
+        with open(config_state_file, "r", encoding="utf-8") as f:
+            config_state = json.load(f)
+            config_states.restore_extension_state(config_state)
+        startup_timer.record("restore extension config")
 
     if cmd_opts.ui_debug_mode:
         shared.sd_upscalers = upscaler.UpscalerLanczos().scalers
@@ -300,6 +312,17 @@ def webui():
         modules.script_callbacks.script_unloaded_callback()
         extensions.list_extensions()
         startup_timer.record("list extensions")
+
+        config_state_file = shared.opts.restore_config_state_file
+        shared.opts.restore_config_state_file = ""
+        shared.opts.save(shared.config_filename)
+
+        if os.path.isfile(config_state_file):
+            print(f"*** About to restore extension state from file: {config_state_file}")
+            with open(config_state_file, "r", encoding="utf-8") as f:
+                config_state = json.load(f)
+                config_states.restore_extension_state(config_state)
+            startup_timer.record("restore extension config")
 
         localization.list_localizations(cmd_opts.localizations_dir)
 

--- a/webui.py
+++ b/webui.py
@@ -114,8 +114,10 @@ def initialize():
         print(f"*** About to restore extension state from file: {config_state_file}")
         with open(config_state_file, "r", encoding="utf-8") as f:
             config_state = json.load(f)
-            config_states.restore_extension_state(config_state)
+            config_states.restore_extension_config(config_state)
         startup_timer.record("restore extension config")
+    else:
+        print(f"!!! Config state backup not found: {config_state_file}")
 
     if cmd_opts.ui_debug_mode:
         shared.sd_upscalers = upscaler.UpscalerLanczos().scalers
@@ -321,8 +323,10 @@ def webui():
             print(f"*** About to restore extension state from file: {config_state_file}")
             with open(config_state_file, "r", encoding="utf-8") as f:
                 config_state = json.load(f)
-                config_states.restore_extension_state(config_state)
+                config_states.restore_extension_config(config_state)
             startup_timer.record("restore extension config")
+        else:
+            print(f"!!! Config state backup not found: {config_state_file}")
 
         localization.list_localizations(cmd_opts.localizations_dir)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

With the recent breaking changes and lots of issues where people are wondering which webui commit was working last, I think it's a good idea to have an ability to backup the list of webui and extension commits to they can be restored later. This adds a new `Backup/Restore` section to the `Extensions` tab that accomplishes that.

How it works:

1. Go to the tab and click `Save Current Config` to save the state of your webui/extensions to a JSON in the `config_states` folder. Alternately the state is backed up just before you update webui extensions when restarting. This state is also useful for a debugging purpose
2. If you want to revert to a previous state, pick an option from the dropdown in the tab. It will show you the webui/extension commits and the changes from the current version.
3. Pick `extensions`, `webui` or `both` for what type of restore to run.
4. Click `Restore Selected Config` to go back to that config. Webui commit gets restored just before the app restarts. Extensions are restored afterwards, during the startup phase

<details>
<summary>Example logs</summary>

```
*** Restoring webui state from backup: extensions ***
Closing server running on port: 7861
Restarting UI...
*** About to restore extension state from file: E:\sd\config_states\2023_03_29-04_13_22_PM.json
* Restoring extension state...
  6%|█████▎                                                                             | 3/47 [00:03<00:50,  1.14s/it]Failed reading extension data from Git repository (a1111-stable-diffusion-webui-randomizer-keywords): Remote named 'origin' didn't exist
Failed reading extension data from Git repository (a1111-stable-diffusion-webui-vram-estimator): Remote named 'origin' didn't exist
 77%|██████████████████████████████████████████████████████████████▊                   | 36/47 [00:34<00:09,  1.15it/s]Failed reading extension data from Git repository (stable-diffusion-webui-vram-alerts): Remote named 'origin' didn't exist
100%|██████████████████████████████████████████████████████████████████████████████████| 47/47 [00:37<00:00,  1.24it/s]
* Finished restoring extensions. Results:
  + a1111-sd-webui-tagcomplete: 811d4622 -> 296b9456
  ! a1111-stable-diffusion-webui-randomizer-keywords: FAILURE (No commit hash found in config)
  ! a1111-stable-diffusion-webui-vram-estimator: FAILURE (No commit hash found in config)
  + sd-dynamic-prompts: 59f44e93 -> c000db92
  + sd-dynamic-thresholding: 8f18058b -> 7a9f2694
  + sd-extension-system-info: d5aa5010 -> be86e562
  + sd-webui-3d-open-pose-editor: 99f3e80d -> ec76ab6e
  + sd-webui-additional-networks: 59a72abc -> d2758b6c
  ! stable-diffusion-webui-send-to-filter: FAILURE (No commit hash found in config)
  ! stable-diffusion-webui-vram-alerts: FAILURE (No commit hash found in config)
```

</details>

**Additional notes and description of your changes**

This was implemented with reading and storing lots of `.git` metadata

I don't think this works as its own extension since it taps into the reload/restart cycle of webui, and I needed to add some new fields to the `Extension` class for tracking Git info

The logs above show that the restore will only work if there's a valid `.git` remote with the name `origin`, since that's the default name. If the extension has a custom remote name then this won't work right now, but that should only happen if you're developing new extensions in the extension folder instead of installing them from the UI

Also, changed extension status to reflect if the origin has new commits or HEAD was reset to an earlier commit but fetch is up-to-date

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

<img width="947" alt="2023-03-29 19_38_04-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/228692523-6a84f00f-b896-420f-adc8-8b8d5a64f021.png">