### PR TITLE
Fix mismatch in api argument list length

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -272,7 +272,8 @@ class Api:
                     raise HTTPException(status_code=422, detail=f"Cannot have a selectable script in the always on scripts params")
                 # always on script with no arg should always run so you don't really need to add them to the requests
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
-                    script_args[alwayson_script.args_from:alwayson_script.args_to] = request.alwayson_scripts[alwayson_script_name]["args"]
+                    this_script_args = request.alwayson_scripts[alwayson_script_name]["args"]
+                    script_args[alwayson_script.args_from:alwayson_script.args_from+len(this_script_args)] = this_script_args
         return script_args
 
     def text2imgapi(self, txt2imgreq: StableDiffusionTxt2ImgProcessingAPI):


### PR DESCRIPTION
The length of the args list in an api request may not match the difference between `alwayson_script.args_from` and `args_to`.

# To reproduce:

- Use the controlnet extension via the api
- set `control_net_max_models_num` to 2
- call the api with parameters set only for the first model (pass `controlnet_model` etc but not `controlnet2_model` etc)

In `api.py`, `default_script_args` allocates two entries in the list for the two possible controlnet arg sets. But  `request.alwayson_scripts[alwayson_script_name]["args"]` is a list of length 1. So `script_args` gets broken at line 275, resulting in downstream exceptions and the failure of the script.

# To fix:

Fix is simply to replace only the first `n` of the allocated entries in `default_script_args`, leaving others at default values.

# Isn't this a bug in the extension?

It could be argued that the bug is in the extension; that it should require all possible parameter sets to be passed, or provide them if not. However, fixing it here makes the code more robust to potentially hard-to-trace bugs in this extension or others.