### PR TITLE
add `--lazy-load` command line argument

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -33,6 +33,7 @@ parser.add_argument("--allow-code", action='store_true', help="allow custom scri
 parser.add_argument("--medvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a little speed for low VRM usage")
 parser.add_argument("--lowvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a lot of speed for very low VRM usage")
 parser.add_argument("--lowram", action='store_true', help="load stable diffusion checkpoint weights to VRAM instead of RAM")
+parser.add_argument("--lazy-load", action='store_true', help="lazy load stable diffusion checkpoint weights at startup")
 parser.add_argument("--always-batch-cond-uncond", action='store_true', help="disables cond/uncond batching that is enabled to save memory with --medvram or --lowvram")
 parser.add_argument("--unload-gfpgan", action='store_true', help="does not do anything.")
 parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast")

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -210,7 +210,6 @@ class StableDiffusionModelHijack:
     def undo_hijack(self, m):
         if not self.weights_loaded:
             return
-        self.weights_loaded = False
         if type(m.cond_stage_model) == xlmr.BertSeriesModelWithTransformation:
             m.cond_stage_model = m.cond_stage_model.wrapped 
 

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -161,13 +161,13 @@ class StableDiffusionModelHijack:
         model_class = type(m)
         @property
         def _lazyload_attr_cond_stage_model(self):
-            self.undo_lazyload(m)
+            model_hijack.undo_lazyload(m)
             modules.sd_models.load_model()
             self.__dict__ = shared.sd_model.__dict__
             return shared.sd_model.cond_stage_model
         @property
         def _lazyload_attr_model(self):
-            self.undo_lazyload(m)
+            model_hijack.undo_lazyload(m)
             modules.sd_models.load_model()
             self.__dict__ = shared.sd_model.__dict__
             return shared.sd_model.model

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -487,6 +487,10 @@ def reload_model_weights(sd_model=None, info=None):
 
     if sd_model is None:  # previous model load failed
         current_checkpoint_info = None
+    elif not sd_hijack.model_hijack.weights_loaded:
+        current_checkpoint_info = sd_model.sd_checkpoint_info
+        sd_hijack.model_hijack.undo_lazyload(sd_model)
+        sd_model = None
     else:
         current_checkpoint_info = sd_model.sd_checkpoint_info
         if sd_model.sd_model_checkpoint == checkpoint_info.filename:

--- a/webui.py
+++ b/webui.py
@@ -146,7 +146,7 @@ def initialize():
 
     shared.opts.data["sd_model_checkpoint"] = shared.sd_model.sd_checkpoint_info.title
 
-    shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()))
+    shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()), call=False)
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("temp_dir", ui_tempdir.on_tmpdir_changed)

--- a/webui.py
+++ b/webui.py
@@ -307,8 +307,9 @@ def webui():
         modules.scripts.reload_scripts()
         startup_timer.record("load scripts")
 
-        modules.script_callbacks.model_loaded_callback(shared.sd_model)
-        startup_timer.record("model loaded callback")
+        if modules.sd_hijack.model_hijack.weights_loaded:
+            modules.script_callbacks.model_loaded_callback(shared.sd_model)
+            startup_timer.record("model loaded callback")
 
         modelloader.load_upscalers()
         startup_timer.record("load upscalers")

--- a/webui.py
+++ b/webui.py
@@ -136,7 +136,7 @@ def initialize():
     startup_timer.record("refresh textual inversion templates")
 
     try:
-        modules.sd_models.load_model()
+        modules.sd_models.load_model(lazy_load=cmd_opts.lazy_load)
     except Exception as e:
         errors.display(e, "loading stable diffusion model")
         print("", file=sys.stderr)


### PR DESCRIPTION

**Describe what this pull request is trying to achieve.**

https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9138

I hope to add a lazy startup command line argument (` --lazy-load`) that loads the weights only when they are needed for the first time to save startup time and RAM.

**Additional notes and description of your changes**

I use the `@property` decorator to load the model weights when the `cond_stage_model` and `model` attributes of `sd_model` are read for the first time.

Only safetensors are supported, because safetensors support loading `state_dict` without loading all parameters, and we need `state_dict` to find the config file before applying weights to model.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 22H2
 - Browser: Chrome 111.0.5563.65
 - Graphics card: NVIDIA GTX 1660Ti 6G

**Screenshots or videos of your changes**

![image](https://user-images.githubusercontent.com/51732678/228841204-3bab34e8-2f46-47af-a3f8-f6a6b73ef4bc.png)
