### PR TITLE
fix metadata in extras

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -49,8 +49,6 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
     for image, name in zip(image_data, image_names):
         shared.state.textinfo = name
 
-        existing_pnginfo = image.info or {}
-
         pp = scripts_postprocessing.PostprocessedImage(image.convert("RGB"))
 
         scripts.scripts_postproc.run(pp, args)
@@ -63,11 +61,13 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         infotext = ", ".join([k if k == v else f'{k}: {generation_parameters_copypaste.quote(v)}' for k, v in pp.info.items() if v is not None])
 
         if opts.enable_pnginfo:
-            pp.image.info = existing_pnginfo
+            _geninfo, items = images.read_info_from_image(image)
+            for k, v in items.items():
+                pp.image.info[k] = v
             pp.image.info["postprocessing"] = infotext
 
         if save_output:
-            images.save_image(pp.image, path=outpath, basename=basename, seed=None, prompt=None, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=None)
+            images.save_image(pp.image, path=outpath, basename=basename, seed=None, prompt=None, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=pp.image.info, forced_filename=None)
 
         if extras_mode != 2 or show_extras_results:
             outputs.append(pp.image)


### PR DESCRIPTION
currently **extras** when loading image simply takes existing `exif` metadata and without any decoding (its an encoded bytearray per exif standard) adds it to output `pnginfo` section thus creating a PNG file with invalid info section.

this pr simply reuses existing metadata parser so its actually used when loading image in extras tab.

example workflow that results in image with corrupt pnginfo:
1. select any JPG with pre-existing metadata
2. load it into WebUI Extras tab
3. perform a task (upscale, face restore, anything)
4. save as PNG

example resulting image metadata - see how exif data is embedded as string in pnginfo and is non-parsable in future ops:
```log
format: PNG
metadata: {
'exif': "b'Exif\x00\x00II*\x00\x08\x00\x00\x00\x04\x00\x12\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x001\x01\x02\x00\x11\x00\x00\x00>\x00\x00\x00\x13\x02\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00i\x87\x04\x00\x01\x00\x00\x00P\x00\x00\x00\x00\x00\x00\x00Shotwell 0.30.16\x00\x00\x03\x00\x90\x92\x02\x00\x04\x00\x00\x00442\x00\x02\xa0\t\x00\x01\x00\x00\x00u\x02\x00\x00\x03\xa0\t\x00\x01\x00\x00\x00\xd5\x03\x00\x00\x00\x00\x00\x00'",
'postprocessing': 'Postprocess upscale to: 2560x2560, Postprocess upscaler: 4x-AnimeSharp, Postprocess upscaler 2: RealESRGAN_x4plus_anime_6B', 'extras': 'Postprocess upscale to: 2560x2560, Postprocess upscaler: 4x-AnimeSharp, Postprocess upscaler 2: RealESRGAN_x4plus_anime_6B'
```

closes #8142, #9078 and possibly others