### PR TITLE
print Exception for Fix #9185 add message

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 import numpy as np
-from PIL import Image, ImageOps, ImageFilter, ImageEnhance, ImageChops
+from PIL import Image, ImageOps, ImageFilter, ImageEnhance, ImageChops, UnidentifiedImageError
 
 from modules import devices, sd_samplers
 from modules.generation_parameters_copypaste import create_override_settings_dict
@@ -46,7 +46,10 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
         if state.interrupted:
             break
 
-        img = Image.open(image)
+        try:
+            img = Image.open(image)
+        except UnidentifiedImageError:
+            continue
         # Use the EXIF orientation of photos taken by smartphones.
         img = ImageOps.exif_transpose(img)
         p.init_images = [img] * p.batch_size


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fix the exception beeing thrown when a file in the source directory of the (img2img > batch) tab is not an image, has improper format or is not supported by Pillow.
A simple try/except/continue to skip that file if PIL.UnidentifiedImageError is raised during PIL.Image.open().

**Additional notes and description of your changes**

Filtering the list for appropriate image extensions is not the best approach (see details in issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9185)

**Environment this was tested in**

 - OS: Windows 10
 - Browser: Firefox latest
 - Graphics card: NVIDIA GTX 1024 Ti 11GB