### PR TITLE
fix disappearing live previews and progressbar during slow tasks

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -138,7 +138,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
                 return
             }
 
-            if(elapsedFromStart > 20 && !res.queued && !res.active){
+            if(elapsedFromStart > 40 && !res.queued && !res.active){
                 removeProgressBar()
                 return
             }

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -138,7 +138,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
                 return
             }
 
-            if(elapsedFromStart > 5 && !res.queued && !res.active){
+            if(elapsedFromStart > 20 && !res.queued && !res.active){
                 removeProgressBar()
                 return
             }


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes disappearing live previews and progress bar for tasks that are too slow to start.

**Additional notes and description of your changes**

After pressing "Generate" button frontend pulls progress for exactly 5 seconds before giving up. Some tasks take a bit longer to start, which results in missing progress bar and live previews for a client. This pull request simple increases wait time from 5s to 40s, which to my observations is enough to start any task.

UPD: My initial assumption that the tasks themselves were too slow to start was wrong. Turns out it was the huge image upload that was the problem. I'm connecting to the api remotely and my internet is not always fast, especially when it comes to uploading giant upscaled PNG images. In any case, this PR fixes my problem so i think it should stay.

**Environment this was tested in**

 - OS: Linux
 - Browser: chromium (brave)
 - Graphics card: NVIDIA RTX 3060 12GB