### PR TITLE
bug: Outpainting Mk2 & Poorman should use the SAMPLE file format to save images, not GRID file format

### DIFF
--- a/scripts/outpainting_mk_2.py
+++ b/scripts/outpainting_mk_2.py
@@ -275,7 +275,7 @@ class Script(scripts.Script):
 
         if opts.samples_save:
             for img in all_processed_images:
-                images.save_image(img, p.outpath_samples, "", res.seed, p.prompt, opts.grid_format, info=res.info, p=p)
+                images.save_image(img, p.outpath_samples, "", res.seed, p.prompt, opts.samples_format, info=res.info, p=p)
 
         if opts.grid_save and not unwanted_grid_because_of_img_count:
             images.save_image(combined_grid_image, p.outpath_grids, "grid", res.seed, p.prompt, opts.grid_format, info=res.info, short_filename=not opts.grid_extended_filename, grid=True, p=p)

--- a/scripts/poor_mans_outpainting.py
+++ b/scripts/poor_mans_outpainting.py
@@ -138,7 +138,7 @@ class Script(scripts.Script):
         combined_image = images.combine_grid(grid)
 
         if opts.samples_save:
-            images.save_image(combined_image, p.outpath_samples, "", initial_seed, p.prompt, opts.grid_format, info=initial_info, p=p)
+            images.save_image(combined_image, p.outpath_samples, "", initial_seed, p.prompt, opts.samples_format, info=initial_info, p=p)
 
         processed = Processed(p, [combined_image], initial_seed, initial_info)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

There's a bug where the Outpainting Mk2 & Poorman scripts incorrectly use the GRID file format `opts.grid_format` to save sample images. But they should use the SAMPLE file format `opts.samples_format` to save.

**Additional notes and description of your changes**

Related to issue #9255 

**Environment this was tested in**

Windows
Chrome
RTX3090 25GB
