### PR TITLE
Add bf16 support for VAE as a fallback

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -101,4 +101,3 @@ parser.add_argument("--no-gradio-queue", action='store_true', help="Disables gra
 parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
-parser.add_argument("--rollback-vae", action='store_true', help="trying to roll back vae when produced nan image, need to enable nan check", default=False)

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -61,7 +61,7 @@ parser.add_argument("--opt-split-attention-v1", action='store_true', help="enabl
 parser.add_argument("--opt-sdp-attention", action='store_true', help="enable scaled dot product cross-attention layer optimization; requires PyTorch 2.*")
 parser.add_argument("--opt-sdp-no-mem-attention", action='store_true', help="enable scaled dot product cross-attention layer optimization without memory efficient attention, makes image generation deterministic; requires PyTorch 2.*")
 parser.add_argument("--disable-opt-split-attention", action='store_true', help="force-disables cross-attention layer optimization")
-parser.add_argument("--disable-nan-check", action='store_true', help="do not check if produced images/latent spaces have nans; useful for running without a checkpoint in CI")
+parser.add_argument("--disable-nan-check", action='store_true', help="do not check if produced images/latent spaces have nans and disable vae auto-conversion; useful for running without a checkpoint in CI")
 parser.add_argument("--use-cpu", nargs='+', help="use CPU as torch device for specified modules", default=[], type=str.lower)
 parser.add_argument("--listen", action='store_true', help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests")
 parser.add_argument("--port", type=int, help="launch gradio with given server port, you need root/admin rights for ports < 1024, defaults to 7860 if available", default=None)

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -101,3 +101,4 @@ parser.add_argument("--no-gradio-queue", action='store_true', help="Disables gra
 parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
+parser.add_argument("--rollback-vae", action='store_true', help="trying to roll back vae when produced nan image, need to enable nan check", default=False)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -11,6 +11,7 @@ import random
 import cv2
 from skimage import exposure
 from typing import Any, Dict, List, Optional
+from packaging import version
 
 import modules.sd_hijack
 from modules import devices, prompt_parser, masking, sd_samplers, lowvram, generation_parameters_copypaste, script_callbacks, extra_networks, sd_vae_approx, scripts
@@ -657,7 +658,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 for x in x_samples_ddim:
                     devices.test_for_nans(x, "vae")
             except devices.NansException as e:
-                if not shared.cmd_opts.no_half and not shared.cmd_opts.no_half_vae and shared.cmd_opts.rollback_vae:
+                if devices.dtype_vae == torch.float16 and version.parse(torch.__version__) >= version.parse('2.1') and torch.cuda.is_bf16_supported():
                     print('\nA tensor with all NaNs was produced in VAE, try converting to bf16.')
                     devices.dtype_vae = torch.bfloat16
                     vae_file, vae_source = sd_vae.resolve_vae(p.sd_model.sd_model_checkpoint)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -657,7 +657,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 for x in x_samples_ddim:
                     devices.test_for_nans(x, "vae")
             except devices.NansException as e:
-                if not shared.cmd_opts.no_half and not shared.cmd_opts.no_half_vae and torch.cuda.get_device_capability()[0] >= 8:
+                if not shared.cmd_opts.no_half and not shared.cmd_opts.no_half_vae and shared.cmd_opts.rollback_vae:
                     print('\nA tensor with all NaNs was produced in VAE, try converting to bf16.')
                     devices.dtype_vae = torch.bfloat16
                     vae_file, vae_source = sd_vae.resolve_vae(p.sd_model.sd_model_checkpoint)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -653,8 +653,20 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 samples_ddim = p.sample(conditioning=c, unconditional_conditioning=uc, seeds=seeds, subseeds=subseeds, subseed_strength=p.subseed_strength, prompts=prompts)
 
             x_samples_ddim = [decode_first_stage(p.sd_model, samples_ddim[i:i+1].to(dtype=devices.dtype_vae))[0].cpu() for i in range(samples_ddim.size(0))]
-            for x in x_samples_ddim:
-                devices.test_for_nans(x, "vae")
+            try:
+                for x in x_samples_ddim:
+                    devices.test_for_nans(x, "vae")
+            except devices.NansException as e:
+                if not shared.cmd_opts.no_half and not shared.cmd_opts.no_half_vae and torch.cuda.get_device_capability()[0] >= 8:
+                    print('\nA tensor with all NaNs was produced in VAE, try converting to bf16.')
+                    devices.dtype_vae = torch.bfloat16
+                    vae_file, vae_source = sd_vae.resolve_vae(p.sd_model.sd_model_checkpoint)
+                    sd_vae.load_vae(p.sd_model, vae_file, vae_source)
+                    x_samples_ddim = [decode_first_stage(p.sd_model, samples_ddim[i:i+1].to(dtype=devices.dtype_vae))[0].cpu() for i in range(samples_ddim.size(0))]
+                    for x in x_samples_ddim:
+                        devices.test_for_nans(x, "vae")
+                else:
+                    raise e
 
             x_samples_ddim = torch.stack(x_samples_ddim).float()
             x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -183,8 +183,6 @@ unspecified = object()
 def reload_vae_weights(sd_model=None, vae_file=unspecified):
     from modules import lowvram, devices, sd_hijack
 
-    if shared.cmd_opts.rollback_vae and devices.dtype_vae == torch.bfloat16:
-        devices.dtype_vae = torch.float16
     if not sd_model:
         sd_model = shared.sd_model
 
@@ -205,6 +203,8 @@ def reload_vae_weights(sd_model=None, vae_file=unspecified):
         sd_model.to(devices.cpu)
 
     sd_hijack.model_hijack.undo_hijack(sd_model)
+    if shared.cmd_opts.rollback_vae and devices.dtype_vae == torch.bfloat16:
+        devices.dtype_vae = torch.float16
 
     load_vae(sd_model, vae_file, vae_source)
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -183,7 +183,7 @@ unspecified = object()
 def reload_vae_weights(sd_model=None, vae_file=unspecified):
     from modules import lowvram, devices, sd_hijack
 
-    if devices.dtype_vae == torch.bfloat16:
+    if shared.cmd_opts.rollback_vae and devices.dtype_vae == torch.bfloat16:
         devices.dtype_vae = torch.float16
     if not sd_model:
         sd_model = shared.sd_model

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -183,6 +183,8 @@ unspecified = object()
 def reload_vae_weights(sd_model=None, vae_file=unspecified):
     from modules import lowvram, devices, sd_hijack
 
+    if devices.dtype_vae == torch.bfloat16:
+        devices.dtype_vae = torch.float16
     if not sd_model:
         sd_model = shared.sd_model
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -203,7 +203,7 @@ def reload_vae_weights(sd_model=None, vae_file=unspecified):
         sd_model.to(devices.cpu)
 
     sd_hijack.model_hijack.undo_hijack(sd_model)
-    if shared.cmd_opts.rollback_vae and devices.dtype_vae == torch.bfloat16:
+    if not shared.cmd_opts.disable_nan_check and devices.device != devices.cpu and devices.dtype_vae == torch.bfloat16:
         devices.dtype_vae = torch.float16
 
     load_vae(sd_model, vae_file, vae_source)

--- a/webui.py
+++ b/webui.py
@@ -98,22 +98,8 @@ Use --skip-version-check commandline argument to disable this check.
             """.strip())
 
 
-def check_rollback_vae():
-    if devices.device == devices.cpu:
-        print("Rollback VAE does not support CPU devices and will not work.")
-        shared.cmd_opts.rollback_vae = False
-    elif shared.cmd_opts.rollback_vae:
-        if version.parse(torch.__version__) < version.parse('2.1'):
-            print("If your PyTorch version is lower than PyTorch 2.1, Rollback VAE will not work.")
-            shared.cmd_opts.rollback_vae = False
-        elif 0 < torch.cuda.get_device_capability()[0] < 8:
-            print('Rollback VAE will not work because your device does not support it.')
-            shared.cmd_opts.rollback_vae = False
-
-
 def initialize():
     check_versions()
-    check_rollback_vae()
 
     extensions.list_extensions()
     localization.list_localizations(cmd_opts.localizations_dir)

--- a/webui.py
+++ b/webui.py
@@ -97,8 +97,12 @@ To reinstall the desired version, run with commandline flag --reinstall-xformers
 Use --skip-version-check commandline argument to disable this check.
             """.strip())
 
+
 def check_rollback_vae():
-    if shared.cmd_opts.rollback_vae:
+    if devices.device == devices.cpu:
+        print("Rollback VAE does not support CPU devices and will not work.")
+        shared.cmd_opts.rollback_vae = False
+    elif shared.cmd_opts.rollback_vae:
         if version.parse(torch.__version__) < version.parse('2.1'):
             print("If your PyTorch version is lower than PyTorch 2.1, Rollback VAE will not work.")
             shared.cmd_opts.rollback_vae = False

--- a/webui.py
+++ b/webui.py
@@ -97,9 +97,19 @@ To reinstall the desired version, run with commandline flag --reinstall-xformers
 Use --skip-version-check commandline argument to disable this check.
             """.strip())
 
+def check_rollback_vae():
+    if shared.cmd_opts.rollback_vae:
+        if version.parse(torch.__version__) < version.parse('2.1'):
+            print("If your PyTorch version is lower than PyTorch 2.1, Rollback VAE will not work.")
+            shared.cmd_opts.rollback_vae = False
+        elif 0 < torch.cuda.get_device_capability()[0] < 8:
+            print('Rollback VAE will not work because your device does not support it.')
+            shared.cmd_opts.rollback_vae = False
+
 
 def initialize():
     check_versions()
+    check_rollback_vae()
 
     extensions.list_extensions()
     localization.list_localizations(cmd_opts.localizations_dir)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

According to the description [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/8691#discussioncomment-5401353), bf16 can solve the problem of VAE working in half precision to generate black images, so I made this commit.

**Additional notes and description of your changes**

bf16 is great to use as a fallback, when the webui detects an empty image generation, it tries to convert and retry on supported devices, works fine on my test case. Note that if you want to use this feature, you need to use a GPU that supports bf16 and the webui works on PyTorch 2.1. For unsupported devices, you can still only use `--no-half-vae`.

**Edit**: In theory, AMD GPUs are also supported.

**Environment this was tested in**

 - OS: Win
 - Browser: chrome
 - Graphics card: NVIDIA Ampere GPU
