### PR TITLE
Embed model merge metadata in .safetensors file

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -263,6 +263,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
         metadata["merge_recipe"] = json.dumps(merge_recipe)
 
         def add_model_metadata(checkpoint_info):
+            checkpoint_info.calculate_shorthash()
             metadata["models"][checkpoint_info.sha256] = {
                 "name": checkpoint_info.name,
                 "legacy_hash": checkpoint_info.hash,

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import json
 
 
 import torch
@@ -71,7 +72,7 @@ def to_half(tensor, enable):
     return tensor
 
 
-def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_model_name, interp_method, multiplier, save_as_half, custom_name, checkpoint_format, config_source, bake_in_vae, discard_weights):
+def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_model_name, interp_method, multiplier, save_as_half, custom_name, checkpoint_format, config_source, bake_in_vae, discard_weights, save_metadata):
     shared.state.begin()
     shared.state.job = 'model-merge'
 
@@ -241,13 +242,52 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     shared.state.textinfo = "Saving"
     print(f"Saving to {output_modelname}...")
 
+    metadata = {"format": "pt", "models": {}, "merge_recipe": None}
+
+    if save_metadata:
+        merge_recipe = {
+            "primary_model_hash": primary_model_info.sha256,
+            "secondary_model_hash": secondary_model_info.sha256 if secondary_model_info else None,
+            "tertiary_model_hash": tertiary_model_info.sha256 if tertiary_model_info else None,
+            "interp_method": interp_method,
+            "multiplier": multiplier,
+            "save_as_half": save_as_half,
+            "custom_name": custom_name,
+            "config_source": config_source,
+            "bake_in_vae": bake_in_vae,
+            "discard_weights": discard_weights,
+            "is_inpainting": result_is_inpainting_model,
+            "is_instruct_pix2pix": result_is_instruct_pix2pix_model
+        }
+        metadata["merge_recipe"] = json.dumps(merge_recipe)
+
+        def add_model_metadata(checkpoint_info):
+            metadata["models"][checkpoint_info.sha256] = {
+                "name": checkpoint_info.name,
+                "legacy_hash": checkpoint_info.hash,
+                "merge_recipe": checkpoint_info.metadata.get("merge_recipe", None)
+            }
+
+            metadata["models"].update(checkpoint_info.metadata.get("models", {}))
+
+        add_model_metadata(primary_model_info)
+        if secondary_model_info:
+            add_model_metadata(secondary_model_info)
+        if tertiary_model_info:
+            add_model_metadata(tertiary_model_info)
+
+        metadata["models"] = json.dumps(metadata["models"])
+
     _, extension = os.path.splitext(output_modelname)
     if extension.lower() == ".safetensors":
-        safetensors.torch.save_file(theta_0, output_modelname, metadata={"format": "pt"})
+        safetensors.torch.save_file(theta_0, output_modelname, metadata=metadata)
     else:
         torch.save(theta_0, output_modelname)
 
     sd_models.list_models()
+    created_model = next((ckpt for ckpt in sd_models.checkpoints_list.values() if ckpt.name == filename), None)
+    if created_model:
+        created_model.calculate_shorthash()
 
     create_config(output_modelname, config_source, primary_model_info, secondary_model_info, tertiary_model_info)
 

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -246,6 +246,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     if save_metadata:
         merge_recipe = {
+            "type": "webui", # indicate this model was merged with webui's built-in merger
             "primary_model_hash": primary_model_info.sha256,
             "secondary_model_hash": secondary_model_info.sha256 if secondary_model_info else None,
             "tertiary_model_hash": tertiary_model_info.sha256 if tertiary_model_info else None,

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -242,7 +242,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     shared.state.textinfo = "Saving"
     print(f"Saving to {output_modelname}...")
 
-    metadata = {"format": "pt", "models": {}, "merge_recipe": None}
+    metadata = {"format": "pt", "sd_merge_models": {}, "sd_merge_recipe": None}
 
     if save_metadata:
         merge_recipe = {
@@ -260,17 +260,17 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
             "is_inpainting": result_is_inpainting_model,
             "is_instruct_pix2pix": result_is_instruct_pix2pix_model
         }
-        metadata["merge_recipe"] = json.dumps(merge_recipe)
+        metadata["sd_merge_recipe"] = json.dumps(merge_recipe)
 
         def add_model_metadata(checkpoint_info):
             checkpoint_info.calculate_shorthash()
-            metadata["models"][checkpoint_info.sha256] = {
+            metadata["sd_merge_models"][checkpoint_info.sha256] = {
                 "name": checkpoint_info.name,
                 "legacy_hash": checkpoint_info.hash,
-                "merge_recipe": checkpoint_info.metadata.get("merge_recipe", None)
+                "sd_merge_recipe": checkpoint_info.metadata.get("sd_merge_recipe", None)
             }
 
-            metadata["models"].update(checkpoint_info.metadata.get("models", {}))
+            metadata["sd_merge_models"].update(checkpoint_info.metadata.get("sd_merge_models", {}))
 
         add_model_metadata(primary_model_info)
         if secondary_model_info:
@@ -278,7 +278,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
         if tertiary_model_info:
             add_model_metadata(tertiary_model_info)
 
-        metadata["models"] = json.dumps(metadata["models"])
+        metadata["sd_merge_models"] = json.dumps(metadata["sd_merge_models"])
 
     _, extension = os.path.splitext(output_modelname)
     if extension.lower() == ".safetensors":

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -52,6 +52,15 @@ class CheckpointInfo:
 
         self.ids = [self.hash, self.model_name, self.title, name, f'{name} [{self.hash}]'] + ([self.shorthash, self.sha256, f'{self.name} [{self.shorthash}]'] if self.shorthash else [])
 
+        self.metadata = {}
+
+        _, ext = os.path.splitext(self.filename)
+        if ext.lower() == ".safetensors":
+            try:
+                self.metadata = read_metadata_from_safetensors(filename)
+            except Exception as e:
+                errors.display(e, f"reading checkpoint metadata: {filename}")
+
     def register(self):
         checkpoints_list[self.title] = self
         for id in self.ids:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1019,8 +1019,9 @@ def create_ui():
                 interp_method.change(fn=update_interp_description, inputs=[interp_method], outputs=[interp_description])
 
                 with FormRow():
-                    checkpoint_format = gr.Radio(choices=["ckpt", "safetensors"], value="ckpt", label="Checkpoint format", elem_id="modelmerger_checkpoint_format")
+                    checkpoint_format = gr.Radio(choices=["ckpt", "safetensors"], value="safetensors", label="Checkpoint format", elem_id="modelmerger_checkpoint_format")
                     save_as_half = gr.Checkbox(value=False, label="Save as float16", elem_id="modelmerger_save_as_half")
+                    save_metadata = gr.Checkbox(value=True, label="Save metadata (.safetensors only)", elem_id="modelmerger_save_metadata")
 
                 with FormRow():
                     with gr.Column():
@@ -1658,6 +1659,7 @@ def create_ui():
                 config_source,
                 bake_in_vae,
                 discard_weights,
+                save_metadata,
             ],
             outputs=[
                 primary_model_name,


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

As we speak there are merged SD models being released where the merge recipe is unclear, and that data can be forever lost due to bitrot. This change is supposed to help by saving all known models and their merge recipes into the model metadata, if the model is in `.safetensors` format

Example saved metadata:

```json
{
  "merge_recipe": {
    "primary_model_hash": "8a353e16bbabf224c30770e222d1d3c03b55604a472448d48d7f537ea9dc29ca",
    "secondary_model_hash": "c330a60ddcb49c61109dbd7c28cf326733dadb77984c6e8d162bdc200a05df9e",
    "tertiary_model_hash": null,
    "interp_method": "Weighted sum",
    "multiplier": 0.3,
    "save_as_half": false,
    "custom_name": "",
    "config_source": 0,
    "bake_in_vae": "None",
    "discard_weights": "",
    "is_inpainting": false,
    "is_instruct_pix2pix": false
  },
  "models": {
    "8a353e16bbabf224c30770e222d1d3c03b55604a472448d48d7f537ea9dc29ca": {
      "name": "0.7(anything-v3-full) + 0.3(AOM3A1).safetensors",
      "hash": "8a353e16bbabf224c30770e222d1d3c03b55604a472448d48d7f537ea9dc29ca",
      "legacy_hash": "43ce4604",
      "merge_recipe": {
        "primary_model_hash": "abcaf14e5acb8023c79c3901f8ffc04eb3c646d7793f3b36a439bf09e32868cd",
        "secondary_model_hash": "f303d108122ddd43a34c160bd46dbb08cb0e088e979acda0bf168a7a1f5820e0",
        "tertiary_model_hash": null,
        "interp_method": "Weighted sum",
        "multiplier": 0.3,
        "save_as_half": false,
        "custom_name": "",
        "config_source": 0,
        "bake_in_vae": "null",
        "discard_weights": "",
        "is_inpainting": false,
        "is_instruct_pix2pix": false
      }
    },
    "abcaf14e5acb8023c79c3901f8ffc04eb3c646d7793f3b36a439bf09e32868cd": {
      "name": "anything-v3-full.safetensors",
      "hash": "abcaf14e5acb8023c79c3901f8ffc04eb3c646d7793f3b36a439bf09e32868cd",
      "legacy_hash": "7731156c",
      "merge_recipe": null
    },
    "f303d108122ddd43a34c160bd46dbb08cb0e088e979acda0bf168a7a1f5820e0": {
      "name": "AOM3A1.safetensors",
      "hash": "f303d108122ddd43a34c160bd46dbb08cb0e088e979acda0bf168a7a1f5820e0",
      "legacy_hash": "9600da17",
      "merge_recipe": null
    },
    "c330a60ddcb49c61109dbd7c28cf326733dadb77984c6e8d162bdc200a05df9e": {
      "name": "7th_anime_v3_A.safetensors",
      "hash": "c330a60ddcb49c61109dbd7c28cf326733dadb77984c6e8d162bdc200a05df9e",
      "legacy_hash": "6b3ba9a7",
      "merge_recipe": null
    }
  }
}
```

**Additional notes and description of your changes**

I'm worried about the UI defaulting to `.ckpt` output which would cause that metadata to be lost, even selecting `.safetensors` as the default will not change the thousands of existing installs that have `.ckpt` selected in the `ui-config.json`.

Plus `.ckpt` is unsafe since it uses the old state dict format, should `.ckpt` option be deprecated?

Also precalc sha256 hash for newly merged models to save time on next load

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**
N/A