### PR TITLE
Fix "Bug batch process"  on extras tab , even with a clean install of "stable diffusion webui"

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -18,7 +18,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
 
     if extras_mode == 1:
         for img in image_folder:
-            image = Image.open(img)
+            image = Image.open(img.name)
             image_data.append(image)
             image_names.append(os.path.splitext(img.orig_name)[0])
     elif extras_mode == 2:


### PR DESCRIPTION
What is this query for?

This request is there to change a line of code which caused a bug even after a clean reinstallation of "stable diffusion webui" concerning the "batch process" in the "Extras" tab



Additional Note

This is a very slight change to one line of code, the bug I'm talking about is an error that looks like an error opening image(s), despite all the updates I have made on pillow, gradio...
I tried images in different formats thinking "pillow" doesn't support them or checking that my images weren't corrupted, inaccessible... it turned out that after changing in "modules/postprocessing .py", line 21, "image=Image.open(img)", so I changed it to "image=Image.open(img.name)", and it worked, I had seen before on some forums it seems to me that "Image.open ( img.name) )" was causing errors, and this should be fixed by "image=Image.open(img.name)"



Environment in which it was tested

Operating System: Windows 10
Browser: Chrome
Graphics: NVIDIA GeForce GTX 1660

![a](https://user-images.githubusercontent.com/129660032/229655301-56236adc-094b-47d5-b040-ff70960be103.png)
![b](https://user-images.githubusercontent.com/129660032/229655298-b842c536-ebdf-437b-9cf8-04be2014c16b.png)