### PR TITLE
get_uiCurrentTab() wrong with Gradio 3.23.0

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ function gradioApp() {
 }
 
 function get_uiCurrentTab() {
-    return gradioApp().querySelector('#tabs button:not(.border-transparent)')
+    return gradioApp().querySelector('#tabs button.selected')
 }
 
 function get_uiCurrentTabContent() {


### PR DESCRIPTION
updated how active tab is presented in DOM with Gradio 3.23.

the implementation of get_uiCurrentTab does not reflect the model behind Gradio 3.23.
classes have changed etc.

Reproduce:
Select tab "img2img"
on console call get_uiCurrentTab(), it results in "txt2img"
![image](https://user-images.githubusercontent.com/7210708/229401195-23c143bf-e358-4bb2-a9f6-36abea8c7f39.png)
