### PR TITLE
allow styles.csv to be symlinked or mounted in docker

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -72,16 +72,14 @@ class StyleDatabase:
         return apply_styles_to_prompt(prompt, [self.styles.get(x, self.no_style).negative_prompt for x in styles])
 
     def save_styles(self, path: str) -> None:
-        # Write to temporary file first, so we don't nuke the file if something goes wrong
-        fd, temp_path = tempfile.mkstemp(".csv")
+        # Always keep a backup file around
+        if os.path.exists(path):
+            shutil.copy(path, path + ".bak")
+
+        fd = os.open(path, os.O_RDWR|os.O_CREAT)
         with os.fdopen(fd, "w", encoding="utf-8-sig", newline='') as file:
             # _fields is actually part of the public API: typing.NamedTuple is a replacement for collections.NamedTuple,
             # and collections.NamedTuple has explicit documentation for accessing _fields. Same goes for _asdict()
             writer = csv.DictWriter(file, fieldnames=PromptStyle._fields)
             writer.writeheader()
             writer.writerows(style._asdict() for k,     style in self.styles.items())
-
-        # Always keep a backup file around
-        if os.path.exists(path):
-            shutil.move(path, path + ".bak")
-        shutil.move(temp_path, path)


### PR DESCRIPTION
In [stable-diffusion-webui-docker](https://github.com/AbdBarho/stable-diffusion-webui-docker) we want to mount the styles.csv to the host system to persist saved styles upon container restart. This is currently difficult as the file is moved around to prevent data loss on write operations.

The file is moved and thus symlinks won't keep up anymore, a direct docker bind mount doesn't work as well, as now the write process failes with `device or resource busy`, as a mounted file cannot be moved.

Further readings on the PR over in stable-diffusion-webui-docker: https://github.com/AbdBarho/stable-diffusion-webui-docker/pull/386

My PR is a simple proposal to work around those problems. Surely not bulletproof, but I wanted to have a quick sample showing what would be a solution on our end, any feedback very welcome, I hope we can work on a solution together :)