### PR TITLE
Added clip skip control with UI slider.

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -78,7 +78,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
                 processed_image.save(os.path.join(output_dir, filename))
 
 
-def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
+def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, clip_skip: int, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, *args):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     is_batch = mode == 5
@@ -134,6 +134,7 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         n_iter=n_iter,
         steps=steps,
         cfg_scale=cfg_scale,
+        clip_skip=clip_skip,
         width=width,
         height=height,
         restore_faces=restore_faces,
@@ -150,6 +151,8 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         inpainting_mask_invert=inpainting_mask_invert,
         override_settings=override_settings,
     )
+
+    p.override_settings['CLIP_stop_at_last_layers'] = clip_skip
 
     p.scripts = modules.scripts.scripts_txt2img
     p.script_args = args

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -105,7 +105,7 @@ class StableDiffusionProcessing:
     """
     The first set of paramaters: sd_models -> do_not_reload_embeddings represent the minimum required to create a StableDiffusionProcessing
     """
-    def __init__(self, sd_model=None, outpath_samples=None, outpath_grids=None, prompt: str = "", styles: List[str] = None, seed: int = -1, subseed: int = -1, subseed_strength: float = 0, seed_resize_from_h: int = -1, seed_resize_from_w: int = -1, seed_enable_extras: bool = True, sampler_name: str = None, batch_size: int = 1, n_iter: int = 1, steps: int = 50, cfg_scale: float = 7.0, width: int = 512, height: int = 512, restore_faces: bool = False, tiling: bool = False, do_not_save_samples: bool = False, do_not_save_grid: bool = False, extra_generation_params: Dict[Any, Any] = None, overlay_images: Any = None, negative_prompt: str = None, eta: float = None, do_not_reload_embeddings: bool = False, denoising_strength: float = 0, ddim_discretize: str = None, s_churn: float = 0.0, s_tmax: float = None, s_tmin: float = 0.0, s_noise: float = 1.0, override_settings: Dict[str, Any] = None, override_settings_restore_afterwards: bool = True, sampler_index: int = None, script_args: list = None):
+    def __init__(self, sd_model=None, outpath_samples=None, outpath_grids=None, prompt: str = "", styles: List[str] = None, seed: int = -1, subseed: int = -1, subseed_strength: float = 0, seed_resize_from_h: int = -1, seed_resize_from_w: int = -1, seed_enable_extras: bool = True, sampler_name: str = None, batch_size: int = 1, n_iter: int = 1, steps: int = 50, cfg_scale: float = 7.0, clip_skip: int = 1, width: int = 512, height: int = 512, restore_faces: bool = False, tiling: bool = False, do_not_save_samples: bool = False, do_not_save_grid: bool = False, extra_generation_params: Dict[Any, Any] = None, overlay_images: Any = None, negative_prompt: str = None, eta: float = None, do_not_reload_embeddings: bool = False, denoising_strength: float = 0, ddim_discretize: str = None, s_churn: float = 0.0, s_tmax: float = None, s_tmin: float = 0.0, s_noise: float = 1.0, override_settings: Dict[str, Any] = None, override_settings_restore_afterwards: bool = True, sampler_index: int = None, script_args: list = None):
         if sampler_index is not None:
             print("sampler_index argument for StableDiffusionProcessing does not do anything; use sampler_name", file=sys.stderr)
 
@@ -125,6 +125,7 @@ class StableDiffusionProcessing:
         self.n_iter: int = n_iter
         self.steps: int = steps
         self.cfg_scale: float = cfg_scale
+        self.clip_skip: int = clip_skip
         self.width: int = width
         self.height: int = height
         self.restore_faces: bool = restore_faces

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -48,6 +48,7 @@ ui_reorder_categories = [
     "hires_fix",
     "dimensions",
     "cfg",
+    "clip_skip",
     "seed",
     "batch",
     "override_settings",

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -9,7 +9,7 @@ import modules.processing as processing
 from modules.ui import plaintext_to_html
 
 
-def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, hr_scale: float, hr_upscaler: str, hr_second_pass_steps: int, hr_resize_x: int, hr_resize_y: int, override_settings_texts, *args):
+def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, steps: int, sampler_index: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, clip_skip: int, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, height: int, width: int, enable_hr: bool, denoising_strength: float, hr_scale: float, hr_upscaler: str, hr_second_pass_steps: int, hr_resize_x: int, hr_resize_y: int, override_settings_texts, *args):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     p = StableDiffusionProcessingTxt2Img(
@@ -30,6 +30,7 @@ def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, step
         n_iter=n_iter,
         steps=steps,
         cfg_scale=cfg_scale,
+        clip_skip=clip_skip,
         width=width,
         height=height,
         restore_faces=restore_faces,
@@ -43,6 +44,8 @@ def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, step
         hr_resize_y=hr_resize_y,
         override_settings=override_settings,
     )
+
+    p.override_settings['CLIP_stop_at_last_layers'] = clip_skip
 
     p.scripts = modules.scripts.scripts_txt2img
     p.script_args = args

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -478,6 +478,9 @@ def create_ui():
                     elif category == "cfg":
                         cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="txt2img_cfg_scale")
 
+                    elif category == "clip_skip":
+                        clip_skip = gr.Slider(minimum=1, maximum=12, step=1, label='Clip skip', value=1, elem_id="txt2img_clip_skip")
+
                     elif category == "seed":
                         seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox = create_seed_inputs('txt2img')
 
@@ -550,6 +553,7 @@ def create_ui():
                     batch_count,
                     batch_size,
                     cfg_scale,
+                    clip_skip,
                     seed,
                     subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox,
                     height,
@@ -762,6 +766,9 @@ def create_ui():
                                 image_cfg_scale = gr.Slider(minimum=0, maximum=3.0, step=0.05, label='Image CFG Scale', value=1.5, elem_id="img2img_image_cfg_scale", visible=shared.sd_model and shared.sd_model.cond_stage_key == "edit")
                             denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.75, elem_id="img2img_denoising_strength")
 
+                    elif category == "clip_skip":                        
+                        clip_skip = gr.Slider(minimum=1, maximum=12, step=1, label='Clip skip', value=1, elem_id="img2img_clip_skip")
+
                     elif category == "seed":
                         seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox = create_seed_inputs('img2img')
 
@@ -856,6 +863,7 @@ def create_ui():
                     batch_size,
                     cfg_scale,
                     image_cfg_scale,
+                    clip_skip,
                     denoising_strength,
                     seed,
                     subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox,


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Added a slider to the text2img and img2img UI sections that allows you to control clip skip without needing to go to settings each time.

**Additional notes and description of your changes**

The slider simply hijacks the system that is already in place for settings overrides (override_settings), manually setting the 'CLIP_stop_at_last_layers' to the slider value.

**Environment this was tested in**

 - OS: Microsoft Windows 11 Pro, 10.0.22621 Build 22621
 - Browser: Google Chrome Version 111.0.5563.147 (Official Build) (64-bit)
 - Graphics card: NVIDIA GeForce RTX 3070

**Screenshots or videos of your changes**

**txt2img**

- Before:

![image](https://user-images.githubusercontent.com/2250534/229574006-09571693-04a7-4ec1-b793-656379e62366.png)

- After:

![image](https://user-images.githubusercontent.com/2250534/229574390-4d776e93-7ba4-43c6-bee8-060118dbdc6f.png)

**img2img:**

- Before:

![image](https://user-images.githubusercontent.com/2250534/229574101-976b8d9d-55b7-43a9-9462-9a51b8d0ed9f.png)

- After:

![image](https://user-images.githubusercontent.com/2250534/229573263-7cee68fd-b8b0-49b1-bb63-18c186933be8.png)