### PR TITLE
Fix Ngrok recreating tunnels every reload

### DIFF
--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -1,6 +1,14 @@
 from pyngrok import ngrok, conf, exception
 
 def connect(token, port, region):
+    # Guard for existing tunnels
+    existing = ngrok.get_tunnels()
+    if existing:
+        public_url = existing[0].public_url
+        print(f'ngrok connected to localhost:{port}! URL: {public_url}\n'
+               'You can use this link after the launch is complete.')
+        return
+
     account = None
     if token is None:
         token = 'None'

--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -1,14 +1,6 @@
 from pyngrok import ngrok, conf, exception
 
 def connect(token, port, region):
-    # Guard for existing tunnels
-    existing = ngrok.get_tunnels()
-    if existing:
-        public_url = existing[0].public_url
-        print(f'ngrok has already been connected to localhost:{port}! URL: {public_url}\n'
-               'You can use this link after the launch is complete.')
-        return
-
     account = None
     if token is None:
         token = 'None'
@@ -21,6 +13,18 @@ def connect(token, port, region):
     config = conf.PyngrokConfig(
         auth_token=token, region=region
     )
+    
+    # Guard for existing tunnels
+    existing = ngrok.get_tunnels(pyngrok_config=config)
+    if existing:
+        for established in existing:
+            # Extra configuration in the case that the user is also using ngrok for other tunnels
+            if established.config['addr'][-4:] == str(port):
+                public_url = existing[0].public_url
+                print(f'ngrok has already been connected to localhost:{port}! URL: {public_url}\n'
+                    'You can use this link after the launch is complete.')
+                return
+    
     try:
         if account is None:
             public_url = ngrok.connect(port, pyngrok_config=config, bind_tls=True).public_url

--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -5,7 +5,7 @@ def connect(token, port, region):
     existing = ngrok.get_tunnels()
     if existing:
         public_url = existing[0].public_url
-        print(f'ngrok connected to localhost:{port}! URL: {public_url}\n'
+        print(f'ngrok has already been connected to localhost:{port}! URL: {public_url}\n'
                'You can use this link after the launch is complete.')
         return
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Added a guard clause to ngrok connection module to use previous tunnels instead of creating new ones

**Additional notes and description of your changes**

Gets a list of tunnels and if the set port is one of the tunnels, uses that instead of creating a new connection. Might have been easier to set the public_url as a temporary variable globally, but I didn't want to mess with anything else since this was also a quick fix. Also since the ngrok library doesn't have a way to access the port, the port was obtained using array slicing, might get deprecated in the future if the ngrok library decides to add it.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3080 12GB

**Screenshots or videos of your changes**

Screenshots both taken after UI reload

Before:
![image](https://user-images.githubusercontent.com/73165142/229726780-955d9c99-90b3-4646-b761-cc5c41d8a1d3.png)

After:
![image](https://user-images.githubusercontent.com/73165142/229726027-312d5fd2-b62e-4370-8c97-a6e0bbc0aefb.png)

