### PR TITLE
Sort available extensions by github stars

### DIFF
--- a/style.css
+++ b/style.css
@@ -621,6 +621,11 @@ div.dimensions-tools{
     font-size: 90%;
 }
 
+#available_extensions .stars{
+    opacity: 0.85;
+    font-size: 90%;
+}
+
 /* replace original footer with ours */
 
 footer {


### PR DESCRIPTION
Scrapes each extension's github repository for number of stars. Only activates when the "github stars" button is clicked.
![added-ui](https://user-images.githubusercontent.com/37772638/229961828-29d6c244-d22a-4694-b613-5577c826172b.png)
