### PR TITLE
Fix orientation bug on preprocess

### DIFF
--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -162,23 +162,7 @@ def preprocess_work(process_src, process_dst, process_width, process_height, pre
         filename = os.path.join(src, imagefile)
         try:
             img = Image.open(filename)
-            # make sure to rotate the image according to EXIF data of the original image
-            # ImageOps.exif_transpose(img) # doesn't work for some reason
-            EXIF = img._getexif()
-            # rotate the image according to the EXIF data
-            try:
-                if EXIF[274] == 3:
-                    # print("Rotating image by 180 degrees")
-                    img = img.rotate(180, expand=True)
-                elif EXIF[274] == 6:
-                    # print("Rotating image by 270 degrees")
-                    img = img.rotate(270, expand=True)
-                elif EXIF[274] == 8:
-                    # print("Rotating image by 90 degrees")
-                    img = img.rotate(90, expand=True)
-            except:
-                pass
-                # print("No EXIF data found for image: " + filename)
+            img = ImageOps.exif_transpose(img)
             img = img.convert("RGB")
         except Exception:
             continue

--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -161,7 +161,25 @@ def preprocess_work(process_src, process_dst, process_width, process_height, pre
         params.subindex = 0
         filename = os.path.join(src, imagefile)
         try:
-            img = Image.open(filename).convert("RGB")
+            img = Image.open(filename)
+            # make sure to rotate the image according to EXIF data of the original image
+            # ImageOps.exif_transpose(img) # doesn't work for some reason
+            EXIF = img._getexif()
+            # rotate the image according to the EXIF data
+            try:
+                if EXIF[274] == 3:
+                    # print("Rotating image by 180 degrees")
+                    img = img.rotate(180, expand=True)
+                elif EXIF[274] == 6:
+                    # print("Rotating image by 270 degrees")
+                    img = img.rotate(270, expand=True)
+                elif EXIF[274] == 8:
+                    # print("Rotating image by 90 degrees")
+                    img = img.rotate(90, expand=True)
+            except:
+                pass
+                # print("No EXIF data found for image: " + filename)
+            img = img.convert("RGB")
         except Exception:
             continue
 


### PR DESCRIPTION
Fixes bug https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9403

The EXIF metadata is lost on `img.convert("RGB")`, which resets the orientation.
So I simply apply the orientation change **before** converting.

**Environment this was tested in**
 - Virtual Environment with Python 3.10.6
 - OS: Ubuntu 22.04.2 LTS
 - Graphics card: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti Lite Hash Rate]
