### PR TITLE
Add [batch_number] and [generation_number] filename patterns

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -352,6 +352,8 @@ class FilenameGenerator:
         'prompt_no_styles': lambda self: self.prompt_no_style(),
         'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),
         'prompt_words': lambda self: self.prompt_words(),
+        'batch_number': lambda self: self.p.batch_index + 1,
+        'generation_number': lambda self: self.p.iteration * self.p.batch_size + self.p.batch_index + 1,
     }
     default_time_format = '%Y%m%d%H%M%S'
 
@@ -403,6 +405,10 @@ class FilenameGenerator:
 
         for m in re_pattern.finditer(x):
             text, pattern = m.groups()
+
+            if pattern is not None and (pattern.lower() == 'batch_number' and self.p.batch_size == 1 or pattern.lower() == 'generation_number' and self.p.n_iter == 1 and self.p.batch_size == 1):
+                continue
+
             res += text
 
             if pattern is None:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -670,6 +670,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
 
             for i, x_sample in enumerate(x_samples_ddim):
+                p.batch_index = i
+
                 x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
                 x_sample = x_sample.astype(np.uint8)
 
@@ -718,7 +720,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                     if opts.return_mask:
                         output_images.append(image_mask)
-                    
+
                     if opts.return_mask_composite:
                         output_images.append(image_mask_composite)
 


### PR DESCRIPTION
For https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory#caution.

- `[batch_number]` is image number (starting from 1) within each batch
  - If batch size is 1 it is ignored together with the text group before it (to prevent dangling separators)
- `[generation_number]` is image number (starting from 1) within each generation (both iterations and batches)
  - If both batch size and count are 1 it is ignored, also with the preceding text group.

That allows e.g. `[datetime<%Y%m%d_%H%M%S>]-[batch_number]`, guaranteeing nice unique names.