### PR TITLE
sort embeddings by name (case insensitive)

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 import inspect
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 import torch
 import tqdm
@@ -108,7 +108,7 @@ class DirWithTextualInversionEmbeddings:
 class EmbeddingDatabase:
     def __init__(self):
         self.ids_lookup = {}
-        self.word_embeddings = {}
+        self.word_embeddings = OrderedDict()
         self.skipped_embeddings = {}
         self.expected_shape = -1
         self.embedding_dirs = {}
@@ -232,6 +232,9 @@ class EmbeddingDatabase:
         for path, embdir in self.embedding_dirs.items():
             self.load_from_dir(embdir)
             embdir.update()
+
+        # re-sort word_embeddings because load_from_dir may not load in alphabetic order.
+        self.word_embeddings = {e.name: e for e in sorted(self.word_embeddings.values(), key=lambda e: e.name.lower())}
 
         displayed_embeddings = (tuple(self.word_embeddings.keys()), tuple(self.skipped_embeddings.keys()))
         if self.previously_displayed_embeddings != displayed_embeddings:

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 import inspect
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 
 import torch
 import tqdm
@@ -108,7 +108,7 @@ class DirWithTextualInversionEmbeddings:
 class EmbeddingDatabase:
     def __init__(self):
         self.ids_lookup = {}
-        self.word_embeddings = OrderedDict()
+        self.word_embeddings = {}
         self.skipped_embeddings = {}
         self.expected_shape = -1
         self.embedding_dirs = {}
@@ -234,7 +234,10 @@ class EmbeddingDatabase:
             embdir.update()
 
         # re-sort word_embeddings because load_from_dir may not load in alphabetic order.
-        self.word_embeddings = {e.name: e for e in sorted(self.word_embeddings.values(), key=lambda e: e.name.lower())}
+        # using a temporary copy so we don't reinitialize self.word_embeddings in case other objects have a reference to it.
+        sorted_word_embeddings = {e.name: e for e in sorted(self.word_embeddings.values(), key=lambda e: e.name.lower())}
+        self.word_embeddings.clear()
+        self.word_embeddings.update(sorted_word_embeddings)
 
         displayed_embeddings = (tuple(self.word_embeddings.keys()), tuple(self.skipped_embeddings.keys()))
         if self.previously_displayed_embeddings != displayed_embeddings:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

The way we currently load embedding files from disk and store them in memory as `word_embeddings` is _not sorted_, making searching through the UI needlessly difficult if you have a large set of files and don't already know the exact name of one you want to use. This PR alphabetically sorts the list of embeddings immediately after they have all been read from disk, making visual navigation much easier.

**Additional notes and description of your changes**

I noticed that the surrounding code is calling `self.word_embeddings.clear()` on instead of just re-instantiating it like `self.word_embeddings = {}`; so, I assume (but have not verified) that other objects may be retaining a reference to it. To play it safe, my change sorts the contents into a second local dict, clears the main one, and then updates the main one with the contents of the sorted dict.

In my manual testing through various web UI functionalities, this seems to be perfectly compatible. A happy side effect is that when the list of embeddings is printed to standard out at startup or when loading models, they're sorted now too.

**Environment this was tested in**

 - OS: Linux
 - Browser: Firefox
 - Graphics card: NVIDIA GeForce RTX 3060 Ti 8GB

**Screenshots or videos of your changes**

*Before* this change. Booo unsorted contents! :-1: 

![list-before](https://user-images.githubusercontent.com/1472326/230741312-72330631-349a-4987-9218-3045b38c7107.jpg)

*After* this change. Yay sorted content! :tada: 

![list-after](https://user-images.githubusercontent.com/1472326/230741319-6c6e3e83-2dc8-431a-bdb4-2d940c34e7f6.jpg)
