### PR TITLE
Preview fix

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -152,7 +152,9 @@ class CFGDenoiser(torch.nn.Module):
         devices.test_for_nans(x_out, "unet")
 
         if opts.live_preview_content == "Prompt":
-            sd_samplers_common.store_latent(x_out[0:uncond.shape[0]])
+            p_step = len(x_out) // batch_size - 1
+            p_step = p_step if p_step > 1 else 1
+            sd_samplers_common.store_latent(x_out[0:-uncond.shape[0]:p_step])
         elif opts.live_preview_content == "Negative prompt":
             sd_samplers_common.store_latent(x_out[-uncond.shape[0]:])
 


### PR DESCRIPTION
This is a simple fix to fix preview display errors, turn off https://github.com/hako-mikan/sd-webui-regional-prompter/issues/41.

It should fix the generate preview error caused when using AND. If you find it breaks existing functionality. please tell me.