### PR TITLE
fix(extras): fix batch image processing on 'Extras\Batch Process' tab

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+from typing import List
 
 from PIL import Image
 
@@ -6,7 +8,7 @@ from modules import shared, images, devices, scripts, scripts_postprocessing, ui
 from modules.shared import opts
 
 
-def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, show_extras_results, *args, save_output: bool = True):
+def run_postprocessing(extras_mode, image, image_folder: List[tempfile.NamedTemporaryFile], input_dir, output_dir, show_extras_results, *args, save_output: bool = True):
     devices.torch_gc()
 
     shared.state.begin()
@@ -18,7 +20,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
 
     if extras_mode == 1:
         for img in image_folder:
-            image = Image.open(img)
+            image = Image.open(os.path.abspath(img.name))
             image_data.append(image)
             image_names.append(os.path.splitext(img.orig_name)[0])
     elif extras_mode == 2:

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -13,7 +13,7 @@ def create_ui():
                     extras_image = gr.Image(label="Source", source="upload", interactive=True, type="pil", elem_id="extras_image")
 
                 with gr.TabItem('Batch Process', elem_id="extras_batch_process_tab") as tab_batch:
-                    image_batch = gr.File(label="Batch Process", file_count="multiple", interactive=True, type="file", elem_id="extras_image_batch")
+                    image_batch = gr.Files(label="Batch Process", interactive=True, elem_id="extras_image_batch")
 
                 with gr.TabItem('Batch from Directory', elem_id="extras_batch_directory_tab") as tab_batch_dir:
                     extras_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs, placeholder="A directory on the same machine where the server is running.", elem_id="extras_batch_input_dir")


### PR DESCRIPTION
This change fixes an issue where an incorrect type was passed to the `PIL.Image.open()` function that caused the whole process to fail.

Screenshot:
!['Extras\Batch Process' tab](https://i.imgur.com/QLUJ2Ma.png)

Scope of this change is limited to only batch image processing, and it shouldn't affect other functionality.

Fixes #8952 #9238 #8986