### PR TITLE
add branch support for extension installation

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -129,7 +129,7 @@ def normalize_git_url(url):
     return url
 
 
-def install_extension_from_url(dirname, url):
+def install_extension_from_url(dirname, branch_name, url):
     check_access()
 
     assert url, 'No URL specified'
@@ -150,7 +150,7 @@ def install_extension_from_url(dirname, url):
 
     try:
         shutil.rmtree(tmpdir, True)
-        with git.Repo.clone_from(url, tmpdir) as repo:
+        with git.Repo.clone_from(url, tmpdir, branch=branch_name if branch_name else '') as repo:
             repo.remote().fetch()
             for submodule in repo.submodules:
                 submodule.update()
@@ -376,13 +376,14 @@ def create_ui():
 
             with gr.TabItem("Install from URL"):
                 install_url = gr.Text(label="URL for extension's git repository")
+                install_branch = gr.Text(label="Branch name for extension's git repository", placeholder="Leave empty for default branch")
                 install_dirname = gr.Text(label="Local directory name", placeholder="Leave empty for auto")
                 install_button = gr.Button(value="Install", variant="primary")
                 install_result = gr.HTML(elem_id="extension_install_result")
 
                 install_button.click(
                     fn=modules.ui.wrap_gradio_call(install_extension_from_url, extra_outputs=[gr.update()]),
-                    inputs=[install_dirname, install_url],
+                    inputs=[install_dirname, install_branch, install_url],
                     outputs=[extensions_table, install_result],
                 )
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -150,10 +150,17 @@ def install_extension_from_url(dirname, branch_name, url):
 
     try:
         shutil.rmtree(tmpdir, True)
-        with git.Repo.clone_from(url, tmpdir, branch=branch_name if branch_name else '') as repo:
-            repo.remote().fetch()
-            for submodule in repo.submodules:
-                submodule.update()
+        if branch_name == '':
+            # if no branch is specified, use the default branch
+            with git.Repo.clone_from(url, tmpdir) as repo:
+                repo.remote().fetch()
+                for submodule in repo.submodules:
+                    submodule.update()
+        else:
+            with git.Repo.clone_from(url, tmpdir, branch=branch_name) as repo:
+                repo.remote().fetch()
+                for submodule in repo.submodules:
+                    submodule.update()
         try:
             os.rename(tmpdir, target_dir)
         except OSError as err:
@@ -376,7 +383,7 @@ def create_ui():
 
             with gr.TabItem("Install from URL"):
                 install_url = gr.Text(label="URL for extension's git repository")
-                install_branch = gr.Text(label="Branch name for extension's git repository", placeholder="Leave empty for default branch")
+                install_branch = gr.Text(label="Specific branch name", placeholder="Leave empty for default main branch")
                 install_dirname = gr.Text(label="Local directory name", placeholder="Leave empty for auto")
                 install_button = gr.Button(value="Install", variant="primary")
                 install_result = gr.HTML(elem_id="extension_install_result")


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

We are developing extension to contribute and find the 'Install from URL' tab is not support user to install from specific branch, e.g. dev, prod, we 'd like to add a 'branch name' option to allow user switch from difference branches of the same repo, especially for the extension in development phase with different feature set provided per branch. Existing user experience will remain and new option can be empty.

**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [Linux, MacOS]
 - Browser: [Chrome]
 - Graphics card: [TU104GL Tesla T4 64GB]

**Screenshots or videos of your changes**
<img width="754" alt="Screen Shot 2023-04-10 at 09 53 52" src="https://user-images.githubusercontent.com/23544182/230810084-8ab32bab-6119-4f17-91a2-ec9e6123409c.png">

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.