### PR TITLE
Fix a bug related to subprocess.run while installing using webui.bat

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -76,7 +76,7 @@ def run(command, desc=None, errdesc=None, custom_env=None, live=False):
         print(desc)
 
     if live:
-        result = subprocess.run(command, shell=True, env=os.environ if custom_env is None else custom_env)
+        result = subprocess.run(command, shell=False, env=os.environ if custom_env is None else custom_env)
         if result.returncode != 0:
             raise RuntimeError(f"""{errdesc or 'Error running command'}.
 Command: {command}
@@ -84,7 +84,7 @@ Error code: {result.returncode}""")
 
         return ""
 
-    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=os.environ if custom_env is None else custom_env)
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False, env=os.environ if custom_env is None else custom_env)
 
     if result.returncode != 0:
 
@@ -100,7 +100,7 @@ stderr: {result.stderr.decode(encoding="utf8", errors="ignore") if len(result.st
 
 
 def check_run(command):
-    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
     return result.returncode == 0
 
 


### PR DESCRIPTION
Might Fix bugs similar to #8222, where the function subprocess.run does not work properly due to the shell=True parameter. This, in turn, might make webui.bat unfunctional on the Windows platform.

Related to any errors of commands that use the return of subprocess.run on launch.py (including webui.bat), such as 'Torch is not able to use GPU; add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check', and any other errors installing requirements.

This fix needs more tests on other versions of Windows before approval.

From https://docs.python.org/3/library/subprocess.html: "The only time you need to specify shell=True on Windows is when the command you wish to execute is built into the shell (e.g. dir or copy). You do not need shell=True to run a batch file or console-based executable."

 - OS: Windows
 - Browser: -
 - Graphics card: NVIDIA RTX 3070

