### PR TITLE
fixed lora unpack bug

### DIFF
--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -136,7 +136,10 @@ def load_lora(name, filename):
     is_sd2 = 'model_transformer_resblocks' in shared.sd_model.lora_layer_mapping
 
     for key_diffusers, weight in sd.items():
-        key_diffusers_without_lora_parts, lora_key = key_diffusers.split(".", 1)
+        lora_key_parts = key_diffusers.split(".", 1)
+        key_diffusers_without_lora_parts = lora_key_parts[0]
+        lora_key = lora_key_parts[1] if len(lora_key_parts) > 1 else ""
+        
         key = convert_diffusers_name_to_compvis(key_diffusers_without_lora_parts, is_sd2)
 
         sd_module = shared.sd_model.lora_layer_mapping.get(key, None)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

fixes #7935

**Additional notes and description of your changes**

The Lora code, when loading a Lora model, was trying to unpack a split, even though the name sometimes did not include a ".", causing an exception.

I changed it to optionally unpack the second part of the split (if it exists) and default to an empty string if it did not exist.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 3080 10GB

**Screenshots or videos of your changes**

When I produced the error, I was running through the `/sdapi/v1/img2img` api, with the following payload:
![image](https://user-images.githubusercontent.com/24630044/231024622-8e7dd034-b1ea-4893-911c-cdbef4ccd8d2.png)
(note: the API currently does not work out-of-the-box, as is being tracked in #9046 and I had to implement MeemeeLab's workaround in the issue comments to get it running)

Before my changes, I got this:
![image](https://user-images.githubusercontent.com/24630044/231024677-505d0ea2-eb84-49d1-85b6-d26b219310a0.png)

After my changes, I get this:
![image](https://user-images.githubusercontent.com/24630044/231024831-c185d839-1aae-4853-8b0a-d468aa4f7ca4.png)