### PR TITLE
Add Metadata/Parameters Imprinting to Images 🚂💨🎵

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -12,11 +12,11 @@ import gradio as gr
 import safetensors.torch
 
 
-def run_pnginfo(image):
+def run_pnginfo(image, imprint_override_password=None):
     if image is None:
         return '', '', ''
 
-    geninfo, items = images.read_info_from_image(image)
+    geninfo, items = images.read_info_from_image(image, imprint_override_password or '')
     items = {**{'parameters': geninfo}, **items}
 
     info = ''

--- a/modules/image_imprint.py
+++ b/modules/image_imprint.py
@@ -1,0 +1,156 @@
+import gzip
+import hashlib
+import os
+
+import numpy as np
+from PIL import Image
+
+try:
+    from Crypto.Cipher import AES
+    from Crypto.Util.Padding import pad, unpad
+    CRYPTO_AVAILABLE = True
+except ImportError:
+    CRYPTO_AVAILABLE = False
+
+# Gzip header to detect if data is compressed
+__GZIP_MAGIC_NUMBER_BYTES = b'\x1F\x8B\x08\x00'
+# Data suffix so we can detect the end of the envelope
+__IMPRINT_MAGIC_NUMBER_BYTES = b'\x0C\xAB\x00\x5E'
+
+def preprocess_imprint_data(input_str: str, compress: bool = True, pass_phrase: str = '') -> bytes:
+    """
+    Preprocess the input data before imprinting onto an image.
+
+    This function compresses and/or encrypts the input data based on the provided arguments.
+
+    Args:
+        input_str (str): The input string to be processed.
+        compress (bool, optional): Indicates whether to compress the data using BZ3. Defaults to True.
+        pass_phrase (str, optional): Passphrase for encrypting the data using AES. If empty, no encryption is applied. Defaults to ''.
+
+    Returns:
+        bytes: The preprocessed data as bytes, ready for imprinting onto an image.
+    """
+    complete_data = bytes(input_str.encode('utf-8'))
+    
+    if pass_phrase and not CRYPTO_AVAILABLE:
+        raise ImportError("pycryptodome package is required for data encryption. Please install it before using this feature.")
+    
+    if compress:
+        complete_data = gzip.compress(complete_data, compresslevel=9)
+    
+    if pass_phrase and CRYPTO_AVAILABLE:
+        # If pass_phrase is not empty, then encrypt the data
+        key = hashlib.sha256(pass_phrase.encode('utf-8')).digest()
+        iv = os.urandom(AES.block_size)
+        cipher = AES.new(key, AES.MODE_CBC, iv)
+        # Ensure that complete_data is padded to AES.block_size
+        complete_data = pad(complete_data, AES.block_size)
+        complete_data = iv + cipher.encrypt(complete_data)
+    
+    complete_data += __IMPRINT_MAGIC_NUMBER_BYTES
+    
+    return complete_data
+
+def encode_imprint_data(input_image: Image, encode_data: bytes) -> Image.Image:
+    """
+    Encode the input data into the input image.
+
+    This function imprints the input data onto the last 8 rows of pixels in the input image.
+
+    Args:
+        input_image (Image): The input image for encoding the data.
+        encode_data (bytes): The preprocessed data to be imprinted onto the image.
+
+    Returns:
+        Image.Image: The resulting image with the encoded data.
+    """
+    input_image = input_image.convert('RGB')
+    
+    # Convert encode_data_final into a 1d numpy array, of type byte
+    encode_data_final = np.frombuffer(encode_data, dtype=np.uint8)
+    encode_data_final = np.unpackbits(encode_data_final)
+    
+    # Convert the image data to a numpy array and reshape it to be flat, R G R G B, so no (200, 3) instead (600, )
+    image_np = np.array(input_image).reshape(-1)
+    
+    # Calculate the starting index of the last 8 rows of pixels.
+    seek_ix = len(image_np) - 8 * (input_image.width * 3)
+    
+    # Get a view of the last 8 rows of pixels from the image
+    last_8_start = image_np[seek_ix:seek_ix + len(encode_data_final)]
+    
+    # Mask off the last 8 rows of pixels so the data slate is clean
+    last_8_start &= 0xFE
+    last_8_start |= encode_data_final
+    
+    # Convert the numpy array back to a PIL image without reallocating a new image.
+    input_image.frombytes(image_np)
+    
+    return input_image
+
+def postprocess_imprint_data(input_bytes: bytes, pass_phrase: str = ''):
+    """
+    Postprocess the extracted data from an image.
+
+    This function decrypts and/or decompresses the input data based on the provided arguments.
+
+    Args:
+        input_bytes (bytes): The extracted data bytes from the image.
+        pass_phrase (str, optional): Passphrase for decrypting the data using AES. If empty, no decryption is applied. Defaults to ''.
+
+    Returns:
+        bytes: The postprocessed data as bytes, ready to be decoded into a string.
+    """
+    end_ix = input_bytes.find(__IMPRINT_MAGIC_NUMBER_BYTES)
+    
+    if end_ix == -1:
+        # Not recognized as imprinted data
+        return bytes(0)
+    
+    input_bytes = input_bytes[:end_ix]
+    
+    if pass_phrase and not CRYPTO_AVAILABLE:
+        raise ImportError("pycryptodome package is required for data encryption. Please install it before using this feature.")
+    
+    if pass_phrase and CRYPTO_AVAILABLE:
+        # If pass_phrase is not empty, then (try to) decrypt the data
+        key = hashlib.sha256(pass_phrase.encode('utf-8')).digest()
+        iv = input_bytes[:AES.block_size]
+        cipher = AES.new(key, AES.MODE_CBC, iv)
+        input_bytes = cipher.decrypt(input_bytes[AES.block_size:end_ix])
+        # Trim trailing 0x00 bytes (likely from padding)
+        input_bytes = unpad(input_bytes, AES.block_size)
+        # input_bytes = input_bytes.rstrip(b'\x00')
+    
+    if len(input_bytes) > 10 and input_bytes[0:4] == __GZIP_MAGIC_NUMBER_BYTES:
+        return gzip.decompress(input_bytes)
+    
+    return input_bytes[:end_ix]
+
+def decode_imprint_data(input_image: Image, pass_phrase: str = '') -> str:
+    """
+    Decode the imprinted data from the input image.
+
+    This function extracts the data from the last 8 rows of pixels in the input image and postprocesses it.
+
+    Args:
+        input_image (Image): The input image with the imprinted data.
+        pass_phrase (str, optional): Passphrase for decrypting the data using AES. If empty, no decryption is applied. Defaults to ''.
+
+    Returns:
+        str: The decoded string extracted from the input image.
+    """
+    image_np = np.array(input_image).reshape(-1)
+    seek_ix = len(image_np) - 8 * (input_image.width * 3)
+    image_np_last_8_rows = image_np[seek_ix:]
+    # Mask off the last 8 rows of data so that each byte is only 0b0000000X
+    image_np_last_8_rows &= 1
+    # Convert the last bits spread across all the bytes back down to packed bytes. This basically just compacts 8 to 1
+    recovered_bytes = np.packbits(image_np_last_8_rows).tobytes()
+    recovered_bytes = postprocess_imprint_data(recovered_bytes, pass_phrase=pass_phrase)
+    decoded_str = recovered_bytes.decode('utf-8') if recovered_bytes else ''
+    return decoded_str
+
+if __name__ == '__main__':
+    pass

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -698,7 +698,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 
                 if opts.samples_save and not p.do_not_save_samples:
-                    images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p)
+                    images.save_image(image, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, enable_imprinting=opts.enable_imprinting)
 
                 text = infotext(n, i)
                 infotexts.append(text)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -236,6 +236,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "n_rows": OptionInfo(-1, "Grid row count; use -1 for autodetect and 0 for it to be same as batch size", gr.Slider, {"minimum": -1, "maximum": 16, "step": 1}),
 
     "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),
+    "enable_imprinting": OptionInfo(True, "Save text information about generation parameters embedded into the image pixels"),
     "save_txt": OptionInfo(False, "Create a text file next to every image with generation parameters."),
     "save_images_before_face_restoration": OptionInfo(False, "Save a copy of image before doing face restoration."),
     "save_images_before_highres_fix": OptionInfo(False, "Save a copy of image before applying highres fix."),
@@ -253,7 +254,8 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "do_not_add_watermark": OptionInfo(False, "Do not add watermark to images"),
-
+    
+    "imprinting_password": OptionInfo("", "A password that encrypts imprinted data (NOT metadata); leave empty to disable."),
     "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),
     "clean_temp_dir_at_start": OptionInfo(False, "Cleanup non-default temporary directory when starting webui"),
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -970,6 +970,7 @@ def create_ui():
         with gr.Row().style(equal_height=False):
             with gr.Column(variant='panel'):
                 image = gr.Image(elem_id="pnginfo_image", label="Source", source="upload", interactive=True, type="pil")
+                imprint_override_password = gr.Textbox(elem_id="pnginfo_imprint_password", label="Imprint password (override)", visible=opts.enable_imprinting)
 
             with gr.Column(variant='panel'):
                 html = gr.HTML()
@@ -985,7 +986,7 @@ def create_ui():
 
         image.change(
             fn=wrap_gradio_call(modules.extras.run_pnginfo),
-            inputs=[image],
+            inputs=[image, imprint_override_password],
             outputs=[html, generation_info, html2],
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ torchsde
 safetensors
 psutil
 rich
+pycryptodome

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -28,3 +28,4 @@ torchsde==0.2.5
 safetensors==0.3.0
 httpcore<=0.15
 fastapi==0.94.0
+pycryptodome==3.15.0


### PR DESCRIPTION
## New Features
- Adds settings for imprinting metadata onto saved image pixels (works for PNG only). Only the last 8 rows.
- Adds decoding capability for the PNG Info tab to decode this information
- Adds an optional password field that will encrypt the imprinted metadata

## Summary

* This pull request adds options to enable the embedding of image generation parameters directly onto the image pixels (PNG only). This functionality ensures that the image file serves as a standalone, self-contained unit, preserving params and other data that helped create it. This enhancement counteracts the common practice of stripping metadata from image file formats by online hosts and websites. This solution is transparent to the end user, with no increase in file size. As long as the file is a PNG, or converted to other lossless formats, the embedded data will remain intact.
* This change has 0 perceptual impact and is carefully constrained to a bottom slice of the image.

## Examples / UI Changes

### Options
![20230410_165819_TviRAXuK9X_option1](https://user-images.githubusercontent.com/2738686/231030442-87b4ea5f-0d01-4d06-89ac-884ff638a62c.png)
![20230410_170038_o0JWWq1bZG_option2](https://user-images.githubusercontent.com/2738686/231030453-4d632df8-6b39-48a1-ad83-071b36d4e4ba.png)

### PNG Info Tab
![20230410_181704_chrome_y9hJ8Can5D](https://user-images.githubusercontent.com/2738686/231030427-f4630b44-b5b6-4afa-9be6-3c203e0e8ef5.png)

https://user-images.githubusercontent.com/2738686/231030398-4067b276-93fb-4e47-b2e1-cab9340d29a7.mp4

## Discussion topics
- Figuring it would be a highly requested immediately, I added the ability to password protect imprinted information, but would like to discourage use of the feature. Whatever UX is a good enough middle ground of totally allowing this for those who seek it out but defaulting users to unpassworded I think would be favorable to the community.
- Possible later option to extend the image down a couple rows, adding a visible pixel bar (that would look like noise) but can be much more densely packed information. This is less aesthetically pleasing but gives a visual indicator that this image is tagged.

## Background

Many online platforms, apps (Discord, Slack), and websites remove metadata from image files to address security concerns. While this practice is very sensible and important, but it results in the loss of essential generation data which the community is built around. The proposed feature seeks to preserve this data by embedding it into the image itself and therefor become resilient to transmission medium.

## Design Considerations
#### Why only 8 rows?
- In order to try to leave the image as unaltered as possible, altering only the last 8 rows of pixels is a happy medium that pushes the data toward the end, but still leaves the image mostly intact. The perceptual difference is still zero, but this way we only affect ~1.5% of the pixels in the image at absolute maximum.
- With the gzip compression in place, `3.6KB` of text can compress down to `928 bytes`, comfortably fitting in the `1.5KB` space limit. Only the absolute largest absurd prompts have any chance of running over this.
- This keeps slightly in alignment with jpeg compression (which uses 8x8 blocks) for future endeavors, possibly working across that block size with a jpeg resilient method at a later time.

#### Why 0x0CAB005E?
- It's cute. Needed to detect the end of the envelope. 🚂💨🎵

#### Why gz?
- This is the clear winner for small strings, even testing experimental compression like bz3
![image](https://user-images.githubusercontent.com/2738686/231032207-5910e90b-fa6f-4174-8e7d-17b63b47e9af.png)

#### New Dependencies
- `pycryptodome` for AES encryption/decryption
- This dependency is wrapped in a try/except block, so if it's not installed, the feature will not be available. If the user has a password set and imprint enabled, it will throw a descriptive error. 

## Changelist

This pull request introduces the following key changes:

1. **Imprinting Functionality**: The new feature integrates the ability to encode image generation data into the image pixels themselves, preserving the metadata throughout the file's transport and storage.
2. **Robustness**: This method ensures that even if an image file is stripped of its metadata, the embedded information will still be present within the image, even surviving conversion to other lossless image formats (but *not jpeg*).

## Algo

#### Encoding
1. The output image is converted to an array of bytes.
2. The offset to the beginning of the last 8 rows of pixels is calculated and then the array is sliced to include only those rows.
3. The image parameters are encoded into a byte string, and then compressed using gz, which is efficient for small text strings.
4. `IF` there is a password/key set in the user options, the compressed string is encrypted using the sha-256 hashed value of the user's password in `AES-256-CBC`, with padding.
5. `0X0CAB005E` is appended as a suffix.
6. For efficiency, rather than loop over pixels, the operation is done in bulk, splitting the data to bits and then [blitting](https://en.wikipedia.org/wiki/Bit_blit) the data over top of the existing image data after truncating the pixel view to the right size. So only as many pixels as it takes to fit the information are affected.
7. The image is reconstituted in place from the byte array without allocating a new image.

#### Decoding
Steps 1, 2 of Encoding, then
1. Extract the bits off the last 8 rows of data and re-compact them.
2. `0X0CAB005E` is sought as a suffix. If not found this was not an imprinted image. If found, the array is sliced to that marker.
3. `IF` there is a password/key set in the user options, the compressed string is decrypted using this password.
4. We check for the magic bytes telling us whether the data is gzip compressed or not, if it is, we decompress it.
5. The byte string is decoded into a utf-8 string and returned.

## Code Changes
- Added `image_imprint.py` module with util methods. A fork of my work on [ArtiFactual](https://github.com/kjerk/artifactual).
- Plumb `imprint_override_password` through `run_pnginfo()` so it can be filled on the spot from the UI.
- Add imprinting to `save_image()`, reusing the `info` string.
- Add imprint reading to `read_info_from_image()`, trying to pull both metadata and the imprinted data, if they are the same anyway, only return the metadata.
- Add `enable_imprinting` and `imprinting_password` options to shared.py
- Add new `imprint_override_password` textbox to the UI. Hidden if `enable_imprinting` is turned off.

## Example Image
This image from the above example video is imprinted and passworded with `cool pass bro`. You can download it and see that there is no metadata in the image. Running this branch, you can decode it as in the example video.
<img src="https://user-images.githubusercontent.com/2738686/231031707-a1eec4bc-0046-45d4-81e8-e265437a6e8e.png" width="512" height="512"></img>

### Tested on
- Windows 10
- Chrome 103
- Python 3.10.8 / Torch 2.0.0+cu118 / CUDA 11.8 / cuDNN 8.8.1 / RTX 4090
- RTX 4090