### PR TITLE
Fixed generation params in gallery

### DIFF
--- a/javascript/generationParams.js
+++ b/javascript/generationParams.js
@@ -16,9 +16,9 @@ onUiUpdate(function(){
 
 let modalObserver = new MutationObserver(function(mutations) {
 	mutations.forEach(function(mutationRecord) {
-		let selectedTab = gradioApp().querySelector('#tabs div button.bg-white')?.innerText
-		if (mutationRecord.target.style.display === 'none' && selectedTab === 'txt2img' || selectedTab === 'img2img')
-			gradioApp().getElementById(selectedTab+"_generation_info_button").click()
+		let selectedTab = gradioApp().querySelector('#tabs div button.selected')?.innerText
+		if (mutationRecord.target.style.display === 'none' && (selectedTab === 'txt2img' || selectedTab === 'img2img'))
+			gradioApp().getElementById(selectedTab+"_generation_info_button")?.click()
 	});
 });
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
This PR fixes a small but annoying bug: after using the fullscreen modal to view images in the gallery, the generation params beneath the image fail to update properly. This bug was caused by a change to the style class of the selected tab.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: firefox
 - Graphics card: NVIDIA RTX 4070 Ti

**Screenshots or videos of your changes**
Here's a **video of the bug** - starting from the first image ("Seed: 1"), I open the modal, move to the right twice, then close the modal. Beneath the image, it displays "Seed: 2", instead of the expected "Seed: 3". After I click the thumbnail, the UI correctly updates to show "Seed: 3":

https://user-images.githubusercontent.com/8740062/231605434-872bc76c-2c2e-4259-a69b-202ed25b1d98.mp4

Here's a **video of my fix** - after following the same steps as above, you can see that after closing the modal, it correctly displays "Seed: 3" beneath the image:

https://user-images.githubusercontent.com/8740062/231606835-b6c19999-38e5-441d-92bb-6d9412b8ef0a.mp4

