### PR TITLE
Fix image mask/composite for weird resolutions

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -708,7 +708,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                 if hasattr(p, 'mask_for_overlay') and p.mask_for_overlay:
                     image_mask = p.mask_for_overlay.convert('RGB')
-                    image_mask_composite = Image.composite(image.convert('RGBA').convert('RGBa'), Image.new('RGBa', image.size), p.mask_for_overlay.convert('L')).convert('RGBA')
+                    image_mask_composite = Image.composite(image.convert('RGBA').convert('RGBa'), Image.new('RGBa', image.size), images.resize_image(2, p.mask_for_overlay, image.width, image.height).convert('L')).convert('RGBA')
 
                     if opts.save_mask:
                         images.save_image(image_mask, p.outpath_samples, "", seeds[i], prompts[i], opts.samples_format, info=infotext(n, i), p=p, suffix="-mask")

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -706,7 +706,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image.info["parameters"] = text
                 output_images.append(image)
 
-                if hasattr(p, 'mask_for_overlay') and p.mask_for_overlay:
+                if hasattr(p, 'mask_for_overlay') and p.mask_for_overlay and any([opts.save_mask, opts.save_mask_composite, opts.return_mask, opts.return_mask_composite]):
                     image_mask = p.mask_for_overlay.convert('RGB')
                     image_mask_composite = Image.composite(image.convert('RGBA').convert('RGBa'), Image.new('RGBa', image.size), images.resize_image(2, p.mask_for_overlay, image.width, image.height).convert('L')).convert('RGBA')
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9092

**Additional notes and description of your changes**

Previously this was not accounting for weird resolutions the user may input.

This PR also slightly changes the functionality and only enters this code block when one of the related options is actually enabled, to shield the majority of users incase something were to somehow go wrong with this again, as none of these options are enabled by default.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090