### PR TITLE
Add filename pattern for CLIP_stop_at_last_layers (clip skip).

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -352,6 +352,7 @@ class FilenameGenerator:
         'prompt_no_styles': lambda self: self.prompt_no_style(),
         'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),
         'prompt_words': lambda self: self.prompt_words(),
+        'clip_skip': lambda: opts.data["CLIP_stop_at_last_layers"],
     }
     default_time_format = '%Y%m%d%H%M%S'
 

--- a/modules/images.py
+++ b/modules/images.py
@@ -352,7 +352,7 @@ class FilenameGenerator:
         'prompt_no_styles': lambda self: self.prompt_no_style(),
         'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),
         'prompt_words': lambda self: self.prompt_words(),
-        'clip_skip': lambda: opts.data["CLIP_stop_at_last_layers"],
+        'clip_skip': lambda self: opts.data["CLIP_stop_at_last_layers"],
     }
     default_time_format = '%Y%m%d%H%M%S'
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This change adds [filename pattern](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory) "[clip_skip]" for CLIP_stop_at_last_layers (clip skip).

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10 Pro 22H2
 - Browser: Microsoft Edge (Version: 112.0.1722.39 64-bits)
 - Graphics card: NVIDIA RTX 3080 10GB

**Screenshots or videos of your changes**

![Exapmle_of_usage](https://user-images.githubusercontent.com/5366053/232287267-41797537-120e-41d0-a947-c12513b9cf8f.png)
