### PR TITLE
Fix prompt schedule for second order samplers

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -639,10 +639,12 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     processed = Processed(p, [], p.seed, "")
                     file.write(processed.infotext(p, 0))
 
-            try:
-                step_multiplier = 2 if sd_samplers.all_samplers_map.get(p.sampler_name).aliases[0] in ['k_dpmpp_2s_a', 'k_dpmpp_2s_a_ka', 'k_dpmpp_sde', 'k_dpmpp_sde_ka', 'k_dpm_2', 'k_dpm_2_a', 'k_heun'] else 1
-            except:
-                step_multiplier = 1
+            step_multiplier = 1
+            if shared.opts.fix_second_order_samplers_schedule:
+                try:
+                    step_multiplier = 2 if sd_samplers.all_samplers_map.get(p.sampler_name).aliases[0] in ['k_dpmpp_2s_a', 'k_dpmpp_2s_a_ka', 'k_dpmpp_sde', 'k_dpmpp_sde_ka', 'k_dpm_2', 'k_dpm_2_a', 'k_heun'] else 1
+                except:
+                    pass
             uc = get_conds_with_caching(prompt_parser.get_learned_conditioning, negative_prompts, p.steps * step_multiplier, cached_uc)
             c = get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, prompts, p.steps * step_multiplier, cached_c)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -639,8 +639,12 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     processed = Processed(p, [], p.seed, "")
                     file.write(processed.infotext(p, 0))
 
-            uc = get_conds_with_caching(prompt_parser.get_learned_conditioning, negative_prompts, p.steps, cached_uc)
-            c = get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, prompts, p.steps, cached_c)
+            try:
+                step_multiplier = 2 if sd_samplers.all_samplers_map.get(p.sampler_name).aliases[0] in ['k_dpmpp_2s_a', 'k_dpmpp_2s_a_ka', 'k_dpmpp_sde', 'k_dpmpp_sde_ka', 'k_dpm_2', 'k_dpm_2_a', 'k_heun'] else 1
+            except:
+                step_multiplier = 1
+            uc = get_conds_with_caching(prompt_parser.get_learned_conditioning, negative_prompts, p.steps * step_multiplier, cached_uc)
+            c = get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, prompts, p.steps * step_multiplier, cached_c)
 
             if len(model_hijack.comments) > 0:
                 for comment in model_hijack.comments:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -640,7 +640,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     file.write(processed.infotext(p, 0))
 
             step_multiplier = 1
-            if shared.opts.fix_second_order_samplers_schedule:
+            if not shared.opts.dont_fix_second_order_samplers_schedule:
                 try:
                     step_multiplier = 2 if sd_samplers.all_samplers_map.get(p.sampler_name).aliases[0] in ['k_dpmpp_2s_a', 'k_dpmpp_2s_a_ka', 'k_dpmpp_sde', 'k_dpmpp_sde_ka', 'k_dpm_2', 'k_dpm_2_a', 'k_heun'] else 1
                 except:

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -338,6 +338,7 @@ options_templates.update(options_section(('compatibility', "Compatibility"), {
     "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
     "no_dpmpp_sde_batch_determinism": OptionInfo(False, "Do not make DPM++ SDE deterministic across different batch sizes."),
     "use_old_hires_fix_width_height": OptionInfo(False, "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to)."),
+    "fix_second_order_samplers_schedule": OptionInfo(False, "Fix prompt schedule for second order samplers."),
 }))
 
 options_templates.update(options_section(('interrogate', "Interrogate Options"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -338,7 +338,7 @@ options_templates.update(options_section(('compatibility', "Compatibility"), {
     "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
     "no_dpmpp_sde_batch_determinism": OptionInfo(False, "Do not make DPM++ SDE deterministic across different batch sizes."),
     "use_old_hires_fix_width_height": OptionInfo(False, "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to)."),
-    "fix_second_order_samplers_schedule": OptionInfo(False, "Fix prompt schedule for second order samplers."),
+    "dont_fix_second_order_samplers_schedule": OptionInfo(False, "Do not fix prompt schedule for second order samplers."),
 }))
 
 options_templates.update(options_section(('interrogate', "Interrogate Options"), {


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7508

Second order samplers (Heun, DPM2/a, DPM++ 2S/a, DPM++ SDE / Karras) cause the prompt schedule to run twice as fast when prompting something like `[dog:cat:0.5]` (i.e. for 100 steps, prompt is `dog` until step 25, `cat` until 50, and remains `dog` until 100). This fixes that by checking if the sampler is any of these second order samplers and multiplies the step count by 2 for calculating the prompt schedule.

**Additional notes and description of your changes**

I've also added a compatibility option to replicate old seeds, as it's otherwise impossible to replicate them since the prompt would always run as twice as fast.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090