### PR TITLE
fix install_dir error

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -23,7 +23,7 @@ fi
 # Install directory without trailing slash
 if [[ -z "${install_dir}" ]]
 then
-    install_dir="/home/$(whoami)"
+    install_dir="${HOME}"
 fi
 
 # Name of the subdirectory (defaults to stable-diffusion-webui)


### PR DESCRIPTION
When the user's home directory and username are inconsistent, an error message stating that the directory cannot be found will appear. Directly default the installation directory to the user's home directory

# Please read the [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing) before submitting a pull request!

If you have a large change, pay special attention to this paragraph:

> Before making changes, if you think that your feature will result in more than 100 lines changing, find me and talk to me about the feature you are proposing. It pains me to reject the hard work someone else did, but I won't add everything to the repo, and it's better if the rejection happens before you have to waste time working on the feature.

Otherwise, after making sure you're following the rules described in wiki page, remove this section and continue on.

**Describe what this pull request is trying to achieve.**

A clear and concise description of what you're trying to accomplish with this, so your intent doesn't have to be extracted from your code.

**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [e.g. Windows, Linux]
 - Browser: [e.g. chrome, safari]
 - Graphics card: [e.g. NVIDIA RTX 2080 8GB, AMD RX 6600 8GB]

**Screenshots or videos of your changes**

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.