### PR TITLE
adds label to buttons to make them hide

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -171,8 +171,8 @@ def create_seed_inputs(target_interface):
     with FormRow(elem_id=target_interface + '_seed_row', variant="compact"):
         seed = (gr.Textbox if cmd_opts.use_textbox_seed else gr.Number)(label='Seed', value=-1, elem_id=target_interface + '_seed')
         seed.style(container=False)
-        random_seed = ToolButton(random_symbol, elem_id=target_interface + '_random_seed')
-        reuse_seed = ToolButton(reuse_symbol, elem_id=target_interface + '_reuse_seed')
+        random_seed = ToolButton(random_symbol, elem_id=target_interface + '_random_seed', label='Random seed')
+        reuse_seed = ToolButton(reuse_symbol, elem_id=target_interface + '_reuse_seed', label='Reuse seed')
 
         seed_checkbox = gr.Checkbox(label='Extra', elem_id=target_interface + '_subseed_show', value=False)
 
@@ -468,7 +468,7 @@ def create_ui():
                                 height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="txt2img_height")
 
                             with gr.Column(elem_id="txt2img_dimensions_row", scale=1, elem_classes="dimensions-tools"):
-                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn")
+                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn", label="Switch dims")
 
                             if opts.dimensions_and_batch_together:
                                 with gr.Column(elem_id="txt2img_column_batch"):
@@ -1705,7 +1705,7 @@ def create_ui():
                 if init_field is not None:
                     init_field(saved_value)
 
-        if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number, gr.Dropdown] and x.visible:
+        if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number, gr.Dropdown, ToolButton] and x.visible:
             apply_field(x, 'visible')
 
         if type(x) == gr.Slider:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
I want to have option to make really simplistic UI, hiding most of the options. This is already possible by modifying the `visible` fields in `ui-config.json` file. But after hiding all the fields I wanted, some buttons were still visible, making it kinda ugly, see:
![image](https://user-images.githubusercontent.com/5525771/232619523-0a4d155c-e141-40d6-89d0-661617dcac19.png)

and because the config is applied only for UI controls which have non-None label, I added the label to 3 buttons I want to have possibility to hide, and I added them to the typecheck. Then I am able to do this using just modifications in the `ui-config.json` file:
![image](https://user-images.githubusercontent.com/5525771/232619739-8fc6ea3c-1cd0-4e5b-881a-083ae8b86c8b.png)

I have checked the UI and it should not break anything because apart from the config json file the labels are not shown anywhere visibly.

I believe this might be valuable feature for some people who try to use this for public, simplistic demos.

**Additional notes and description of your changes**

Nothing I'd be aware of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10
 - Browser: chrome
 - Graphics card: Nvidia GTX 1080Ti

**Screenshots or videos of your changes**

see above