### PR TITLE
Fix the problem that the Hire.fix option is not fully displayed under linux

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -43,7 +43,9 @@ from modules.generation_parameters_copypaste import image_from_url_text
 import modules.extras
 
 warnings.filterwarnings("default" if opts.show_warnings else "ignore", category=UserWarning)
-
+# get OS name and version
+os_name, os_version = platform.system(), platform.release()
+print(f"Current OS version:{os_name} {os_version}")
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
 mimetypes.add_type('application/javascript', '.js')
@@ -490,15 +492,26 @@ def create_ui():
 
                     elif category == "hires_fix":
                         with FormGroup(visible=False, elem_id="txt2img_hires_fix") as hr_options:
-                            with FormRow(elem_id="txt2img_hires_fix_row1", variant="compact"):
-                                hr_upscaler = gr.Dropdown(label="Upscaler", elem_id="txt2img_hr_upscaler", choices=[*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]], value=shared.latent_upscale_default_mode)
-                                hr_second_pass_steps = gr.Slider(minimum=0, maximum=150, step=1, label='Hires steps', value=0, elem_id="txt2img_hires_steps")
-                                denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7, elem_id="txt2img_denoising_strength")
+                            if os_name == "Linux":
+                                with FormRow(elem_id="txt2img_hires_fix_row1", variant="compact"):
+                                    hr_upscaler = gr.Dropdown(label="Upscaler", elem_id="txt2img_hr_upscaler",choices=[*shared.latent_upscale_modes,*[x.name for x in shared.sd_upscalers]], value=shared.latent_upscale_default_mode)
+                                    hr_second_pass_steps = gr.Slider(minimum=0, maximum=150, step=1,label='Hires steps', value=0, elem_id="txt2img_hires_steps")
+                                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01,label='Denoising strength', value=0.7, elem_id="txt2img_denoising_strength")
+                                    hr_scale = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label="Upscale by", value=2.0, elem_id="txt2img_hr_scale")
+                                    hr_resize_x = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize width to", value=0, elem_id="txt2img_hr_resize_x")
+                                    hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
 
-                            with FormRow(elem_id="txt2img_hires_fix_row2", variant="compact"):
-                                hr_scale = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label="Upscale by", value=2.0, elem_id="txt2img_hr_scale")
-                                hr_resize_x = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize width to", value=0, elem_id="txt2img_hr_resize_x")
-                                hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
+                            else:
+                                with FormRow(elem_id="txt2img_hires_fix_row1", variant="compact"):
+                                    hr_upscaler = gr.Dropdown(label="Upscaler", elem_id="txt2img_hr_upscaler",choices=[*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]], value=shared.latent_upscale_default_mode)
+                                    hr_second_pass_steps = gr.Slider(minimum=0, maximum=150, step=1,label='Hires steps', value=0, elem_id="txt2img_hires_steps")
+                                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7, elem_id="txt2img_denoising_strength")
+
+                                with FormRow(elem_id="txt2img_hires_fix_row2", variant="compact"):
+                                    hr_scale = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label="Upscale by", value=2.0, elem_id="txt2img_hr_scale")
+                                    hr_resize_x = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize width to", value=0, elem_id="txt2img_hr_resize_x")
+                                    hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
+
 
                     elif category == "batch":
                         if not opts.dimensions_and_batch_together:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
I installed webui under linux and tested it. I found that when the txt2img->Hire.fix label is selected, it cannot be displayed normally according to the code in ui.py. The two-line option affects the use due to an unknown gradio bug.
**Additional notes and description of your changes**
However, if the hires_fix FormGroup visible property is set to True from the beginning, the display will be two lines of options
I wrote a simple method to solve this problem by reading OS information and judging whether it is a linux system

Temporarily make all options of Hire.fix functional under linux system by writing all options in a Row line
I think there is no problem after testing under linux and windows
I'll update if I find a better solution or run into other issues：)

**Environment this was tested in**
linux 5.15.0-25-generic Ubuntu 22.04
firefox
RTX2080TI *2
windows 10
chrome
RTX2070
**Screenshots or videos of your changes**


https://user-images.githubusercontent.com/47637249/232976116-79b94e72-c0be-4892-aba1-78ebc45aa634.mp4


https://user-images.githubusercontent.com/47637249/232976125-e805432d-e1ec-4314-b379-8ac74f2f33ba.mp4

https://user-images.githubusercontent.com/47637249/232976134-9142262b-fcee-4cea-b6cd-402c832fc6a6.mp4


