### PR TITLE
add tiled inference support for ScuNET

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -283,6 +283,8 @@ options_templates.update(options_section(('upscaling', "Upscaling"), {
     "ESRGAN_tile_overlap": OptionInfo(8, "Tile overlap, in pixels for ESRGAN upscalers. Low values = visible seam.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}),
     "realesrgan_enabled_models": OptionInfo(["R-ESRGAN 4x+", "R-ESRGAN 4x+ Anime6B"], "Select which Real-ESRGAN models to show in the web UI. (Requires restart)", gr.CheckboxGroup, lambda: {"choices": shared_items.realesrgan_models_names()}),
     "upscaler_for_img2img": OptionInfo(None, "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in sd_upscalers]}),
+    "SCUNET_tile": OptionInfo(256, "Tile size for SCUNET upscalers. 0 = no tiling.", gr.Slider, {"minimum": 0, "maximum": 512, "step": 16}),
+    "SCUNET_tile_overlap": OptionInfo(8, "Tile overlap, in pixels for SCUNET upscalers. Low values = visible seam.", gr.Slider, {"minimum": 0, "maximum": 64, "step": 1}),
 }))
 
 options_templates.update(options_section(('face-restoration', "Face restoration"), {


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

add tiled inference support for ScuNET, avoid OOM issue when denoising large images. Tested to be working.
![original](https://user-images.githubusercontent.com/119634810/233005384-a9534530-04ab-44c0-8b93-a45bcb132c34.jpeg)
![denoised](https://user-images.githubusercontent.com/119634810/233005422-190d465b-6781-40a5-8cbe-301b35df558f.png)



**Additional notes and description of your changes**

Code adapted from SwinIR upscaler's tiling part.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.

Should not break anything, but FYI:
 - OS: Linux 6.2.8-1-default x86_64, Open SUSE Tumbleweed 
 - Browser: Firefox 110.0.1
 - Graphics card: NVIDIA RTX 3070 8GB

**Screenshots or videos of your changes**

Added settings for ScuNET tile and overlaps above LSDR's: 
![UI_change](https://user-images.githubusercontent.com/119634810/233004847-54593cda-a15d-4228-9195-17d8303e414d.png)

This is **required** for anything that touches the user interface.