### PR TITLE
Remove old code roll random artists

### DIFF
--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -161,14 +161,6 @@ addContextMenuEventListener = initResponse[2];
   appendContextMenuOption('#img2img_interrupt','Cancel generate forever',cancelGenerateForever)
   appendContextMenuOption('#img2img_generate', 'Cancel generate forever',cancelGenerateForever)
 
-  appendContextMenuOption('#roll','Roll three',
-    function(){
-      let rollbutton = get_uiCurrentTabContent().querySelector('#roll');
-      setTimeout(function(){rollbutton.click()},100)
-      setTimeout(function(){rollbutton.click()},200)
-      setTimeout(function(){rollbutton.click()},300)
-    }
-  )
 })();
 //End example Context Menu Items
 


### PR DESCRIPTION
Simply removed the hidden context menu entry for a button that no longer exists which was used for rolling artists from the now removed artists.csv.

It was probably meant to be removed at commit 6d805b6.
