### PR TITLE
Fix exit code: 123 by update to webui.bat

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -29,7 +29,7 @@ if ["%SKIP_VENV%"] == ["1"] goto :skip_venv
 dir "%VENV_DIR%\Scripts\Python.exe" >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :activate_venv
 
-for /f "delims=" %%i in ('CALL %PYTHON% -c "import sys; print(sys.executable)"') do set PYTHON_FULLNAME="%%i"
+for /f "delims=" %%i in ('CALL %PYTHON% -c "import sys; print(sys.executable)"') do set PYTHON_FULLNAME=%%i
 echo Creating venv in directory %VENV_DIR% using python %PYTHON_FULLNAME%
 %PYTHON_FULLNAME% -m venv "%VENV_DIR%" >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :activate_venv


### PR DESCRIPTION
Fixed first-time setup error for Windows:

Unable to create venv in directory "..."

 exit code: 123

stderr:
The filename, directory name, or volume label syntax is incorrect.

# What is the error?
On first-time setup of the repo will cause an error in the webui.bat. This is because on line 32 PYTHON_FULLNAME="%%i" will set the PYTHON_FULLNAME=". This can be fixed by "%%i" > %%i.

- OS: Windows
 - Browser: Chrome
 - Graphics card: NVIDIA RTX 3080 12GB