### PR TITLE
Automatically select current word when adjusting weight with ctrl+up/down

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -46,6 +46,7 @@ function keyupEditAttention(event){
     
     function selectCurrentWord(){
         if (selectionStart !== selectionEnd) return false;
+        const delimiters = ".,\/#!$%\^&\*;:{}=\-_`~()";
         
         // Select the current word, find the start and end of the word (first space before and after)
         const wordStart = text.substring(0, selectionStart).lastIndexOf(" ") + 1;
@@ -59,10 +60,10 @@ function keyupEditAttention(event){
         selectionStart = wordStart;
 
         // Remove all punctuation at the end and beginning of the word
-        while (text[selectionStart].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+        while (delimiters.includes(text[selectionStart])) {
             selectionStart++;
         }
-        while (text[selectionEnd - 1].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+        while (delimiters.includes(text[selectionEnd - 1])) {
             selectionEnd--;
         }
         target.setSelectionRange(selectionStart, selectionEnd);

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -46,7 +46,7 @@ function keyupEditAttention(event){
     
     function selectCurrentWord(){
         if (selectionStart !== selectionEnd) return false;
-        const delimiters = " .,\\/!?%^*;:{}=-_`~()\r\n\t";
+        const delimiters = " .,\\/!?%^*;:{}=`~()\r\n\t";
         
         // seek backward until to find beggining
         while (!delimiters.includes(text[selectionStart - 1]) && selectionStart > 0) {

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -46,7 +46,7 @@ function keyupEditAttention(event){
     
     function selectCurrentWord(){
         if (selectionStart !== selectionEnd) return false;
-        const delimiters = " .,\\/!?%^*;:{}=`~()\r\n\t";
+        const delimiters = opts.keyedit_delimiters + " \r\n\t";
         
         // seek backward until to find beggining
         while (!delimiters.includes(text[selectionStart - 1]) && selectionStart > 0) {

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -17,7 +17,7 @@ function keyupEditAttention(event){
 		// Find opening parenthesis around current cursor
 		const before = text.substring(0, selectionStart);
 		let beforeParen = before.lastIndexOf(OPEN);
-		if (beforeParen == -1) return  false;
+		if (beforeParen == -1) return false;
 		let beforeParenClose = before.lastIndexOf(CLOSE);
 		while (beforeParenClose !== -1 && beforeParenClose > beforeParen) {
 			beforeParen = before.lastIndexOf(OPEN, beforeParen - 1);
@@ -27,7 +27,7 @@ function keyupEditAttention(event){
 		// Find closing parenthesis around current cursor
 		const after = text.substring(selectionStart);
 		let afterParen = after.indexOf(CLOSE);
-		if (afterParen == -1) return  false;
+		if (afterParen == -1) return false;
 		let afterParenOpen = after.indexOf(OPEN);
 		while (afterParenOpen !== -1 && afterParen > afterParenOpen) {
 			afterParen = after.indexOf(CLOSE, afterParen + 1);
@@ -43,10 +43,35 @@ function keyupEditAttention(event){
 		target.setSelectionRange(selectionStart, selectionEnd);
 		return true;
     }
+    
+    function selectCurrentWord(){
+        if (selectionStart !== selectionEnd) return false;
+        
+        // Select the current word, find the start and end of the word (first space before and after)
+        const wordStart = text.substring(0, selectionStart).lastIndexOf(" ") + 1;
+        const wordEnd = text.substring(selectionEnd).indexOf(" ");
+        // If there is no space after the word, select to the end of the string
+        if (wordEnd === -1) {
+            selectionEnd = text.length;
+        } else {
+            selectionEnd += wordEnd;
+        }
+        selectionStart = wordStart;
 
-	// If the user hasn't selected anything, let's select their current parenthesis block
-    if(! selectCurrentParenthesisBlock('<', '>')){
-        selectCurrentParenthesisBlock('(', ')')
+        // Remove all punctuation at the end and beginning of the word
+        while (text[selectionStart].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+            selectionStart++;
+        }
+        while (text[selectionEnd - 1].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+            selectionEnd--;
+        }
+        target.setSelectionRange(selectionStart, selectionEnd);
+        return true;
+    }
+
+	// If the user hasn't selected anything, let's select their current parenthesis block or word
+    if (!selectCurrentParenthesisBlock('<', '>') && !selectCurrentParenthesisBlock('(', ')')) {
+        selectCurrentWord();
     }
 
 	event.preventDefault();

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -46,7 +46,7 @@ function keyupEditAttention(event){
     
     function selectCurrentWord(){
         if (selectionStart !== selectionEnd) return false;
-        const delimiters = ".,\/#!$%\^&\*;:{}=\-_`~() ";
+        const delimiters = " .,\\/!?%^*;:{}=-_`~()\r\n\t";
         
         // seek backward until to find beggining
         while (!delimiters.includes(text[selectionStart - 1]) && selectionStart > 0) {

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -46,26 +46,18 @@ function keyupEditAttention(event){
     
     function selectCurrentWord(){
         if (selectionStart !== selectionEnd) return false;
-        const delimiters = ".,\/#!$%\^&\*;:{}=\-_`~()";
+        const delimiters = ".,\/#!$%\^&\*;:{}=\-_`~() ";
         
-        // Select the current word, find the start and end of the word (first space before and after)
-        const wordStart = text.substring(0, selectionStart).lastIndexOf(" ") + 1;
-        const wordEnd = text.substring(selectionEnd).indexOf(" ");
-        // If there is no space after the word, select to the end of the string
-        if (wordEnd === -1) {
-            selectionEnd = text.length;
-        } else {
-            selectionEnd += wordEnd;
+        // seek backward until to find beggining
+        while (!delimiters.includes(text[selectionStart - 1]) && selectionStart > 0) {
+            selectionStart--;
         }
-        selectionStart = wordStart;
+        
+        // seek forward to find end
+        while (!delimiters.includes(text[selectionEnd]) && selectionEnd < text.length) {
+            selectionEnd++;
+        }
 
-        // Remove all punctuation at the end and beginning of the word
-        while (delimiters.includes(text[selectionStart])) {
-            selectionStart++;
-        }
-        while (delimiters.includes(text[selectionEnd - 1])) {
-            selectionEnd--;
-        }
         target.setSelectionRange(selectionStart, selectionEnd);
         return true;
     }

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -99,7 +99,13 @@ function keyupEditAttention(event){
 	weight = parseFloat(weight.toPrecision(12));
 	if(String(weight).length == 1) weight += ".0"
 
-	text = text.slice(0, selectionEnd + 1) + weight + text.slice(selectionEnd + 1 + end - 1);
+    if (closeCharacter == ')' && weight == 1) {
+        text = text.slice(0, selectionStart - 1) + text.slice(selectionStart, selectionEnd) + text.slice(selectionEnd + 5);
+        selectionStart--;
+        selectionEnd--;
+    } else {
+        text = text.slice(0, selectionEnd + 1) + weight + text.slice(selectionEnd + 1 + end - 1);
+    }
 
 	target.focus();
 	target.value = text;

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -382,6 +382,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row"),
     "keyedit_precision_attention": OptionInfo(0.1, "Ctrl+up/down precision when editing (attention:1.1)", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
+    "keyedit_delimiters": OptionInfo(".,\/!?%^*;:{}=`~()", "Ctrl+up/down word delimiters"),
     "quicksettings": OptionInfo("sd_model_checkpoint", "Quicksettings list"),
     "hidden_tabs": OptionInfo([], "Hidden UI tabs (requires restart)", ui_components.DropdownMulti, lambda: {"choices": [x for x in tab_names]}),
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order"),


### PR DESCRIPTION
Automatically selects the current word if nothing is selected.
Preselected text and existing emphasis blocks are unaffected and still work as they do now.

**Environment this was tested in**
 - OS: Windows 10
 - Browser: Edge

**Screenshots or videos of your changes**

https://user-images.githubusercontent.com/4073789/233257089-57823af8-db6d-46b6-8c56-937e97caf382.mp4

