### PR TITLE
Add readme popup for external networks

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -140,6 +140,14 @@ function extraNetworksShowMetadata(text){
     popup(elem);
 }
 
+function extraNetworksShowReadme(text) {
+    elem = document.createElement('div')
+    elem.classList.add('readme-popup');
+    elem.innerHTML = text;
+
+    popup(elem);
+}
+
 function requestGet(url, data, handler, errorHandler){
     var xhr = new XMLHttpRequest();
     var args = Object.keys(data).map(function(k){ return encodeURIComponent(k) + '=' + encodeURIComponent(data[k]) }).join('&')
@@ -171,6 +179,20 @@ function extraNetworksRequestMetadata(event, extraPage, cardName){
         if(data && data.metadata){
             extraNetworksShowMetadata(data.metadata)
         } else{
+            showError()
+        }
+    }, showError)
+
+    event.stopPropagation()
+}
+
+function extraNetworksRequestReadme(event, readme_file) {
+    showError = function () { extraNetworksShowReadme("there was an error showing readme"); }
+
+    requestGet("./sd_extra_networks/readme", { "file": readme_file }, function (data) {
+        if (data && data.content) {
+            extraNetworksShowReadme(data.content)
+        } else {
             showError()
         }
     }, showError)

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -51,10 +51,21 @@ def get_metadata(page: str = "", item: str = ""):
 
     return JSONResponse({"metadata": metadata})
 
+def get_readme(file: str = ""):
+    from starlette.responses import JSONResponse
+    import markdown
+    
+    if not os.path.isfile(file):
+        return JSONResponse({})
+
+    with open(file, "r") as _file:
+        return JSONResponse({"content": markdown.markdown(_file.read())})
+
 
 def add_pages_to_demo(app):
     app.add_api_route("/sd_extra_networks/thumb", fetch_file, methods=["GET"])
     app.add_api_route("/sd_extra_networks/metadata", get_metadata, methods=["GET"])
+    app.add_api_route("/sd_extra_networks/readme", get_readme, methods=["GET"])
 
 
 class ExtraNetworksPage:
@@ -157,12 +168,18 @@ class ExtraNetworksPage:
         if metadata:
             metadata_button = f"<div class='metadata-button' title='Show metadata' onclick='extraNetworksRequestMetadata(event, {json.dumps(self.name)}, {json.dumps(item['name'])})'></div>"
 
+        readme_link = ""
+        filename = item.get("filename")
+        readme_file = filename + ".md"
+        if filename and os.path.isfile(readme_file):
+            readme_link=f"<span class='readme-link' title='Show readme' onclick='extraNetworksRequestReadme(event, {json.dumps(readme_file)})'>ℹ</span>"
+
         args = {
             "style": f"'{height}{width}{background_image}'",
             "prompt": item.get("prompt", None),
             "tabname": json.dumps(tabname),
             "local_preview": json.dumps(item["local_preview"]),
-            "name": item["name"],
+            "name": readme_link + item["name"],
             "description": (item.get("description") or ""),
             "card_clicked": onclick,
             "save_card_preview": '"' + html.escape(f"""return saveCardPreview(event, {json.dumps(tabname)}, {json.dumps(item["local_preview"])})""") + '"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ torchsde
 safetensors
 psutil
 rich
+markdown

--- a/style.css
+++ b/style.css
@@ -433,6 +433,28 @@ div.dimensions-tools{
     white-space: pre-wrap;
 }
 
+.readme-link{
+    color: rgba(0, 0, 0,0.7) !important;
+    background: rgba(255,255,255,0.7) !important;
+    margin-right: 0.4rem;
+    font-weight: bold;
+    border-radius: 20%;
+    transition: 0.2s;
+}
+
+.readme-link:hover{
+    color: rgb(0, 0, 0) !important;
+    background: rgb(255,255,255) !important;
+}
+
+.readme-popup{
+    color: black;
+    background: white;
+    display: inline-block;
+    padding: 1em;
+    white-space: pre-wrap;
+}
+
 .global-popup{
     display: flex;
     position: fixed;


### PR DESCRIPTION
As networks usually require keywords, special settings and in general knowledge, readme as file allows to hold
such file near the network

Usage: Create a md file with readme content
with the same fileanme as model, e.g.

Model: `./models/Stable-Diffusion/example.safetensors`
Readme: `./models/Stable-Diffusion/example.md`

![image](https://user-images.githubusercontent.com/1686874/233813858-261dc7a2-441c-4514-b9ba-7c50325de522.png)
![image](https://user-images.githubusercontent.com/1686874/233813864-c7e157ca-1c29-49e1-84ee-70717a0bca45.png)
![image](https://user-images.githubusercontent.com/1686874/233813879-e82f3bf8-4a2a-4de7-8ae1-ffa38a1bb149.png)
