### PR TITLE
fix: couldn't remove interrogate_tmp dir while downloading interrogate categories

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -41,7 +41,7 @@ def download_default_clip_interrogate_categories(content_dir):
         errors.display(e, "downloading default CLIP interrogate categories")
     finally:
         if os.path.exists(tmpdir):
-            os.remove(tmpdir)
+            os.removedirs(tmpdir)
 
 
 class InterrogateModels:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
When "Interogate BLIP" is clicked the first time, it tries to download interrogate categories into interrogate_tmp. If the the download gets interrupted, succeeding attempts always fail with errors because os.remove() cannot remove a directory.

```
FileExistsError: [Errno 17] File exists: 'interrogate_tmp'
```
and
```
IsADirectoryError: [Errno 21] Is a directory: 'interrogate_tmp'
```
**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**
 - OS: [Linux]
 - Browser: [chrome]
