### PR TITLE
Add image rotate preprocessing

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -111,7 +111,9 @@ titles = {
     "Resize height to": "Resizes image to this height. If 0, height is inferred from either of two nearby sliders.",
     "Multiplier for extra networks": "When adding extra network such as Hypernetwork or Lora to prompt, use this multiplier for it.",
     "Discard weights with matching name": "Regular expression; if weights's name matches it, the weights is not written to the resulting checkpoint. Use ^model_ema to discard EMA weights.",
-    "Extra networks tab order": "Comma-separated list of tab names; tabs listed here will appear in the extra networks UI first and in order lsited."
+    "Extra networks tab order": "Comma-separated list of tab names; tabs listed here will appear in the extra networks UI first and in order lsited.",
+
+    "Rotate steps": "Determines how many times to rotate an image by \"Rotate Angle / Rotate Steps\" degrees.",
 }
 
 

--- a/modules/textual_inversion/preprocess.py
+++ b/modules/textual_inversion/preprocess.py
@@ -11,7 +11,7 @@ from modules.shared import opts, cmd_opts
 from modules.textual_inversion import autocrop
 
 
-def preprocess(id_task, process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
+def preprocess(id_task, process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None, process_rotate=None, process_rotate_angle=None, process_rotate_steps=None):
     try:
         if process_caption:
             shared.interrogator.load()
@@ -19,7 +19,7 @@ def preprocess(id_task, process_src, process_dst, process_width, process_height,
         if process_caption_deepbooru:
             deepbooru.model.start()
 
-        preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru, split_threshold, overlap_ratio, process_focal_crop, process_focal_crop_face_weight, process_focal_crop_entropy_weight, process_focal_crop_edges_weight, process_focal_crop_debug, process_multicrop, process_multicrop_mindim, process_multicrop_maxdim, process_multicrop_minarea, process_multicrop_maxarea, process_multicrop_objective, process_multicrop_threshold)
+        preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru, split_threshold, overlap_ratio, process_focal_crop, process_focal_crop_face_weight, process_focal_crop_entropy_weight, process_focal_crop_edges_weight, process_focal_crop_debug, process_multicrop, process_multicrop_mindim, process_multicrop_maxdim, process_multicrop_minarea, process_multicrop_maxarea, process_multicrop_objective, process_multicrop_threshold, process_rotate, process_rotate_angle, process_rotate_steps)
 
     finally:
 
@@ -39,6 +39,9 @@ class PreprocessParams:
     dstdir = None
     subindex = 0
     flip = False
+    rotate = False
+    rotate_angle = 0.0
+    rotate_steps = 0
     process_caption = False
     process_caption_deepbooru = False
     preprocess_txt_action = None
@@ -78,8 +81,12 @@ def save_pic_with_caption(image, index, params: PreprocessParams, existing_capti
     params.subindex += 1
 
 
-def save_pic(image, index, params, existing_caption=None):
+def save_pic(image, index, params, existing_caption=None, rotate=True):
     save_pic_with_caption(image, index, params, existing_caption=existing_caption)
+
+    if params.rotate and rotate:
+        for i in range(params.rotate_steps):
+            save_pic(rotate_crop(image, params.rotate_angle / params.rotate_steps * (i + 1)), index, params, existing_caption=existing_caption, rotate=False)
 
     if params.flip:
         save_pic_with_caption(ImageOps.mirror(image), index, params, existing_caption=existing_caption)
@@ -131,7 +138,35 @@ def multicrop_pic(image: Image, mindim, maxdim, minarea, maxarea, objective, thr
     return wh and center_crop(image, *wh)
     
 
-def preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None):
+def rotate_crop(image, angle):
+    rotated = image.rotate(angle, Image.BICUBIC, True)
+
+    # Calculate the aspect ratios and rotation angle in radians
+    aspect_ratio = float(image.size[0]) / image.size[1]
+    rotated_aspect_ratio = float(rotated.size[0]) / rotated.size[1]
+    angle = math.fabs(angle) * math.pi / 180
+
+    # Calculate the total height of the rotated image
+    if aspect_ratio < 1:
+        total_height = float(image.size[0]) / rotated_aspect_ratio
+    else:
+        total_height = float(image.size[1])
+
+    # Calculate the height and width of the output image after rotation
+    h = total_height / (aspect_ratio * math.fabs(math.sin(angle)) + math.fabs(math.cos(angle)))
+    w = h * aspect_ratio
+
+    # Calculate the cropping coordinates
+    left = (rotated.size[0] - w) / 2
+    top = (rotated.size[1] - h) / 2
+    right = (rotated.size[0] + w) / 2
+    bottom = (rotated.size[1] + h) / 2
+
+    # Crop the rotated image
+    cropped = rotated.crop((left, top, right, bottom))
+    return cropped
+
+def preprocess_work(process_src, process_dst, process_width, process_height, preprocess_txt_action, process_flip, process_split, process_caption, process_caption_deepbooru=False, split_threshold=0.5, overlap_ratio=0.2, process_focal_crop=False, process_focal_crop_face_weight=0.9, process_focal_crop_entropy_weight=0.3, process_focal_crop_edges_weight=0.5, process_focal_crop_debug=False, process_multicrop=None, process_multicrop_mindim=None, process_multicrop_maxdim=None, process_multicrop_minarea=None, process_multicrop_maxarea=None, process_multicrop_objective=None, process_multicrop_threshold=None, process_rotate=None, process_rotate_angle=None, process_rotate_steps=None):
     width = process_width
     height = process_height
     src = os.path.abspath(process_src)
@@ -152,6 +187,9 @@ def preprocess_work(process_src, process_dst, process_width, process_height, pre
     params = PreprocessParams()
     params.dstdir = dst
     params.flip = process_flip
+    params.rotate = process_rotate
+    params.rotate_angle = process_rotate_angle
+    params.rotate_steps = int(process_rotate_steps)
     params.process_caption = process_caption
     params.process_caption_deepbooru = process_caption_deepbooru
     params.preprocess_txt_action = preprocess_txt_action

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1093,6 +1093,7 @@ def create_ui():
                         process_multicrop = gr.Checkbox(label='Auto-sized crop', elem_id="train_process_multicrop")
                         process_caption = gr.Checkbox(label='Use BLIP for caption', elem_id="train_process_caption")
                         process_caption_deepbooru = gr.Checkbox(label='Use deepbooru for caption', visible=True, elem_id="train_process_caption_deepbooru")
+                        process_rotate = gr.Checkbox(label='Rotate images', visible=True, elem_id="train_process_rotate")
 
                     with gr.Row(visible=False) as process_split_extra_row:
                         process_split_threshold = gr.Slider(label='Split image threshold', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_split_threshold")
@@ -1103,6 +1104,10 @@ def create_ui():
                         process_focal_crop_entropy_weight = gr.Slider(label='Focal point entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_entropy_weight")
                         process_focal_crop_edges_weight = gr.Slider(label='Focal point edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="train_process_focal_crop_edges_weight")
                         process_focal_crop_debug = gr.Checkbox(label='Create debug image', elem_id="train_process_focal_crop_debug")
+                    
+                    with gr.Row(visible=False) as process_rotate_row:
+                        process_rotate_angle = gr.Slider(label='Rotate angle', value=90.0, minimum=0.0, maximum=359.9, step=1.0, elem_id="train_process_rotate_angle")
+                        process_rotate_steps = gr.Slider(label='Rotate steps', value=3.0, minimum=1.0, maximum=100, step=1.0, elem_id="train_process_rotate_steps")
                     
                     with gr.Column(visible=False) as process_multicrop_col:
                         gr.Markdown('Each image is center-cropped with an automatically chosen width and height.')
@@ -1135,6 +1140,12 @@ def create_ui():
                         fn=lambda show: gr_show(show),
                         inputs=[process_focal_crop],
                         outputs=[process_focal_crop_row],
+                    )
+
+                    process_rotate.change(
+                        fn=lambda show: gr_show(show),
+                        inputs=[process_rotate],
+                        outputs=[process_rotate_row],
                     )
 
                     process_multicrop.change(
@@ -1271,6 +1282,9 @@ def create_ui():
                 process_multicrop_maxarea,
                 process_multicrop_objective,
                 process_multicrop_threshold,
+                process_rotate,
+                process_rotate_angle,
+                process_rotate_steps,
             ],
             outputs=[
                 ti_output,


### PR DESCRIPTION
**Description**

This feature allows you to rotate images in preprocessing.

**Additional notes and description**

It takes two parameters:
* Rotate angle - simple the angle you want to rotate images
* Rotate steps - how many times to rotate images before reaching the rotate angle. I.e. if you want to rotate the image three times by 30 degrees, you set angle to 90 degrees and set steps to 3.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3080 10GB

**Screenshots**
![image](https://user-images.githubusercontent.com/36414434/233854490-5b79f049-eb4f-47ba-9529-ead605c911dc.png)
![d6SwBA7k](https://user-images.githubusercontent.com/36414434/233854500-aaac753e-915c-4028-a9e5-a7e4cbcc02a6.png)
![uM5tECk8](https://user-images.githubusercontent.com/36414434/233854503-3da5e03d-8f8a-45bd-9261-f222d2158154.png)
