### PR TITLE
fix ui img2img scripts

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -151,7 +151,7 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         override_settings=override_settings,
     )
 
-    p.scripts = modules.scripts.scripts_txt2img
+    p.scripts = modules.scripts.scripts_img2img
     p.script_args = args
 
     if shared.cmd_opts.enable_console_prompts:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
img2img scripts run by ui are not consistent with those run by api. img2img scripts run by ui were mistakenly assigned to  modules.scripts.scripts_txt2img?