### PR TITLE
Fix CLIP FileExistsError

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -32,7 +32,8 @@ def download_default_clip_interrogate_categories(content_dir):
     category_types = ["artists", "flavors", "mediums", "movements"]
 
     try:
-        os.makedirs(tmpdir)
+        if not os.path.exists(tmpdir):
+            os.makedirs(tmpdir)
         for category_type in category_types:
             torch.hub.download_url_to_file(f"https://raw.githubusercontent.com/pharmapsychotic/clip-interrogator/main/clip_interrogator/data/{category_type}.txt", os.path.join(tmpdir, f"{category_type}.txt"))
         os.rename(tmpdir, content_dir)
@@ -41,7 +42,7 @@ def download_default_clip_interrogate_categories(content_dir):
         errors.display(e, "downloading default CLIP interrogate categories")
     finally:
         if os.path.exists(tmpdir):
-            os.remove(tmpdir)
+            os.removedirs(tmpdir)
 
 
 class InterrogateModels:


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
The code should check if the directory already exists before attempting to create it. 
Also the way the original code deleted the directory was incorrect.

**Additional notes and description of your changes**
If the user's interrupts the program after creating a folder due to network problems (there may be some censorship network countries), then there is a risk of this error.

**Environment this was tested in**
 - OS: Windows
 - Browser: Edge
 - Graphics card: GTX1060

**Screenshots or videos of your changes**
![image](https://user-images.githubusercontent.com/119397407/234320041-26550e47-a3e7-4a68-85c0-aff065458fbd.png)

