### PR TITLE
perf(webui): Remove duplicate code

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -126,9 +126,6 @@ def initialize():
     modules.scripts.load_scripts()
     startup_timer.record("load scripts")
 
-    modelloader.load_upscalers()
-    startup_timer.record("load upscalers")
-
     modules.sd_vae.refresh_vae_list()
     startup_timer.record("refresh VAE")
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I noticed that the `modelloader.load_upscalers()` function is called twice during initialization. Can we reduce it to one call?

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/22bcc7be428c94e9408f589966c2040187245d81/webui.py#L123
=>
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/22bcc7be428c94e9408f589966c2040187245d81/modules/modelloader.py#L135-L137

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/22bcc7be428c94e9408f589966c2040187245d81/webui.py#L129







