### PR TITLE
Add possibility to hide any subfolder from the GUI models' list

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -42,6 +42,8 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
             if os.path.exists(place):
                 for file in glob.iglob(place + '**/**', recursive=True):
                     full_path = file
+                    if '.off' in full_path:
+                        continue
                     if os.path.isdir(full_path):
                         continue
                     if os.path.islink(full_path) and not os.path.exists(full_path):


### PR DESCRIPTION
Very small but useful update which allows to hide any subfolder (inside the 'models' folder) from the models' list in the GUI 
You just need to add '.off' to subfolder name and refresh the SD-models' list in the GUI
And all the models (inside the subfolder with '.off' in its name) won't be showing in the SD-models' list in your GUI
It's very useful when you have subfolders with merging experiments or training-in-process or etc and you don't want them to be visible in the GUI

#### Step 1:
<img src="https://lovemet.ru/www/img/a1111-sd-hide-folder-2.png" alt="hide-subfolder-demo" width="50%"/>

#### Step 2:
<img src="https://lovemet.ru/www/img/a1111-sd-hide-folder-3.png" alt="hide-subfolder-demo" width="50%"/>