### PR TITLE
Add a Darwin(macOS) specific workaround against metadata files in emb…

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import traceback
 import inspect
@@ -199,12 +200,18 @@ class EmbeddingDatabase:
         if not os.path.isdir(embdir.path):
             return
 
+        platform_name = platform.system()
+
         for root, dirs, fns in os.walk(embdir.path, followlinks=True):
             for fn in fns:
                 try:
                     fullfn = os.path.join(root, fn)
 
                     if os.stat(fullfn).st_size == 0:
+                        continue
+
+                    # Darwin(macOS) with ExFAT workaround
+                    if platform_name == 'Darwin' and fn.startswith('._'):
                         continue
 
                     self.load_from_file(fullfn, fn)


### PR DESCRIPTION
### Add a Darwin(macOS) specific workaround against metadata files in embeddings directory automatically created by the OS

I saw too many error messages were printed when the WebUI started on macOS on Apple Computers because of automatically created metadata files on ExFAT disks. So I made a workaround by minimal code changes to avoid the error messages.

Many Apple computer users use external storage devices, and in many cases the disk format is ExFAT for some reason. When macOS accesses the ExFAT disk, this problem can be happened.

In ExFAT disks, macOS creates and updates hidden metadata files when it scans or accesses the files in the disk automatically, and for textual inversion(embedding) files, there will be metadata files its names started with '._' and ended with '.pt' or '.bin'. For example. if the name of actual embedding file is 'vintagemap_f.pt', its metadata file name will be '._vintagemap_f.pt'.

When the WebUI is starting, it scans textual inversion directory, and tries to load *.pt or *.bin files. The automatically created metadata files also have same extensions, so the program did not know what the actual embeddings files are and what the metadata files are.

So, usually error messages like this fills the terminal window.
```
Error verifying pickled file from embeddings/styles/._vintagemap_f.pt:
Traceback (most recent call last):
  File "/Volumes/stable_diff/stable-diffusion-webui/modules/safe.py", line 81, in check_pt
    with zipfile.ZipFile(filename) as z:
  File "/Users/knut/.pyenv/versions/3.10.10/lib/python3.10/zipfile.py", line 1267, in __init__
    self._RealGetContents()
  File "/Users/knut/.pyenv/versions/3.10.10/lib/python3.10/zipfile.py", line 1334, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/stable_diff/stable-diffusion-webui/modules/safe.py", line 135, in load_with_extra
    check_pt(filename, extra_handler)
  File "/Volumes/stable_diff/stable-diffusion-webui/modules/safe.py", line 102, in check_pt
    unpickler.load()
_pickle.UnpicklingError: invalid load key, '\x00'.

-----> !!!! The file is most likely corrupted !!!! <-----
You can skip this check with --disable-safe-unpickle commandline argument, but that is not going to help you.


Error loading embedding ._vintagemap_f.pt:
Traceback (most recent call last):
  File "/Volumes/stable_diff/stable-diffusion-webui/modules/textual_inversion/textual_inversion.py", line 210, in load_from_dir
    self.load_from_file(fullfn, fn)
  File "/Volumes/stable_diff/stable-diffusion-webui/modules/textual_inversion/textual_inversion.py", line 168, in load_from_file
    if 'string_to_param' in data:
TypeError: argument of type 'NoneType' is not iterable

```

The change I made is very simple. If platform.sytem() is 'Darwin' and the file name is started with '._', then it will not be loaded. The change was happened in function load_from_dir in  modules/textual_inversion/textual_inversion.py.

I tested it on my computer (Apple M1 with macOS) only, but it worked well.
