### PR TITLE
override setting "model override" enhancement

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -498,6 +498,11 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     stored_opts = {k: opts.data[k] for k in p.override_settings.keys()}
 
     try:
+        # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint
+        if sd_models.checkpoint_alisases.get(p.override_settings.get('sd_model_checkpoint')) is None:
+            p.override_settings.pop('sd_model_checkpoint', None)
+            sd_models.reload_model_weights()
+
         for k, v in p.override_settings.items():
             setattr(opts, k, v)
 
@@ -514,8 +519,6 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
         if p.override_settings_restore_afterwards:
             for k, v in stored_opts.items():
                 setattr(opts, k, v)
-                if k == 'sd_model_checkpoint':
-                    sd_models.reload_model_weights()
 
                 if k == 'sd_vae':
                     sd_vae.reload_vae_weights()


### PR DESCRIPTION
### currently there are some issues with model override setting
![image](https://user-images.githubusercontent.com/40751091/235377202-2dd04772-109a-40f5-801e-9d113726780b.png)

1. if override model is not found, then webui it will load the first model on the list, not the current loaded model (I think this is under that behavior)
2. when the job is finished the override will get immediately reset to the original model, while this is functioning as intended but it means that whenever a model is overrided the model will have to be reloaded every job, causing extra overhead which in some cases would rendered this entire function to be meaningless

there was a user experiencing issue because of model override
[[Bug]: Webui keep switching to the same model and shows obsessive behavior when switching model](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7669)
the model keeps getting loading and unloading causing lots of overhead for each job

### the modification to the code does 2 things

1. checks if a model can be found, and if not remove the model override entry
2. removing the restoring of loaded model at the end of the job, and instead moving it to the beginning of a job
this makes it so that a model does not have to be repeatedly loaded and unloaded when one is using an override model setting
removing unnecessary overhead
normal manual switching off model is not affected, the model will still switch at demand, it's only at the beginning of a job that it will check that if the model loaded is the correct model

### Test
I have tested the override and the loading and unloading on models, and didn't find any issue
I've tested with XYZ grid and found that this change is compatible

note1:
if a model is already loaded the model loader would return early, so running `sd_models.reload_model_weights()` performance impact is minuscule
note2:
I don't believe this will have any issues with extensions, since it's based on the original override mechanics
note3:
during testing with XYZ good I discovered some [issues with model loading after the XYZ grid](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9959) has finished
the issue is from before RC and is unchanged by this PR