### PR TITLE
XYZ checkpoint switch via Override

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -86,7 +86,7 @@ def apply_checkpoint(p, x, xs):
     info = modules.sd_models.get_closet_checkpoint_match(x)
     if info is None:
         raise RuntimeError(f"Unknown checkpoint: {x}")
-    modules.sd_models.reload_model_weights(shared.sd_model, info)
+    p.override_settings['sd_model_checkpoint'] = info.hash
 
 
 def confirm_checkpoints(p, xs):


### PR DESCRIPTION
close https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9959

change xyz grid apply_checkpoint()
to use override settings to apply the checkpoint change 
letting `process_images` `sd_models.reload_model_weights()` handle the checkpoint loading

### while this PR can work as a standalone fix, it should be combined with PR [override setting "model override" enhancement](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9958)
If this is not combined with the above PR, this fix would cause extra overhead due to model switching model switching 
and causing this fix to be **not worth the fix**

this method also had the added benefit of allowing `xyz grid's checkpoint axle` to override the `override settings > model hash : xxx`
previously if one were to use `xyz grid's checkpoint axle` and forgot to remove override model, all model switching done by xyz gird will be override by the override settings, resulting in a grid of images labeled with different models but actually generate with the same model

I've tested that XYZ grid does still work after the change, model is also changed correctly
even in cases where model hasn't been loaded so the hash hasn't been cached

possible issues I can think of
there is a very very low chance that if you have 2 models with the same hash, I believe it could cause a wrong model loaded
but this is basically impossible since hash V2

test output (working correctly)
![20230501-181010-239461-1-1girl](https://user-images.githubusercontent.com/40751091/235433625-fa7bfb86-3c00-4a22-80ae-2a8027371177.png)
