### PR TITLE
Initialize the upscalers

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -133,11 +133,8 @@ forbidden_upscaler_classes = set()
 
 
 def list_builtin_upscalers():
-    load_upscalers()
-
     builtin_upscaler_classes.clear()
     builtin_upscaler_classes.extend(Upscaler.__subclasses__())
-
 
 def forbid_loaded_nonbuiltin_upscalers():
     for cls in Upscaler.__subclasses__():

--- a/webui.py
+++ b/webui.py
@@ -185,6 +185,9 @@ def initialize():
     modules.scripts.load_scripts()
     startup_timer.record("load scripts")
 
+    modelloader.load_upscalers()
+    #startup_timer.record("load upscalers") #Is this necessary? I don't know.
+
     modules.sd_vae.refresh_vae_list()
     startup_timer.record("refresh VAE")
 


### PR DESCRIPTION
Add modelloader.load_upscalers to def initialize()

# Please read the [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing) before submitting a pull request!

If you have a large change, pay special attention to this paragraph:

> Before making changes, if you think that your feature will result in more than 100 lines changing, find me and talk to me about the feature you are proposing. It pains me to reject the hard work someone else did, but I won't add everything to the repo, and it's better if the rejection happens before you have to waste time working on the feature.

Otherwise, after making sure you're following the rules described in wiki page, remove this section and continue on.

**Describe what this pull request is trying to achieve.**
Change so that the upscaler is also initialized when webui.py is initialized.
#9982 
We solve this problem.

**Additional notes and description of your changes**

Call modelloader.load_upscalers() during initialize
Add one additional line, excluding comments

**Environment this was tested in**

 - OS:  Linux(WSL2)
 - Browser: Microsoft Edge
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**
None
If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.