### PR TITLE
print PIL.UnidentifiedImageError

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -48,7 +48,8 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
 
         try:
             img = Image.open(image)
-        except UnidentifiedImageError:
+        except UnidentifiedImageError as e:
+            print(e)
             continue
         # Use the EXIF orientation of photos taken by smartphones.
         img = ImageOps.exif_transpose(img)


### PR DESCRIPTION
print [PIL.UnidentifiedImageError](https://pillow.readthedocs.io/en/stable/PIL.html#PIL.UnidentifiedImageError) for PR [**print Exception** for Fix #9185 add message #9219](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9219)

well ....... they did not print the exception

in most cases printing exceptions won't be of any use because the exception as it's raised due to trying to open a non-image file
but from a short read of [PIL's Doc](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open) it seems the exception might also be raised due to an image file is not  supported by PIL

currently if this happened a user will have no indication that image has not been processed
depending on their workflow this would be hard to notice / debug