### PR TITLE
Support to save full settings in web ui

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1520,6 +1520,9 @@ def create_ui():
         with gr.Row():
             with gr.Column(scale=6):
                 settings_submit = gr.Button(value="Apply settings", variant='primary', elem_id="settings_submit")
+            # button to save panel settings
+            with gr.Column(scale=6):
+                settings_save = gr.Button(value="Save settings", variant='primary', elem_id="settings_save")
             with gr.Column():
                 restart_gradio = gr.Button(value='Reload UI', variant='primary', elem_id="settings_restart_gradio")
 
@@ -1625,6 +1628,22 @@ def create_ui():
         def request_restart():
             shared.state.interrupt()
             shared.state.need_restart = True
+
+        def save_ui_config():
+            # currently only interface settings are saved
+            visit(txt2img_interface, loadsave, "txt2img")
+            visit(img2img_interface, loadsave, "img2img")
+            visit(extras_interface, loadsave, "extras")
+            visit(modelmerger_interface, loadsave, "modelmerger")
+            visit(train_interface, loadsave, "train")
+            with open(ui_config_file, "w", encoding="utf8") as file:
+                json.dump(ui_settings, file, indent=4)
+        # save panel settings to ui-config.json
+        settings_save.click(
+            fn=save_ui_config,
+            inputs=[],
+            outputs=[],
+        )
 
         restart_gradio.click(
             fn=request_restart,


### PR DESCRIPTION
# Please read the [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing) before submitting a pull request!

If you have a large change, pay special attention to this paragraph:

> Before making changes, if you think that your feature will result in more than 100 lines changing, find me and talk to me about the feature you are proposing. It pains me to reject the hard work someone else did, but I won't add everything to the repo, and it's better if the rejection happens before you have to waste time working on the feature.

Otherwise, after making sure you're following the rules described in wiki page, remove this section and continue on.

**Describe what this pull request is trying to achieve.**
**What**
Extra button called "Save settings" in "Settings" tab to save full settings of web ui, including txt2img, img2img, checkpoint merge and training into local file (ui-config.json)

**Why**
We 'd like to provide extension for user to migrate training & inference workload onto cloud instead of on local standalone server, and latest user settings in txt2img, img2img, checkpoint merge and training are needed for cloud service to execute. However, those detailed settings only saved in ui-config.json at initial time. Furthermore, saving full settings in web ui allow user to continue & replicate their env, in case of env is broken or need to be cloned for other team member.
Currently we had to parse the html element and extract the setting value using JS, alike some [discussions and workaround](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/3229) it's not a optimized way due to: 1) time consuming and error prone to parse all 100+ settings, most workarounds only cover settings in txt2img/img2img; 2) easily outdated since most workaround are implemented by extensions to parse all detailed settings manually, which will easily failed once upstream branch is updated.

**How**
Current, we multiplex the function loadsave/visit to make the change small as possible (20-30 lines), and saved configuration file will overwrite the ui-config.json file.

**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Ubuntu
 - Browser: Chrome
 - Graphics card: Tesla T4 
**Screenshots or videos of your changes**
<img width="1453" alt="Screen Shot 2023-05-04 at 17 31 08" src="https://user-images.githubusercontent.com/23544182/236166772-7f41e388-2398-4e2c-9765-f8f62c202434.png">

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.