### PR TITLE
Enable showing gallery in preview mode

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -388,6 +388,7 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
 
 options_templates.update(options_section(('ui', "User interface"), {
     "return_grid": OptionInfo(True, "Show grid in results for web"),
+    "gallery_preview": OptionInfo(False, "Show image gallery in preview mode"),
     "return_mask": OptionInfo(False, "For inpainting, include the greyscale mask in results for web"),
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -9,7 +9,6 @@ import subprocess as sp
 
 from modules import call_queue, shared
 from modules.generation_parameters_copypaste import image_from_url_text
-from modules.shared import opts
 import modules.images
 
 folder_symbol = '\U0001f4c2'  # 📂
@@ -126,7 +125,7 @@ Requested path was: {f}
 
     with gr.Column(variant='panel', elem_id=f"{tabname}_results"):
         with gr.Group(elem_id=f"{tabname}_gallery_container"):
-            result_gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"{tabname}_gallery").style(columns=4).style(preview=opts.gallery_preview)
+            result_gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"{tabname}_gallery").style(columns=4).style(preview=shared.opts.gallery_preview)
 
         generation_info = None
         with gr.Column():

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -9,6 +9,7 @@ import subprocess as sp
 
 from modules import call_queue, shared
 from modules.generation_parameters_copypaste import image_from_url_text
+from modules.shared import opts
 import modules.images
 
 folder_symbol = '\U0001f4c2'  # 📂
@@ -125,7 +126,7 @@ Requested path was: {f}
 
     with gr.Column(variant='panel', elem_id=f"{tabname}_results"):
         with gr.Group(elem_id=f"{tabname}_gallery_container"):
-            result_gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"{tabname}_gallery").style(columns=4)
+            result_gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"{tabname}_gallery").style(columns=4).style(preview=opts.gallery_preview)
 
         generation_info = None
         with gr.Column():


### PR DESCRIPTION
# Enabling preview mode for the Gallery

This small change allow for users to view the gallery after the images are finished processing in preview mode. The normal display is not bad unless you are doing one image at a time and then clicking on the image to make it bigger is slightly (very slightly) annoying. i.e.

![image](https://user-images.githubusercontent.com/24731980/236297637-da907475-a2a9-4e92-a5a5-bc5c000af15f.png)


instead of this:

![image](https://user-images.githubusercontent.com/24731980/236297811-a3ea555e-2a2f-4ec5-9ac3-a99417f5a519.png)


So instead of all the images being displayed as:

![image](https://user-images.githubusercontent.com/24731980/236296400-db5ef4f2-e88f-4fd2-be01-148131e34cab.png)


They will instead be displayed as:

![image](https://user-images.githubusercontent.com/24731980/236296168-3fd00aa7-a3e7-4740-9f58-cc308ab626d9.png)

Also added the setting under `User Interface > Show image gallery in preview mode`

![image](https://user-images.githubusercontent.com/24731980/236296908-4627aeaf-db54-443d-ae8d-66357bd99b1c.png)


**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome & Edge
 - Graphics card: 4070 TI