### PR TITLE
style.css: Make the image in the ImageViewer be resized correctly

### DIFF
--- a/style.css
+++ b/style.css
@@ -534,6 +534,7 @@ div#extras_scale_to_tab div.form{
 #lightboxModal > img.modalImageFullscreen{
     object-fit: contain;
     height: 100%;
+    min-height: 0;
 }
 
 .modalPrev,


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

In the recent update I found that the images in the ImageViewer always went beyond the height of one screen, making me have to scroll down to see them all. This was caused by the default value of min-width in the Flexbox layout, so I committed this change to fix this behaviour.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Edge

**Screenshots or videos of your changes**

Before:

![before](https://i.imgur.com/RqQdq5z.png)

After:

![after](https://i.imgur.com/zP2eVVA.png)