### PR TITLE
Fix gamepad navigation

### DIFF
--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,15 +1,27 @@
-const delay = 250//ms
+const delay = 350//ms
+let isWaiting = false;
 window.addEventListener('gamepadconnected', (e) => {
-    setInterval(() => {
-        if (!opts.js_modal_lightbox_gamepad) return;
+    setInterval(async () => {
+        if (!opts.js_modal_lightbox_gamepad || isWaiting) return;
         const gamepad = navigator.getGamepads()[0];
         const xValue = gamepad.axes[0];
-        if (xValue < -0.3) {
+        if (xValue <= -0.3) {
             modalPrevImage(e);
-        } else if (xValue > 0.3) {
+            isWaiting = true;
+        } else if (xValue >= 0.3) {
             modalNextImage(e);
+            isWaiting = true;
         }
-    }, delay);
+        if (isWaiting) {
+            await sleepUntil(() => {
+                const xValue = navigator.getGamepads()[0].axes[0]
+                if (xValue < 0.3 && xValue > -0.3) {
+                    return true;
+                }
+            }, delay);
+            isWaiting = false;
+        }
+    }, 10);
 });
 
 /*
@@ -31,3 +43,15 @@ window.addEventListener('wheel', (e) => {
         isScrolling = false;
     }, delay);
 });
+
+function sleepUntil(f, timeout) {
+    return new Promise((resolve) => {
+        const timeStart = new Date();
+        const wait = setInterval(function() {
+            if (f() || new Date() - timeStart > timeout) {
+                clearInterval(wait);
+                resolve();
+            }
+        }, 20);
+    });
+}

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,4 +1,3 @@
-const delay = 350//ms
 let isWaiting = false;
 window.addEventListener('gamepadconnected', (e) => {
     setInterval(async () => {
@@ -18,7 +17,7 @@ window.addEventListener('gamepadconnected', (e) => {
                 if (xValue < 0.3 && xValue > -0.3) {
                     return true;
                 }
-            }, delay);
+            }, opts.js_modal_lightbox_gamepad_repeat);
             isWaiting = false;
         }
     }, 10);
@@ -41,7 +40,7 @@ window.addEventListener('wheel', (e) => {
 
     setTimeout(() => {
         isScrolling = false;
-    }, delay);
+    }, opts.js_modal_lightbox_gamepad_repeat);
 });
 
 function sleepUntil(f, timeout) {

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,8 +1,9 @@
-let isWaiting = false;
 window.addEventListener('gamepadconnected', (e) => {
+    const index = e.gamepad.index;
+    let isWaiting = false;
     setInterval(async () => {
         if (!opts.js_modal_lightbox_gamepad || isWaiting) return;
-        const gamepad = navigator.getGamepads()[0];
+        const gamepad = navigator.getGamepads()[index];
         const xValue = gamepad.axes[0];
         if (xValue <= -0.3) {
             modalPrevImage(e);
@@ -13,7 +14,7 @@ window.addEventListener('gamepadconnected', (e) => {
         }
         if (isWaiting) {
             await sleepUntil(() => {
-                const xValue = navigator.getGamepads()[0].axes[0]
+                const xValue = navigator.getGamepads()[index].axes[0]
                 if (xValue < 0.3 && xValue > -0.3) {
                     return true;
                 }

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,36 +1,33 @@
-    let delay = 350//ms
-    window.addEventListener('gamepadconnected', (e) => {
-        console.log("Gamepad connected!")
-        const gamepad = e.gamepad;
-        setInterval(() => {
-            const xValue = gamepad.axes[0].toFixed(2);
-            if (xValue < -0.3) {
-                modalPrevImage(e);
-            } else if (xValue > 0.3) {
-                modalNextImage(e);
-            }
-
-        }, delay);
-    });
-
-
-    /*
-    Primarily for vr controller type pointer devices.
-    I use the wheel event because there's currently no way to do it properly with web xr.
-     */
-
-    let isScrolling = false;
-    window.addEventListener('wheel', (e) => {
-        if (isScrolling) return;
-        isScrolling = true;
-
-        if (e.deltaX <= -0.6) {
+const delay = 250//ms
+window.addEventListener('gamepadconnected', (e) => {
+    setInterval(() => {
+        if (!opts.js_modal_lightbox_gamepad) return;
+        const gamepad = navigator.getGamepads()[0];
+        const xValue = gamepad.axes[0];
+        if (xValue < -0.3) {
             modalPrevImage(e);
-        } else if (e.deltaX >= 0.6) {
+        } else if (xValue > 0.3) {
             modalNextImage(e);
         }
+    }, delay);
+});
 
-        setTimeout(() => {
-            isScrolling = false;
-        }, delay);
-    });
+/*
+Primarily for vr controller type pointer devices.
+I use the wheel event because there's currently no way to do it properly with web xr.
+ */
+let isScrolling = false;
+window.addEventListener('wheel', (e) => {
+    if (!opts.js_modal_lightbox_gamepad || isScrolling) return;
+    isScrolling = true;
+
+    if (e.deltaX <= -0.6) {
+        modalPrevImage(e);
+    } else if (e.deltaX >= 0.6) {
+        modalNextImage(e);
+    }
+
+    setTimeout(() => {
+        isScrolling = false;
+    }, delay);
+});

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -399,6 +399,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "font": OptionInfo("", "Font for image grids that have text"),
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
+    "js_modal_lightbox_gamepad": OptionInfo(True, "Navagete image viewer with gamepad"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group"),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row"),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -400,6 +400,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
     "js_modal_lightbox_gamepad": OptionInfo(True, "Navigate image viewer with gamepad"),
+    "js_modal_lightbox_gamepad_repeat": OptionInfo(250, "Gamepad repeat period, in milliseconds"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group"),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row"),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -399,7 +399,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "font": OptionInfo("", "Font for image grids that have text"),
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
-    "js_modal_lightbox_gamepad": OptionInfo(True, "Navagete image viewer with gamepad"),
+    "js_modal_lightbox_gamepad": OptionInfo(True, "Navigate image viewer with gamepad"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group"),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row"),


### PR DESCRIPTION
The gamepad script (#7632) didn't actually work with gamepads. It only polled the gamepad when first detected, so it just constantly repeated its initial state. I suspect it was only tested with an oculus quest controller.

I've also added settings for repeat speed and to enable/disable it.

Fixes #10114

**Environment this was tested in**
 - OS: WIndows 10
 - Browser: Edge
 - Graphics card: RTX 4070ti