### PR TITLE
Update webui.sh

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -35,7 +35,7 @@ fi
 # python3 executable
 if [[ -z "${python_cmd}" ]]
 then
-    python_cmd="python3"
+    python_cmd="python"
 fi
 
 # git executable


### PR DESCRIPTION
python3, the default was an alias to system python, not an env python, which failed to run after an update.
python2 is out of support, python is version 3. And apparently not all environments use a python3 link anymore,

My OS is Linux, one question is, is this also true for Darwin and other OSs that run this shell script?