### PR TITLE
Add api method to get LoRA models

### DIFF
--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -343,6 +343,7 @@ def lora_MultiheadAttention_load_state_dict(self, *args, **kwargs):
 
 def list_available_loras():
     available_loras.clear()
+    list_loras.clear()
 
     os.makedirs(shared.cmd_opts.lora_dir, exist_ok=True)
 
@@ -357,9 +358,11 @@ def list_available_loras():
 
         name = os.path.splitext(os.path.basename(filename))[0]
 
+        list_loras[name] = filename
         available_loras[name] = LoraOnDisk(name, filename)
 
 
+list_loras = {}
 available_loras = {}
 loaded_loras = []
 

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -182,6 +182,7 @@ class Api:
         self.add_api_route("/sdapi/v1/upscalers", self.get_upscalers, methods=["GET"], response_model=List[UpscalerItem])
         self.add_api_route("/sdapi/v1/sd-models", self.get_sd_models, methods=["GET"], response_model=List[SDModelItem])
         self.add_api_route("/sdapi/v1/hypernetworks", self.get_hypernetworks, methods=["GET"], response_model=List[HypernetworkItem])
+        self.add_api_route("/sdapi/v1/loras", self.get_loras, methods=["GET"], response_model=List[LoRAItem])
         self.add_api_route("/sdapi/v1/face-restorers", self.get_face_restorers, methods=["GET"], response_model=List[FaceRestorerItem])
         self.add_api_route("/sdapi/v1/realesrgan-models", self.get_realesrgan_models, methods=["GET"], response_model=List[RealesrganItem])
         self.add_api_route("/sdapi/v1/prompt-styles", self.get_prompt_styles, methods=["GET"], response_model=List[PromptStyleItem])
@@ -526,6 +527,11 @@ class Api:
 
     def get_hypernetworks(self):
         return [{"name": name, "path": shared.hypernetworks[name]} for name in shared.hypernetworks]
+
+    def get_loras(self):
+        if len(shared.loras) == 0:
+            shared.reload_loras()
+        return [{"name": name, "path": shared.loras[name], "prompt": "not support now"} for name in shared.loras]
 
     def get_face_restorers(self):
         return [{"name":x.name(), "cmd_dir": getattr(x, "cmd_dir", None)} for x in shared.face_restorers]

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -252,6 +252,11 @@ class HypernetworkItem(BaseModel):
     name: str = Field(title="Name")
     path: Optional[str] = Field(title="Path")
 
+class LoRAItem(BaseModel):
+    name: str = Field(title="Name")
+    path: Optional[str] = Field(title="Path")
+    prompt: Optional[str] = Field(title="Prompt")
+
 class FaceRestorerItem(BaseModel):
     name: str = Field(title="Name")
     cmd_dir: Optional[str] = Field(title="Path")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -95,6 +95,14 @@ def reload_hypernetworks():
 
     hypernetworks = hypernetwork.list_hypernetworks(cmd_opts.hypernetwork_dir)
 
+loras = {}
+
+def reload_loras():
+    import importlib
+    lora = importlib.import_module('extensions-builtin.Lora.lora')
+    global loras
+    lora.list_available_loras()
+    loras = lora.list_loras
 
 class State:
     skipped = False


### PR DESCRIPTION
 https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7865

Use "/sdapi/v1/loras" to get the LoRA model list. 
The method will return the data like follow:
`[
    {
        "name": "",
        "path": "",
        "prompt": "not support now"
    }
]`
