### PR TITLE
Webui page title customization

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -47,7 +47,7 @@ function formatTime(secs){
 }
 
 function setTitle(progress){
-    var title = 'Stable Diffusion'
+    var title = opts.ui_window_title;
 
     if(opts.show_progress_in_title && progress){
         title = '[' + progress.trim() + '] ' + title;

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -102,3 +102,4 @@ parser.add_argument("--no-gradio-queue", action='store_true', help="Disables gra
 parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
+parser.add_argument("--ui-webpage-title", type=str, help="Title to use for the webui (appearing on browser tab)", default="Stable Diffusion")

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -102,4 +102,3 @@ parser.add_argument("--no-gradio-queue", action='store_true', help="Disables gra
 parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
-parser.add_argument("--ui-webpage-title", type=str, help="Title to use for the webui (appearing on browser tab)", default="Stable Diffusion")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -399,6 +399,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "font": OptionInfo("", "Font for image grids that have text"),
     "js_modal_lightbox": OptionInfo(True, "Enable full page image viewer"),
     "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Show images zoomed in by default in full page image viewer"),
+    "ui_window_title": OptionInfo("Stable Diffusion", "Window title (requires restart)"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group"),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1652,7 +1652,7 @@ def create_ui():
     for _interface, label, _ifid in interfaces:
         shared.tab_names.append(label)
 
-    with gr.Blocks(theme=shared.gradio_theme, analytics_enabled=False, title=cmd_opts.ui_webpage_title) as demo:
+    with gr.Blocks(theme=shared.gradio_theme, analytics_enabled=False, title=opts.ui_window_title) as demo:
         with gr.Row(elem_id="quicksettings", variant="compact"):
             for i, k, item in sorted(quicksettings_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
                 component = create_setting_component(k, is_quicksettings=True)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1652,7 +1652,7 @@ def create_ui():
     for _interface, label, _ifid in interfaces:
         shared.tab_names.append(label)
 
-    with gr.Blocks(theme=shared.gradio_theme, analytics_enabled=False, title="Stable Diffusion") as demo:
+    with gr.Blocks(theme=shared.gradio_theme, analytics_enabled=False, title=cmd_opts.ui_webpage_title) as demo:
         with gr.Row(elem_id="quicksettings", variant="compact"):
             for i, k, item in sorted(quicksettings_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
                 component = create_setting_component(k, is_quicksettings=True)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Adding the possibility to customize the webui page title with a command argument.

**Additional notes and description of your changes**

I think this could be useful when people have more than one instance running to easily identify on which environnement they are connected.

The argument is --ui-webpage-title and defaults to "Stable Diffusion" like before the change.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA 3060

Screenshot:
![Capture d'écran 2023-05-07 185649](https://user-images.githubusercontent.com/1480586/236706658-b04ed99b-d6c3-460a-b52d-03cce950b48a.png)
