### PR TITLE
1.1.1 quicksettings list migration

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -549,6 +549,10 @@ class Options:
         with open(filename, "r", encoding="utf8") as file:
             self.data = json.load(file)
 
+        # 1.1.1 quicksettings list migration
+        if self.data.get('quicksettings') is not None and self.data.get('quicksettings_list') is None:
+            self.data['quicksettings_list'] = [i.strip() for i in self.data.get('quicksettings').split(',')]
+
         bad_settings = 0
         for k, v in self.data.items():
             info = self.data_labels.get(k, None)


### PR DESCRIPTION
migration the old quicksettings to quicksettings_list

if you want backwards compatibility you can add this to `save()`
```py
if self.data.get('quicksettings', None) is not None:
    self.data['quicksettings'] = ','.join(self.data.get('quicksettings_list', None))
```

this is meant to be a patch, remove the code, when you deem it's unnecessary

to be honest this isn't really needed, in the first place
since there's basically no documentation on quicksettings feature, those that are using the features probably are able to easily re-configure it