### PR TITLE
Replace pylint CI with ruff

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -18,22 +18,29 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.10.6
-          cache: pip
-          cache-dependency-path: |
-            **/requirements*txt
-      - name: Install PyLint
-        run: | 
-          python -m pip install --upgrade pip
-          pip install pylint
-      # This lets PyLint check to see if it can resolve imports
-      - name: Install dependencies
-        run: |
-          export COMMANDLINE_ARGS="--skip-torch-cuda-test --exit"
-          python launch.py
-      - name: Analysing the code with pylint
-        run: |
-          pylint $(git ls-files '*.py')
+          python-version: 3.11
+          # NB: there's no cache: pip here since we're not installing anything
+          #     from the requirements.txt file(s) in the repository; it's faster
+          #     not to have GHA download an (at the time of writing) 4 GB cache
+          #     of PyTorch and other dependencies.
+      - name: Install Ruff
+        run: pip install ruff==0.0.265
+      - name: Run Ruff
+        run: ruff .
+
+# The rest are currently disabled pending fixing of e.g. installing the torch dependency.
+
+#      - name: Install PyLint
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install pylint
+#      # This lets PyLint check to see if it can resolve imports
+#      - name: Install dependencies
+#        run: |
+#          export COMMANDLINE_ARGS="--skip-torch-cuda-test --exit"
+#          python launch.py
+#      - name: Analysing the code with pylint
+#        run: |
+#          pylint $(git ls-files '*.py')

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+target-version = "py310"
+
+select = [
+    "E999",  # syntax error
+]
+
+extend-exclude = [
+    "extensions",
+    "extensions-disabled",
+]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This PR replaces the GitHub Actions lint action (that hasn't successfully run for a while) with a simple one based on the excellent [Ruff](https://github.com/charliermarsh/ruff/) linter.

* For a starting point, the configuration is extremely simple and only enables the E999 (Syntax Error) lint; i.e. ruff just checks that the code is syntactically valid Python 3.10+ code. If this is fine, we (or I - I don't mind doing the work) can enable a broader set of lints in a future PR; Ruff's default configuration already reveals some possible bugs.
* I left the broken pylint config in in the YAML file so it could be re-enabled easily later.
* As noted in the YAML, there is purposely no cache here, and we're also purposely not using a specific version of Python to avoid having to download a new one onto the runner. **This makes the total run time for the CI about 8 seconds.**

**Additional notes and description of your changes**

I've put in similar ruff work in in Gradio; see https://github.com/gradio-app/gradio/pull/3710, https://github.com/gradio-app/gradio/pull/3979, https://github.com/gradio-app/gradio/pull/4038

**Environment this was tested in**

 - OS: Windows (or well, Linux in GHA)
 - Browser: irrelevant
 - Graphics card: irrelevant
