### PR TITLE
Add loading local extensions

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import pathlib
 from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir, sd_default_config, sd_model_file
 
 parser = argparse.ArgumentParser()
@@ -103,3 +104,4 @@ parser.add_argument("--skip-version-check", action='store_true', help="Do not ch
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
 parser.add_argument('--subpath', type=str, help='customize the subpath for gradio, use with reverse proxy')
+parser.add_argument("--local-extension", action="append", type=pathlib.Path, default=[], help="allow load external extensions from local path")

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -117,7 +117,7 @@ class Extension:
         self.have_info_from_repo = False
 
 
-def list_extensions():
+def list_extensions(local_extensions=None):
     extensions.clear()
 
     if not os.path.isdir(extensions_dir):
@@ -139,6 +139,11 @@ def list_extensions():
                 continue
 
             extension_paths.append((extension_dirname, path, dirname == extensions_builtin_dir))
+
+    if local_extensions:
+        for extension_path in local_extensions:
+            if extension_path.is_dir():
+                extension_paths.append((extension_path.stem, str(extension_path), False))
 
     for dirname, path, is_builtin in extension_paths:
         extension = Extension(name=dirname, path=path, enabled=dirname not in shared.opts.disabled_extensions, is_builtin=is_builtin)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -30,6 +30,7 @@ if os.environ.get('IGNORE_CMD_ARGS_ERRORS', None) is None:
 else:
     cmd_opts, _ = parser.parse_known_args()
 
+script_loading.preload_local_extensions(parser, cmd_opts.local_extension)
 
 restricted_opts = {
     "samples_filename_pattern",

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -362,7 +362,7 @@ def install_extension_from_url(dirname, url, branch_name=None):
         import launch
         launch.run_extension_installer(target_dir)
 
-        extensions.list_extensions()
+        extensions.list_extensions(local_extensions=shared.cmd_opts.local_extension)
         return [extension_table(), html.escape(f"Installed into {target_dir}. Use Installed tab to restart.")]
     finally:
         shutil.rmtree(tmpdir, True)

--- a/webui.py
+++ b/webui.py
@@ -149,7 +149,7 @@ def initialize():
 
     check_versions()
 
-    extensions.list_extensions()
+    extensions.list_extensions(local_extensions=cmd_opts.local_extension)
     localization.list_localizations(cmd_opts.localizations_dir)
     startup_timer.record("list extensions")
 
@@ -370,7 +370,7 @@ def webui():
         sd_samplers.set_samplers()
 
         modules.script_callbacks.script_unloaded_callback()
-        extensions.list_extensions()
+        extensions.list_extensions(local_extensions=cmd_opts.local_extension)
         startup_timer.record("list extensions")
 
         config_state_file = shared.opts.restore_config_state_file


### PR DESCRIPTION
List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Linux
 - Browser: chrome, firefox
 - Graphics card: NVIDIA RTX 2060 8GB

New CLI argument allow loading extensions from local folders. It's may useful for extensions development and testing, when developing extension files not appropriate store in webui tree or use symlink.

Usage example:
`./webui.sh --local-extension /path/to/IDE_Workspace/First-Extension --local-extension /path/to/IDE_Workspace/Second-Extension`
