### PR TITLE
Added API request to see script required arguments

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -289,3 +289,9 @@ class MemoryResponse(BaseModel):
 class ScriptsList(BaseModel):
     txt2img: list = Field(default=None,title="Txt2img", description="Titles of scripts (txt2img)")
     img2img: list = Field(default=None,title="Img2img", description="Titles of scripts (img2img)")
+
+class ScriptArgsRequest(BaseModel):
+    script: str = Field(title="Script", description="The script to get arguments for")
+
+class ScriptArgs(BaseModel):
+    args: dict = Field(title="Args", description="The arguments to pass to the script")


### PR DESCRIPTION
It was unclear how to use "script_args" in the API for both the txt2img and img2img routes. You could get some info from the error it returned but not a lot. 
I added a POST method to  /sdapi/v1/scripts that gives an overview of what each argument is expecting. This should make it easier from the API alone to figure out what arguments the script needs.

 - OS: Arch Linux
 - Graphics card: NVIDIA RTX 3090
