### PR TITLE
Update clean-fid to loosen transitive dependency pins

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -17,7 +17,7 @@ timm==0.6.7
 piexif==1.1.3
 einops==0.4.1
 jsonmerge==1.8.0
-clean-fid==0.1.29
+clean-fid==0.1.35
 resize-right==0.0.2
 torchdiffeq==0.2.3
 kornia==0.6.7


### PR DESCRIPTION
I skimmed the diff between 0.1.29 and 0.1.35 (the upstream clean-fid repository doesn't use tags, more's the pity) at https://github.com/GaParmar/clean-fid/compare/bd92e684ff06819058083c5a9fddc6f712045d46...c8ffa420a3923e8fd87c1e75170de2cf59d2644b and it doesn't look like there are API incompatible changes.

In terms of this project, **the main reason for this bump** is that clean-fid==0.1.29 has a unnecessary strict pin on `requests`, which causes spurious `pip` warnings that confuse users.

**Environment this was tested in**

I didn't have the chance to test this yet, but as said, I skimmed the diff, and it should be straightforward to revert this if something fails. 

Also, `clean-fid` is a dependency of `k-diffusion` and isn't pinned over there at all, so presumably people using `k-diffusion` in other projects will have been using 0.1.35 already.
  * Furthermore, `k-diffusion` itself only uses `clean-fid` for `InceptionV3FeatureExtractor`, which I don't think we use, since that itself is only used by `k-diffusion` itself in `train.py`.
    * I made a PR upstream for `k-diffusion`: https://github.com/crowsonkb/k-diffusion/pull/60
