### PR TITLE
Use CPU Torch in CI, etc.

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -17,6 +17,7 @@ jobs:
           cache: pip
           cache-dependency-path: |
             **/requirements*txt
+            launch.py
       - name: Run tests
         run: python launch.py --tests test --no-half --disable-opt-split-attention --use-cpu all --skip-torch-cuda-test
         env:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -19,6 +19,11 @@ jobs:
             **/requirements*txt
       - name: Run tests
         run: python launch.py --tests test --no-half --disable-opt-split-attention --use-cpu all --skip-torch-cuda-test
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+          PIP_PROGRESS_BAR: "off"
+          TORCH_INDEX_URL: https://download.pytorch.org/whl/cpu
+          WEBUI_LAUNCH_LIVE_OUTPUT: "1"
       - name: Upload main app stdout-stderr
         uses: actions/upload-artifact@v3
         if: always()

--- a/launch.py
+++ b/launch.py
@@ -22,6 +22,9 @@ stored_commit_hash = None
 stored_git_tag = None
 dir_repos = "repositories"
 
+# Whether to default to printing command output
+default_command_live = (os.environ.get('WEBUI_LAUNCH_LIVE_OUTPUT') == "1")
+
 if 'GRADIO_ANALYTICS_ENABLED' not in os.environ:
     os.environ['GRADIO_ANALYTICS_ENABLED'] = 'False'
 
@@ -85,7 +88,7 @@ def git_tag():
     return stored_git_tag
 
 
-def run(command, desc=None, errdesc=None, custom_env=None, live=False):
+def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live):
     if desc is not None:
         print(desc)
 
@@ -135,7 +138,7 @@ def run_python(code, desc=None, errdesc=None):
     return run(f'"{python}" -c "{code}"', desc, errdesc)
 
 
-def run_pip(command, desc=None, live=False):
+def run_pip(command, desc=None, live=default_command_live):
     if args.skip_install:
         return
 

--- a/launch.py
+++ b/launch.py
@@ -248,9 +248,9 @@ def prepare_environment():
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.17')
-    gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "git+https://github.com/TencentARC/GFPGAN.git@8d2447a2d918f8eba5a4a01463fd48e45126a379")
-    clip_package = os.environ.get('CLIP_PACKAGE', "git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1")
-    openclip_package = os.environ.get('OPENCLIP_PACKAGE', "git+https://github.com/mlfoundations/open_clip.git@bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b")
+    gfpgan_package = os.environ.get('GFPGAN_PACKAGE', "https://github.com/TencentARC/GFPGAN/archive/8d2447a2d918f8eba5a4a01463fd48e45126a379.zip")
+    clip_package = os.environ.get('CLIP_PACKAGE', "https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip")
+    openclip_package = os.environ.get('OPENCLIP_PACKAGE', "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip")
 
     stable_diffusion_repo = os.environ.get('STABLE_DIFFUSION_REPO', "https://github.com/Stability-AI/stablediffusion.git")
     taming_transformers_repo = os.environ.get('TAMING_TRANSFORMERS_REPO', "https://github.com/CompVis/taming-transformers.git")

--- a/launch.py
+++ b/launch.py
@@ -244,7 +244,8 @@ def run_extensions_installers(settings_file):
 
 
 def prepare_environment():
-    torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.0.1 torchvision==0.15.2 --extra-index-url https://download.pytorch.org/whl/cu118")
+    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu118")
+    torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.0.1 torchvision==0.15.2 --extra-index-url {torch_index_url}")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.17')


### PR DESCRIPTION
## Describe what this pull request is trying to achieve.

Make the CI run nicely using CPU Torch wheels.

## But how?!

* The main thing is to just add an envvar to control the default Torch index URL and then pass the CPU index URL in CI

Additionally, this PR

* adds an envvar that makes `launch.py` less secretive about subprocess output by default (I understand why the default is False, but for expert users, it's useful to see what's happening as it's happening; I'd done this change locally before)
* cleans up `launch.py` a bit
* switches to the Github archive .zip URLs for gfpgan, clip, and openclip; the content is the same, but it doesn't require a shallow git checkout and all that stuff. That should be faster.
  * This could also be done for k-diffusion (instead of checking it out under `repositories/`), since the repo is pip installable, but I think that's a different PR.
* does miscellaneous CI plumbing 

## What next?!

I have half the mind to rework how the tests are being run to something a little more standard, e.g. pytest, but that's a different PR.

## Environment this was tested in

GHA `ubuntu-latest` 😁 
