### PR TITLE
Fix symlink scanning for extra networks

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -741,7 +741,7 @@ def walk_files(path, allowed_extensions=None):
     if allowed_extensions is not None:
         allowed_extensions = set(allowed_extensions)
 
-    for root, _, files in os.walk(path):
+    for root, _, files in os.walk(path, followlinks=True):
         for filename in files:
             if allowed_extensions is not None:
                 _, ext = os.path.splitext(filename)

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -90,7 +90,7 @@ class ExtraNetworksPage:
 
         subdirs = {}
         for parentdir in [os.path.abspath(x) for x in self.allowed_directories_for_previews()]:
-            for root, dirs, _ in os.walk(parentdir):
+            for root, dirs, _ in os.walk(parentdir, followlinks=True):
                 for dirname in dirs:
                     x = os.path.join(root, dirname)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes symlinks for extra networks, which was broken by https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/083dc3c76ab7dbc7b2b04f3396d4f5280b002906 with the replacement of `glob`.

**Environment this was tested in**

 - OS: Windows 11