### PR TITLE
Make live previews use JPEG only for large images

### DIFF
--- a/modules/progress.py
+++ b/modules/progress.py
@@ -95,9 +95,17 @@ def progressapi(req: ProgressRequest):
         image = shared.state.current_image
         if image is not None:
             buffered = io.BytesIO()
-            image.save(buffered, format=opts.live_previews_format)
+            format = opts.live_previews_format
+            save_kwargs = {}
+            if format == "auto":
+                if max(*image.size) > 256:
+                    format = "jpeg"
+                else:
+                    format = "png"
+                    save_kwargs = {"optimize": True}
+            image.save(buffered, format=format, **save_kwargs)
             base64_image = base64.b64encode(buffered.getvalue()).decode('ascii')
-            live_preview = f"data:image/{opts.live_previews_format};base64,{base64_image}"
+            live_preview = f"data:image/{format};base64,{base64_image}"
             id_live_preview = shared.state.id_live_preview
         else:
             live_preview = None

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -420,7 +420,7 @@ options_templates.update(options_section(('infotext', "Infotext"), {
 options_templates.update(options_section(('ui', "Live previews"), {
     "show_progressbar": OptionInfo(True, "Show progressbar"),
     "live_previews_enable": OptionInfo(True, "Show live previews of the created image"),
-    "live_previews_format": OptionInfo("jpeg", "Live preview file format", gr.Radio, {"choices": ["jpeg", "png", "webp"]}),
+    "live_previews_format": OptionInfo("auto", "Live preview file format", gr.Radio, {"choices": ["auto", "jpeg", "png", "webp"]}),
     "show_progress_grid": OptionInfo(True, "Show previews of all images generated in a batch as a grid"),
     "show_progress_every_n_steps": OptionInfo(10, "Show new live preview image every N sampling steps. Set to -1 to show after completion of batch.", gr.Slider, {"minimum": -1, "maximum": 32, "step": 1}),
     "show_progress_type": OptionInfo("Approx NN", "Image creation progress preview mode", gr.Radio, {"choices": ["Full", "Approx NN", "Approx cheap"]}),


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Follows up on b7e160a87d07b2fd1c12812c43786e141cc86bd5 - I somewhat rely on previews and the JPEGs were kinda grubby since e.g. 64x88 is only a couple 16x16 macroblocks.

So instead of always using JPEGs, only use them when there's enough pixels to squeeze.

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: GTX 1070

**Screenshots or videos of your changes**

(You can imagine a less blocky preview image here.)
