### PR TITLE
Bump some versions to avoid downgrading them

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -5,12 +5,12 @@ basicsr==1.4.2
 gfpgan==1.3.8
 gradio==3.29.0
 numpy==1.23.5
-Pillow==9.4.0
+Pillow==9.5.0
 realesrgan==0.3.0
 torch
 omegaconf==2.2.3
 pytorch_lightning==1.9.4
-scikit-image==0.19.2
+scikit-image==0.20.0
 timm==0.6.7
 piexif==1.1.3
 einops==0.4.1


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

While working on #10291, I noticed some packages were getting downgraded after a higher version had been installed from other deps. Might as well not.

Images seem to generate & save fine on my machine.

**Environment this was tested in**

 - OS: Windows
 - Browser: Chrome
 - Graphics card: GTX 1070, 8 GB