### PR TITLE
Split mask blur into X and Y components, patch Outpainting MK2 accordingly

### DIFF
--- a/scripts/outpainting_mk_2.py
+++ b/scripts/outpainting_mk_2.py
@@ -145,7 +145,6 @@ class Script(scripts.Script):
         process_width = p.width
         process_height = p.height
 
-        p.mask_blur = mask_blur*4
         p.inpaint_full_res = False
         p.inpainting_fill = 1
         p.do_not_save_samples = True
@@ -155,6 +154,19 @@ class Script(scripts.Script):
         right = pixels if "right" in direction else 0
         up = pixels if "up" in direction else 0
         down = pixels if "down" in direction else 0
+
+        if left > 0 or right > 0:
+            mask_blur_x = mask_blur
+        else:
+            mask_blur_x = 0
+
+        if up > 0 or down > 0:
+            mask_blur_y = mask_blur
+        else:
+            mask_blur_y = 0
+
+        p.mask_blur_x = mask_blur_x*4
+        p.mask_blur_y = mask_blur_y*4
 
         init_img = p.init_images[0]
         target_w = math.ceil((init_img.width + left + right) / 64) * 64
@@ -191,10 +203,10 @@ class Script(scripts.Script):
                 mask = Image.new("RGB", (process_res_w, process_res_h), "white")
                 draw = ImageDraw.Draw(mask)
                 draw.rectangle((
-                    expand_pixels + mask_blur if is_left else 0,
-                    expand_pixels + mask_blur if is_top else 0,
-                    mask.width - expand_pixels - mask_blur if is_right else res_w,
-                    mask.height - expand_pixels - mask_blur if is_bottom else res_h,
+                    expand_pixels + mask_blur_x if is_left else 0,
+                    expand_pixels + mask_blur_y if is_top else 0,
+                    mask.width - expand_pixels - mask_blur_x if is_right else res_w,
+                    mask.height - expand_pixels - mask_blur_y if is_bottom else res_h,
                 ), fill="black")
 
                 np_image = (np.asarray(img) / 255.0).astype(np.float64)
@@ -224,10 +236,10 @@ class Script(scripts.Script):
             latent_mask = Image.new("RGB", (p.width, p.height), "white")
             draw = ImageDraw.Draw(latent_mask)
             draw.rectangle((
-                expand_pixels + mask_blur * 2 if is_left else 0,
-                expand_pixels + mask_blur * 2 if is_top else 0,
-                mask.width - expand_pixels - mask_blur * 2 if is_right else res_w,
-                mask.height - expand_pixels - mask_blur * 2 if is_bottom else res_h,
+                expand_pixels + mask_blur_x * 2 if is_left else 0,
+                expand_pixels + mask_blur_y * 2 if is_top else 0,
+                mask.width - expand_pixels - mask_blur_x * 2 if is_right else res_w,
+                mask.height - expand_pixels - mask_blur_y * 2 if is_bottom else res_h,
             ), fill="black")
             p.latent_mask = latent_mask
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

The mask blur in img2img was applied equally in both X and Y dimensions. This caused a bug in the Outpainting MK2 script, where noise would be introduced near borders other than the outpainted border. This PR splits out the mask blur into X and Y dimensions, which fixes the bad behavior.

**Additional notes and description of your changes**

PIL doesn't support applying a Gaussian blur in a single dimension, so I replaced PIL's Gaussian blur with that of OpenCV. I picked a kernel size that should be easily large enough to avoid quality issues; it may be a tad overkill but that shouldn't hurt anything.

I suspect that the bug will remain if you instruct MK2 to outpaint in more than one dimension at once, but that's not a regression, and AFAIK most users only outpaint in one direction at a time.

I didn't expose the new functionality to anything in the UI other than Outpainting MK2, but it should be easy for someone to do so if it's desired. (I couldn't think of a reason anyone would want this other than to fix the outpainting bug, but maybe I wasn't creative enough.)

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox
 - Graphics card: CPU

**Screenshots or videos of your changes**

Sample input image: https://github.com/Splendide-Imaginarius/stable-diffusion-webui/blob/mk2-blur-mask-docs/samples/original.png

Sample left-outpainted image without this PR: https://github.com/Splendide-Imaginarius/stable-diffusion-webui/blob/mk2-blur-mask-docs/samples/outpainted-broken.png

Sample left-outpainted image with this PR: https://github.com/Splendide-Imaginarius/stable-diffusion-webui/blob/mk2-blur-mask-docs/samples/outpainted-fixed.png

Note the noise along the bottom border of the outpainted image without this PR, and note that with this PR, the bottom border is the same as that of the input image.
