### PR TITLE
fix --data-dir ignored when launching via webui-user.bat COMMANDLINE_ARGS

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -3,15 +3,11 @@ import subprocess
 import os
 import sys
 import importlib.util
-import shlex
 import platform
 import json
 
 from modules import cmd_args
 from modules.paths_internal import script_path, extensions_dir
-
-commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
-sys.argv += shlex.split(commandline_args)
 
 args, _ = cmd_args.parser.parse_known_args()
 

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -2,6 +2,11 @@
 
 import argparse
 import os
+import sys
+import shlex
+
+commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
+sys.argv += shlex.split(commandline_args)
 
 modules_path = os.path.dirname(os.path.realpath(__file__))
 script_path = os.path.dirname(modules_path)


### PR DESCRIPTION
if one use launches webui via webui-user.bat and set `--data-dir` via COMMANDLINE_ARGS `--data-dir` will not be read
because COMMANDLINE_ARGS is not read at the time when `--data-dir` is parsed

this pr moves reading of env COMMANDLINE_ARGS into paths_internal.py so --data-dir can be properly parsed