### PR TITLE
Set PyTorch version to 2.0.1 for macOS

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -11,7 +11,7 @@ fi
 
 export install_dir="$HOME"
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half-vae --use-cpu interrogate"
-export TORCH_COMMAND="pip install torch torchvision"
+export TORCH_COMMAND="pip install torch==2.0.1 torchvision==0.15.2"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
 export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"
 export PYTORCH_ENABLE_MPS_FALLBACK=1


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Specify the torch install version as 2.0.1 and torchvision version as 0.15.2 for macOS. Fixes the `--reinstall-torch` flag.

**Environment this was tested in**

 - OS: macOS 13.3.1
 - Browser: Safari
 - Graphics card: M1 Max 64 GB