### PR TITLE
Allow web UI to be ran fully offline

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -665,20 +665,19 @@ def reload_gradio_theme(theme_name=None):
     if not theme_name:
         theme_name = opts.gradio_theme
 
+    default_theme_args = dict(
+        font=["Source Sans Pro", 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
+    )
+
     if theme_name == "Default":
-        gradio_theme = gr.themes.Default(
-            font=['Helvetica', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-            font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
-        )
+        gradio_theme = gr.themes.Default(**default_theme_args)
     else:
         try:
             gradio_theme = gr.themes.ThemeClass.from_hub(theme_name)
         except Exception as e:
             errors.display(e, "changing gradio theme")
-            gradio_theme = gr.themes.Default(
-                font=['Helvetica', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-                font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
-            )
+            gradio_theme = gr.themes.Default(**default_theme_args)
 
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -666,13 +666,19 @@ def reload_gradio_theme(theme_name=None):
         theme_name = opts.gradio_theme
 
     if theme_name == "Default":
-        gradio_theme = gr.themes.Default()
+        gradio_theme = gr.themes.Default(
+            font=['Helvetica', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
+        )
     else:
         try:
             gradio_theme = gr.themes.ThemeClass.from_hub(theme_name)
         except Exception as e:
             errors.display(e, "changing gradio theme")
-            gradio_theme = gr.themes.Default()
+            gradio_theme = gr.themes.Default(
+                font=['Helvetica', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+                font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
+            )
 
 
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,6 @@
+/* temporary fix to load default gradio font in frontend instead of backend */
+
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
 
 /* general gradio fixes */
 

--- a/webui.py
+++ b/webui.py
@@ -28,7 +28,16 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="torchvisi
 
 startup_timer.record("import torch")
 
+import requests
+def gradio_get(url, **kwargs):
+    kwargs.setdefault('allow_redirects', True)
+    return requests.api.request('get', 'http://127.0.0.1/', **kwargs)
+
+original_get = requests.get
+requests.get = gradio_get
 import gradio
+requests.get = original_get
+
 startup_timer.record("import gradio")
 
 import ldm.modules.encoders.modules  # noqa: F401

--- a/webui.py
+++ b/webui.py
@@ -31,8 +31,6 @@ startup_timer.record("import torch")
 import gradio
 startup_timer.record("import gradio")
 
-startup_timer.record("import gradio")
-
 import ldm.modules.encoders.modules  # noqa: F401
 startup_timer.record("import ldm")
 

--- a/webui.py
+++ b/webui.py
@@ -28,15 +28,8 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="torchvisi
 
 startup_timer.record("import torch")
 
-import requests
-def gradio_get(url, **kwargs):
-    kwargs.setdefault('allow_redirects', True)
-    return requests.api.request('get', 'http://127.0.0.1/', **kwargs)
-
-original_get = requests.get
-requests.get = gradio_get
 import gradio
-requests.get = original_get
+startup_timer.record("import gradio")
 
 startup_timer.record("import gradio")
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10024

This PR allows the web UI to be ran fully offline via ~~two~~ one change.

~~The 1st change blocks an initial phone-home request that Gradio makes on first import, something that cannot be blocked by setting `GRADIO_ANALYTICS_ENABLED` to `False`, and was [mentioned here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8658#issuecomment-1476968094) but hasn't been taken care of until now. The text-generation-webui employs this same technique. https://github.com/oobabooga/text-generation-webui/blob/c746a5bd00c39776bec0091a570f3348aa785caa/server.py#L12~~
Removed per suggestion. Expected to be resolved upstream by https://github.com/gradio-app/gradio/pull/4194 

The 2nd change removes [the requirement of pulling fonts from Google Fonts](https://github.com/gradio-app/gradio/blob/ef1049e3b29d941c80219eb487bad7e7e69c59bf/gradio/themes/default.py#L19-L34), by manually specifying the font list to use for the default Gradio theme, and importing in the font via the frontend CSS from Google Fonts. When attempting to run offline without this modification, in my tests this causes the web UI to hang and never finish loading. 

**Additional notes and description of your changes**

**In regards to the frontend**: Gradio currently has a [hardcoded JS import for iFrame Resizer](https://github.com/gradio-app/gradio/blob/ef1049e3b29d941c80219eb487bad7e7e69c59bf/js/app/index.html#L49), something that ~~is~~ was in the works to be removed for Gradio 3.0, but in an offline environment will not cause the UI to hang if it's not loaded, nor does it hamper the UI in any way, as I believe the only purpose this serves is for some workaround on Huggingface Spaces. There is also a [hardcoded preconnect for `fonts.googleapis.com`](https://github.com/gradio-app/gradio/blob/ef1049e3b29d941c80219eb487bad7e7e69c59bf/js/app/index.html#L43-L48) but that is again something that doesn't prevent the UI from being used offline, only the backend code causes that. While neither of these have a simple method of removal from the code, everything mentioned in this paragraph can easily be blocked by something like uBlock Origin if the user would like to prevent all outbound connections on the webpage itself (assuming there is an active Internet connection).

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox, Chrome
 - Graphics card: n/a