### PR TITLE
Allow bf16 in safe unpickler

### DIFF
--- a/modules/safe.py
+++ b/modules/safe.py
@@ -40,7 +40,7 @@ class RestrictedUnpickler(pickle.Unpickler):
             return getattr(collections, name)
         if module == 'torch._utils' and name in ['_rebuild_tensor_v2', '_rebuild_parameter', '_rebuild_device_tensor_from_numpy']:
             return getattr(torch._utils, name)
-        if module == 'torch' and name in ['FloatStorage', 'HalfStorage', 'IntStorage', 'LongStorage', 'DoubleStorage', 'ByteStorage', 'float32']:
+        if module == 'torch' and name in ['FloatStorage', 'HalfStorage', 'IntStorage', 'LongStorage', 'DoubleStorage', 'ByteStorage', 'float32', 'BFloat16Storage']:
             return getattr(torch, name)
         if module == 'torch.nn.modules.container' and name in ['ParameterDict']:
             return getattr(torch.nn.modules.container, name)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Allows `BFloat16Storage` in the safe unpickler module. This is required for LoRAs saved with bf16 precision, and will fail to load otherwise. https://github.com/kohya-ss/sd-scripts/blob/cd984992cf6587dfc9582c45bcbe15c25f87bb89/library/train_util.py#L1986-L1992

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090