### PR TITLE
Apply Prettier

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -2,45 +2,59 @@
 name: Run Linting/Formatting on Pull Requests
 
 on:
-  - push
-  - pull_request
-  # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore for syntax docs
-  # if you want to filter out branches, delete the `- pull_request` and uncomment these lines :
-  # pull_request:  
-  #  branches:
-  #    - master
-  #  branches-ignore:
-  #    - development
+    - push
+    - pull_request
+    # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore for syntax docs
+    # if you want to filter out branches, delete the `- pull_request` and uncomment these lines :
+    # pull_request:
+    #  branches:
+    #    - master
+    #  branches-ignore:
+    #    - development
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          # NB: there's no cache: pip here since we're not installing anything
-          #     from the requirements.txt file(s) in the repository; it's faster
-          #     not to have GHA download an (at the time of writing) 4 GB cache
-          #     of PyTorch and other dependencies.
-      - name: Install Ruff
-        run: pip install ruff==0.0.265
-      - name: Run Ruff
-        run: ruff .
+    lint-python:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: 3.11
+                  # NB: there's no cache: pip here since we're not installing anything
+                  #     from the requirements.txt file(s) in the repository; it's faster
+                  #     not to have GHA download an (at the time of writing) 4 GB cache
+                  #     of PyTorch and other dependencies.
+            - name: Install Ruff
+              run: pip install ruff==0.0.265
+            - name: Run Ruff
+              run: ruff .
 
-# The rest are currently disabled pending fixing of e.g. installing the torch dependency.
+    # The rest are currently disabled pending fixing of e.g. installing the torch dependency.
 
-#      - name: Install PyLint
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install pylint
-#      # This lets PyLint check to see if it can resolve imports
-#      - name: Install dependencies
-#        run: |
-#          export COMMANDLINE_ARGS="--skip-torch-cuda-test --exit"
-#          python launch.py
-#      - name: Analysing the code with pylint
-#        run: |
-#          pylint $(git ls-files '*.py')
+    #      - name: Install PyLint
+    #        run: |
+    #          python -m pip install --upgrade pip
+    #          pip install pylint
+    #      # This lets PyLint check to see if it can resolve imports
+    #      - name: Install dependencies
+    #        run: |
+    #          export COMMANDLINE_ARGS="--skip-torch-cuda-test --exit"
+    #          python launch.py
+    #      - name: Analysing the code with pylint
+    #        run: |
+    #          pylint $(git ls-files '*.py')
+
+    lint-prettier:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+            - name: Install Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+            - name: Install Prettier
+              run: npm i --ci
+            - name: Run Prettier
+              run: npm run check-prettier

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ notification.mp3
 /test/stderr.txt
 /cache.json*
 /config_states/
+/node_modules
+/package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+/*.md
+/.*cache
+/.github
+/cache.json
+/config.json
+/configs
+/extensions
+/extensions-disabled
+/html/licenses.html
+/models
+/repositories
+/style.css
+/venv

--- a/environment-wsl2.yaml
+++ b/environment-wsl2.yaml
@@ -1,11 +1,11 @@
 name: automatic
 channels:
-  - pytorch
-  - defaults
+    - pytorch
+    - defaults
 dependencies:
-  - python=3.10
-  - pip=23.0
-  - cudatoolkit=11.8
-  - pytorch=2.0
-  - torchvision=0.15
-  - numpy=1.23
+    - python=3.10
+    - pip=23.0
+    - cudatoolkit=11.8
+    - pytorch=2.0
+    - torchvision=0.15
+    - numpy=1.23

--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -4,39 +4,37 @@
 // If there's a mismatch, the keyword counter turns red and if you hover on it, a tooltip tells you what's wrong.
 
 function checkBrackets(textArea, counterElt) {
-  var counts = {};
-  (textArea.value.match(/[(){}\[\]]/g) || []).forEach(bracket => {
-    counts[bracket] = (counts[bracket] || 0) + 1;
-  });
-  var errors = [];
+    var counts = {};
+    (textArea.value.match(/[(){}\[\]]/g) || []).forEach((bracket) => {
+        counts[bracket] = (counts[bracket] || 0) + 1;
+    });
+    var errors = [];
 
-  function checkPair(open, close, kind) {
-    if (counts[open] !== counts[close]) {
-      errors.push(
-        `${open}...${close} - Detected ${counts[open] || 0} opening and ${counts[close] || 0} closing ${kind}.`
-      );
+    function checkPair(open, close, kind) {
+        if (counts[open] !== counts[close]) {
+            errors.push(`${open}...${close} - Detected ${counts[open] || 0} opening and ${counts[close] || 0} closing ${kind}.`);
+        }
     }
-  }
 
-  checkPair('(', ')', 'round brackets');
-  checkPair('[', ']', 'square brackets');
-  checkPair('{', '}', 'curly brackets');
-  counterElt.title = errors.join('\n');
-  counterElt.classList.toggle('error', errors.length !== 0);
+    checkPair("(", ")", "round brackets");
+    checkPair("[", "]", "square brackets");
+    checkPair("{", "}", "curly brackets");
+    counterElt.title = errors.join("\n");
+    counterElt.classList.toggle("error", errors.length !== 0);
 }
 
 function setupBracketChecking(id_prompt, id_counter) {
-  var textarea = gradioApp().querySelector("#" + id_prompt + " > label > textarea");
-  var counter = gradioApp().getElementById(id_counter)
+    var textarea = gradioApp().querySelector("#" + id_prompt + " > label > textarea");
+    var counter = gradioApp().getElementById(id_counter);
 
-  if (textarea && counter) {
-    textarea.addEventListener("input", () => checkBrackets(textarea, counter));
-  }
+    if (textarea && counter) {
+        textarea.addEventListener("input", () => checkBrackets(textarea, counter));
+    }
 }
 
 onUiLoaded(function () {
-  setupBracketChecking('txt2img_prompt', 'txt2img_token_counter');
-  setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter');
-  setupBracketChecking('img2img_prompt', 'img2img_token_counter');
-  setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter');
+    setupBracketChecking("txt2img_prompt", "txt2img_token_counter");
+    setupBracketChecking("txt2img_neg_prompt", "txt2img_negative_token_counter");
+    setupBracketChecking("img2img_prompt", "img2img_token_counter");
+    setupBracketChecking("img2img_neg_prompt", "img2img_negative_token_counter");
 });

--- a/html/extra-networks-card.html
+++ b/html/extra-networks-card.html
@@ -1,15 +1,14 @@
-<div class='card' style={style} onclick={card_clicked}>
-	{metadata_button}
+<div class="card" style="{style}" onclick="{card_clicked}">
+    {metadata_button}
 
-	<div class='actions'>
-		<div class='additional'>
-			<ul>
-				<a href="#" title="replace preview image with currently selected in gallery" onclick={save_card_preview}>replace preview</a>
-			</ul>
-			<span style="display:none" class='search_term{serach_only}'>{search_term}</span>
-		</div>
-		<span class='name'>{name}</span>
-		<span class='description'>{description}</span>
-	</div>
+    <div class="actions">
+        <div class="additional">
+            <ul>
+                <a href="#" title="replace preview image with currently selected in gallery" onclick="{save_card_preview}">replace preview</a>
+            </ul>
+            <span style="display: none" class="search_term{serach_only}">{search_term}</span>
+        </div>
+        <span class="name">{name}</span>
+        <span class="description">{description}</span>
+    </div>
 </div>
-

--- a/html/extra-networks-no-cards.html
+++ b/html/extra-networks-no-cards.html
@@ -1,8 +1,7 @@
-<div class='nocards'>
-<h1>Nothing here. Add some content to the following directories:</h1>
+<div class="nocards">
+    <h1>Nothing here. Add some content to the following directories:</h1>
 
-<ul>
-{dirs}
-</ul>
+    <ul>
+        {dirs}
+    </ul>
 </div>
-

--- a/html/footer.html
+++ b/html/footer.html
@@ -1,13 +1,11 @@
 <div>
-        <a href="/docs">API</a>
-         • 
-        <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">Github</a>
-         • 
-        <a href="https://gradio.app">Gradio</a>
-         • 
-        <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false">Reload UI</a>
+    <a href="/docs">API</a>
+     • 
+    <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">Github</a>
+     • 
+    <a href="https://gradio.app">Gradio</a>
+     • 
+    <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false">Reload UI</a>
 </div>
 <br />
-<div class="versions">
-{versions}
-</div>
+<div class="versions">{versions}</div>

--- a/javascript/aspectRatioOverlay.js
+++ b/javascript/aspectRatioOverlay.js
@@ -1,111 +1,108 @@
-
 let currentWidth = null;
 let currentHeight = null;
-let arFrameTimeout = setTimeout(function(){},0);
+let arFrameTimeout = setTimeout(function () {}, 0);
 
-function dimensionChange(e, is_width, is_height){
+function dimensionChange(e, is_width, is_height) {
+    if (is_width) {
+        currentWidth = e.target.value * 1.0;
+    }
+    if (is_height) {
+        currentHeight = e.target.value * 1.0;
+    }
 
-	if(is_width){
-		currentWidth = e.target.value*1.0
-	}
-	if(is_height){
-		currentHeight = e.target.value*1.0
-	}
+    var inImg2img = gradioApp().querySelector("#tab_img2img").style.display == "block";
 
-	var inImg2img = gradioApp().querySelector("#tab_img2img").style.display == "block";
+    if (!inImg2img) {
+        return;
+    }
 
-	if(!inImg2img){
-		return;
-	}
+    var targetElement = null;
 
-	var targetElement = null;
+    var tabIndex = get_tab_index("mode_img2img");
+    if (tabIndex == 0) {
+        // img2img
+        targetElement = gradioApp().querySelector("#img2img_image div[data-testid=image] img");
+    } else if (tabIndex == 1) {
+        //Sketch
+        targetElement = gradioApp().querySelector("#img2img_sketch div[data-testid=image] img");
+    } else if (tabIndex == 2) {
+        // Inpaint
+        targetElement = gradioApp().querySelector("#img2maskimg div[data-testid=image] img");
+    } else if (tabIndex == 3) {
+        // Inpaint sketch
+        targetElement = gradioApp().querySelector("#inpaint_sketch div[data-testid=image] img");
+    }
 
-    var tabIndex = get_tab_index('mode_img2img')
-	if(tabIndex == 0){ // img2img
-		targetElement = gradioApp().querySelector('#img2img_image div[data-testid=image] img');
-	} else if(tabIndex == 1){ //Sketch
-		targetElement = gradioApp().querySelector('#img2img_sketch div[data-testid=image] img');
-	} else if(tabIndex == 2){ // Inpaint
-		targetElement = gradioApp().querySelector('#img2maskimg div[data-testid=image] img');
-	} else if(tabIndex == 3){ // Inpaint sketch
-		targetElement = gradioApp().querySelector('#inpaint_sketch div[data-testid=image] img');
-	}
+    if (targetElement) {
+        var arPreviewRect = gradioApp().querySelector("#imageARPreview");
+        if (!arPreviewRect) {
+            arPreviewRect = document.createElement("div");
+            arPreviewRect.id = "imageARPreview";
+            gradioApp().appendChild(arPreviewRect);
+        }
 
+        var viewportOffset = targetElement.getBoundingClientRect();
 
-	if(targetElement){
+        var viewportscale = Math.min(targetElement.clientWidth / targetElement.naturalWidth, targetElement.clientHeight / targetElement.naturalHeight);
 
-		var arPreviewRect = gradioApp().querySelector('#imageARPreview');
-		if(!arPreviewRect){
-		    arPreviewRect = document.createElement('div')
-		    arPreviewRect.id = "imageARPreview";
-		    gradioApp().appendChild(arPreviewRect)
-		}
+        var scaledx = targetElement.naturalWidth * viewportscale;
+        var scaledy = targetElement.naturalHeight * viewportscale;
 
+        var cleintRectTop = viewportOffset.top + window.scrollY;
+        var cleintRectLeft = viewportOffset.left + window.scrollX;
+        var cleintRectCentreY = cleintRectTop + targetElement.clientHeight / 2;
+        var cleintRectCentreX = cleintRectLeft + targetElement.clientWidth / 2;
 
+        var arscale = Math.min(scaledx / currentWidth, scaledy / currentHeight);
+        var arscaledx = currentWidth * arscale;
+        var arscaledy = currentHeight * arscale;
 
-		var viewportOffset = targetElement.getBoundingClientRect();
+        var arRectTop = cleintRectCentreY - arscaledy / 2;
+        var arRectLeft = cleintRectCentreX - arscaledx / 2;
+        var arRectWidth = arscaledx;
+        var arRectHeight = arscaledy;
 
-		var viewportscale = Math.min(  targetElement.clientWidth/targetElement.naturalWidth, targetElement.clientHeight/targetElement.naturalHeight )
+        arPreviewRect.style.top = arRectTop + "px";
+        arPreviewRect.style.left = arRectLeft + "px";
+        arPreviewRect.style.width = arRectWidth + "px";
+        arPreviewRect.style.height = arRectHeight + "px";
 
-		var scaledx = targetElement.naturalWidth*viewportscale
-		var scaledy = targetElement.naturalHeight*viewportscale
+        clearTimeout(arFrameTimeout);
+        arFrameTimeout = setTimeout(function () {
+            arPreviewRect.style.display = "none";
+        }, 2000);
 
-		var cleintRectTop    = (viewportOffset.top+window.scrollY)
-		var cleintRectLeft   = (viewportOffset.left+window.scrollX)
-		var cleintRectCentreY = cleintRectTop  + (targetElement.clientHeight/2)
-		var cleintRectCentreX = cleintRectLeft + (targetElement.clientWidth/2)
-
-		var arscale = Math.min(  scaledx/currentWidth, scaledy/currentHeight )
-		var arscaledx = currentWidth*arscale
-		var arscaledy = currentHeight*arscale
-
-		var arRectTop    = cleintRectCentreY-(arscaledy/2)
-		var arRectLeft   = cleintRectCentreX-(arscaledx/2)
-		var arRectWidth  = arscaledx
-		var arRectHeight = arscaledy
-
-	    arPreviewRect.style.top  = arRectTop+'px';
-	    arPreviewRect.style.left = arRectLeft+'px';
-	    arPreviewRect.style.width = arRectWidth+'px';
-	    arPreviewRect.style.height = arRectHeight+'px';
-
-	    clearTimeout(arFrameTimeout);
-	    arFrameTimeout = setTimeout(function(){
-	    	arPreviewRect.style.display = 'none';
-	    },2000);
-
-	    arPreviewRect.style.display = 'block';
-
-	}
-
+        arPreviewRect.style.display = "block";
+    }
 }
 
-
-onUiUpdate(function(){
-	var arPreviewRect = gradioApp().querySelector('#imageARPreview');
-	if(arPreviewRect){
-		arPreviewRect.style.display = 'none';
-	}
+onUiUpdate(function () {
+    var arPreviewRect = gradioApp().querySelector("#imageARPreview");
+    if (arPreviewRect) {
+        arPreviewRect.style.display = "none";
+    }
     var tabImg2img = gradioApp().querySelector("#tab_img2img");
     if (tabImg2img) {
         var inImg2img = tabImg2img.style.display == "block";
-        if(inImg2img){
-            let inputs = gradioApp().querySelectorAll('input');
-            inputs.forEach(function(e){
-                var is_width = e.parentElement.id == "img2img_width"
-                var is_height = e.parentElement.id == "img2img_height"
+        if (inImg2img) {
+            let inputs = gradioApp().querySelectorAll("input");
+            inputs.forEach(function (e) {
+                var is_width = e.parentElement.id == "img2img_width";
+                var is_height = e.parentElement.id == "img2img_height";
 
-                if((is_width || is_height) && !e.classList.contains('scrollwatch')){
-                    e.addEventListener('input', function(e){dimensionChange(e, is_width, is_height)} )
-                    e.classList.add('scrollwatch')
+                if ((is_width || is_height) && !e.classList.contains("scrollwatch")) {
+                    e.addEventListener("input", function (e) {
+                        dimensionChange(e, is_width, is_height);
+                    });
+                    e.classList.add("scrollwatch");
                 }
-                if(is_width){
-                    currentWidth = e.value*1.0
+                if (is_width) {
+                    currentWidth = e.value * 1.0;
                 }
-                if(is_height){
-                    currentHeight = e.value*1.0
+                if (is_height) {
+                    currentHeight = e.value * 1.0;
                 }
-            })
+            });
         }
     }
 });

--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -1,166 +1,158 @@
+contextMenuInit = function () {
+    let eventListenerApplied = false;
+    let menuSpecs = new Map();
 
-contextMenuInit = function(){
-  let eventListenerApplied=false;
-  let menuSpecs = new Map();
+    const uid = function () {
+        return Date.now().toString(36) + Math.random().toString(36).substring(2);
+    };
 
-  const uid = function(){
-    return Date.now().toString(36) + Math.random().toString(36).substring(2);
-  }
+    function showContextMenu(event, element, menuEntries) {
+        let posx = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
+        let posy = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
 
-  function showContextMenu(event,element,menuEntries){
-    let posx = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
-    let posy = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
-
-    let oldMenu = gradioApp().querySelector('#context-menu')
-    if(oldMenu){
-      oldMenu.remove()
-    }
-
-    let baseStyle = window.getComputedStyle(uiCurrentTab)
-
-    const contextMenu = document.createElement('nav')
-    contextMenu.id = "context-menu"
-    contextMenu.style.background = baseStyle.background
-    contextMenu.style.color = baseStyle.color
-    contextMenu.style.fontFamily = baseStyle.fontFamily
-    contextMenu.style.top = posy+'px'
-    contextMenu.style.left = posx+'px'
-
-
-
-    const contextMenuList = document.createElement('ul')
-    contextMenuList.className = 'context-menu-items';
-    contextMenu.append(contextMenuList);
-
-    menuEntries.forEach(function(entry){
-      let contextMenuEntry = document.createElement('a')
-      contextMenuEntry.innerHTML = entry['name']
-      contextMenuEntry.addEventListener("click", function() {
-        entry['func']();
-      })
-      contextMenuList.append(contextMenuEntry);
-
-    })
-
-    gradioApp().appendChild(contextMenu)
-
-    let menuWidth = contextMenu.offsetWidth + 4;
-    let menuHeight = contextMenu.offsetHeight + 4;
-
-    let windowWidth = window.innerWidth;
-    let windowHeight = window.innerHeight;
-
-    if ( (windowWidth - posx) < menuWidth ) {
-      contextMenu.style.left = windowWidth - menuWidth + "px";
-    }
-
-    if ( (windowHeight - posy) < menuHeight ) {
-      contextMenu.style.top = windowHeight - menuHeight + "px";
-    }
-
-  }
-
-  function appendContextMenuOption(targetElementSelector,entryName,entryFunction){
-
-    var currentItems = menuSpecs.get(targetElementSelector)
-
-    if(!currentItems){
-      currentItems = []
-      menuSpecs.set(targetElementSelector,currentItems);
-    }
-    let newItem = {'id':targetElementSelector+'_'+uid(),
-                   'name':entryName,
-                   'func':entryFunction,
-                   'isNew':true}
-
-    currentItems.push(newItem)
-    return newItem['id']
-  }
-
-  function removeContextMenuOption(uid){
-    menuSpecs.forEach(function(v) {
-      let index = -1
-      v.forEach(function(e,ei){if(e['id']==uid){index=ei}})
-      if(index>=0){
-        v.splice(index, 1);
-      }
-    })
-  }
-
-  function addContextMenuEventListener(){
-    if(eventListenerApplied){
-      return;
-    }
-    gradioApp().addEventListener("click", function(e) {
-      if(! e.isTrusted){
-        return
-      }
-
-      let oldMenu = gradioApp().querySelector('#context-menu')
-      if(oldMenu){
-        oldMenu.remove()
-      }
-    });
-    gradioApp().addEventListener("contextmenu", function(e) {
-      let oldMenu = gradioApp().querySelector('#context-menu')
-      if(oldMenu){
-        oldMenu.remove()
-      }
-      menuSpecs.forEach(function(v,k) {
-        if(e.composedPath()[0].matches(k)){
-          showContextMenu(e,e.composedPath()[0],v)
-          e.preventDefault()
+        let oldMenu = gradioApp().querySelector("#context-menu");
+        if (oldMenu) {
+            oldMenu.remove();
         }
-      })
-    });
-    eventListenerApplied=true
 
-  }
+        let baseStyle = window.getComputedStyle(uiCurrentTab);
 
-  return [appendContextMenuOption, removeContextMenuOption, addContextMenuEventListener]
-}
+        const contextMenu = document.createElement("nav");
+        contextMenu.id = "context-menu";
+        contextMenu.style.background = baseStyle.background;
+        contextMenu.style.color = baseStyle.color;
+        contextMenu.style.fontFamily = baseStyle.fontFamily;
+        contextMenu.style.top = posy + "px";
+        contextMenu.style.left = posx + "px";
+
+        const contextMenuList = document.createElement("ul");
+        contextMenuList.className = "context-menu-items";
+        contextMenu.append(contextMenuList);
+
+        menuEntries.forEach(function (entry) {
+            let contextMenuEntry = document.createElement("a");
+            contextMenuEntry.innerHTML = entry["name"];
+            contextMenuEntry.addEventListener("click", function () {
+                entry["func"]();
+            });
+            contextMenuList.append(contextMenuEntry);
+        });
+
+        gradioApp().appendChild(contextMenu);
+
+        let menuWidth = contextMenu.offsetWidth + 4;
+        let menuHeight = contextMenu.offsetHeight + 4;
+
+        let windowWidth = window.innerWidth;
+        let windowHeight = window.innerHeight;
+
+        if (windowWidth - posx < menuWidth) {
+            contextMenu.style.left = windowWidth - menuWidth + "px";
+        }
+
+        if (windowHeight - posy < menuHeight) {
+            contextMenu.style.top = windowHeight - menuHeight + "px";
+        }
+    }
+
+    function appendContextMenuOption(targetElementSelector, entryName, entryFunction) {
+        var currentItems = menuSpecs.get(targetElementSelector);
+
+        if (!currentItems) {
+            currentItems = [];
+            menuSpecs.set(targetElementSelector, currentItems);
+        }
+        let newItem = { id: targetElementSelector + "_" + uid(), name: entryName, func: entryFunction, isNew: true };
+
+        currentItems.push(newItem);
+        return newItem["id"];
+    }
+
+    function removeContextMenuOption(uid) {
+        menuSpecs.forEach(function (v) {
+            let index = -1;
+            v.forEach(function (e, ei) {
+                if (e["id"] == uid) {
+                    index = ei;
+                }
+            });
+            if (index >= 0) {
+                v.splice(index, 1);
+            }
+        });
+    }
+
+    function addContextMenuEventListener() {
+        if (eventListenerApplied) {
+            return;
+        }
+        gradioApp().addEventListener("click", function (e) {
+            if (!e.isTrusted) {
+                return;
+            }
+
+            let oldMenu = gradioApp().querySelector("#context-menu");
+            if (oldMenu) {
+                oldMenu.remove();
+            }
+        });
+        gradioApp().addEventListener("contextmenu", function (e) {
+            let oldMenu = gradioApp().querySelector("#context-menu");
+            if (oldMenu) {
+                oldMenu.remove();
+            }
+            menuSpecs.forEach(function (v, k) {
+                if (e.composedPath()[0].matches(k)) {
+                    showContextMenu(e, e.composedPath()[0], v);
+                    e.preventDefault();
+                }
+            });
+        });
+        eventListenerApplied = true;
+    }
+
+    return [appendContextMenuOption, removeContextMenuOption, addContextMenuEventListener];
+};
 
 initResponse = contextMenuInit();
-appendContextMenuOption     = initResponse[0];
-removeContextMenuOption     = initResponse[1];
+appendContextMenuOption = initResponse[0];
+removeContextMenuOption = initResponse[1];
 addContextMenuEventListener = initResponse[2];
 
-(function(){
-  //Start example Context Menu Items
-  let generateOnRepeat = function(genbuttonid,interruptbuttonid){
-    let genbutton = gradioApp().querySelector(genbuttonid);
-    let interruptbutton = gradioApp().querySelector(interruptbuttonid);
-    if(!interruptbutton.offsetParent){
-      genbutton.click();
-    }
-    clearInterval(window.generateOnRepeatInterval)
-    window.generateOnRepeatInterval = setInterval(function(){
-      if(!interruptbutton.offsetParent){
-        genbutton.click();
-      }
-    },
-    500)
-  }
+(function () {
+    //Start example Context Menu Items
+    let generateOnRepeat = function (genbuttonid, interruptbuttonid) {
+        let genbutton = gradioApp().querySelector(genbuttonid);
+        let interruptbutton = gradioApp().querySelector(interruptbuttonid);
+        if (!interruptbutton.offsetParent) {
+            genbutton.click();
+        }
+        clearInterval(window.generateOnRepeatInterval);
+        window.generateOnRepeatInterval = setInterval(function () {
+            if (!interruptbutton.offsetParent) {
+                genbutton.click();
+            }
+        }, 500);
+    };
 
-  appendContextMenuOption('#txt2img_generate','Generate forever',function(){
-    generateOnRepeat('#txt2img_generate','#txt2img_interrupt');
-  })
-  appendContextMenuOption('#img2img_generate','Generate forever',function(){
-    generateOnRepeat('#img2img_generate','#img2img_interrupt');
-  })
+    appendContextMenuOption("#txt2img_generate", "Generate forever", function () {
+        generateOnRepeat("#txt2img_generate", "#txt2img_interrupt");
+    });
+    appendContextMenuOption("#img2img_generate", "Generate forever", function () {
+        generateOnRepeat("#img2img_generate", "#img2img_interrupt");
+    });
 
-  let cancelGenerateForever = function(){
-    clearInterval(window.generateOnRepeatInterval)
-  }
+    let cancelGenerateForever = function () {
+        clearInterval(window.generateOnRepeatInterval);
+    };
 
-  appendContextMenuOption('#txt2img_interrupt','Cancel generate forever',cancelGenerateForever)
-  appendContextMenuOption('#txt2img_generate', 'Cancel generate forever',cancelGenerateForever)
-  appendContextMenuOption('#img2img_interrupt','Cancel generate forever',cancelGenerateForever)
-  appendContextMenuOption('#img2img_generate', 'Cancel generate forever',cancelGenerateForever)
-
+    appendContextMenuOption("#txt2img_interrupt", "Cancel generate forever", cancelGenerateForever);
+    appendContextMenuOption("#txt2img_generate", "Cancel generate forever", cancelGenerateForever);
+    appendContextMenuOption("#img2img_interrupt", "Cancel generate forever", cancelGenerateForever);
+    appendContextMenuOption("#img2img_generate", "Cancel generate forever", cancelGenerateForever);
 })();
 //End example Context Menu Items
 
-onUiUpdate(function(){
-  addContextMenuEventListener()
+onUiUpdate(function () {
+    addContextMenuEventListener();
 });

--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -1,97 +1,91 @@
 // allows drag-dropping files into gradio image elements, and also pasting images from clipboard
 
-function isValidImageList( files ) {
-    return files && files?.length === 1 && ['image/png', 'image/gif', 'image/jpeg'].includes(files[0].type);
+function isValidImageList(files) {
+    return files && files?.length === 1 && ["image/png", "image/gif", "image/jpeg"].includes(files[0].type);
 }
 
-function dropReplaceImage( imgWrap, files ) {
-    if ( ! isValidImageList( files ) ) {
+function dropReplaceImage(imgWrap, files) {
+    if (!isValidImageList(files)) {
         return;
     }
 
     const tmpFile = files[0];
 
-    imgWrap.querySelector('.modify-upload button + button, .touch-none + div button + button')?.click();
+    imgWrap.querySelector(".modify-upload button + button, .touch-none + div button + button")?.click();
     const callback = () => {
         const fileInput = imgWrap.querySelector('input[type="file"]');
-        if ( fileInput ) {
-            if ( files.length === 0 ) {
+        if (fileInput) {
+            if (files.length === 0) {
                 files = new DataTransfer();
                 files.items.add(tmpFile);
                 fileInput.files = files.files;
             } else {
                 fileInput.files = files;
             }
-            fileInput.dispatchEvent(new Event('change'));   
+            fileInput.dispatchEvent(new Event("change"));
         }
     };
-    
-    if ( imgWrap.closest('#pnginfo_image') ) {
+
+    if (imgWrap.closest("#pnginfo_image")) {
         // special treatment for PNG Info tab, wait for fetch request to finish
         const oldFetch = window.fetch;
         window.fetch = async (input, options) => {
             const response = await oldFetch(input, options);
-            if ( 'api/predict/' === input ) {
+            if ("api/predict/" === input) {
                 const content = await response.text();
                 window.fetch = oldFetch;
-                window.requestAnimationFrame( () => callback() );
+                window.requestAnimationFrame(() => callback());
                 return new Response(content, {
                     status: response.status,
                     statusText: response.statusText,
-                    headers: response.headers
-                })
+                    headers: response.headers,
+                });
             }
             return response;
-        };        
+        };
     } else {
-        window.requestAnimationFrame( () => callback() );
+        window.requestAnimationFrame(() => callback());
     }
 }
 
-window.document.addEventListener('dragover', e => {
+window.document.addEventListener("dragover", (e) => {
     const target = e.composedPath()[0];
     const imgWrap = target.closest('[data-testid="image"]');
-    if ( !imgWrap && target.placeholder && target.placeholder.indexOf("Prompt") == -1) {
+    if (!imgWrap && target.placeholder && target.placeholder.indexOf("Prompt") == -1) {
         return;
     }
     e.stopPropagation();
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
+    e.dataTransfer.dropEffect = "copy";
 });
 
-window.document.addEventListener('drop', e => {
+window.document.addEventListener("drop", (e) => {
     const target = e.composedPath()[0];
     if (target.placeholder.indexOf("Prompt") == -1) {
         return;
     }
     const imgWrap = target.closest('[data-testid="image"]');
-    if ( !imgWrap ) {
+    if (!imgWrap) {
         return;
     }
     e.stopPropagation();
     e.preventDefault();
     const files = e.dataTransfer.files;
-    dropReplaceImage( imgWrap, files );
+    dropReplaceImage(imgWrap, files);
 });
 
-window.addEventListener('paste', e => {
+window.addEventListener("paste", (e) => {
     const files = e.clipboardData.files;
-    if ( ! isValidImageList( files ) ) {
+    if (!isValidImageList(files)) {
         return;
     }
 
-    const visibleImageFields = [...gradioApp().querySelectorAll('[data-testid="image"]')]
-        .filter(el => uiElementIsVisible(el));
-    if ( ! visibleImageFields.length ) {
+    const visibleImageFields = [...gradioApp().querySelectorAll('[data-testid="image"]')].filter((el) => uiElementIsVisible(el));
+    if (!visibleImageFields.length) {
         return;
     }
-    
-    const firstFreeImageField = visibleImageFields
-        .filter(el => el.querySelector('input[type=file]'))?.[0];
 
-    dropReplaceImage(
-        firstFreeImageField ?
-        firstFreeImageField :
-        visibleImageFields[visibleImageFields.length - 1]
-    , files );
+    const firstFreeImageField = visibleImageFields.filter((el) => el.querySelector("input[type=file]"))?.[0];
+
+    dropReplaceImage(firstFreeImageField ? firstFreeImageField : visibleImageFields[visibleImageFields.length - 1], files);
 });

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -1,58 +1,58 @@
-function keyupEditAttention(event){
-	let target = event.originalTarget || event.composedPath()[0];
-	if (! target.matches("[id*='_toprow'] [id*='_prompt'] textarea")) return;
-	if (! (event.metaKey || event.ctrlKey)) return;
+function keyupEditAttention(event) {
+    let target = event.originalTarget || event.composedPath()[0];
+    if (!target.matches("[id*='_toprow'] [id*='_prompt'] textarea")) return;
+    if (!(event.metaKey || event.ctrlKey)) return;
 
-	let isPlus = event.key == "ArrowUp"
-	let isMinus = event.key == "ArrowDown"
-	if (!isPlus && !isMinus) return;
+    let isPlus = event.key == "ArrowUp";
+    let isMinus = event.key == "ArrowDown";
+    if (!isPlus && !isMinus) return;
 
-	let selectionStart = target.selectionStart;
-	let selectionEnd = target.selectionEnd;
-	let text = target.value;
+    let selectionStart = target.selectionStart;
+    let selectionEnd = target.selectionEnd;
+    let text = target.value;
 
-    function selectCurrentParenthesisBlock(OPEN, CLOSE){
+    function selectCurrentParenthesisBlock(OPEN, CLOSE) {
         if (selectionStart !== selectionEnd) return false;
 
-		// Find opening parenthesis around current cursor
-		const before = text.substring(0, selectionStart);
-		let beforeParen = before.lastIndexOf(OPEN);
-		if (beforeParen == -1) return false;
-		let beforeParenClose = before.lastIndexOf(CLOSE);
-		while (beforeParenClose !== -1 && beforeParenClose > beforeParen) {
-			beforeParen = before.lastIndexOf(OPEN, beforeParen - 1);
-			beforeParenClose = before.lastIndexOf(CLOSE, beforeParenClose - 1);
-		}
+        // Find opening parenthesis around current cursor
+        const before = text.substring(0, selectionStart);
+        let beforeParen = before.lastIndexOf(OPEN);
+        if (beforeParen == -1) return false;
+        let beforeParenClose = before.lastIndexOf(CLOSE);
+        while (beforeParenClose !== -1 && beforeParenClose > beforeParen) {
+            beforeParen = before.lastIndexOf(OPEN, beforeParen - 1);
+            beforeParenClose = before.lastIndexOf(CLOSE, beforeParenClose - 1);
+        }
 
-		// Find closing parenthesis around current cursor
-		const after = text.substring(selectionStart);
-		let afterParen = after.indexOf(CLOSE);
-		if (afterParen == -1) return false;
-		let afterParenOpen = after.indexOf(OPEN);
-		while (afterParenOpen !== -1 && afterParen > afterParenOpen) {
-			afterParen = after.indexOf(CLOSE, afterParen + 1);
-			afterParenOpen = after.indexOf(OPEN, afterParenOpen + 1);
-		}
-		if (beforeParen === -1 || afterParen === -1) return false;
+        // Find closing parenthesis around current cursor
+        const after = text.substring(selectionStart);
+        let afterParen = after.indexOf(CLOSE);
+        if (afterParen == -1) return false;
+        let afterParenOpen = after.indexOf(OPEN);
+        while (afterParenOpen !== -1 && afterParen > afterParenOpen) {
+            afterParen = after.indexOf(CLOSE, afterParen + 1);
+            afterParenOpen = after.indexOf(OPEN, afterParenOpen + 1);
+        }
+        if (beforeParen === -1 || afterParen === -1) return false;
 
-		// Set the selection to the text between the parenthesis
-		const parenContent = text.substring(beforeParen + 1, selectionStart + afterParen);
-		const lastColon = parenContent.lastIndexOf(":");
-		selectionStart = beforeParen + 1;
-		selectionEnd = selectionStart + lastColon;
-		target.setSelectionRange(selectionStart, selectionEnd);
-		return true;
+        // Set the selection to the text between the parenthesis
+        const parenContent = text.substring(beforeParen + 1, selectionStart + afterParen);
+        const lastColon = parenContent.lastIndexOf(":");
+        selectionStart = beforeParen + 1;
+        selectionEnd = selectionStart + lastColon;
+        target.setSelectionRange(selectionStart, selectionEnd);
+        return true;
     }
-    
-    function selectCurrentWord(){
+
+    function selectCurrentWord() {
         if (selectionStart !== selectionEnd) return false;
         const delimiters = opts.keyedit_delimiters + " \r\n\t";
-        
+
         // seek backward until to find beggining
         while (!delimiters.includes(text[selectionStart - 1]) && selectionStart > 0) {
             selectionStart--;
         }
-        
+
         // seek forward to find end
         while (!delimiters.includes(text[selectionEnd]) && selectionEnd < text.length) {
             selectionEnd++;
@@ -62,27 +62,26 @@ function keyupEditAttention(event){
         return true;
     }
 
-	// If the user hasn't selected anything, let's select their current parenthesis block or word
-    if (!selectCurrentParenthesisBlock('<', '>') && !selectCurrentParenthesisBlock('(', ')')) {
+    // If the user hasn't selected anything, let's select their current parenthesis block or word
+    if (!selectCurrentParenthesisBlock("<", ">") && !selectCurrentParenthesisBlock("(", ")")) {
         selectCurrentWord();
     }
 
-	event.preventDefault();
+    event.preventDefault();
 
-    var closeCharacter = ')'
-    var delta = opts.keyedit_precision_attention
+    var closeCharacter = ")";
+    var delta = opts.keyedit_precision_attention;
 
-    if (selectionStart > 0 && text[selectionStart - 1] == '<'){
-        closeCharacter = '>'
-        delta = opts.keyedit_precision_extra
+    if (selectionStart > 0 && text[selectionStart - 1] == "<") {
+        closeCharacter = ">";
+        delta = opts.keyedit_precision_extra;
     } else if (selectionStart == 0 || text[selectionStart - 1] != "(") {
-
         // do not include spaces at the end
-        while(selectionEnd > selectionStart && text[selectionEnd-1] == ' '){
+        while (selectionEnd > selectionStart && text[selectionEnd - 1] == " ") {
             selectionEnd -= 1;
         }
-        if(selectionStart == selectionEnd){
-            return
+        if (selectionStart == selectionEnd) {
+            return;
         }
 
         text = text.slice(0, selectionStart) + "(" + text.slice(selectionStart, selectionEnd) + ":1.0)" + text.slice(selectionEnd);
@@ -91,15 +90,15 @@ function keyupEditAttention(event){
         selectionEnd += 1;
     }
 
-	var end = text.slice(selectionEnd + 1).indexOf(closeCharacter) + 1;
-	var weight = parseFloat(text.slice(selectionEnd + 1, selectionEnd + 1 + end));
-	if (isNaN(weight)) return;
+    var end = text.slice(selectionEnd + 1).indexOf(closeCharacter) + 1;
+    var weight = parseFloat(text.slice(selectionEnd + 1, selectionEnd + 1 + end));
+    if (isNaN(weight)) return;
 
-	weight += isPlus ? delta : -delta;
-	weight = parseFloat(weight.toPrecision(12));
-	if(String(weight).length == 1) weight += ".0"
+    weight += isPlus ? delta : -delta;
+    weight = parseFloat(weight.toPrecision(12));
+    if (String(weight).length == 1) weight += ".0";
 
-    if (closeCharacter == ')' && weight == 1) {
+    if (closeCharacter == ")" && weight == 1) {
         text = text.slice(0, selectionStart - 1) + text.slice(selectionStart, selectionEnd) + text.slice(selectionEnd + 5);
         selectionStart--;
         selectionEnd--;
@@ -107,14 +106,14 @@ function keyupEditAttention(event){
         text = text.slice(0, selectionEnd + 1) + weight + text.slice(selectionEnd + 1 + end - 1);
     }
 
-	target.focus();
-	target.value = text;
-	target.selectionStart = selectionStart;
-	target.selectionEnd = selectionEnd;
+    target.focus();
+    target.value = text;
+    target.selectionStart = selectionStart;
+    target.selectionEnd = selectionEnd;
 
-	updateInput(target)
+    updateInput(target);
 }
 
-addEventListener('keydown', (event) => {
+addEventListener("keydown", (event) => {
     keyupEditAttention(event);
 });

--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -1,51 +1,50 @@
+function extensions_apply(_disabled_list, _update_list, disable_all) {
+    var disable = [];
+    var update = [];
 
-function extensions_apply(_disabled_list, _update_list, disable_all){
-    var disable = []
-    var update = []
+    gradioApp()
+        .querySelectorAll('#extensions input[type="checkbox"]')
+        .forEach(function (x) {
+            if (x.name.startsWith("enable_") && !x.checked) disable.push(x.name.substring(7));
 
-    gradioApp().querySelectorAll('#extensions input[type="checkbox"]').forEach(function(x){
-        if(x.name.startsWith("enable_") && ! x.checked)
-            disable.push(x.name.substring(7))
+            if (x.name.startsWith("update_") && x.checked) update.push(x.name.substring(7));
+        });
 
-        if(x.name.startsWith("update_") && x.checked)
-            update.push(x.name.substring(7))
-    })
+    restart_reload();
 
-    restart_reload()
-
-    return [JSON.stringify(disable), JSON.stringify(update), disable_all]
+    return [JSON.stringify(disable), JSON.stringify(update), disable_all];
 }
 
-function extensions_check(){
-    var disable = []
+function extensions_check() {
+    var disable = [];
 
-    gradioApp().querySelectorAll('#extensions input[type="checkbox"]').forEach(function(x){
-        if(x.name.startsWith("enable_") && ! x.checked)
-            disable.push(x.name.substring(7))
-    })
+    gradioApp()
+        .querySelectorAll('#extensions input[type="checkbox"]')
+        .forEach(function (x) {
+            if (x.name.startsWith("enable_") && !x.checked) disable.push(x.name.substring(7));
+        });
 
-    gradioApp().querySelectorAll('#extensions .extension_status').forEach(function(x){
-        x.innerHTML = "Loading..."
-    })
+    gradioApp()
+        .querySelectorAll("#extensions .extension_status")
+        .forEach(function (x) {
+            x.innerHTML = "Loading...";
+        });
 
+    var id = randomId();
+    requestProgress(id, gradioApp().getElementById("extensions_installed_top"), null, function () {});
 
-    var id = randomId()
-    requestProgress(id, gradioApp().getElementById('extensions_installed_top'), null, function(){
-
-    })
-
-    return [id, JSON.stringify(disable)]
+    return [id, JSON.stringify(disable)];
 }
 
-function install_extension_from_index(button, url){
-    button.disabled = "disabled"
-    button.value = "Installing..."
+function install_extension_from_index(button, url) {
+    button.disabled = "disabled";
+    button.value = "Installing...";
 
-    var textarea = gradioApp().querySelector('#extension_to_install textarea')
-    textarea.value = url
-    updateInput(textarea)
+    var textarea = gradioApp().querySelector("#extension_to_install textarea");
+    textarea.value = url;
+    updateInput(textarea);
 
-    gradioApp().querySelector('#install_extension_button').click()
+    gradioApp().querySelector("#install_extension_button").click();
 }
 
 function config_state_confirm_restore(_, config_state_name, config_restore_type) {
@@ -63,9 +62,11 @@ function config_state_confirm_restore(_, config_state_name, config_restore_type)
     let confirmed = confirm("Are you sure you want to restore from this state?\nThis will reset " + restored + ".");
     if (confirmed) {
         restart_reload();
-        gradioApp().querySelectorAll('#extensions .extension_status').forEach(function(x){
-            x.innerHTML = "Loading..."
-        })
+        gradioApp()
+            .querySelectorAll("#extensions .extension_status")
+            .forEach(function (x) {
+                x.innerHTML = "Loading...";
+            });
     }
     return [confirmed, config_state_name, config_restore_type];
 }

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -1,30 +1,34 @@
-function setupExtraNetworksForTab(tabname){
-    gradioApp().querySelector('#'+tabname+'_extra_tabs').classList.add('extra-networks')
+function setupExtraNetworksForTab(tabname) {
+    gradioApp()
+        .querySelector("#" + tabname + "_extra_tabs")
+        .classList.add("extra-networks");
 
-    var tabs = gradioApp().querySelector('#'+tabname+'_extra_tabs > div')
-    var search = gradioApp().querySelector('#'+tabname+'_extra_search textarea')
-    var refresh = gradioApp().getElementById(tabname+'_extra_refresh')
+    var tabs = gradioApp().querySelector("#" + tabname + "_extra_tabs > div");
+    var search = gradioApp().querySelector("#" + tabname + "_extra_search textarea");
+    var refresh = gradioApp().getElementById(tabname + "_extra_refresh");
 
-    search.classList.add('search')
-    tabs.appendChild(search)
-    tabs.appendChild(refresh)
+    search.classList.add("search");
+    tabs.appendChild(search);
+    tabs.appendChild(refresh);
 
-    var applyFilter = function(){
-        var searchTerm = search.value.toLowerCase()
+    var applyFilter = function () {
+        var searchTerm = search.value.toLowerCase();
 
-        gradioApp().querySelectorAll('#'+tabname+'_extra_tabs div.card').forEach(function(elem){
-            var searchOnly = elem.querySelector('.search_only')
-            var text = elem.querySelector('.name').textContent.toLowerCase() + " " + elem.querySelector('.search_term').textContent.toLowerCase()
+        gradioApp()
+            .querySelectorAll("#" + tabname + "_extra_tabs div.card")
+            .forEach(function (elem) {
+                var searchOnly = elem.querySelector(".search_only");
+                var text = elem.querySelector(".name").textContent.toLowerCase() + " " + elem.querySelector(".search_term").textContent.toLowerCase();
 
-            var visible = text.indexOf(searchTerm) != -1
+                var visible = text.indexOf(searchTerm) != -1;
 
-            if(searchOnly && searchTerm.length < 4){
-                visible = false
-            }
+                if (searchOnly && searchTerm.length < 4) {
+                    visible = false;
+                }
 
-            elem.style.display = visible ? "" : "none"
-        })
-    }
+                elem.style.display = visible ? "" : "none";
+            });
+    };
 
     search.addEventListener("input", applyFilter);
     applyFilter();
@@ -32,143 +36,154 @@ function setupExtraNetworksForTab(tabname){
     extraNetworksApplyFilter[tabname] = applyFilter;
 }
 
-function applyExtraNetworkFilter(tabname){
+function applyExtraNetworkFilter(tabname) {
     setTimeout(extraNetworksApplyFilter[tabname], 1);
 }
 
-var extraNetworksApplyFilter = {}
+var extraNetworksApplyFilter = {};
 var activePromptTextarea = {};
 
-function setupExtraNetworks(){
-    setupExtraNetworksForTab('txt2img')
-    setupExtraNetworksForTab('img2img')
+function setupExtraNetworks() {
+    setupExtraNetworksForTab("txt2img");
+    setupExtraNetworksForTab("img2img");
 
-    function registerPrompt(tabname, id){
+    function registerPrompt(tabname, id) {
         var textarea = gradioApp().querySelector("#" + id + " > label > textarea");
 
-        if (! activePromptTextarea[tabname]){
-            activePromptTextarea[tabname] = textarea
+        if (!activePromptTextarea[tabname]) {
+            activePromptTextarea[tabname] = textarea;
         }
 
-		textarea.addEventListener("focus", function(){
+        textarea.addEventListener("focus", function () {
             activePromptTextarea[tabname] = textarea;
-		});
+        });
     }
 
-    registerPrompt('txt2img', 'txt2img_prompt')
-    registerPrompt('txt2img', 'txt2img_neg_prompt')
-    registerPrompt('img2img', 'img2img_prompt')
-    registerPrompt('img2img', 'img2img_neg_prompt')
+    registerPrompt("txt2img", "txt2img_prompt");
+    registerPrompt("txt2img", "txt2img_neg_prompt");
+    registerPrompt("img2img", "img2img_prompt");
+    registerPrompt("img2img", "img2img_neg_prompt");
 }
 
-onUiLoaded(setupExtraNetworks)
+onUiLoaded(setupExtraNetworks);
 
-var re_extranet   =    /<([^:]+:[^:]+):[\d\.]+>/;
+var re_extranet = /<([^:]+:[^:]+):[\d\.]+>/;
 var re_extranet_g = /\s+<([^:]+:[^:]+):[\d\.]+>/g;
 
-function tryToRemoveExtraNetworkFromPrompt(textarea, text){
-    var m = text.match(re_extranet)
-    var replaced = false
-    var newTextareaText
-    if(m) {
-        var partToSearch = m[1]
-        newTextareaText = textarea.value.replaceAll(re_extranet_g, function(found){
+function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
+    var m = text.match(re_extranet);
+    var replaced = false;
+    var newTextareaText;
+    if (m) {
+        var partToSearch = m[1];
+        newTextareaText = textarea.value.replaceAll(re_extranet_g, function (found) {
             m = found.match(re_extranet);
-            if(m[1] == partToSearch){
+            if (m[1] == partToSearch) {
                 replaced = true;
-                return ""
+                return "";
             }
             return found;
-        })
+        });
     } else {
-        newTextareaText = textarea.value.replaceAll(new RegExp(text, "g"), function(found){
-            if(found == text) {
+        newTextareaText = textarea.value.replaceAll(new RegExp(text, "g"), function (found) {
+            if (found == text) {
                 replaced = true;
-                return ""
+                return "";
             }
             return found;
-        })
+        });
     }
 
-    if(replaced){
-        textarea.value = newTextareaText
+    if (replaced) {
+        textarea.value = newTextareaText;
         return true;
     }
 
-    return false
+    return false;
 }
 
-function cardClicked(tabname, textToAdd, allowNegativePrompt){
-    var textarea = allowNegativePrompt ? activePromptTextarea[tabname] : gradioApp().querySelector("#" + tabname + "_prompt > label > textarea")
+function cardClicked(tabname, textToAdd, allowNegativePrompt) {
+    var textarea = allowNegativePrompt ? activePromptTextarea[tabname] : gradioApp().querySelector("#" + tabname + "_prompt > label > textarea");
 
-    if(! tryToRemoveExtraNetworkFromPrompt(textarea, textToAdd)){
-        textarea.value = textarea.value + opts.extra_networks_add_text_separator + textToAdd
+    if (!tryToRemoveExtraNetworkFromPrompt(textarea, textToAdd)) {
+        textarea.value = textarea.value + opts.extra_networks_add_text_separator + textToAdd;
     }
 
-    updateInput(textarea)
+    updateInput(textarea);
 }
 
-function saveCardPreview(event, tabname, filename){
-    var textarea = gradioApp().querySelector("#" + tabname + '_preview_filename  > label > textarea')
-    var button = gradioApp().getElementById(tabname + '_save_preview')
+function saveCardPreview(event, tabname, filename) {
+    var textarea = gradioApp().querySelector("#" + tabname + "_preview_filename  > label > textarea");
+    var button = gradioApp().getElementById(tabname + "_save_preview");
 
-    textarea.value = filename
-    updateInput(textarea)
+    textarea.value = filename;
+    updateInput(textarea);
 
-    button.click()
+    button.click();
 
-    event.stopPropagation()
-    event.preventDefault()
+    event.stopPropagation();
+    event.preventDefault();
 }
 
-function extraNetworksSearchButton(tabs_id, event){
-    var searchTextarea = gradioApp().querySelector("#" + tabs_id + ' > div > textarea')
-    var button = event.target
-    var text = button.classList.contains("search-all") ? "" : button.textContent.trim()
+function extraNetworksSearchButton(tabs_id, event) {
+    var searchTextarea = gradioApp().querySelector("#" + tabs_id + " > div > textarea");
+    var button = event.target;
+    var text = button.classList.contains("search-all") ? "" : button.textContent.trim();
 
-    searchTextarea.value = text
-    updateInput(searchTextarea)
+    searchTextarea.value = text;
+    updateInput(searchTextarea);
 }
 
 var globalPopup = null;
 var globalPopupInner = null;
-function popup(contents){
-    if(! globalPopup){
-        globalPopup = document.createElement('div')
-        globalPopup.onclick = function(){ globalPopup.style.display = "none"; };
-        globalPopup.classList.add('global-popup');
+function popup(contents) {
+    if (!globalPopup) {
+        globalPopup = document.createElement("div");
+        globalPopup.onclick = function () {
+            globalPopup.style.display = "none";
+        };
+        globalPopup.classList.add("global-popup");
 
-        var close = document.createElement('div')
-        close.classList.add('global-popup-close');
-        close.onclick = function(){ globalPopup.style.display = "none"; };
+        var close = document.createElement("div");
+        close.classList.add("global-popup-close");
+        close.onclick = function () {
+            globalPopup.style.display = "none";
+        };
         close.title = "Close";
-        globalPopup.appendChild(close)
+        globalPopup.appendChild(close);
 
-        globalPopupInner = document.createElement('div')
-        globalPopupInner.onclick = function(event){ event.stopPropagation(); return false; };
-        globalPopupInner.classList.add('global-popup-inner');
-        globalPopup.appendChild(globalPopupInner)
+        globalPopupInner = document.createElement("div");
+        globalPopupInner.onclick = function (event) {
+            event.stopPropagation();
+            return false;
+        };
+        globalPopupInner.classList.add("global-popup-inner");
+        globalPopup.appendChild(globalPopupInner);
 
         gradioApp().appendChild(globalPopup);
     }
 
-    globalPopupInner.innerHTML = '';
+    globalPopupInner.innerHTML = "";
     globalPopupInner.appendChild(contents);
 
     globalPopup.style.display = "flex";
 }
 
-function extraNetworksShowMetadata(text){
-    var elem = document.createElement('pre')
-    elem.classList.add('popup-metadata');
+function extraNetworksShowMetadata(text) {
+    var elem = document.createElement("pre");
+    elem.classList.add("popup-metadata");
     elem.textContent = text;
 
     popup(elem);
 }
 
-function requestGet(url, data, handler, errorHandler){
+function requestGet(url, data, handler, errorHandler) {
     var xhr = new XMLHttpRequest();
-    var args = Object.keys(data).map(function(k){ return encodeURIComponent(k) + '=' + encodeURIComponent(data[k]) }).join('&')
+    var args = Object.keys(data)
+        .map(function (k) {
+            return encodeURIComponent(k) + "=" + encodeURIComponent(data[k]);
+        })
+        .join("&");
     xhr.open("GET", url + "?" + args, true);
 
     xhr.onreadystatechange = function () {
@@ -176,13 +191,13 @@ function requestGet(url, data, handler, errorHandler){
             if (xhr.status === 200) {
                 try {
                     var js = JSON.parse(xhr.responseText);
-                    handler(js)
+                    handler(js);
                 } catch (error) {
                     console.error(error);
-                    errorHandler()
+                    errorHandler();
                 }
-            } else{
-                errorHandler()
+            } else {
+                errorHandler();
             }
         }
     };
@@ -190,16 +205,23 @@ function requestGet(url, data, handler, errorHandler){
     xhr.send(js);
 }
 
-function extraNetworksRequestMetadata(event, extraPage, cardName){
-    var showError = function(){ extraNetworksShowMetadata("there was an error getting metadata"); }
+function extraNetworksRequestMetadata(event, extraPage, cardName) {
+    var showError = function () {
+        extraNetworksShowMetadata("there was an error getting metadata");
+    };
 
-    requestGet("./sd_extra_networks/metadata", {"page": extraPage, "item": cardName}, function(data){
-        if(data && data.metadata){
-            extraNetworksShowMetadata(data.metadata)
-        } else{
-            showError()
-        }
-    }, showError)
+    requestGet(
+        "./sd_extra_networks/metadata",
+        { page: extraPage, item: cardName },
+        function (data) {
+            if (data && data.metadata) {
+                extraNetworksShowMetadata(data.metadata);
+            } else {
+                showError();
+            }
+        },
+        showError,
+    );
 
-    event.stopPropagation()
+    event.stopPropagation();
 }

--- a/javascript/generationParams.js
+++ b/javascript/generationParams.js
@@ -1,33 +1,44 @@
 // attaches listeners to the txt2img and img2img galleries to update displayed generation param text when the image changes
 
-let txt2img_gallery, img2img_gallery, modal = undefined;
-onUiUpdate(function(){
-	if (!txt2img_gallery) {
-		txt2img_gallery = attachGalleryListeners("txt2img")
-	}
-	if (!img2img_gallery) {
-		img2img_gallery = attachGalleryListeners("img2img")
-	}
-	if (!modal) {
-		modal = gradioApp().getElementById('lightboxModal')
-		modalObserver.observe(modal,  { attributes : true, attributeFilter : ['style'] });
-	}
+let txt2img_gallery,
+    img2img_gallery,
+    modal = undefined;
+onUiUpdate(function () {
+    if (!txt2img_gallery) {
+        txt2img_gallery = attachGalleryListeners("txt2img");
+    }
+    if (!img2img_gallery) {
+        img2img_gallery = attachGalleryListeners("img2img");
+    }
+    if (!modal) {
+        modal = gradioApp().getElementById("lightboxModal");
+        modalObserver.observe(modal, { attributes: true, attributeFilter: ["style"] });
+    }
 });
 
-let modalObserver = new MutationObserver(function(mutations) {
-	mutations.forEach(function(mutationRecord) {
-		let selectedTab = gradioApp().querySelector('#tabs div button.selected')?.innerText
-		if (mutationRecord.target.style.display === 'none' && (selectedTab === 'txt2img' || selectedTab === 'img2img'))
-			gradioApp().getElementById(selectedTab+"_generation_info_button")?.click()
-	});
+let modalObserver = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutationRecord) {
+        let selectedTab = gradioApp().querySelector("#tabs div button.selected")?.innerText;
+        if (mutationRecord.target.style.display === "none" && (selectedTab === "txt2img" || selectedTab === "img2img"))
+            gradioApp()
+                .getElementById(selectedTab + "_generation_info_button")
+                ?.click();
+    });
 });
 
 function attachGalleryListeners(tab_name) {
-	var gallery = gradioApp().querySelector('#'+tab_name+'_gallery')
-	gallery?.addEventListener('click', () => gradioApp().getElementById(tab_name+"_generation_info_button").click());
-	gallery?.addEventListener('keydown', (e) => {
-		if (e.keyCode == 37 || e.keyCode == 39) // left or right arrow
-			gradioApp().getElementById(tab_name+"_generation_info_button").click()
-	});
-	return gallery;
+    var gallery = gradioApp().querySelector("#" + tab_name + "_gallery");
+    gallery?.addEventListener("click", () =>
+        gradioApp()
+            .getElementById(tab_name + "_generation_info_button")
+            .click(),
+    );
+    gallery?.addEventListener("keydown", (e) => {
+        if (e.keyCode == 37 || e.keyCode == 39)
+            // left or right arrow
+            gradioApp()
+                .getElementById(tab_name + "_generation_info_button")
+                .click();
+    });
+    return gallery;
 }

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -3,14 +3,14 @@
 titles = {
     "Sampling steps": "How many times to improve the generated image iteratively; higher values take longer; very low values can produce bad results",
     "Sampling method": "Which algorithm to use to produce the image",
-	"GFPGAN": "Restore low quality faces using GFPGAN neural network",
-	"Euler a": "Euler Ancestral - very creative, each can get a completely different picture depending on step count, setting steps higher than 30-40 does not help",
-	"DDIM": "Denoising Diffusion Implicit Models - best at inpainting",
-	"UniPC": "Unified Predictor-Corrector Framework for Fast Sampling of Diffusion Models",
-	"DPM adaptive": "Ignores step count - uses a number of steps determined by the CFG and resolution", 
+    "GFPGAN": "Restore low quality faces using GFPGAN neural network",
+    "Euler a": "Euler Ancestral - very creative, each can get a completely different picture depending on step count, setting steps higher than 30-40 does not help",
+    "DDIM": "Denoising Diffusion Implicit Models - best at inpainting",
+    "UniPC": "Unified Predictor-Corrector Framework for Fast Sampling of Diffusion Models",
+    "DPM adaptive": "Ignores step count - uses a number of steps determined by the CFG and resolution",
 
-	"Batch count": "How many batches of images to create (has no impact on generation performance or VRAM usage)",
-	"Batch size": "How many image to create in a single batch (increases generation performance at cost of higher VRAM usage)",
+    "Batch count": "How many batches of images to create (has no impact on generation performance or VRAM usage)",
+    "Batch size": "How many image to create in a single batch (increases generation performance at cost of higher VRAM usage)",
     "CFG Scale": "Classifier Free Guidance Scale - how strongly the image should conform to prompt - lower values produce more creative results",
     "Seed": "A value that determines the output of random number generator - if you create an image with same parameters and seed as another image, you'll get the same result",
     "\u{1f3b2}\ufe0f": "Set seed to -1, which will cause a new random number to be used every time",
@@ -40,7 +40,7 @@ titles = {
     "Inpaint at full resolution": "Upscale masked region to target resolution, do inpainting, downscale back and paste into original image",
 
     "Denoising strength": "Determines how little respect the algorithm should have for image's content. At 0, nothing will change, and at 1 you'll get an unrelated image. With values below 1.0, processing will take less steps than the Sampling Steps slider specifies.",
-    
+
     "Skip": "Stop processing current image and continue processing.",
     "Interrupt": "Stop processing images and return any results accumulated so far.",
     "Save": "Write image to a directory (default - log/images) and generation parameters into csv file.",
@@ -96,7 +96,7 @@ titles = {
     "Add difference": "Result = A + (B - C) * M",
     "No interpolation": "Result = A",
 
-	"Initialization text": "If the number of tokens is more than the number of vectors, some may be skipped.\nLeave the textbox empty to start with zeroed out vectors",
+    "Initialization text": "If the number of tokens is more than the number of vectors, some may be skipped.\nLeave the textbox empty to start with zeroed out vectors",
     "Learning rate": "How fast should training go. Low values will take longer to train, high values may fail to converge (not generate accurate results) and/or may break the embedding (This has happened if you see Loss: nan in the training info textbox. If this happens, you need to manually restore your embedding from an older not-broken backup).\n\nYou can set a single numeric value, or multiple learning rates using the syntax:\n\n   rate_1:max_steps_1, rate_2:max_steps_2, ...\n\nEG:   0.005:100, 1e-3:1000, 1e-5\n\nWill train with rate of 0.005 for first 100 steps, then 1e-3 until 1000 steps, then 1e-5 for all remaining steps.",
 
     "Clip skip": "Early stopping parameter for CLIP model; 1 is stop at last layer as usual, 2 is stop at penultimate layer, etc.",
@@ -112,39 +112,42 @@ titles = {
     "Multiplier for extra networks": "When adding extra network such as Hypernetwork or Lora to prompt, use this multiplier for it.",
     "Discard weights with matching name": "Regular expression; if weights's name matches it, the weights is not written to the resulting checkpoint. Use ^model_ema to discard EMA weights.",
     "Extra networks tab order": "Comma-separated list of tab names; tabs listed here will appear in the extra networks UI first and in order lsited.",
-    "Negative Guidance minimum sigma": "Skip negative prompt for steps where image is already mostly denoised; the higher this value, the more skips there will be; provides increased performance in exchange for minor quality reduction."
-}
+    "Negative Guidance minimum sigma": "Skip negative prompt for steps where image is already mostly denoised; the higher this value, the more skips there will be; provides increased performance in exchange for minor quality reduction.",
+};
 
+onUiUpdate(function () {
+    gradioApp()
+        .querySelectorAll("span, button, select, p")
+        .forEach(function (span) {
+            if (span.title) return; // already has a title
 
-onUiUpdate(function(){
-	gradioApp().querySelectorAll('span, button, select, p').forEach(function(span){
-		if (span.title) return;  // already has a title
+            let tooltip = localization[titles[span.textContent]] || titles[span.textContent];
 
-		let tooltip = localization[titles[span.textContent]] || titles[span.textContent];
+            if (!tooltip) {
+                tooltip = localization[titles[span.value]] || titles[span.value];
+            }
 
-    if(!tooltip){
-		    tooltip = localization[titles[span.value]] || titles[span.value];
-		}
+            if (!tooltip) {
+                for (const c of span.classList) {
+                    if (c in titles) {
+                        tooltip = localization[titles[c]] || titles[c];
+                        break;
+                    }
+                }
+            }
 
-		if(!tooltip){
-			for (const c of span.classList) {
-				if (c in titles) {
-					tooltip = localization[titles[c]] || titles[c];
-					break;
-				}
-			}
-		}
+            if (tooltip) {
+                span.title = tooltip;
+            }
+        });
 
-		if(tooltip){
-			span.title = tooltip;
-		}
-	})
+    gradioApp()
+        .querySelectorAll("select")
+        .forEach(function (select) {
+            if (select.onchange != null) return;
 
-	gradioApp().querySelectorAll('select').forEach(function(select){
-	    if (select.onchange != null) return;
-
-	    select.onchange = function(){
-            select.title = localization[titles[select.value]] || titles[select.value] || "";
-	    }
-	})
-})
+            select.onchange = function () {
+                select.title = localization[titles[select.value]] || titles[select.value] || "";
+            };
+        });
+});

--- a/javascript/hires_fix.js
+++ b/javascript/hires_fix.js
@@ -1,18 +1,17 @@
-
-function onCalcResolutionHires(enable, width, height, hr_scale, hr_resize_x, hr_resize_y){
-    function setInactive(elem, inactive){
-        elem.classList.toggle('inactive', !!inactive)
+function onCalcResolutionHires(enable, width, height, hr_scale, hr_resize_x, hr_resize_y) {
+    function setInactive(elem, inactive) {
+        elem.classList.toggle("inactive", !!inactive);
     }
 
-    var hrUpscaleBy = gradioApp().getElementById('txt2img_hr_scale')
-    var hrResizeX = gradioApp().getElementById('txt2img_hr_resize_x')
-    var hrResizeY = gradioApp().getElementById('txt2img_hr_resize_y')
+    var hrUpscaleBy = gradioApp().getElementById("txt2img_hr_scale");
+    var hrResizeX = gradioApp().getElementById("txt2img_hr_resize_x");
+    var hrResizeY = gradioApp().getElementById("txt2img_hr_resize_y");
 
-    gradioApp().getElementById('txt2img_hires_fix_row2').style.display = opts.use_old_hires_fix_width_height ? "none" : ""
+    gradioApp().getElementById("txt2img_hires_fix_row2").style.display = opts.use_old_hires_fix_width_height ? "none" : "";
 
-    setInactive(hrUpscaleBy, opts.use_old_hires_fix_width_height || hr_resize_x > 0 || hr_resize_y > 0)
-    setInactive(hrResizeX, opts.use_old_hires_fix_width_height || hr_resize_x == 0)
-    setInactive(hrResizeY, opts.use_old_hires_fix_width_height || hr_resize_y == 0)
+    setInactive(hrUpscaleBy, opts.use_old_hires_fix_width_height || hr_resize_x > 0 || hr_resize_y > 0);
+    setInactive(hrResizeX, opts.use_old_hires_fix_width_height || hr_resize_x == 0);
+    setInactive(hrResizeY, opts.use_old_hires_fix_width_height || hr_resize_y == 0);
 
-    return [enable, width, height, hr_scale, hr_resize_x, hr_resize_y]
+    return [enable, width, height, hr_scale, hr_resize_x, hr_resize_y];
 }

--- a/javascript/imageMaskFix.js
+++ b/javascript/imageMaskFix.js
@@ -3,18 +3,18 @@
  * @see https://github.com/gradio-app/gradio/issues/1721
  */
 function imageMaskResize() {
-    const canvases = gradioApp().querySelectorAll('#img2maskimg .touch-none canvas');
-    if ( ! canvases.length ) {
-    canvases_fixed = false; // TODO: this is unused..?
-    window.removeEventListener( 'resize', imageMaskResize );
-    return;
+    const canvases = gradioApp().querySelectorAll("#img2maskimg .touch-none canvas");
+    if (!canvases.length) {
+        canvases_fixed = false; // TODO: this is unused..?
+        window.removeEventListener("resize", imageMaskResize);
+        return;
     }
 
-    const wrapper = canvases[0].closest('.touch-none');
+    const wrapper = canvases[0].closest(".touch-none");
     const previewImage = wrapper.previousElementSibling;
 
-    if ( ! previewImage.complete ) {
-        previewImage.addEventListener( 'load', imageMaskResize);
+    if (!previewImage.complete) {
+        previewImage.addEventListener("load", imageMaskResize);
         return;
     }
 
@@ -24,21 +24,21 @@ function imageMaskResize() {
     const nh = previewImage.naturalHeight;
     const portrait = nh > nw;
 
-    const wW = Math.min(w, portrait ? h/nh*nw : w/nw*nw);
-    const wH = Math.min(h, portrait ? h/nh*nh : w/nw*nh);
+    const wW = Math.min(w, portrait ? (h / nh) * nw : (w / nw) * nw);
+    const wH = Math.min(h, portrait ? (h / nh) * nh : (w / nw) * nh);
 
     wrapper.style.width = `${wW}px`;
     wrapper.style.height = `${wH}px`;
     wrapper.style.left = `0px`;
     wrapper.style.top = `0px`;
 
-    canvases.forEach( c => {
-        c.style.width = c.style.height = '';
-        c.style.maxWidth = '100%';
-        c.style.maxHeight = '100%';
-        c.style.objectFit = 'contain';
+    canvases.forEach((c) => {
+        c.style.width = c.style.height = "";
+        c.style.maxWidth = "100%";
+        c.style.maxHeight = "100%";
+        c.style.objectFit = "contain";
     });
 }
 
 onUiUpdate(imageMaskResize);
-window.addEventListener( 'resize', imageMaskResize);
+window.addEventListener("resize", imageMaskResize);

--- a/javascript/imageParams.js
+++ b/javascript/imageParams.js
@@ -1,18 +1,18 @@
-window.onload = (function(){
-    window.addEventListener('drop', e => {
+window.onload = function () {
+    window.addEventListener("drop", (e) => {
         const target = e.composedPath()[0];
         if (target.placeholder.indexOf("Prompt") == -1) return;
 
-        let prompt_target = get_tab_index('tabs') == 1 ? "img2img_prompt_image" : "txt2img_prompt_image";
+        let prompt_target = get_tab_index("tabs") == 1 ? "img2img_prompt_image" : "txt2img_prompt_image";
 
         e.stopPropagation();
         e.preventDefault();
         const imgParent = gradioApp().getElementById(prompt_target);
         const files = e.dataTransfer.files;
         const fileInput = imgParent.querySelector('input[type="file"]');
-        if ( fileInput ) {
+        if (fileInput) {
             fileInput.files = files;
-            fileInput.dispatchEvent(new Event('change'));
+            fileInput.dispatchEvent(new Event("change"));
         }
     });
-});
+};

--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -5,24 +5,24 @@ function closeModal() {
 
 function showModal(event) {
     const source = event.target || event.srcElement;
-    const modalImage = gradioApp().getElementById("modalImage")
-    const lb = gradioApp().getElementById("lightboxModal")
-    modalImage.src = source.src
-    if (modalImage.style.display === 'none') {
-        lb.style.setProperty('background-image', 'url(' + source.src + ')');
+    const modalImage = gradioApp().getElementById("modalImage");
+    const lb = gradioApp().getElementById("lightboxModal");
+    modalImage.src = source.src;
+    if (modalImage.style.display === "none") {
+        lb.style.setProperty("background-image", "url(" + source.src + ")");
     }
     lb.style.display = "flex";
-    lb.focus()
+    lb.focus();
 
-    const tabTxt2Img = gradioApp().getElementById("tab_txt2img")
-    const tabImg2Img = gradioApp().getElementById("tab_img2img")
+    const tabTxt2Img = gradioApp().getElementById("tab_txt2img");
+    const tabImg2Img = gradioApp().getElementById("tab_img2img");
     // show the save button in modal only on txt2img or img2img tabs
     if (tabTxt2Img.style.display != "none" || tabImg2Img.style.display != "none") {
-        gradioApp().getElementById("modal_save").style.display = "inline"
+        gradioApp().getElementById("modal_save").style.display = "inline";
     } else {
-        gradioApp().getElementById("modal_save").style.display = "none"
+        gradioApp().getElementById("modal_save").style.display = "none";
     }
-    event.stopPropagation()
+    event.stopPropagation();
 }
 
 function negmod(n, m) {
@@ -30,14 +30,14 @@ function negmod(n, m) {
 }
 
 function updateOnBackgroundChange() {
-    const modalImage = gradioApp().getElementById("modalImage")
+    const modalImage = gradioApp().getElementById("modalImage");
     if (modalImage && modalImage.offsetParent) {
         let currentButton = selected_gallery_button();
 
         if (currentButton?.children?.length > 0 && modalImage.src != currentButton.children[0].src) {
             modalImage.src = currentButton.children[0].src;
-            if (modalImage.style.display === 'none') {
-                modal.style.setProperty('background-image', `url(${modalImage.src})`)
+            if (modalImage.style.display === "none") {
+                modal.style.setProperty("background-image", `url(${modalImage.src})`);
             }
         }
     }
@@ -49,68 +49,68 @@ function modalImageSwitch(offset) {
     if (galleryButtons.length > 1) {
         var currentButton = selected_gallery_button();
 
-        var result = -1
-        galleryButtons.forEach(function(v, i) {
+        var result = -1;
+        galleryButtons.forEach(function (v, i) {
             if (v == currentButton) {
-                result = i
+                result = i;
             }
-        })
+        });
 
         if (result != -1) {
-            var nextButton = galleryButtons[negmod((result + offset), galleryButtons.length)]
-            nextButton.click()
+            var nextButton = galleryButtons[negmod(result + offset, galleryButtons.length)];
+            nextButton.click();
             const modalImage = gradioApp().getElementById("modalImage");
             const modal = gradioApp().getElementById("lightboxModal");
             modalImage.src = nextButton.children[0].src;
-            if (modalImage.style.display === 'none') {
-                modal.style.setProperty('background-image', `url(${modalImage.src})`)
+            if (modalImage.style.display === "none") {
+                modal.style.setProperty("background-image", `url(${modalImage.src})`);
             }
-            setTimeout(function() {
-                modal.focus()
-            }, 10)
+            setTimeout(function () {
+                modal.focus();
+            }, 10);
         }
     }
 }
 
-function saveImage(){
-    const tabTxt2Img = gradioApp().getElementById("tab_txt2img")
-    const tabImg2Img = gradioApp().getElementById("tab_img2img")
-    const saveTxt2Img = "save_txt2img"
-    const saveImg2Img = "save_img2img"
+function saveImage() {
+    const tabTxt2Img = gradioApp().getElementById("tab_txt2img");
+    const tabImg2Img = gradioApp().getElementById("tab_img2img");
+    const saveTxt2Img = "save_txt2img";
+    const saveImg2Img = "save_img2img";
     if (tabTxt2Img.style.display != "none") {
-        gradioApp().getElementById(saveTxt2Img).click()
+        gradioApp().getElementById(saveTxt2Img).click();
     } else if (tabImg2Img.style.display != "none") {
-        gradioApp().getElementById(saveImg2Img).click()
+        gradioApp().getElementById(saveImg2Img).click();
     } else {
-        console.error("missing implementation for saving modal of this type")
+        console.error("missing implementation for saving modal of this type");
     }
 }
 
 function modalSaveImage(event) {
-    saveImage()
-    event.stopPropagation()
+    saveImage();
+    event.stopPropagation();
 }
 
 function modalNextImage(event) {
-    modalImageSwitch(1)
-    event.stopPropagation()
+    modalImageSwitch(1);
+    event.stopPropagation();
 }
 
 function modalPrevImage(event) {
-    modalImageSwitch(-1)
-    event.stopPropagation()
+    modalImageSwitch(-1);
+    event.stopPropagation();
 }
 
 function modalKeyHandler(event) {
     switch (event.key) {
         case "s":
-            saveImage()
+            saveImage();
             break;
         case "ArrowLeft":
-            modalPrevImage(event)
+            modalPrevImage(event);
             break;
         case "ArrowRight":
-            modalNextImage(event)
+            modalNextImage(event);
             break;
         case "Escape":
             closeModal();
@@ -119,140 +119,141 @@ function modalKeyHandler(event) {
 }
 
 function setupImageForLightbox(e) {
-	if (e.dataset.modded)
-		return;
+    if (e.dataset.modded) return;
 
-	e.dataset.modded = true;
-	e.style.cursor='pointer'
-	e.style.userSelect='none'
+    e.dataset.modded = true;
+    e.style.cursor = "pointer";
+    e.style.userSelect = "none";
 
-	var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
+    var isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
 
-	// For Firefox, listening on click first switched to next image then shows the lightbox.
-	// If you know how to fix this without switching to mousedown event, please.
-	// For other browsers the event is click to make it possiblr to drag picture.
-	var event = isFirefox ? 'mousedown' : 'click'
+    // For Firefox, listening on click first switched to next image then shows the lightbox.
+    // If you know how to fix this without switching to mousedown event, please.
+    // For other browsers the event is click to make it possiblr to drag picture.
+    var event = isFirefox ? "mousedown" : "click";
 
-	e.addEventListener(event, function (evt) {
-		if(!opts.js_modal_lightbox || evt.button != 0) return;
+    e.addEventListener(
+        event,
+        function (evt) {
+            if (!opts.js_modal_lightbox || evt.button != 0) return;
 
-		modalZoomSet(gradioApp().getElementById('modalImage'), opts.js_modal_lightbox_initially_zoomed)
-		evt.preventDefault()
-		showModal(evt)
-	}, true);
-
+            modalZoomSet(gradioApp().getElementById("modalImage"), opts.js_modal_lightbox_initially_zoomed);
+            evt.preventDefault();
+            showModal(evt);
+        },
+        true,
+    );
 }
 
 function modalZoomSet(modalImage, enable) {
-    if(modalImage) modalImage.classList.toggle('modalImageFullscreen', !!enable);
+    if (modalImage) modalImage.classList.toggle("modalImageFullscreen", !!enable);
 }
 
 function modalZoomToggle(event) {
     var modalImage = gradioApp().getElementById("modalImage");
-    modalZoomSet(modalImage, !modalImage.classList.contains('modalImageFullscreen'))
-    event.stopPropagation()
+    modalZoomSet(modalImage, !modalImage.classList.contains("modalImageFullscreen"));
+    event.stopPropagation();
 }
 
 function modalTileImageToggle(event) {
     const modalImage = gradioApp().getElementById("modalImage");
     const modal = gradioApp().getElementById("lightboxModal");
-    const isTiling = modalImage.style.display === 'none';
+    const isTiling = modalImage.style.display === "none";
     if (isTiling) {
-        modalImage.style.display = 'block';
-        modal.style.setProperty('background-image', 'none')
+        modalImage.style.display = "block";
+        modal.style.setProperty("background-image", "none");
     } else {
-        modalImage.style.display = 'none';
-        modal.style.setProperty('background-image', `url(${modalImage.src})`)
+        modalImage.style.display = "none";
+        modal.style.setProperty("background-image", `url(${modalImage.src})`);
     }
 
-    event.stopPropagation()
+    event.stopPropagation();
 }
 
 function galleryImageHandler(e) {
     //if (e && e.parentElement.tagName == 'BUTTON') {
-        e.onclick = showGalleryImage;
+    e.onclick = showGalleryImage;
     //}
 }
 
-onUiUpdate(function() {
-    var fullImg_preview = gradioApp().querySelectorAll('.gradio-gallery > div > img')
+onUiUpdate(function () {
+    var fullImg_preview = gradioApp().querySelectorAll(".gradio-gallery > div > img");
     if (fullImg_preview != null) {
         fullImg_preview.forEach(setupImageForLightbox);
     }
     updateOnBackgroundChange();
-})
+});
 
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
     //const modalFragment = document.createDocumentFragment();
-    const modal = document.createElement('div')
+    const modal = document.createElement("div");
     modal.onclick = closeModal;
     modal.id = "lightboxModal";
-    modal.tabIndex = 0
-    modal.addEventListener('keydown', modalKeyHandler, true)
+    modal.tabIndex = 0;
+    modal.addEventListener("keydown", modalKeyHandler, true);
 
-    const modalControls = document.createElement('div')
-    modalControls.className = 'modalControls gradio-container';
+    const modalControls = document.createElement("div");
+    modalControls.className = "modalControls gradio-container";
     modal.append(modalControls);
 
-    const modalZoom = document.createElement('span')
-    modalZoom.className = 'modalZoom cursor';
-    modalZoom.innerHTML = '&#10529;'
-    modalZoom.addEventListener('click', modalZoomToggle, true)
+    const modalZoom = document.createElement("span");
+    modalZoom.className = "modalZoom cursor";
+    modalZoom.innerHTML = "&#10529;";
+    modalZoom.addEventListener("click", modalZoomToggle, true);
     modalZoom.title = "Toggle zoomed view";
-    modalControls.appendChild(modalZoom)
+    modalControls.appendChild(modalZoom);
 
-    const modalTileImage = document.createElement('span')
-    modalTileImage.className = 'modalTileImage cursor';
-    modalTileImage.innerHTML = '&#8862;'
-    modalTileImage.addEventListener('click', modalTileImageToggle, true)
+    const modalTileImage = document.createElement("span");
+    modalTileImage.className = "modalTileImage cursor";
+    modalTileImage.innerHTML = "&#8862;";
+    modalTileImage.addEventListener("click", modalTileImageToggle, true);
     modalTileImage.title = "Preview tiling";
-    modalControls.appendChild(modalTileImage)
+    modalControls.appendChild(modalTileImage);
 
-    const modalSave = document.createElement("span")
-    modalSave.className = "modalSave cursor"
-    modalSave.id = "modal_save"
-    modalSave.innerHTML = "&#x1F5AB;"
-    modalSave.addEventListener("click", modalSaveImage, true)
-    modalSave.title = "Save Image(s)"
-    modalControls.appendChild(modalSave)
+    const modalSave = document.createElement("span");
+    modalSave.className = "modalSave cursor";
+    modalSave.id = "modal_save";
+    modalSave.innerHTML = "&#x1F5AB;";
+    modalSave.addEventListener("click", modalSaveImage, true);
+    modalSave.title = "Save Image(s)";
+    modalControls.appendChild(modalSave);
 
-    const modalClose = document.createElement('span')
-    modalClose.className = 'modalClose cursor';
-    modalClose.innerHTML = '&times;'
+    const modalClose = document.createElement("span");
+    modalClose.className = "modalClose cursor";
+    modalClose.innerHTML = "&times;";
     modalClose.onclick = closeModal;
     modalClose.title = "Close image viewer";
-    modalControls.appendChild(modalClose)
+    modalControls.appendChild(modalClose);
 
-    const modalImage = document.createElement('img')
-    modalImage.id = 'modalImage';
+    const modalImage = document.createElement("img");
+    modalImage.id = "modalImage";
     modalImage.onclick = closeModal;
-    modalImage.tabIndex = 0
-    modalImage.addEventListener('keydown', modalKeyHandler, true)
-    modal.appendChild(modalImage)
+    modalImage.tabIndex = 0;
+    modalImage.addEventListener("keydown", modalKeyHandler, true);
+    modal.appendChild(modalImage);
 
-    const modalPrev = document.createElement('a')
-    modalPrev.className = 'modalPrev';
-    modalPrev.innerHTML = '&#10094;'
-    modalPrev.tabIndex = 0
-    modalPrev.addEventListener('click', modalPrevImage, true);
-    modalPrev.addEventListener('keydown', modalKeyHandler, true)
-    modal.appendChild(modalPrev)
+    const modalPrev = document.createElement("a");
+    modalPrev.className = "modalPrev";
+    modalPrev.innerHTML = "&#10094;";
+    modalPrev.tabIndex = 0;
+    modalPrev.addEventListener("click", modalPrevImage, true);
+    modalPrev.addEventListener("keydown", modalKeyHandler, true);
+    modal.appendChild(modalPrev);
 
-    const modalNext = document.createElement('a')
-    modalNext.className = 'modalNext';
-    modalNext.innerHTML = '&#10095;'
-    modalNext.tabIndex = 0
-    modalNext.addEventListener('click', modalNextImage, true);
-    modalNext.addEventListener('keydown', modalKeyHandler, true)
+    const modalNext = document.createElement("a");
+    modalNext.className = "modalNext";
+    modalNext.innerHTML = "&#10095;";
+    modalNext.tabIndex = 0;
+    modalNext.addEventListener("click", modalNextImage, true);
+    modalNext.addEventListener("keydown", modalKeyHandler, true);
 
-    modal.appendChild(modalNext)
+    modal.appendChild(modalNext);
 
     try {
-		gradioApp().appendChild(modal);
-	} catch (e) {
-		gradioApp().body.appendChild(modal);
-	}
+        gradioApp().appendChild(modal);
+    } catch (e) {
+        gradioApp().body.appendChild(modal);
+    }
 
     document.body.appendChild(modal);
-
 });

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,4 +1,4 @@
-window.addEventListener('gamepadconnected', (e) => {
+window.addEventListener("gamepadconnected", (e) => {
     const index = e.gamepad.index;
     let isWaiting = false;
     setInterval(async () => {
@@ -14,7 +14,7 @@ window.addEventListener('gamepadconnected', (e) => {
         }
         if (isWaiting) {
             await sleepUntil(() => {
-                const xValue = navigator.getGamepads()[index].axes[0]
+                const xValue = navigator.getGamepads()[index].axes[0];
                 if (xValue < 0.3 && xValue > -0.3) {
                     return true;
                 }
@@ -29,7 +29,7 @@ Primarily for vr controller type pointer devices.
 I use the wheel event because there's currently no way to do it properly with web xr.
  */
 let isScrolling = false;
-window.addEventListener('wheel', (e) => {
+window.addEventListener("wheel", (e) => {
     if (!opts.js_modal_lightbox_gamepad || isScrolling) return;
     isScrolling = true;
 
@@ -47,7 +47,7 @@ window.addEventListener('wheel', (e) => {
 function sleepUntil(f, timeout) {
     return new Promise((resolve) => {
         const timeStart = new Date();
-        const wait = setInterval(function() {
+        const wait = setInterval(function () {
             if (f() || new Date() - timeStart > timeout) {
                 clearInterval(wait);
                 resolve();

--- a/javascript/localization.js
+++ b/javascript/localization.js
@@ -1,127 +1,128 @@
-
 // localization = {} -- the dict with translations is created by the backend
 
-ignore_ids_for_localization={
-    setting_sd_hypernetwork: 'OPTION',
-    setting_sd_model_checkpoint: 'OPTION',
-    setting_realesrgan_enabled_models: 'OPTION',
-    modelmerger_primary_model_name: 'OPTION',
-    modelmerger_secondary_model_name: 'OPTION',
-    modelmerger_tertiary_model_name: 'OPTION',
-    train_embedding: 'OPTION',
-    train_hypernetwork: 'OPTION',
-    txt2img_styles: 'OPTION',
-    img2img_styles: 'OPTION',
-    setting_random_artist_categories: 'SPAN',
-    setting_face_restoration_model: 'SPAN',
-    setting_realesrgan_enabled_models: 'SPAN',
-    extras_upscaler_1: 'SPAN',
-    extras_upscaler_2: 'SPAN',
-}
+ignore_ids_for_localization = {
+    setting_sd_hypernetwork: "OPTION",
+    setting_sd_model_checkpoint: "OPTION",
+    setting_realesrgan_enabled_models: "OPTION",
+    modelmerger_primary_model_name: "OPTION",
+    modelmerger_secondary_model_name: "OPTION",
+    modelmerger_tertiary_model_name: "OPTION",
+    train_embedding: "OPTION",
+    train_hypernetwork: "OPTION",
+    txt2img_styles: "OPTION",
+    img2img_styles: "OPTION",
+    setting_random_artist_categories: "SPAN",
+    setting_face_restoration_model: "SPAN",
+    setting_realesrgan_enabled_models: "SPAN",
+    extras_upscaler_1: "SPAN",
+    extras_upscaler_2: "SPAN",
+};
 
-re_num = /^[\.\d]+$/
-re_emoji = /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F9B0}-\u{1F9B3}]/u
+re_num = /^[\.\d]+$/;
+re_emoji = /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F9B0}-\u{1F9B3}]/u;
 
-original_lines = {}
-translated_lines = {}
+original_lines = {};
+translated_lines = {};
 
 function hasLocalization() {
     return window.localization && Object.keys(window.localization).length > 0;
 }
 
-function textNodesUnder(el){
-    var n, a=[], walk=document.createTreeWalker(el,NodeFilter.SHOW_TEXT,null,false);
-    while(n=walk.nextNode()) a.push(n);
+function textNodesUnder(el) {
+    var n,
+        a = [],
+        walk = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+    while ((n = walk.nextNode())) a.push(n);
     return a;
 }
 
-function canBeTranslated(node, text){
-    if(! text) return false;
-    if(! node.parentElement) return false;
+function canBeTranslated(node, text) {
+    if (!text) return false;
+    if (!node.parentElement) return false;
 
-    var parentType = node.parentElement.nodeName
-    if(parentType=='SCRIPT' || parentType=='STYLE' || parentType=='TEXTAREA') return false;
+    var parentType = node.parentElement.nodeName;
+    if (parentType == "SCRIPT" || parentType == "STYLE" || parentType == "TEXTAREA") return false;
 
-    if (parentType=='OPTION' || parentType=='SPAN'){
-        var pnode = node
-        for(var level=0; level<4; level++){
-            pnode = pnode.parentElement
-            if(! pnode) break;
+    if (parentType == "OPTION" || parentType == "SPAN") {
+        var pnode = node;
+        for (var level = 0; level < 4; level++) {
+            pnode = pnode.parentElement;
+            if (!pnode) break;
 
-            if(ignore_ids_for_localization[pnode.id] == parentType) return false;
+            if (ignore_ids_for_localization[pnode.id] == parentType) return false;
         }
     }
 
-    if(re_num.test(text)) return false;
-    if(re_emoji.test(text)) return false;
-    return true
+    if (re_num.test(text)) return false;
+    if (re_emoji.test(text)) return false;
+    return true;
 }
 
-function getTranslation(text){
-    if(! text) return undefined
+function getTranslation(text) {
+    if (!text) return undefined;
 
-    if(translated_lines[text] === undefined){
-        original_lines[text] = 1
+    if (translated_lines[text] === undefined) {
+        original_lines[text] = 1;
     }
 
-    tl = localization[text]
-    if(tl !== undefined){
-        translated_lines[tl] = 1
+    tl = localization[text];
+    if (tl !== undefined) {
+        translated_lines[tl] = 1;
     }
 
-    return tl
+    return tl;
 }
 
-function processTextNode(node){
-    var text = node.textContent.trim()
+function processTextNode(node) {
+    var text = node.textContent.trim();
 
-    if(! canBeTranslated(node, text)) return
+    if (!canBeTranslated(node, text)) return;
 
-    tl = getTranslation(text)
-    if(tl !== undefined){
-        node.textContent = tl
+    tl = getTranslation(text);
+    if (tl !== undefined) {
+        node.textContent = tl;
     }
 }
 
-function processNode(node){
-    if(node.nodeType == 3){
-        processTextNode(node)
-        return
+function processNode(node) {
+    if (node.nodeType == 3) {
+        processTextNode(node);
+        return;
     }
 
-    if(node.title){
-        tl = getTranslation(node.title)
-        if(tl !== undefined){
-            node.title = tl
+    if (node.title) {
+        tl = getTranslation(node.title);
+        if (tl !== undefined) {
+            node.title = tl;
         }
     }
 
-    if(node.placeholder){
-        tl = getTranslation(node.placeholder)
-        if(tl !== undefined){
-            node.placeholder = tl
+    if (node.placeholder) {
+        tl = getTranslation(node.placeholder);
+        if (tl !== undefined) {
+            node.placeholder = tl;
         }
     }
 
-    textNodesUnder(node).forEach(function(node){
-        processTextNode(node)
-    })
+    textNodesUnder(node).forEach(function (node) {
+        processTextNode(node);
+    });
 }
 
-function dumpTranslations(){
-    if(!hasLocalization()) {
+function dumpTranslations() {
+    if (!hasLocalization()) {
         // If we don't have any localization,
         // we will not have traversed the app to find
         // original_lines, so do that now.
         processNode(gradioApp());
     }
-    var dumped = {}
+    var dumped = {};
     if (localization.rtl) {
         dumped.rtl = true;
     }
 
     for (const text in original_lines) {
-        if(dumped[text] !== undefined) continue;
+        if (dumped[text] !== undefined) continue;
         dumped[text] = localization[text] || text;
     }
 
@@ -129,12 +130,12 @@ function dumpTranslations(){
 }
 
 function download_localization() {
-    var text = JSON.stringify(dumpTranslations(), null, 4)
+    var text = JSON.stringify(dumpTranslations(), null, 4);
 
-    var element = document.createElement('a');
-    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-    element.setAttribute('download', "localization.json");
-    element.style.display = 'none';
+    var element = document.createElement("a");
+    element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(text));
+    element.setAttribute("download", "localization.json");
+    element.style.display = "none";
     document.body.appendChild(element);
 
     element.click();
@@ -150,28 +151,31 @@ document.addEventListener("DOMContentLoaded", function () {
     onUiUpdate(function (m) {
         m.forEach(function (mutation) {
             mutation.addedNodes.forEach(function (node) {
-                processNode(node)
-            })
+                processNode(node);
+            });
         });
-    })
+    });
 
-    processNode(gradioApp())
+    processNode(gradioApp());
 
-    if (localization.rtl) {  // if the language is from right to left,
-        (new MutationObserver((mutations, observer) => { // wait for the style to load
-            mutations.forEach(mutation => {
-                mutation.addedNodes.forEach(node => {
-                    if (node.tagName === 'STYLE') {
+    if (localization.rtl) {
+        // if the language is from right to left,
+        new MutationObserver((mutations, observer) => {
+            // wait for the style to load
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.tagName === "STYLE") {
                         observer.disconnect();
 
-                        for (const x of node.sheet.rules) {  // find all rtl media rules
-                            if (Array.from(x.media || []).includes('rtl')) {
-                                x.media.appendMedium('all');  // enable them
+                        for (const x of node.sheet.rules) {
+                            // find all rtl media rules
+                            if (Array.from(x.media || []).includes("rtl")) {
+                                x.media.appendMedium("all"); // enable them
                             }
                         }
                     }
-                })
+                });
             });
-        })).observe(gradioApp(), { childList: true });
+        }).observe(gradioApp(), { childList: true });
     }
-})
+});

--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -4,14 +4,18 @@ let lastHeadImg = null;
 
 let notificationButton = null;
 
-onUiUpdate(function(){
-    if(notificationButton == null){
-        notificationButton = gradioApp().getElementById('request_notifications')
+onUiUpdate(function () {
+    if (notificationButton == null) {
+        notificationButton = gradioApp().getElementById("request_notifications");
 
-        if(notificationButton != null){
-            notificationButton.addEventListener('click', () => {
-                void Notification.requestPermission();
-            },true);
+        if (notificationButton != null) {
+            notificationButton.addEventListener(
+                "click",
+                () => {
+                    void Notification.requestPermission();
+                },
+                true,
+            );
         }
     }
 
@@ -26,23 +30,20 @@ onUiUpdate(function(){
     lastHeadImg = headImg;
 
     // play notification sound if available
-    gradioApp().querySelector('#audio_notification audio')?.play();
+    gradioApp().querySelector("#audio_notification audio")?.play();
 
     if (document.hasFocus()) return;
 
     // Multiple copies of the images are in the DOM when one is selected. Dedup with a Set to get the real number generated.
-    const imgs = new Set(Array.from(galleryPreviews).map(img => img.src));
+    const imgs = new Set(Array.from(galleryPreviews).map((img) => img.src));
 
-    const notification = new Notification(
-        'Stable Diffusion',
-        {
-            body: `Generated ${imgs.size > 1 ? imgs.size - opts.return_grid : 1} image${imgs.size > 1 ? 's' : ''}`,
-            icon: headImg,
-            image: headImg,
-        }
-    );
+    const notification = new Notification("Stable Diffusion", {
+        body: `Generated ${imgs.size > 1 ? imgs.size - opts.return_grid : 1} image${imgs.size > 1 ? "s" : ""}`,
+        icon: headImg,
+        image: headImg,
+    });
 
-    notification.onclick = function(_){
+    notification.onclick = function (_) {
         parent.focus();
         this.close();
     };

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -1,14 +1,10 @@
 // code related to showing and updating progressbar shown as the image is being made
 
-function rememberGallerySelection(){
+function rememberGallerySelection() {}
 
-}
+function getGallerySelectedIndex() {}
 
-function getGallerySelectedIndex(){
-
-}
-
-function request(url, data, handler, errorHandler){
+function request(url, data, handler, errorHandler) {
     var xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);
     xhr.setRequestHeader("Content-Type", "application/json");
@@ -17,13 +13,13 @@ function request(url, data, handler, errorHandler){
             if (xhr.status === 200) {
                 try {
                     var js = JSON.parse(xhr.responseText);
-                    handler(js)
+                    handler(js);
                 } catch (error) {
                     console.error(error);
-                    errorHandler()
+                    errorHandler();
                 }
-            } else{
-                errorHandler()
+            } else {
+                errorHandler();
             }
         }
     };
@@ -31,147 +27,148 @@ function request(url, data, handler, errorHandler){
     xhr.send(js);
 }
 
-function pad2(x){
-    return x<10 ? '0'+x : x
+function pad2(x) {
+    return x < 10 ? "0" + x : x;
 }
 
-function formatTime(secs){
-    if(secs > 3600){
-        return pad2(Math.floor(secs/60/60)) + ":" + pad2(Math.floor(secs/60)%60) + ":" + pad2(Math.floor(secs)%60)
-    } else if(secs > 60){
-        return pad2(Math.floor(secs/60)) + ":" + pad2(Math.floor(secs)%60)
-    } else{
-        return Math.floor(secs) + "s"
+function formatTime(secs) {
+    if (secs > 3600) {
+        return pad2(Math.floor(secs / 60 / 60)) + ":" + pad2(Math.floor(secs / 60) % 60) + ":" + pad2(Math.floor(secs) % 60);
+    } else if (secs > 60) {
+        return pad2(Math.floor(secs / 60)) + ":" + pad2(Math.floor(secs) % 60);
+    } else {
+        return Math.floor(secs) + "s";
     }
 }
 
-function setTitle(progress){
-    var title = 'Stable Diffusion'
+function setTitle(progress) {
+    var title = "Stable Diffusion";
 
-    if(opts.show_progress_in_title && progress){
-        title = '[' + progress.trim() + '] ' + title;
+    if (opts.show_progress_in_title && progress) {
+        title = "[" + progress.trim() + "] " + title;
     }
 
-    if(document.title != title){
-        document.title =  title;
+    if (document.title != title) {
+        document.title = title;
     }
 }
 
-
-function randomId(){
-    return "task(" + Math.random().toString(36).slice(2, 7) + Math.random().toString(36).slice(2, 7) + Math.random().toString(36).slice(2, 7)+")"
+function randomId() {
+    return "task(" + Math.random().toString(36).slice(2, 7) + Math.random().toString(36).slice(2, 7) + Math.random().toString(36).slice(2, 7) + ")";
 }
 
 // starts sending progress requests to "/internal/progress" uri, creating progressbar above progressbarContainer element and
 // preview inside gallery element. Cleans up all created stuff when the task is over and calls atEnd.
 // calls onProgress every time there is a progress update
-function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgress, inactivityTimeout=40){
-    var dateStart = new Date()
-    var wasEverActive = false
-    var parentProgressbar = progressbarContainer.parentNode
-    var parentGallery = gallery ? gallery.parentNode : null
+function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgress, inactivityTimeout = 40) {
+    var dateStart = new Date();
+    var wasEverActive = false;
+    var parentProgressbar = progressbarContainer.parentNode;
+    var parentGallery = gallery ? gallery.parentNode : null;
 
-    var divProgress = document.createElement('div')
-    divProgress.className='progressDiv'
-    divProgress.style.display = opts.show_progressbar ? "block" : "none"
-    var divInner = document.createElement('div')
-    divInner.className='progress'
+    var divProgress = document.createElement("div");
+    divProgress.className = "progressDiv";
+    divProgress.style.display = opts.show_progressbar ? "block" : "none";
+    var divInner = document.createElement("div");
+    divInner.className = "progress";
 
-    divProgress.appendChild(divInner)
-    parentProgressbar.insertBefore(divProgress, progressbarContainer)
+    divProgress.appendChild(divInner);
+    parentProgressbar.insertBefore(divProgress, progressbarContainer);
 
-    if(parentGallery){
-        var livePreview = document.createElement('div')
-        livePreview.className='livePreview'
-        parentGallery.insertBefore(livePreview, gallery)
+    if (parentGallery) {
+        var livePreview = document.createElement("div");
+        livePreview.className = "livePreview";
+        parentGallery.insertBefore(livePreview, gallery);
     }
 
-    var removeProgressBar = function(){
-        setTitle("")
-        parentProgressbar.removeChild(divProgress)
-        if(parentGallery) parentGallery.removeChild(livePreview)
-        atEnd()
-    }
+    var removeProgressBar = function () {
+        setTitle("");
+        parentProgressbar.removeChild(divProgress);
+        if (parentGallery) parentGallery.removeChild(livePreview);
+        atEnd();
+    };
 
-    var fun = function(id_task, id_live_preview){
-        request("./internal/progress", {"id_task": id_task, "id_live_preview": id_live_preview}, function(res){
-            if(res.completed){
-                removeProgressBar()
-                return
-            }
-
-            var rect = progressbarContainer.getBoundingClientRect()
-
-            if(rect.width){
-                divProgress.style.width = rect.width + "px";
-            }
-
-            let progressText = ""
-
-            divInner.style.width = ((res.progress || 0) * 100.0) + '%'
-            divInner.style.background = res.progress ? "" : "transparent"
-
-            if(res.progress > 0){
-                progressText = ((res.progress || 0) * 100.0).toFixed(0) + '%'
-            }
-
-            if(res.eta){
-                progressText += " ETA: " + formatTime(res.eta)
-            }
-
-
-            setTitle(progressText)
-
-            if(res.textinfo && res.textinfo.indexOf("\n") == -1){
-                progressText = res.textinfo + " " + progressText
-            }
-
-            divInner.textContent = progressText
-
-            var elapsedFromStart = (new Date() - dateStart) / 1000
-
-            if(res.active) wasEverActive = true;
-
-            if(! res.active && wasEverActive){
-                removeProgressBar()
-                return
-            }
-
-            if(elapsedFromStart > inactivityTimeout && !res.queued && !res.active){
-                removeProgressBar()
-                return
-            }
-
-
-            if(res.live_preview && gallery){
-                var rect = gallery.getBoundingClientRect()
-                if(rect.width){
-                    livePreview.style.width = rect.width + "px"
-                    livePreview.style.height = rect.height + "px"
+    var fun = function (id_task, id_live_preview) {
+        request(
+            "./internal/progress",
+            { id_task: id_task, id_live_preview: id_live_preview },
+            function (res) {
+                if (res.completed) {
+                    removeProgressBar();
+                    return;
                 }
 
-                var img = new Image();
-                img.onload = function() {
-                    livePreview.appendChild(img)
-                    if(livePreview.childElementCount > 2){
-                        livePreview.removeChild(livePreview.firstElementChild)
+                var rect = progressbarContainer.getBoundingClientRect();
+
+                if (rect.width) {
+                    divProgress.style.width = rect.width + "px";
+                }
+
+                let progressText = "";
+
+                divInner.style.width = (res.progress || 0) * 100.0 + "%";
+                divInner.style.background = res.progress ? "" : "transparent";
+
+                if (res.progress > 0) {
+                    progressText = ((res.progress || 0) * 100.0).toFixed(0) + "%";
+                }
+
+                if (res.eta) {
+                    progressText += " ETA: " + formatTime(res.eta);
+                }
+
+                setTitle(progressText);
+
+                if (res.textinfo && res.textinfo.indexOf("\n") == -1) {
+                    progressText = res.textinfo + " " + progressText;
+                }
+
+                divInner.textContent = progressText;
+
+                var elapsedFromStart = (new Date() - dateStart) / 1000;
+
+                if (res.active) wasEverActive = true;
+
+                if (!res.active && wasEverActive) {
+                    removeProgressBar();
+                    return;
+                }
+
+                if (elapsedFromStart > inactivityTimeout && !res.queued && !res.active) {
+                    removeProgressBar();
+                    return;
+                }
+
+                if (res.live_preview && gallery) {
+                    var rect = gallery.getBoundingClientRect();
+                    if (rect.width) {
+                        livePreview.style.width = rect.width + "px";
+                        livePreview.style.height = rect.height + "px";
                     }
+
+                    var img = new Image();
+                    img.onload = function () {
+                        livePreview.appendChild(img);
+                        if (livePreview.childElementCount > 2) {
+                            livePreview.removeChild(livePreview.firstElementChild);
+                        }
+                    };
+                    img.src = res.live_preview;
                 }
-                img.src = res.live_preview;
-            }
 
+                if (onProgress) {
+                    onProgress(res);
+                }
 
-            if(onProgress){
-                onProgress(res)
-            }
+                setTimeout(() => {
+                    fun(id_task, res.id_live_preview);
+                }, opts.live_preview_refresh_period || 500);
+            },
+            function () {
+                removeProgressBar();
+            },
+        );
+    };
 
-            setTimeout(() => {
-                fun(id_task, res.id_live_preview);
-            }, opts.live_preview_refresh_period || 500)
-        }, function(){
-            removeProgressBar()
-        })
-    }
-
-    fun(id_task, 0)
+    fun(id_task, 0);
 }

--- a/javascript/textualInversion.js
+++ b/javascript/textualInversion.js
@@ -1,17 +1,20 @@
+function start_training_textual_inversion() {
+    gradioApp().querySelector("#ti_error").innerHTML = "";
 
+    var id = randomId();
+    requestProgress(
+        id,
+        gradioApp().getElementById("ti_output"),
+        gradioApp().getElementById("ti_gallery"),
+        function () {},
+        function (progress) {
+            gradioApp().getElementById("ti_progress").innerHTML = progress.textinfo;
+        },
+    );
 
+    var res = args_to_array(arguments);
 
-function start_training_textual_inversion(){
-    gradioApp().querySelector('#ti_error').innerHTML=''
+    res[0] = id;
 
-    var id = randomId()
-    requestProgress(id, gradioApp().getElementById('ti_output'), gradioApp().getElementById('ti_gallery'), function(){}, function(progress){
-        gradioApp().getElementById('ti_progress').innerHTML = progress.textinfo
-    })
-
-    var res = args_to_array(arguments)
-
-    res[0] = id
-
-    return res
+    return res;
 }

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -1,55 +1,59 @@
 // various functions for interaction with ui.py not large enough to warrant putting them in separate files
 
-function set_theme(theme){
-    var gradioURL = window.location.href
-    if (!gradioURL.includes('?__theme=')) {
-      window.location.replace(gradioURL + '?__theme=' + theme);
+function set_theme(theme) {
+    var gradioURL = window.location.href;
+    if (!gradioURL.includes("?__theme=")) {
+        window.location.replace(gradioURL + "?__theme=" + theme);
     }
 }
 
 function all_gallery_buttons() {
     var allGalleryButtons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery].gradio-gallery .thumbnails > .thumbnail-item.thumbnail-small');
     var visibleGalleryButtons = [];
-    allGalleryButtons.forEach(function(elem) {
+    allGalleryButtons.forEach(function (elem) {
         if (elem.parentElement.offsetParent) {
             visibleGalleryButtons.push(elem);
         }
-    })
+    });
     return visibleGalleryButtons;
 }
 
 function selected_gallery_button() {
     var allCurrentButtons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery].gradio-gallery .thumbnail-item.thumbnail-small.selected');
     var visibleCurrentButton = null;
-    allCurrentButtons.forEach(function(elem) {
+    allCurrentButtons.forEach(function (elem) {
         if (elem.parentElement.offsetParent) {
             visibleCurrentButton = elem;
         }
-    })
+    });
     return visibleCurrentButton;
 }
 
-function selected_gallery_index(){
+function selected_gallery_index() {
     var buttons = all_gallery_buttons();
     var button = selected_gallery_button();
 
-    var result = -1
-    buttons.forEach(function(v, i){ if(v==button) { result = i } })
+    var result = -1;
+    buttons.forEach(function (v, i) {
+        if (v == button) {
+            result = i;
+        }
+    });
 
-    return result
+    return result;
 }
 
-function extract_image_from_gallery(gallery){
-    if (gallery.length == 0){
+function extract_image_from_gallery(gallery) {
+    if (gallery.length == 0) {
         return [null];
     }
-    if (gallery.length == 1){
+    if (gallery.length == 1) {
         return [gallery[0]];
     }
 
-    var index = selected_gallery_index()
+    var index = selected_gallery_index();
 
-    if (index < 0 || index >= gallery.length){
+    if (index < 0 || index >= gallery.length) {
         // Use the first image in the gallery as the default
         index = 0;
     }
@@ -57,385 +61,402 @@ function extract_image_from_gallery(gallery){
     return [gallery[index]];
 }
 
-function args_to_array(args){
-    var res = []
-    for(var i=0;i<args.length;i++){
-        res.push(args[i])
+function args_to_array(args) {
+    var res = [];
+    for (var i = 0; i < args.length; i++) {
+        res.push(args[i]);
     }
-    return res
+    return res;
 }
 
-function switch_to_txt2img(){
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[0].click();
+function switch_to_txt2img() {
+    gradioApp().querySelector("#tabs").querySelectorAll("button")[0].click();
 
     return args_to_array(arguments);
 }
 
-function switch_to_img2img_tab(no){
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
-    gradioApp().getElementById('mode_img2img').querySelectorAll('button')[no].click();
+function switch_to_img2img_tab(no) {
+    gradioApp().querySelector("#tabs").querySelectorAll("button")[1].click();
+    gradioApp().getElementById("mode_img2img").querySelectorAll("button")[no].click();
 }
-function switch_to_img2img(){
+function switch_to_img2img() {
     switch_to_img2img_tab(0);
     return args_to_array(arguments);
 }
 
-function switch_to_sketch(){
+function switch_to_sketch() {
     switch_to_img2img_tab(1);
     return args_to_array(arguments);
 }
 
-function switch_to_inpaint(){
+function switch_to_inpaint() {
     switch_to_img2img_tab(2);
     return args_to_array(arguments);
 }
 
-function switch_to_inpaint_sketch(){
+function switch_to_inpaint_sketch() {
     switch_to_img2img_tab(3);
     return args_to_array(arguments);
 }
 
-function switch_to_inpaint(){
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[1].click();
-    gradioApp().getElementById('mode_img2img').querySelectorAll('button')[2].click();
+function switch_to_inpaint() {
+    gradioApp().querySelector("#tabs").querySelectorAll("button")[1].click();
+    gradioApp().getElementById("mode_img2img").querySelectorAll("button")[2].click();
 
     return args_to_array(arguments);
 }
 
-function switch_to_extras(){
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[2].click();
+function switch_to_extras() {
+    gradioApp().querySelector("#tabs").querySelectorAll("button")[2].click();
 
     return args_to_array(arguments);
 }
 
-function get_tab_index(tabId){
-    var res = 0
+function get_tab_index(tabId) {
+    var res = 0;
 
-    gradioApp().getElementById(tabId).querySelector('div').querySelectorAll('button').forEach(function(button, i){
-        if(button.className.indexOf('selected') != -1)
-            res = i
-    })
+    gradioApp()
+        .getElementById(tabId)
+        .querySelector("div")
+        .querySelectorAll("button")
+        .forEach(function (button, i) {
+            if (button.className.indexOf("selected") != -1) res = i;
+        });
 
-    return res
+    return res;
 }
 
-function create_tab_index_args(tabId, args){
-    var res = []
-    for(var i=0; i<args.length; i++){
-        res.push(args[i])
+function create_tab_index_args(tabId, args) {
+    var res = [];
+    for (var i = 0; i < args.length; i++) {
+        res.push(args[i]);
     }
 
-    res[0] = get_tab_index(tabId)
+    res[0] = get_tab_index(tabId);
 
-    return res
+    return res;
 }
 
 function get_img2img_tab_index() {
-    let res = args_to_array(arguments)
-    res.splice(-2)
-    res[0] = get_tab_index('mode_img2img')
-    return res
+    let res = args_to_array(arguments);
+    res.splice(-2);
+    res[0] = get_tab_index("mode_img2img");
+    return res;
 }
 
-function create_submit_args(args){
-    var res = []
-    for(var i=0;i<args.length;i++){
-        res.push(args[i])
+function create_submit_args(args) {
+    var res = [];
+    for (var i = 0; i < args.length; i++) {
+        res.push(args[i]);
     }
 
     // As it is currently, txt2img and img2img send back the previous output args (txt2img_gallery, generation_info, html_info) whenever you generate a new image.
     // This can lead to uploading a huge gallery of previously generated images, which leads to an unnecessary delay between submitting and beginning to generate.
     // I don't know why gradio is sending outputs along with inputs, but we can prevent sending the image gallery here, which seems to be an issue for some.
     // If gradio at some point stops sending outputs, this may break something
-    if(Array.isArray(res[res.length - 3])){
-        res[res.length - 3] = null
+    if (Array.isArray(res[res.length - 3])) {
+        res[res.length - 3] = null;
     }
 
-    return res
+    return res;
 }
 
-function showSubmitButtons(tabname, show){
-    gradioApp().getElementById(tabname+'_interrupt').style.display = show ? "none" : "block"
-    gradioApp().getElementById(tabname+'_skip').style.display = show ? "none" : "block"
+function showSubmitButtons(tabname, show) {
+    gradioApp().getElementById(tabname + "_interrupt").style.display = show ? "none" : "block";
+    gradioApp().getElementById(tabname + "_skip").style.display = show ? "none" : "block";
 }
 
-function showRestoreProgressButton(tabname, show){
-    var button = gradioApp().getElementById(tabname + "_restore_progress")
-    if(! button) return
+function showRestoreProgressButton(tabname, show) {
+    var button = gradioApp().getElementById(tabname + "_restore_progress");
+    if (!button) return;
 
-    button.style.display = show ? "flex" : "none"
+    button.style.display = show ? "flex" : "none";
 }
 
-function submit(){
-    rememberGallerySelection('txt2img_gallery')
-    showSubmitButtons('txt2img', false)
+function submit() {
+    rememberGallerySelection("txt2img_gallery");
+    showSubmitButtons("txt2img", false);
 
-    var id = randomId()
+    var id = randomId();
     localStorage.setItem("txt2img_task_id", id);
 
-    requestProgress(id, gradioApp().getElementById('txt2img_gallery_container'), gradioApp().getElementById('txt2img_gallery'), function(){
-        showSubmitButtons('txt2img', true)
-        localStorage.removeItem("txt2img_task_id")
-        showRestoreProgressButton('txt2img', false)
-    })
+    requestProgress(id, gradioApp().getElementById("txt2img_gallery_container"), gradioApp().getElementById("txt2img_gallery"), function () {
+        showSubmitButtons("txt2img", true);
+        localStorage.removeItem("txt2img_task_id");
+        showRestoreProgressButton("txt2img", false);
+    });
 
-    var res = create_submit_args(arguments)
+    var res = create_submit_args(arguments);
 
-    res[0] = id
+    res[0] = id;
 
-    return res
+    return res;
 }
 
-function submit_img2img(){
-    rememberGallerySelection('img2img_gallery')
-    showSubmitButtons('img2img', false)
+function submit_img2img() {
+    rememberGallerySelection("img2img_gallery");
+    showSubmitButtons("img2img", false);
 
-    var id = randomId()
+    var id = randomId();
     localStorage.setItem("img2img_task_id", id);
 
-    requestProgress(id, gradioApp().getElementById('img2img_gallery_container'), gradioApp().getElementById('img2img_gallery'), function(){
-        showSubmitButtons('img2img', true)
-        localStorage.removeItem("img2img_task_id")
-        showRestoreProgressButton('img2img', false)
-    })
+    requestProgress(id, gradioApp().getElementById("img2img_gallery_container"), gradioApp().getElementById("img2img_gallery"), function () {
+        showSubmitButtons("img2img", true);
+        localStorage.removeItem("img2img_task_id");
+        showRestoreProgressButton("img2img", false);
+    });
 
-    var res = create_submit_args(arguments)
+    var res = create_submit_args(arguments);
 
-    res[0] = id
-    res[1] = get_tab_index('mode_img2img')
+    res[0] = id;
+    res[1] = get_tab_index("mode_img2img");
 
-    return res
+    return res;
 }
 
-function restoreProgressTxt2img(){
-    showRestoreProgressButton("txt2img", false)
-    var id = localStorage.getItem("txt2img_task_id")
+function restoreProgressTxt2img() {
+    showRestoreProgressButton("txt2img", false);
+    var id = localStorage.getItem("txt2img_task_id");
 
-    id = localStorage.getItem("txt2img_task_id")
+    id = localStorage.getItem("txt2img_task_id");
 
-    if(id) {
-        requestProgress(id, gradioApp().getElementById('txt2img_gallery_container'), gradioApp().getElementById('txt2img_gallery'), function(){
-            showSubmitButtons('txt2img', true)
-        }, null, 0)
+    if (id) {
+        requestProgress(
+            id,
+            gradioApp().getElementById("txt2img_gallery_container"),
+            gradioApp().getElementById("txt2img_gallery"),
+            function () {
+                showSubmitButtons("txt2img", true);
+            },
+            null,
+            0,
+        );
     }
 
-    return id
+    return id;
 }
 
-function restoreProgressImg2img(){
-    showRestoreProgressButton("img2img", false)
-    
-    var id = localStorage.getItem("img2img_task_id")
+function restoreProgressImg2img() {
+    showRestoreProgressButton("img2img", false);
 
-    if(id) {
-        requestProgress(id, gradioApp().getElementById('img2img_gallery_container'), gradioApp().getElementById('img2img_gallery'), function(){
-            showSubmitButtons('img2img', true)
-        }, null, 0)
+    var id = localStorage.getItem("img2img_task_id");
+
+    if (id) {
+        requestProgress(
+            id,
+            gradioApp().getElementById("img2img_gallery_container"),
+            gradioApp().getElementById("img2img_gallery"),
+            function () {
+                showSubmitButtons("img2img", true);
+            },
+            null,
+            0,
+        );
     }
 
-    return id
+    return id;
 }
-
 
 onUiLoaded(function () {
-    showRestoreProgressButton('txt2img', localStorage.getItem("txt2img_task_id"))
-    showRestoreProgressButton('img2img', localStorage.getItem("img2img_task_id"))
+    showRestoreProgressButton("txt2img", localStorage.getItem("txt2img_task_id"));
+    showRestoreProgressButton("img2img", localStorage.getItem("img2img_task_id"));
 });
 
+function modelmerger() {
+    var id = randomId();
+    requestProgress(id, gradioApp().getElementById("modelmerger_results_panel"), null, function () {});
 
-function modelmerger(){
-    var id = randomId()
-    requestProgress(id, gradioApp().getElementById('modelmerger_results_panel'), null, function(){})
-
-    var res = create_submit_args(arguments)
-    res[0] = id
-    return res
+    var res = create_submit_args(arguments);
+    res[0] = id;
+    return res;
 }
 
-
 function ask_for_style_name(_, prompt_text, negative_prompt_text) {
-    var name_ = prompt('Style name:')
-    return [name_, prompt_text, negative_prompt_text]
+    var name_ = prompt("Style name:");
+    return [name_, prompt_text, negative_prompt_text];
 }
 
 function confirm_clear_prompt(prompt, negative_prompt) {
-    if(confirm("Delete prompt?")) {
-        prompt = ""
-        negative_prompt = ""
+    if (confirm("Delete prompt?")) {
+        prompt = "";
+        negative_prompt = "";
     }
 
-    return [prompt, negative_prompt]
+    return [prompt, negative_prompt];
 }
 
+promptTokecountUpdateFuncs = {};
 
-promptTokecountUpdateFuncs = {}
-
-function recalculatePromptTokens(name){
-    if(promptTokecountUpdateFuncs[name]){
-        promptTokecountUpdateFuncs[name]()
+function recalculatePromptTokens(name) {
+    if (promptTokecountUpdateFuncs[name]) {
+        promptTokecountUpdateFuncs[name]();
     }
 }
 
-function recalculate_prompts_txt2img(){
-    recalculatePromptTokens('txt2img_prompt')
-    recalculatePromptTokens('txt2img_neg_prompt')
+function recalculate_prompts_txt2img() {
+    recalculatePromptTokens("txt2img_prompt");
+    recalculatePromptTokens("txt2img_neg_prompt");
     return args_to_array(arguments);
 }
 
-function recalculate_prompts_img2img(){
-    recalculatePromptTokens('img2img_prompt')
-    recalculatePromptTokens('img2img_neg_prompt')
+function recalculate_prompts_img2img() {
+    recalculatePromptTokens("img2img_prompt");
+    recalculatePromptTokens("img2img_neg_prompt");
     return args_to_array(arguments);
 }
 
+var opts = {};
+onUiUpdate(function () {
+    if (Object.keys(opts).length != 0) return;
 
-var opts = {}
-onUiUpdate(function(){
-	if(Object.keys(opts).length != 0) return;
+    var json_elem = gradioApp().getElementById("settings_json");
+    if (json_elem == null) return;
 
-	var json_elem = gradioApp().getElementById('settings_json')
-	if(json_elem == null) return;
-
-    var textarea = json_elem.querySelector('textarea')
-    var jsdata = textarea.value
-    opts = JSON.parse(jsdata)
+    var textarea = json_elem.querySelector("textarea");
+    var jsdata = textarea.value;
+    opts = JSON.parse(jsdata);
     executeCallbacks(optionsChangedCallbacks);
 
-    Object.defineProperty(textarea, 'value', {
-        set: function(newValue) {
-            var valueProp = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+    Object.defineProperty(textarea, "value", {
+        set: function (newValue) {
+            var valueProp = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
             var oldValue = valueProp.get.call(textarea);
             valueProp.set.call(textarea, newValue);
 
             if (oldValue != newValue) {
-                opts = JSON.parse(textarea.value)
+                opts = JSON.parse(textarea.value);
             }
 
             executeCallbacks(optionsChangedCallbacks);
         },
-        get: function() {
-            var valueProp = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+        get: function () {
+            var valueProp = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
             return valueProp.get.call(textarea);
-        }
+        },
     });
 
-    json_elem.parentElement.style.display="none"
+    json_elem.parentElement.style.display = "none";
 
-    function registerTextarea(id, id_counter, id_button){
-        var prompt = gradioApp().getElementById(id)
-        var counter = gradioApp().getElementById(id_counter)
+    function registerTextarea(id, id_counter, id_button) {
+        var prompt = gradioApp().getElementById(id);
+        var counter = gradioApp().getElementById(id_counter);
         var textarea = gradioApp().querySelector("#" + id + " > label > textarea");
 
-        if(counter.parentElement == prompt.parentElement){
-            return
+        if (counter.parentElement == prompt.parentElement) {
+            return;
         }
 
-        prompt.parentElement.insertBefore(counter, prompt)
-        prompt.parentElement.style.position = "relative"
+        prompt.parentElement.insertBefore(counter, prompt);
+        prompt.parentElement.style.position = "relative";
 
-		promptTokecountUpdateFuncs[id] = function(){ update_token_counter(id_button); }
-		textarea.addEventListener("input", promptTokecountUpdateFuncs[id]);
+        promptTokecountUpdateFuncs[id] = function () {
+            update_token_counter(id_button);
+        };
+        textarea.addEventListener("input", promptTokecountUpdateFuncs[id]);
     }
 
-    registerTextarea('txt2img_prompt', 'txt2img_token_counter', 'txt2img_token_button')
-    registerTextarea('txt2img_neg_prompt', 'txt2img_negative_token_counter', 'txt2img_negative_token_button')
-    registerTextarea('img2img_prompt', 'img2img_token_counter', 'img2img_token_button')
-    registerTextarea('img2img_neg_prompt', 'img2img_negative_token_counter', 'img2img_negative_token_button')
+    registerTextarea("txt2img_prompt", "txt2img_token_counter", "txt2img_token_button");
+    registerTextarea("txt2img_neg_prompt", "txt2img_negative_token_counter", "txt2img_negative_token_button");
+    registerTextarea("img2img_prompt", "img2img_token_counter", "img2img_token_button");
+    registerTextarea("img2img_neg_prompt", "img2img_negative_token_counter", "img2img_negative_token_button");
 
-    var show_all_pages = gradioApp().getElementById('settings_show_all_pages')
-    var settings_tabs = gradioApp().querySelector('#settings div')
-    if(show_all_pages && settings_tabs){
-        settings_tabs.appendChild(show_all_pages)
-        show_all_pages.onclick = function(){
-            gradioApp().querySelectorAll('#settings > div').forEach(function(elem){
-                if(elem.id == "settings_tab_licenses")
-                    return;
+    var show_all_pages = gradioApp().getElementById("settings_show_all_pages");
+    var settings_tabs = gradioApp().querySelector("#settings div");
+    if (show_all_pages && settings_tabs) {
+        settings_tabs.appendChild(show_all_pages);
+        show_all_pages.onclick = function () {
+            gradioApp()
+                .querySelectorAll("#settings > div")
+                .forEach(function (elem) {
+                    if (elem.id == "settings_tab_licenses") return;
 
-                elem.style.display = "block";
-            })
-        }
+                    elem.style.display = "block";
+                });
+        };
     }
-})
+});
 
-onOptionsChanged(function(){
-    var elem = gradioApp().getElementById('sd_checkpoint_hash')
-    var sd_checkpoint_hash = opts.sd_checkpoint_hash || ""
-    var shorthash = sd_checkpoint_hash.substring(0,10)
+onOptionsChanged(function () {
+    var elem = gradioApp().getElementById("sd_checkpoint_hash");
+    var sd_checkpoint_hash = opts.sd_checkpoint_hash || "";
+    var shorthash = sd_checkpoint_hash.substring(0, 10);
 
-	if(elem && elem.textContent != shorthash){
-	    elem.textContent = shorthash
-	    elem.title = sd_checkpoint_hash
-	    elem.href = "https://google.com/search?q=" + sd_checkpoint_hash
-	}
-})
+    if (elem && elem.textContent != shorthash) {
+        elem.textContent = shorthash;
+        elem.title = sd_checkpoint_hash;
+        elem.href = "https://google.com/search?q=" + sd_checkpoint_hash;
+    }
+});
 
-let txt2img_textarea, img2img_textarea = undefined;
-let wait_time = 800
+let txt2img_textarea,
+    img2img_textarea = undefined;
+let wait_time = 800;
 let token_timeouts = {};
 
 function update_txt2img_tokens(...args) {
-	update_token_counter("txt2img_token_button")
-	if (args.length == 2)
-		return args[0]
-	return args;
+    update_token_counter("txt2img_token_button");
+    if (args.length == 2) return args[0];
+    return args;
 }
 
 function update_img2img_tokens(...args) {
-	update_token_counter("img2img_token_button")
-	if (args.length == 2)
-		return args[0]
-	return args;
+    update_token_counter("img2img_token_button");
+    if (args.length == 2) return args[0];
+    return args;
 }
 
 function update_token_counter(button_id) {
-	if (token_timeouts[button_id])
-		clearTimeout(token_timeouts[button_id]);
-	token_timeouts[button_id] = setTimeout(() => gradioApp().getElementById(button_id)?.click(), wait_time);
+    if (token_timeouts[button_id]) clearTimeout(token_timeouts[button_id]);
+    token_timeouts[button_id] = setTimeout(() => gradioApp().getElementById(button_id)?.click(), wait_time);
 }
 
-function restart_reload(){
-    document.body.innerHTML='<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>';
+function restart_reload() {
+    document.body.innerHTML = '<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>';
 
-    var requestPing = function(){
-        requestGet("./internal/ping", {}, function(data){
-            location.reload();
-        }, function(){
-            setTimeout(requestPing, 500);
-        })
-    }
+    var requestPing = function () {
+        requestGet(
+            "./internal/ping",
+            {},
+            function (data) {
+                location.reload();
+            },
+            function () {
+                setTimeout(requestPing, 500);
+            },
+        );
+    };
 
     setTimeout(requestPing, 2000);
 
-    return []
+    return [];
 }
 
 // Simulate an `input` DOM event for Gradio Textbox component. Needed after you edit its contents in javascript, otherwise your edits
 // will only visible on web page and not sent to python.
-function updateInput(target){
-	let e = new Event("input", { bubbles: true })
-	Object.defineProperty(e, "target", {value: target})
-	target.dispatchEvent(e);
+function updateInput(target) {
+    let e = new Event("input", { bubbles: true });
+    Object.defineProperty(e, "target", { value: target });
+    target.dispatchEvent(e);
 }
-
 
 var desiredCheckpointName = null;
-function selectCheckpoint(name){
+function selectCheckpoint(name) {
     desiredCheckpointName = name;
-    gradioApp().getElementById('change_checkpoint').click()
+    gradioApp().getElementById("change_checkpoint").click();
 }
 
-function currentImg2imgSourceResolution(_, _, scaleBy){
-    var img = gradioApp().querySelector('#mode_img2img > div[style="display: block;"] img')
-    return img ? [img.naturalWidth, img.naturalHeight, scaleBy] : [0, 0, scaleBy]
+function currentImg2imgSourceResolution(_, _, scaleBy) {
+    var img = gradioApp().querySelector('#mode_img2img > div[style="display: block;"] img');
+    return img ? [img.naturalWidth, img.naturalHeight, scaleBy] : [0, 0, scaleBy];
 }
 
-function updateImg2imgResizeToTextAfterChangingImage(){
+function updateImg2imgResizeToTextAfterChangingImage() {
     // At the time this is called from gradio, the image has no yet been replaced.
     // There may be a better solution, but this is simple and straightforward so I'm going with it.
 
-    setTimeout(function() {
-        gradioApp().getElementById('img2img_update_resize_to').click()
+    setTimeout(function () {
+        gradioApp().getElementById("img2img_update_resize_to").click();
     }, 500);
 
-    return []
+    return [];
 }

--- a/javascript/ui_settings_hints.js
+++ b/javascript/ui_settings_hints.js
@@ -1,62 +1,64 @@
 // various hints and extra info for the settings tab
 
-settingsHintsSetup = false
+settingsHintsSetup = false;
 
-onOptionsChanged(function(){
-    if(settingsHintsSetup) return
-    settingsHintsSetup = true
+onOptionsChanged(function () {
+    if (settingsHintsSetup) return;
+    settingsHintsSetup = true;
 
-    gradioApp().querySelectorAll('#settings [id^=setting_]').forEach(function(div){
-        var name = div.id.substr(8)
-        var commentBefore = opts._comments_before[name]
-        var commentAfter = opts._comments_after[name]
+    gradioApp()
+        .querySelectorAll("#settings [id^=setting_]")
+        .forEach(function (div) {
+            var name = div.id.substr(8);
+            var commentBefore = opts._comments_before[name];
+            var commentAfter = opts._comments_after[name];
 
-        if(! commentBefore && !commentAfter) return
+            if (!commentBefore && !commentAfter) return;
 
-        var span = null
-        if(div.classList.contains('gradio-checkbox')) span = div.querySelector('label span')
-        else if(div.classList.contains('gradio-checkboxgroup')) span = div.querySelector('span').firstChild
-        else if(div.classList.contains('gradio-radio')) span = div.querySelector('span').firstChild
-        else span = div.querySelector('label span').firstChild
+            var span = null;
+            if (div.classList.contains("gradio-checkbox")) span = div.querySelector("label span");
+            else if (div.classList.contains("gradio-checkboxgroup")) span = div.querySelector("span").firstChild;
+            else if (div.classList.contains("gradio-radio")) span = div.querySelector("span").firstChild;
+            else span = div.querySelector("label span").firstChild;
 
-        if(!span) return
+            if (!span) return;
 
-        if(commentBefore){
-            var comment = document.createElement('DIV')
-            comment.className = 'settings-comment'
-            comment.innerHTML = commentBefore
-            span.parentElement.insertBefore(document.createTextNode('\xa0'), span)
-            span.parentElement.insertBefore(comment, span)
-            span.parentElement.insertBefore(document.createTextNode('\xa0'), span)
-        }
-        if(commentAfter){
-            var comment = document.createElement('DIV')
-            comment.className = 'settings-comment'
-            comment.innerHTML = commentAfter
-            span.parentElement.insertBefore(comment, span.nextSibling)
-            span.parentElement.insertBefore(document.createTextNode('\xa0'), span.nextSibling)
-        }
-    })
-})
+            if (commentBefore) {
+                var comment = document.createElement("DIV");
+                comment.className = "settings-comment";
+                comment.innerHTML = commentBefore;
+                span.parentElement.insertBefore(document.createTextNode("\xa0"), span);
+                span.parentElement.insertBefore(comment, span);
+                span.parentElement.insertBefore(document.createTextNode("\xa0"), span);
+            }
+            if (commentAfter) {
+                var comment = document.createElement("DIV");
+                comment.className = "settings-comment";
+                comment.innerHTML = commentAfter;
+                span.parentElement.insertBefore(comment, span.nextSibling);
+                span.parentElement.insertBefore(document.createTextNode("\xa0"), span.nextSibling);
+            }
+        });
+});
 
-function settingsHintsShowQuicksettings(){
-	requestGet("./internal/quicksettings-hint", {}, function(data){
-		var table = document.createElement('table')
-		table.className = 'settings-value-table'
+function settingsHintsShowQuicksettings() {
+    requestGet("./internal/quicksettings-hint", {}, function (data) {
+        var table = document.createElement("table");
+        table.className = "settings-value-table";
 
-		data.forEach(function(obj){
-			var tr = document.createElement('tr')
-			var td = document.createElement('td')
-			td.textContent = obj.name
-			tr.appendChild(td)
+        data.forEach(function (obj) {
+            var tr = document.createElement("tr");
+            var td = document.createElement("td");
+            td.textContent = obj.name;
+            tr.appendChild(td);
 
-			var td = document.createElement('td')
-			td.textContent = obj.label
-			tr.appendChild(td)
+            var td = document.createElement("td");
+            td.textContent = obj.label;
+            tr.appendChild(td);
 
-			table.appendChild(tr)
-		})
+            table.appendChild(tr);
+        });
 
-		popup(table);
-	})
+        popup(table);
+    });
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "devDependencies": {
+        "prettier": "^2.8.8"
+    },
+    "scripts": {
+        "check-prettier": "prettier --check .",
+        "prettify": "prettier --write ."
+    },
+    "prettier": {
+        "printWidth": 9001,
+        "quoteProps": "consistent",
+        "tabWidth": 4,
+        "trailingComma": "all"
+    }
+}

--- a/script.js
+++ b/script.js
@@ -1,101 +1,106 @@
 function gradioApp() {
-    const elems = document.getElementsByTagName('gradio-app')
-    const elem = elems.length == 0 ? document : elems[0]
+    const elems = document.getElementsByTagName("gradio-app");
+    const elem = elems.length == 0 ? document : elems[0];
 
-    if (elem !== document) elem.getElementById = function(id){ return document.getElementById(id) }
-    return elem.shadowRoot ? elem.shadowRoot : elem
+    if (elem !== document)
+        elem.getElementById = function (id) {
+            return document.getElementById(id);
+        };
+    return elem.shadowRoot ? elem.shadowRoot : elem;
 }
 
 function get_uiCurrentTab() {
-    return gradioApp().querySelector('#tabs button.selected')
+    return gradioApp().querySelector("#tabs button.selected");
 }
 
 function get_uiCurrentTabContent() {
-    return gradioApp().querySelector('.tabitem[id^=tab_]:not([style*="display: none"])')
+    return gradioApp().querySelector('.tabitem[id^=tab_]:not([style*="display: none"])');
 }
 
-uiUpdateCallbacks = []
-uiLoadedCallbacks = []
-uiTabChangeCallbacks = []
-optionsChangedCallbacks = []
-let uiCurrentTab = null
+uiUpdateCallbacks = [];
+uiLoadedCallbacks = [];
+uiTabChangeCallbacks = [];
+optionsChangedCallbacks = [];
+let uiCurrentTab = null;
 
-function onUiUpdate(callback){
-    uiUpdateCallbacks.push(callback)
+function onUiUpdate(callback) {
+    uiUpdateCallbacks.push(callback);
 }
-function onUiLoaded(callback){
-    uiLoadedCallbacks.push(callback)
+function onUiLoaded(callback) {
+    uiLoadedCallbacks.push(callback);
 }
-function onUiTabChange(callback){
-    uiTabChangeCallbacks.push(callback)
+function onUiTabChange(callback) {
+    uiTabChangeCallbacks.push(callback);
 }
-function onOptionsChanged(callback){
-    optionsChangedCallbacks.push(callback)
+function onOptionsChanged(callback) {
+    optionsChangedCallbacks.push(callback);
 }
 
-function runCallback(x, m){
+function runCallback(x, m) {
     try {
-        x(m)
+        x(m);
     } catch (e) {
         (console.error || console.log).call(console, e.message, e);
     }
 }
 function executeCallbacks(queue, m) {
-    queue.forEach(function(x){runCallback(x, m)})
+    queue.forEach(function (x) {
+        runCallback(x, m);
+    });
 }
 
 var executedOnLoaded = false;
 
-document.addEventListener("DOMContentLoaded", function() {
-    var mutationObserver = new MutationObserver(function(m){
-        if(!executedOnLoaded && gradioApp().querySelector('#txt2img_prompt')){
+document.addEventListener("DOMContentLoaded", function () {
+    var mutationObserver = new MutationObserver(function (m) {
+        if (!executedOnLoaded && gradioApp().querySelector("#txt2img_prompt")) {
             executedOnLoaded = true;
             executeCallbacks(uiLoadedCallbacks);
         }
 
         executeCallbacks(uiUpdateCallbacks, m);
         const newTab = get_uiCurrentTab();
-        if ( newTab && ( newTab !== uiCurrentTab ) ) {
+        if (newTab && newTab !== uiCurrentTab) {
             uiCurrentTab = newTab;
             executeCallbacks(uiTabChangeCallbacks);
         }
     });
-    mutationObserver.observe( gradioApp(), { childList:true, subtree:true })
+    mutationObserver.observe(gradioApp(), { childList: true, subtree: true });
 });
 
 /**
  * Add a ctrl+enter as a shortcut to start a generation
  */
-document.addEventListener('keydown', function(e) {
+document.addEventListener("keydown", function (e) {
     var handled = false;
     if (e.key !== undefined) {
-        if((e.key == "Enter" && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
+        if (e.key == "Enter" && (e.metaKey || e.ctrlKey || e.altKey)) handled = true;
     } else if (e.keyCode !== undefined) {
-        if((e.keyCode == 13 && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
+        if (e.keyCode == 13 && (e.metaKey || e.ctrlKey || e.altKey)) handled = true;
     }
     if (handled) {
-        button = get_uiCurrentTabContent().querySelector('button[id$=_generate]');
+        button = get_uiCurrentTabContent().querySelector("button[id$=_generate]");
         if (button) {
             button.click();
         }
         e.preventDefault();
     }
-})
+});
 
 /**
  * checks that a UI element is not in another hidden element or tab content
  */
 function uiElementIsVisible(el) {
-    let isVisible = !el.closest('.\\!hidden');
-    if ( ! isVisible ) {
+    let isVisible = !el.closest(".\\!hidden");
+    if (!isVisible) {
         return false;
     }
 
-    while( isVisible = el.closest('.tabitem')?.style.display !== 'none' ) {
-        if ( ! isVisible ) {
+    while ((isVisible = el.closest(".tabitem")?.style.display !== "none")) {
+        if (!isVisible) {
             return false;
-        } else if ( el.parentElement ) {
-            el = el.parentElement
+        } else if (el.parentElement) {
+            el = el.parentElement;
         } else {
             break;
         }


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This PR tries to unify the style in the non-Python files in the repo using Prettier.

As discussed on Discord, it's purposefully using a very large `printWidth` so Prettier doesn't wrap lines when it doesn't need to.


* adds Prettier to package.json (default configuration) and relevant .gitignores, and a .prettierignore too
  * Prettier has been currently set to ignore `.github` and `/style.css`; those can be enabled too if desired
* adds Prettier to the GHA CI configuration
* finally runs `prettier --write` (purely mechanical). 
  * This commit could/should be added to the `.git-blame-ignore-revs` file after merge, so clueful Git clients don't care about it.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows
 - Browser: Chrome
 - Graphics card: irrelevant
