### PR TITLE
Confirm on generate forever when seed manually set

### DIFF
--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -130,6 +130,10 @@ addContextMenuEventListener = initResponse[2];
   let generateOnRepeat = function(genbuttonid,interruptbuttonid){
     let genbutton = gradioApp().querySelector(genbuttonid);
     let interruptbutton = gradioApp().querySelector(interruptbuttonid);
+    let seedinput = get_uiCurrentTabContent().querySelector('[id$="_settings"] [id$="_seed"] input')?.value || -1;
+    if (parseInt(seedinput) !== -1 && !confirm('Seed not set to -1. Are you sure you want to continue?')) {
+      return;
+    }
     if(!interruptbutton.offsetParent){
       genbutton.click();
     }


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

When the seed is manually set (anything other than `-1`), and generate forever is used, this will show a confirmation popup to the user, warning them that they have manually set a seed. This is to prevent users from mistakenly generating a bunch of the same images. 

**Additional notes and description of your changes**

A few extensions like ControlNet and Dynamic Prompts can potentially still be randomized even with a set seed, so I used `confirm` rather than something like `alert`. This will also fallback to assuming the seed is `-1` if the seed input is unable to be found somehow.

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/3f0c4666-3e6a-439b-a949-8203848ec0e3)
