### PR TITLE
(Token Merging) Prevent some confusion

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -369,8 +369,8 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "CLIP_stop_at_last_layers": OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 1}),
     "upcast_attn": OptionInfo(False, "Upcast cross attention layer to float32"),
     "randn_source": OptionInfo("GPU", "Random number generator source. Changes seeds drastically. Use CPU to produce the same picture across different vidocard vendors.", gr.Radio, {"choices": ["GPU", "CPU"]}),
-    "token_merging_ratio": OptionInfo(0.0, "Token merging ratio", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}).link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9256").info("0=disable, higher=faster"),
-    "token_merging_ratio_hr": OptionInfo(0.0, "Togen merging ratio for high-res pass", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}),
+    "token_merging_ratio_hr": OptionInfo(0.0, "Token merging ratio for high-res pass", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}).link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9256").info("0=disable, higher=faster"),
+    "token_merging_ratio": OptionInfo(0.0, "Token merging ratio for first pass", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}),
 }))
 
 options_templates.update(options_section(('compatibility', "Compatibility"), {


### PR DESCRIPTION
Related to #9256 

I want to make sure that there isn't any confusion when cranking up the top slider and not seeing any noticeable speedup. The more important slider should be the high-res pass one so i moved it up. I also added an explicit mention of "first pass" on the second.