### PR TITLE
add macOS .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ notification.mp3
 /test/stderr.txt
 /cache.json*
 /config_states/
+.DS_Store


### PR DESCRIPTION
Add macOS .DS_Store files to .gitignore exceptions.

.DS_Store files are folder metadata files automatically generated in macOS. These files are not part of AUTOMATIC1111 and are not required for it to work.

Tested on macOS 13.3.1 (a) 'Ventura'.
