### PR TITLE
fix xyz checkpoint

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -86,7 +86,7 @@ def apply_checkpoint(p, x, xs):
     info = modules.sd_models.get_closet_checkpoint_match(x)
     if info is None:
         raise RuntimeError(f"Unknown checkpoint: {x}")
-    p.override_settings['sd_model_checkpoint'] = info.hash
+    p.override_settings['sd_model_checkpoint'] = info.name
 
 
 def confirm_checkpoints(p, xs):


### PR DESCRIPTION
fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10354
I've accidentally introduced an issue in PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/cfbe68184c6e0659f92a6a91a9dd6249959270b1

the issue is triggered when using models that have not been previously loaded hash cashed in xyz

I wrongly use the `info.hash` which might not be vailid for all model
switching to `info.name` (relative path) will guarantee the correct model to be selected

