### PR TITLE
launch.py: Don't involve shell for running Python or getting Git output

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -58,7 +58,7 @@ Use --skip-python-version-check to suppress this warning.
 @lru_cache()
 def commit_hash():
     try:
-        return subprocess.check_output(f"{git} rev-parse HEAD", encoding='utf8').strip()
+        return subprocess.check_output([git, "rev-parse", "HEAD"], shell=False, encoding='utf8').strip()
     except Exception:
         return "<none>"
 
@@ -66,7 +66,7 @@ def commit_hash():
 @lru_cache()
 def git_tag():
     try:
-        return subprocess.check_output(f"{git} describe --tags", encoding='utf8').strip()
+        return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
     except Exception:
         return "<none>"
 
@@ -125,7 +125,7 @@ def run_pip(command, desc=None, live=default_command_live):
 
 
 def check_run_python(code: str) -> bool:
-    result = subprocess.run([python, "-c", code], capture_output=True, shell=True)
+    result = subprocess.run([python, "-c", code], capture_output=True, shell=False)
     return result.returncode == 0
 
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes Linux regression in 451d255b5859580c4adf99d67760330d58d76446

**Additional notes and description of your changes**

We don't need the shell to run Python, and it seems to hang on POSIXes for some reason.

**Environment this was tested in**

 - OS: Windows (bug verified on Linux by @mcmonkey4eva)
 - Browser: irrelephant
 - Graphics card: TTY
