### PR TITLE
remove some redundant Token merge operations

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -998,11 +998,6 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
         # apply token merging optimizations from tomesd for high-res pass
         if opts.token_merging_ratio_hr > 0:
-            # in case the user has used separate merge ratios
-            if opts.token_merging_ratio > 0:
-                tomesd.remove_patch(self.sd_model)
-                logger.debug('Adjusting token merging ratio for high-res pass')
-
             sd_models.apply_token_merging(sd_model=self.sd_model, hr=True)
             logger.debug(f"Applied token merging for high-res pass. Ratio: '{opts.token_merging_ratio_hr}'")
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -995,7 +995,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         devices.torch_gc()
 
         # apply token merging optimizations from tomesd for high-res pass
-        if opts.token_merging_ratio_hr > 0:
+        if opts.token_merging_ratio_hr > 0 and opts.token_merging_ratio_hr != opts.token_merging_ratio:
             sd_models.apply_token_merging(sd_model=self.sd_model, hr=True)
             logger.debug(f"Applied token merging for high-res pass. Ratio: '{opts.token_merging_ratio_hr}'")
 


### PR DESCRIPTION
`Token merge apply` already contains remove procedure
no need to do it ourselves

for hires pass if opts.token_merging_ratio_hr != opts.token_merging_ratio
no need to re-apply

it's okay to leave the model in the patched state after a job is done