### PR TITLE
Remove max width for model dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -363,12 +363,10 @@ div#extras_scale_to_tab div.form{
 
 /* settings */
 #quicksettings {
-    width: fit-content;
     align-items: end;
 }
 
 #quicksettings > div, #quicksettings > fieldset{
-    max-width: 24em;
     min-width: 24em;
     padding: 0;
     border: none;


### PR DESCRIPTION
Remove max width for model dropdown

Additional notes and description of your changes

Removing the max width for the model dropdown allows the user to see the full name of a model especially when it is long.
Model names are getting more complex and longer and the current width almost always cuts off model names.
If a user leverages folders than it pretty much always cuts off the name...

Lemme know if there is a better or more preferred way of doing this. But in general this has been a problem for a while and I'd like to help get it fixed.

Environment this was tested in

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.

OS: Windows
Browser: Chrome
Graphics card: NVIDIA 3080ti 12GB
Screenshots or videos of your changes
https://photos.app.goo.gl/ZNCpgWcXuEvc1ZTX9