### PR TITLE
Added support for Gradio launch options 'allowed_paths' and 'blocked_paths'.

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -283,6 +283,16 @@ def api_only():
 def webui():
     launch_api = cmd_opts.api
     initialize()
+    
+    try:
+        paths_allowed = open('paths_allowed.txt').read().split()
+    except:
+        paths_allowed = []
+
+    try:
+        paths_blocked = open('paths_blocked.txt').read().split()
+    except:
+        paths_blocked = []
 
     while 1:
         if shared.opts.clean_temp_dir_at_start:
@@ -326,7 +336,9 @@ def webui():
             debug=cmd_opts.gradio_debug,
             auth=[tuple(cred.split(':')) for cred in gradio_auth_creds] if gradio_auth_creds else None,
             inbrowser=cmd_opts.autolaunch,
-            prevent_thread_lock=True
+            prevent_thread_lock=True,
+            allowed_paths=paths_allowed, 
+            blocked_paths=paths_blocked
         )
         # after initial launch, disable --autolaunch for subsequent restarts
         cmd_opts.autolaunch = False


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Added support for Gradio launch options 'allowed_paths' and 'blocked_paths'. If user receives a '403 Forbidden' response on some UI elements they will be able to create a 'paths_allowed.txt' in their WebUI base folder to explicitly grant Gradio permission to access those paths. Conversely if users want to block a specific path, they can create a 'paths_blocked.txt' file .

**Additional notes and description of your changes**

Added two try blocks to webui() to check if 'paths_allowed.txt' or 'paths_blocked.txt' are present and set the shared.demo.launch() options 'allowed_paths' and 'blocked_paths' accordingly. 

**Environment this was tested in**

 - OS: Windows
 - Browser: Vivaldi, Chrome
 - Graphics card: NVIDIA RTX 3070ti

**Screenshots or videos of your changes**

Screenshots of the issue this pull requests addresses.

![403_forbidden](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/37027067/37b94510-8d09-4d14-8c40-4f24bb6ca6a5)
![broken_ui](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/37027067/21645cb8-2599-4310-a08f-90dbf64b0e19)
![footer](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/37027067/48040548-9967-4190-a468-f5146c9ddfc7)

