### PR TITLE
not clear checkpoints cache when config changes

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -538,7 +538,6 @@ def reload_model_weights(sd_model=None, info=None):
 
     if sd_model is None or checkpoint_config != sd_model.used_config:
         del sd_model
-        checkpoints_loaded.clear()
         load_model(checkpoint_info, already_loaded_state_dict=state_dict)
         return model_data.sd_model
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

As far as i can see, there is no need to clear checkpoints cache when config changes. Checkpoints cache holds the state dict which is not related to checkpoint config.