### PR TITLE
Fix remove `textual inversion` prompt

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -68,18 +68,27 @@ var re_extranet_g = /\s+<([^:]+:[^:]+):[\d\.]+>/g;
 
 function tryToRemoveExtraNetworkFromPrompt(textarea, text){
     var m = text.match(re_extranet)
-    if(! m) return false
-
-    var partToSearch = m[1]
     var replaced = false
-    var newTextareaText = textarea.value.replaceAll(re_extranet_g, function(found){
-        m = found.match(re_extranet);
-        if(m[1] == partToSearch){
-            replaced = true;
-            return ""
-        }
-        return found;
-    })
+    var newTextareaText
+    if(m) {
+        var partToSearch = m[1]
+        newTextareaText = textarea.value.replaceAll(re_extranet_g, function(found){
+            m = found.match(re_extranet);
+            if(m[1] == partToSearch){
+                replaced = true;
+                return ""
+            }
+            return found;
+        })
+    } else {
+        newTextareaText = textarea.value.replaceAll(new RegExp(text, "g"), function(found){
+            if(found == text) {
+                replaced = true;
+                return ""
+            }
+            return found;
+        })
+    }
 
     if(replaced){
         textarea.value = newTextareaText


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

When clicking for the second time, the prompt of textual inversion type can be automatically removed. but i'm not sure if it's necessary

**Environment this was tested in**

 - OS: Mac M1
 - Browser: chrome, safari

**Screenshots or videos of your changes**

![May-17-2023 11-07-47](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/841395/1ee4e505-9312-4c0e-afff-0db44c3d9c8a)
