### PR TITLE
Massive UI perf improvement via hints.js optimization

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -116,7 +116,7 @@ titles = {
 }
 
 
-onUiUpdate(function(){
+onUiLoaded(function(){
 	gradioApp()
 	.querySelectorAll('span:not(.name, .description, .search_term), button:not([onclick^="extraNetworksSearchButton("]), select, p')
 	.forEach(function(span){

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -117,7 +117,9 @@ titles = {
 
 
 onUiUpdate(function(){
-	gradioApp().querySelectorAll('span, button, select, p').forEach(function(span){
+	gradioApp()
+	.querySelectorAll('span:not(.name, .description, .search_term), button:not([onclick^="extraNetworksSearchButton("]), select, p')
+	.forEach(function(span){
 		if (span.title) return;  // already has a title
 
 		let tooltip = localization[titles[span.textContent]] || titles[span.textContent];


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Doing a quick profile, `hints.js` seems to make up 50-60% of execution time in UI updates when the user has a lot of extra networks. This is because the CSS selector is pretty generic and could potentially select tens of thousands of elements, almost all being from the extra networks card `span` and `button` elements.

This PR makes it a bit more granular with `:not` and improves performance, knocking it down to only about 5-10% of execution time for me. Still not as good as I'd like it to be but it's a start. `span` in particular seems to be the bottleneck for this.

**Edit**: Changing `onUiUpdate` to `onUiLoaded` improves performance dramatically, as the element list is only ever queried once. I'm not sure when Gradio ever adds elements to the DOM dynamically (I thought all were just hidden), and localizations still work with this change in my testing, but I would like to think I'm missing something. 

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox, Chrome
 - Graphics card: NVIDIA RTX 3090