### PR TITLE
Fix the search for symbolic links

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -748,7 +748,7 @@ def walk_files(path, allowed_extensions=None):
     if allowed_extensions is not None:
         allowed_extensions = set(allowed_extensions)
 
-    for root, dirs, files in os.walk(path):
+    for root, dirs, files in os.walk(path, followlinks=True):
         for filename in files:
             if allowed_extensions is not None:
                 _, ext = os.path.splitext(filename)

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -91,7 +91,7 @@ class ExtraNetworksPage:
 
         subdirs = {}
         for parentdir in [os.path.abspath(x) for x in self.allowed_directories_for_previews()]:
-            for root, dirs, files in os.walk(parentdir):
+            for root, dirs, files in os.walk(parentdir, followlinks=True):
                 for dirname in dirs:
                     x = os.path.join(root, dirname)
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This is a fix to read the symbolic links created in the models folder and the Extra Networks folder. 
Previously they were read normally, but now they are unreadable. 


**Additional notes and description of your changes**

Change os.walk to read symbolic links by adding followlinks=True
These are mentioned in #10346, #10390, #10405, and a fix was attempted in dev’s cb3f8ff. 
However, since the version has been raised without being reflected in the master version, this is a re-request.


**Environment this was tested in**
 - OS: Linux(WSL2)
 - Browser: Microsoft Edge
 - Graphics card: NVIDIA RTX 3090


