### PR TITLE
Graceful server stopping

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -103,3 +103,4 @@ parser.add_argument("--skip-version-check", action='store_true', help="Do not ch
 parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
 parser.add_argument('--subpath', type=str, help='customize the subpath for gradio, use with reverse proxy')
+parser.add_argument('--add-stop-route', action='store_true', help='add /_stop route to stop server')

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1609,12 +1609,8 @@ def create_ui():
             outputs=[]
         )
 
-        def request_restart():
-            shared.state.interrupt()
-            shared.state.need_restart = True
-
         restart_gradio.click(
-            fn=request_restart,
+            fn=shared.state.request_restart,
             _js='restart_reload',
             inputs=[],
             outputs=[],

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -52,9 +52,7 @@ def apply_and_restart(disable_list, update_list, disable_all):
     shared.opts.disabled_extensions = disabled
     shared.opts.disable_all_extensions = disable_all
     shared.opts.save(shared.config_filename)
-
-    shared.state.interrupt()
-    shared.state.need_restart = True
+    shared.state.request_restart()
 
 
 def save_config_state(name):
@@ -92,8 +90,7 @@ def restore_config_state(confirmed, config_state_name, restore_type):
     if restore_type == "webui" or restore_type == "both":
         config_states.restore_webui_config(config_state)
 
-    shared.state.interrupt()
-    shared.state.need_restart = True
+    shared.state.request_restart()
 
     return ""
 


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

This is a part of #10291 (test overhaul). 

The point is to be able to gracefully shut down the server (e.g. to be able to save code coverage information, for testing).

**Additional notes and description of your changes**

* the `need_restart` mechanism is changed to `server_command` (with `"stop"` and `"restart"` being valid values)
* there's a new `state.request_restart()` API for setting this, which deduplicates a couple copy-pasted segments
* instead of having the `webui()` poll for `need_restart` every 0.5 seconds, there's a new `wait_for_server_command()` API
* finally, there's a new option to add a `_stop` route that will cause `server_command` to be set to `"stop"`. This is so that the CI process can start the server in the background and then ask it to quit when tests are finished. 
  * This could be changed to a signal such as `SIGUSR1` too, if the option and HTTP route is too much. 
  * I figured an option would be better than just always enabling a remote way to make the server die.

**Environment this was tested in**

 - OS: Windows, macOS
 - Browser: Chrome
 - Graphics card: Irrelevant
