### PR TITLE
Copy s_min_uncond to Processed

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -316,6 +316,7 @@ class Processed:
         self.s_tmin = p.s_tmin
         self.s_tmax = p.s_tmax
         self.s_noise = p.s_noise
+        self.s_min_uncond = p.s_min_uncond
         self.sampler_noise_scheduler_override = p.sampler_noise_scheduler_override
         self.prompt = self.prompt if type(self.prompt) != list else self.prompt[0]
         self.negative_prompt = self.negative_prompt if type(self.negative_prompt) != list else self.negative_prompt[0]


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixes #10416, probably.

It looks like `s_min_uncond` should be copied to `Processed` like the rest of the `s_` attributes, but that wasn't happening.

**Environment this was tested in**

None, but looks pretty straightforward.
