### PR TITLE
Fix #10460

### DIFF
--- a/modules/extras.py
+++ b/modules/extras.py
@@ -242,9 +242,10 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     shared.state.textinfo = "Saving"
     print(f"Saving to {output_modelname}...")
 
-    metadata = {"format": "pt", "sd_merge_models": {}, "sd_merge_recipe": None}
+    metadata = None
 
     if save_metadata:
+        metadata = {"format": "pt", "sd_merge_models": {}}
         merge_recipe = {
             "type": "webui", # indicate this model was merged with webui's built-in merger
             "primary_model_hash": primary_model_info.sha256,


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

If i uncheck the checkbox "Save metadata (.safetensors only"), this error will be reported:

```
Loading /Users/weiming.dong/workspace/stable-diffusion-webui/models/Stable-diffusion/CounterfeitV30_v30.safetensors...
Loading /Users/weiming.dong/workspace/stable-diffusion-webui/models/Stable-diffusion/AnythingV5_v5PrtRE.safetensors...
Merging...
100%|██████████████████████████████████████████████████████████████████████████████████████████| 1133/1133 [00:02<00:00, 429.50it/s]
Saving to /Users/weiming.dong/workspace/stable-diffusion-webui/models/Stable-diffusion/0.85(AnythingV5_v5PrtRE) + 0.15(CounterfeitV30_v30).safetensors...
Error loading/saving model file:
Traceback (most recent call last):
  File "/Users/weiming.dong/workspace/stable-diffusion-webui/modules/ui.py", line 1719, in modelmerger
    results = modules.extras.run_modelmerger(*args)
  File "/Users/weiming.dong/workspace/stable-diffusion-webui/modules/extras.py", line 285, in run_modelmerger
    safetensors.torch.save_file(theta_0, output_modelname, metadata=metadata)
  File "/Users/weiming.dong/workspace/stable-diffusion-webui/venv/lib/python3.10/site-packages/safetensors/torch.py", line 232, in save_file
    serialize_file(_flatten(tensors), filename, metadata=metadata)
TypeError: argument 'metadata': 'dict' object cannot be converted to 'PyString'
```

I fixed this error: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10460

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Mac M1
 - Browser: chrome, safari

This is **required** for anything that touches the user interface.