### PR TITLE
Fix typo in syntax

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -172,7 +172,7 @@ class ExtraNetworksPage:
 
         # if this is true, the item must not be show in the default view, and must instead only be
         # shown when searching for it
-        serach_only = "/." in local_path or "\\." in local_path
+        search_only = "/." in local_path or "\\." in local_path
 
         args = {
             "style": f"'display: none; {height}{width}{background_image}'",
@@ -185,7 +185,7 @@ class ExtraNetworksPage:
             "save_card_preview": '"' + html.escape(f"""return saveCardPreview(event, {json.dumps(tabname)}, {json.dumps(item["local_preview"])})""") + '"',
             "search_term": item.get("search_term", ""),
             "metadata_button": metadata_button,
-            "serach_only": " search_only" if serach_only else "",
+            "search_only": " search_only" if search_only else "",
         }
 
         return self.card_page.format(**args)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Fixed the typo regarding `serach_only` changed it to `search_only`

- Variable changed to reflect this in the code to resolve issue #10459

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [Windows 11 Pro Version 10.0.22621 Build 22621]
 - Browser: [Microsoft Edge 113.0.1774.42 (Official build) (64-bit)]
 - Graphics card: [RTX 2070 Super]

**Screenshots or videos of your changes**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/97270760/ed9a19fd-2700-4541-9e9b-6f150d96183f)