### PR TITLE
Prompt comments

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -276,6 +276,8 @@ re_attention = re.compile(r"""
 
 re_break = re.compile(r"\s*\bBREAK\b\s*", re.S)
 
+re_comment = re.compile(r"\r?\n(\/\/.*)")
+
 def parse_prompt_attention(text):
     """
     Parses a string with attention tokens and returns a list of pairs: text and its associated weight.
@@ -326,6 +328,9 @@ def parse_prompt_attention(text):
     for m in re_attention.finditer(text):
         text = m.group(0)
         weight = m.group(1)
+
+        # ignore commented lines
+        text = re_comment.sub('', text)
 
         if text.startswith('\\'):
             res.append([text[1:], 1.0])

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -276,7 +276,12 @@ re_attention = re.compile(r"""
 
 re_break = re.compile(r"\s*\bBREAK\b\s*", re.S)
 
-re_comment = re.compile(r"\r?\n(\/\/.*)")
+#       //this text will be ignored
+re_single_line_comment_slash = re.compile(r"\/\/.*")
+#       #this text will be ignored
+re_single_line_comment_hash = re.compile(r"\#.*")
+#       /*this text will be ignored*/
+re_multi_line_comment = re.compile(r"\/\*.*?\*\/", re.S)
 
 def parse_prompt_attention(text):
     """
@@ -325,12 +330,14 @@ def parse_prompt_attention(text):
         for p in range(start_position, len(res)):
             res[p][1] *= multiplier
 
+    # ignore comments
+    text = re_multi_line_comment.sub('', text)
+    text = re_single_line_comment_slash.sub('', text)
+    text = re_single_line_comment_hash.sub('', text)
+
     for m in re_attention.finditer(text):
         text = m.group(0)
         weight = m.group(1)
-
-        # ignore commented lines
-        text = re_comment.sub('', text)
 
         if text.startswith('\\'):
             res.append([text[1:], 1.0])


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Writing C- and Python-style comments in the prompt. This would:
1. Provide a clearer syntax than existing alternatives.
2. Allow separating a prompt into meaningful sections.
3. Allow commenting parts of a prompt when sharing.
4. Simplify managing variants of a prompt.
5. Make switching out parts of a prompt faster.

Targets requests #4263 and #9076.

**Additional notes and description of your changes**

It's as simple as it could get. The text affected by comments is regexed out of the prompt at the parsing stage, just before parsing attentions. 

Comments can either be single-line (`//`, `#`) or multi-line (`/* */`).
The commented text persists in the image's metadata, which is intended.
Single line comments do not affect line breaks, as they're ignored later anyway.
Commented text does not count towards the token limit.

**Environment this was tested in**

 - OS: Windows
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 2060S 8GB

**Screenshots or videos of your changes**

| animal, painting on a wall,<br>red stripes,<br>//blue spots | animal, painting on a wall,<br>//red stripes,<br>blue spots|
| ----------- | ----------- |
| ![20230517221320-233417208](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/54472750/5d3a4945-030a-4414-b2ed-40a25d864f74) | ![20230517221331-233417208](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/54472750/f3821d6b-35d2-4b66-9837-089e9f6ab93a) |
