### PR TITLE
Error improvement for install torch

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -94,6 +94,14 @@ else
     printf "\n%s\n" "${delimiter}"
 fi
 
+if [[ $(getconf LONG_BIT) = 32 ]]
+then
+    printf "\n%s\n" "${delimiter}"
+    printf "\e[1m\e[31mERROR: Unsupported Running on a 32bit OS\e[0m"
+    printf "\n%s\n" "${delimiter}"
+    exit 1
+fi
+
 if [[ -d .git ]]
 then
     printf "\n%s\n" "${delimiter}"
@@ -119,8 +127,9 @@ esac
 if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
 then
     # AMD users will still use torch 1.13 because 2.0 does not seem to work.
+
     export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
-fi  
+fi
 
 for preq in "${GIT}" "${python_cmd}"
 do


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I have seen [a lot of issues](https://github.com/search?q=repo%3AAUTOMATIC1111%2Fstable-diffusion-webui++No+matching+distribution+found&type=issues) about the failure to install packages such as `torch`, most of which are due to systems using an architecture that [torch currently does not support](https://download.pytorch.org/whl/rocm5.2/torch_stable.html).  for example, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10444, If it shows `(from versions: none)` except that an unsupported python version is used, it is for this reason.

So I think when the user runs `webui.sh`, directly throwing an error and pointing out the reason will make the user understand the problem more clearly, which can reduce the number of related issues.

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Mac
 - Browser: chrome, safari

**Screenshots or videos of your changes**

<img width="1108" alt="Screenshot 2023-05-18 at 12 36 55 PM" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/841395/fa92ed20-9db8-4229-8f33-5ec5221b7749">