### PR TITLE
Improve width/height slider responsiveness

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -513,21 +513,25 @@ def create_ui():
                         with FormGroup(elem_id="txt2img_script_container"):
                             custom_inputs = modules.scripts.scripts_txt2img.setup_ui()
 
-            hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
-            for input in hr_resolution_preview_inputs:
-                input.change(
+            def update_resolution_hires_input(inp, evt):
+                getattr(inp, evt)(
                     fn=calc_resolution_hires,
                     inputs=hr_resolution_preview_inputs,
                     outputs=[hr_final_resolution],
                     show_progress=False,
                 )
-                input.change(
+                getattr(inp, evt)(
                     None,
                     _js="onCalcResolutionHires",
                     inputs=hr_resolution_preview_inputs,
                     outputs=[],
                     show_progress=False,
                 )
+
+            hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
+            update_resolution_hires_input(enable_hr, 'change')
+            for input in hr_resolution_preview_inputs[1:]:
+                update_resolution_hires_input(input, 'release')
 
             txt2img_gallery, generation_info, html_info, html_log = create_output_panel("txt2img", opts.outdir_txt2img_samples)
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -513,6 +513,8 @@ def create_ui():
                         with FormGroup(elem_id="txt2img_script_container"):
                             custom_inputs = modules.scripts.scripts_txt2img.setup_ui()
 
+            hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
+
             def update_resolution_hires_input(inp, evt):
                 getattr(inp, evt)(
                     fn=calc_resolution_hires,
@@ -528,7 +530,6 @@ def create_ui():
                     show_progress=False,
                 )
 
-            hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
             update_resolution_hires_input(enable_hr, 'change')
             for input in hr_resolution_preview_inputs[1:]:
                 update_resolution_hires_input(input, 'release')


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Improved version of https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8785.

The width/height sliders currently are sluggish and take a moment to update due to `change` event listener. I'm personally also not a fan of the "text flickering" effect this causes when hires fix is open. This fixes it by instead using `release`, which now also supports manually typing in values, and holding down on the arrow up/down button (https://github.com/gradio-app/gradio/pull/3589), which was also cited as a reason this was not merged prior (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/8785#issuecomment-1483758160).

**Environment this was tested in**

 - OS: Windows 11
 - Browser: Firefox
 - Graphics card: NVIDIA RTX 3090

**Screenshots or videos of your changes**

<details>
<summary>Current behavior</summary>

![old](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/1073b7a2-aaf7-497d-a006-fe8d8220531d)
</details>

<details>
<summary>New behavior</summary>

![new](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/9ac3b0ce-bb81-4960-8e0e-36e9ebbaa362)
</details>

The current behavior is actually much worse on my system with several extensions installed, so I'm showing what that behavior looks like as well.

<details>
<summary>Current behavior</summary>

![old](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/b5bbbef5-df74-4e37-82eb-22178e69d8b0)
</details>

<details>
<summary>New behavior</summary>

![new](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/a85f17b8-4572-4a39-95f6-2a47849acdd0)
</details>

I recommend trying out the changes yourself as the .gifs don't do it justice.