### PR TITLE
Use name in xyz_grid

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -86,7 +86,7 @@ def apply_checkpoint(p, x, xs):
     info = modules.sd_models.get_closet_checkpoint_match(x)
     if info is None:
         raise RuntimeError(f"Unknown checkpoint: {x}")
-    p.override_settings['sd_model_checkpoint'] = info.hash
+    p.override_settings['sd_model_checkpoint'] = info.name
 
 
 def confirm_checkpoints(p, xs):


### PR DESCRIPTION

**Describe what this pull request is trying to achieve.**
X/Y/Z grid was still using the old hash, prone to collisions. This changes it to use the new `shorthash`, and calculates it if not yet known.

Should fix #10521.

**Additional notes and description of your changes**


Had the same issue as poster of issue #10521, where X/Y/Z grid would sometimes load the wrong model. Found out that in my case it was due to the hashes colliding, as X/Y/Z was using the old hash. This changes to use the new shorthash. Also, the shorthash is calculated if it wasn't known before. No extra work is done since it would otherwise be calculated while loading anyway.

**Environment this was tested in**

Should work on all platforms where loading models by shorthash works.

Tested on:
 - OS: Windows, Linux
 - Browser: Firefox
 - Graphics card: N/A (Nvidia RTX3070)