### PR TITLE
More hidable UI

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -94,7 +94,7 @@ def add_paste_fields(tabname, init_img, fields, override_settings_component=None
 def create_buttons(tabs_list):
     buttons = {}
     for tab in tabs_list:
-        buttons[tab] = gr.Button(f"Send to {tab}", elem_id=f"{tab}_tab")
+        buttons[tab] = gr.Button(f"Send to {tab}", elem_id=f"{tab}_tab", label=f"Send to {tab}")
     return buttons
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -485,6 +485,11 @@ options_templates.update(options_section(('ui', "User interface"), {
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order").needs_restart(),
     "hires_fix_show_sampler": OptionInfo(False, "Hires fix: show hires sampler selection").needs_restart(),
     "hires_fix_show_prompts": OptionInfo(False, "Hires fix: show hires prompt and negative prompt").needs_restart(),
+    "hide_negative_prompt": OptionInfo(False,
+                                       "if true, will hide negative prompt from the text info under images in UI"),
+    "footer_file": OptionInfo("footer.html", "Name of the footer file"),
+    "additional_css": OptionInfo("", "Optional css file to be added. If it's empty, no file is loaded."),
+    "hide_external_links": OptionInfo(False, "If true, hides all links to external files, useful in kiosk mode."),
 }))
 
 options_templates.update(options_section(('infotext', "Infotext"), {

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -488,7 +488,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "hide_negative_prompt": OptionInfo(False,
                                        "if true, will hide negative prompt from the text info under images in UI"),
     "footer_file": OptionInfo("footer.html", "Name of the footer file"),
-    "additional_css": OptionInfo("", "Optional css file to be added. If it's empty, no file is loaded."),
+    "additional_css": OptionInfo("user.css", "Optional css file to be added. If it's empty, no file is loaded."),
     "hide_external_links": OptionInfo(False, "If true, hides all links to external files, useful in kiosk mode."),
 }))
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -60,6 +60,13 @@ def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, step
 
     shared.total_tqdm.clear()
 
+    if opts.hide_negative_prompt:
+        for i, text in enumerate(processed.infotexts):
+            processed.infotexts[i] = text.replace(f'Negative prompt: {negative_prompt}', '')
+        processed.info = processed.info.replace(f'Negative prompt: {negative_prompt}', '')
+        processed.negative_prompt = ''
+        processed.all_negative_prompts = ['' for _ in processed.all_negative_prompts]
+
     generation_info_js = processed.js()
     if opts.samples_log_stdout:
         print(generation_info_js)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -305,11 +305,11 @@ def create_toprow(is_img2img):
                 )
 
             with gr.Row(elem_id=f"{id_part}_tools"):
-                paste = ToolButton(value=paste_symbol, elem_id="paste")
-                clear_prompt_button = ToolButton(value=clear_prompt_symbol, elem_id=f"{id_part}_clear_prompt")
-                extra_networks_button = ToolButton(value=extra_networks_symbol, elem_id=f"{id_part}_extra_networks")
-                prompt_style_apply = ToolButton(value=apply_style_symbol, elem_id=f"{id_part}_style_apply")
-                save_style = ToolButton(value=save_style_symbol, elem_id=f"{id_part}_style_create")
+                paste = ToolButton(value=paste_symbol, elem_id="paste", label='Paste prompt')
+                clear_prompt_button = ToolButton(value=clear_prompt_symbol, elem_id=f"{id_part}_clear_prompt", label='Clear prompt')
+                extra_networks_button = ToolButton(value=extra_networks_symbol, elem_id=f"{id_part}_extra_networks", label = 'Extra networks')
+                prompt_style_apply = ToolButton(value=apply_style_symbol, elem_id=f"{id_part}_style_apply", label='Style apply')
+                save_style = ToolButton(value=save_style_symbol, elem_id=f"{id_part}_style_create", label='Style create')
                 restore_progress_button = ToolButton(value=restore_progress_symbol, elem_id=f"{id_part}_restore_progress", visible=False)
 
                 token_counter = gr.HTML(value="<span>0/75</span>", elem_id=f"{id_part}_token_counter", elem_classes=["token-counter"])
@@ -378,7 +378,7 @@ def create_refresh_button(refresh_component, refresh_method, refreshed_args, ele
 
         return gr.update(**(args or {}))
 
-    refresh_button = ToolButton(value=refresh_symbol, elem_id=elem_id)
+    refresh_button = ToolButton(value=refresh_symbol, elem_id=elem_id, label=elem_id+'_label')
     refresh_button.click(
         fn=refresh,
         inputs=[],

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1700,7 +1700,7 @@ def create_ui():
         if os.path.exists(os.path.join(script_path, "notification.mp3")):
             gr.Audio(interactive=False, value=os.path.join(script_path, "notification.mp3"), elem_id="audio_notification", visible=False)
 
-        footer = shared.html("footer.html")
+        footer = shared.html(shared.opts.footer_file)
         footer = footer.format(versions=versions_html())
         gr.HTML(footer, elem_id="footer")
 
@@ -1837,6 +1837,9 @@ def css_html():
     if os.path.exists(os.path.join(data_path, "user.css")):
         head += stylesheet(os.path.join(data_path, "user.css"))
 
+    if shared.opts.additional_css != "" and os.path.exists(os.path.join(data_path, shared.opts.additional_css)):
+        head += stylesheet(os.path.join(data_path, shared.opts.additional_css))
+
     return head
 
 
@@ -1872,8 +1875,12 @@ def versions_html():
     else:
         xformers_version = "N/A"
 
+    if shared.opts.hide_external_links:
+        version_row = f"version: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/{commit}"
+    else:
+        version_row = f"""version: version: <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/{commit}">{tag}</a>"""
     return f"""
-version: <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/{commit}">{tag}</a>
+{version_row}
 &#x2000;•&#x2000;
 python: <span title="{sys.version}">{python_version}</span>
 &#x2000;•&#x2000;

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1834,9 +1834,6 @@ def css_html():
 
         head += stylesheet(cssfile)
 
-    if os.path.exists(os.path.join(data_path, "user.css")):
-        head += stylesheet(os.path.join(data_path, "user.css"))
-
     if shared.opts.additional_css != "" and os.path.exists(os.path.join(data_path, shared.opts.additional_css)):
         head += stylesheet(os.path.join(data_path, shared.opts.additional_css))
 

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -133,8 +133,8 @@ Requested path was: {f}
                 open_folder_button = gr.Button(folder_symbol, visible=not shared.cmd_opts.hide_ui_dir_config)
 
                 if tabname != "extras":
-                    save = gr.Button('Save', elem_id=f'save_{tabname}')
-                    save_zip = gr.Button('Zip', elem_id=f'save_zip_{tabname}')
+                    save = gr.Button('Save', elem_id=f'save_{tabname}', label=f'Save {tabname}')
+                    save_zip = gr.Button('Zip', elem_id=f'save_zip_{tabname}', label=f'Save zip {tabname}')
 
                 buttons = parameters_copypaste.create_buttons(["img2img", "inpaint", "extras"])
 

--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -55,7 +55,7 @@ class UiLoadsave:
             if field == 'value' and key not in self.component_mapping:
                 self.component_mapping[key] = x
 
-        if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number, gr.Dropdown, ToolButton] and x.visible:
+        if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number, gr.Dropdown, ToolButton, gr.Button] and x.visible:
             apply_field(x, 'visible')
 
         if type(x) == gr.Slider:


### PR DESCRIPTION
## Rationale

This UI is great for tinkerers who are experimenting a lot with various parameters, but with slight adjustments, it can be used even for wide audience which just want to have a positive prompt and button to generate images.
I have successfully used this web UI at anime convention where visitors were able to generate images on a desktop PC using kiosk mode (so people would not do nasty things with the PC). This setup required few things:
- hide most of the UI to make it as simple as possible
- disable all external links, because they break the browser in kiosk mode
- have a way to change some html and css using a config file
- hardcode and hide negative prompt to complicate generating inappropriate content
- kiosk mode in windows (not to be confused with kiosk mode feature of the browser, which is different thing) does not allow to set default zoom of the text, so it requires custom css to make the text larger
And because I think such use-case could be of interest to others and this UI is so great that is can be used as such with just small changes.

## Changes

This PR adds few changes which enable the above-mentioned use-case.
Adding following cli flags:
 - hide_negative_prompt: hides the negative prompt from the result shown to user. Keeps it in the PNG metadata
 - footer_file: allows changing the footer file using config file (useful for providing alternative footer which does not contain clickable links, but still contains all informations and credits)
 - additional_css: I know there is user.css file, but the name is hardcoded, in my usecase I needed to switch the css file by the config, and I think it would be useful for others too, so I parameterized the `user.css` by the parameter. In the default value, the current behavior should not change, but it allows more versatility
 - hide_external_links: This hides the external links from parts generated in python, not in HTML
Adding labels to buttons and extending visibility toggling to `gr.Button`: this allows to hide most of the buttons and enables creation of minimalistic UI.

## Other notes

In the actual convention I used even some other changes which I have in my fork, but I felt they are too specific and I consider the contents of this PR to be the widely usable part, to be of interest to the rest of the community.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows 10, 64bit
 - Browser: chrome
 - Graphics card: GTX 1080Ti, GTX 1080.

## Demonstration of the new features

**Screenshots or videos of your changes**

The screenshot is after following local changes (outside of the PR, because they are the configuration), demonstrating the capabilities:
```bash
COMMANDLINE_ARGS=--ui-config-file ui-config.json --ui-settings-file config.json --freeze-settings --hide-ui-dir-config
```

changes in file `config.json`:
```json
{
    "hidden_tabs": ["img2img", "Extras", "PNG Info", "Checkpoint Merger", "Train", "Settings", "Extensions"],
    "hide_negative_prompt": true,
    "footer_file": "footer2.html",
    "additional_css": "custom.css",
    "hide_external_links": true,
}
```

changes in file `ui-config.json`:
```json
"*/visible": false,
```
for everything except
```json
    "txt2img/Prompt/visible": true,
```


new file: `html/footer2.html`:
```html
<div>
        GitHub: https://github.com/AUTOMATIC1111/stable-diffusion-webui
         • 
        Gradio: https://gradio.app
         • 
        <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false">Reload UI</a>
</div>
<br />
<div class="versions">
{versions}
</div>

```

new file: `custom.css`:
```css
#txt2img_prompt > label:nth-child(1) > textarea:nth-child(2) {
    font-size: 28px;
}
#tabs > div:nth-child(1) > button:nth-child(1) {
    font-size: 32px;
}
#txt2img_generate {
    font-size: 24px;
}
```
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/5525771/37c5f2e3-c1ff-4579-9e23-6ac6e23af19f)

the changes above showcase the power of the configuration and MWE of setting up the web UI in a way general public can use it in the kiosk mode.
Of course I'm open to suggestions how to make it better or change the PR so it would be more aligned with the codebase.