### PR TITLE
rewrite uiElementIsVisible

### DIFF
--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -81,7 +81,10 @@ window.addEventListener('paste', e => {
     }
 
     const visibleImageFields = [...gradioApp().querySelectorAll('[data-testid="image"]')]
-        .filter(el => uiElementIsVisible(el));
+        .filter(el => uiElementIsVisible(el))
+        .sort((a,b) => uiElementInSight(b) - uiElementInSight(a));
+
+
     if (!visibleImageFields.length) {
         return;
     }

--- a/script.js
+++ b/script.js
@@ -92,19 +92,17 @@ document.addEventListener('keydown', function(e) {
  * checks that a UI element is not in another hidden element or tab content
  */
 function uiElementIsVisible(el) {
-    let isVisible = !el.closest('.\\!hidden');
-    if (!isVisible) {
-        return false;
+    if (el === document) {
+        return true;
     }
 
-    while ((isVisible = el.closest('.tabitem')?.style.display) !== 'none') {
-        if (!isVisible) {
-            return false;
-        } else if (el.parentElement) {
-            el = el.parentElement;
-        } else {
-            break;
-        }
-    }
-    return isVisible;
+    const computedStyle = getComputedStyle(el);
+    const isVisible = computedStyle.display !== 'none';
+
+    const clRect = el.getBoundingClientRect();
+    const windowHeight = window.innerHeight;
+    const onScreen = clRect.bottom > 0 && clRect.top < windowHeight;
+
+    if (!isVisible || !onScreen) return false;
+    return uiElementIsVisible(el.parentNode);
 }

--- a/script.js
+++ b/script.js
@@ -99,10 +99,14 @@ function uiElementIsVisible(el) {
     const computedStyle = getComputedStyle(el);
     const isVisible = computedStyle.display !== 'none';
 
+    if (!isVisible) return false;
+    return uiElementIsVisible(el.parentNode);
+}
+
+function uiElementInSight(el) {
     const clRect = el.getBoundingClientRect();
     const windowHeight = window.innerHeight;
-    const onScreen = clRect.bottom > 0 && clRect.top < windowHeight;
+    const isOnScreen = clRect.bottom > 0 && clRect.top < windowHeight;
 
-    if (!isVisible || !onScreen) return false;
-    return uiElementIsVisible(el.parentNode);
+    return isOnScreen;
 }


### PR DESCRIPTION
rewrite visibility checking to be more generic/cleaner as well as add functionality to check if the element is scrolled on screen for more intuitive paste-target selection, fixes #10488

the improvement is that now we check the scroll location of viable elements when pasting an image and paste the image into the topmost element that's visible **on screen**, making pasted image inputs more intuitive

previously if using controlnets/segmentation etc in i2i, the pasted image would always land in the i2i input image window, now if you scroll down to controlnet such that the i2i window is no longer visible, the pasted image will end up in the controlnet input rather than the i2i input, this simplifies the use of addons that accept image input in conjunction with i2i or when using multiple addons that accept image input in t2i

i've done a bit of testing with different addons and have not found any regressions vs the previous 1.1 functionality, and this fixes an issue in 1.2 where in some circumstances pasted images would end up in a hidden pane as per #10488

**Environment this was tested in**

 - OS: Windows 10
 - Browser: firefox, chrome
 - Graphics card: NVIDIA GV100

**Screenshots or videos of your changes**

This is not strictly a UI change as the UI still appears the exact same? I'm not sure exactly what I should provide a screenshot/video of here.