### PR TITLE
Fix python binpath on macOS

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -212,5 +212,5 @@ else
     printf "Launching launch.py..."
     printf "\n%s\n" "${delimiter}"
     prepare_tcmalloc
-    exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+    exec "${venv_dir}/bin/python3" "${LAUNCH_SCRIPT}" "$@"
 fi


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

I installed an environment locally using `python3.11`. But when it starts, it is found that `python3.10` is still used:

<img width="1520" alt="Screenshot 2023-05-19 at 9 42 37 AM" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/841395/19f8559d-1ac5-4be9-987e-dd10de02701c">


I found that it was because the Python version was specified in `webui-macos-env.sh`:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/89f9faa63388756314e8a1d96cf86bf5e0663045/webui-macos-env.sh#L7-L10

So *the Python in venv will not be used when starting the environment*, I fixed this.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Mac M1
 - Browser: chrome, safari

**Screenshots or videos of your changes**

