### PR TITLE
extensions clone --filter=blob:none

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -345,12 +345,12 @@ def install_extension_from_url(dirname, url, branch_name=None):
         shutil.rmtree(tmpdir, True)
         if not branch_name:
             # if no branch is specified, use the default branch
-            with git.Repo.clone_from(url, tmpdir, depth=1) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none']) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
         else:
-            with git.Repo.clone_from(url, tmpdir, depth=1, branch=branch_name) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], branch=branch_name) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -345,12 +345,12 @@ def install_extension_from_url(dirname, url, branch_name=None):
         shutil.rmtree(tmpdir, True)
         if not branch_name:
             # if no branch is specified, use the default branch
-            with git.Repo.clone_from(url, tmpdir) as repo:
+            with git.Repo.clone_from(url, tmpdir, depth=1) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
         else:
-            with git.Repo.clone_from(url, tmpdir, branch=branch_name) as repo:
+            with git.Repo.clone_from(url, tmpdir, depth=1, branch=branch_name) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()


### PR DESCRIPTION
make it so it doesn't download entire history of the extension repo
as it's not useful for most end users
and prevent stuff like this from happening
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c0e2e729-f3c0-4f30-9f8b-eeb37d9a12dc)

a usere who has the need of the entire history can run `git pull --unshallow` to pull the entire history