### PR TITLE
Change 'images.zip' to pattern settings

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -314,6 +314,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "grid_extended_filename": OptionInfo(False, "Add extended info (seed, prompt) to filename when saving grid"),
     "grid_only_if_multiple": OptionInfo(True, "Do not save grids consisting of one picture"),
     "grid_prevent_empty_spots": OptionInfo(False, "Prevent empty spots in grid (when set to autodetect)"),
+    "grid_zip_filename_pattern": OptionInfo("", "Archive filename pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),
     "n_rows": OptionInfo(-1, "Grid row count; use -1 for autodetect and 0 for it to be same as batch size", gr.Slider, {"minimum": -1, "maximum": 16, "step": 1}),
 
     "enable_pnginfo": OptionInfo(True, "Save text information about generation parameters as chunks to png files"),

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -50,9 +50,10 @@ def save_files(js_data, images, do_make_zip, index):
     save_to_dirs = shared.opts.use_save_to_dirs_for_ui
     extension: str = shared.opts.samples_format
     start_index = 0
+    only_one = False
 
     if index > -1 and shared.opts.save_selected_only and (index >= data["index_of_first_image"]):  # ensures we are looking at a specific non-grid picture, and we have save_selected_only
-
+        only_one = True
         images = [images[index]]
         start_index = index
 
@@ -70,6 +71,7 @@ def save_files(js_data, images, do_make_zip, index):
             is_grid = image_index < p.index_of_first_image
             i = 0 if is_grid else (image_index - p.index_of_first_image)
 
+            p.batch_index = image_index-1
             fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=p.all_seeds[i], prompt=p.all_prompts[i], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
 
             filename = os.path.relpath(fullfn, path)
@@ -83,7 +85,10 @@ def save_files(js_data, images, do_make_zip, index):
 
     # Make Zip
     if do_make_zip:
-        zip_filepath = os.path.join(path, "images.zip")
+        zip_fileseed = p.all_seeds[index-1] if only_one else p.all_seeds[0]
+        namegen = modules.images.FilenameGenerator(p, zip_fileseed, p.all_prompts[0], image, True)
+        zip_filename = namegen.apply(shared.opts.grid_zip_filename_pattern or "[datetime]_[[model_name]]_[seed]-[seed_last]")
+        zip_filepath = os.path.join(path, f"{zip_filename}.zip")
 
         from zipfile import ZipFile
         with ZipFile(zip_filepath, "w") as zip_file:


### PR DESCRIPTION
It's inconvenient to rename the archive every time I save it, so I added a filename generation based on pattern from Settings tab.
Also, I added some new patters:

- `seed_first` - returns first seed from batch or single seed
- `seed_last` - returns last seed from batch or **NOTHING_AND_SKIP_PREVIOUS_TEXT**
- `batch_size` - nuff said

Default pattern is `[datetime]_[[model_name]]_[seed]-[seed_last]`

![изображение](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4334058/89a81ebd-27c9-4bbe-8b06-0786d3bb788d)
![изображение](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4334058/23549ef6-6ac7-4ae2-be43-f8a9f2c5b696)
![изображение](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4334058/5662000e-9bad-449d-be72-6dbca00e4bbc)
![изображение](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4334058/d234a763-9b26-45ff-b53c-b388bd50ccf5)


