### PR TITLE
Windows file path error fix

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -36,7 +36,7 @@ def save_pil_to_file(pil_image, dir=None):
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)
 
-        file_obj = Savedfile(f'{already_saved_as}?{os.path.getmtime(already_saved_as)}')
+        file_obj = Savedfile(f'{already_saved_as}')
         return file_obj
 
     if shared.opts.temp_dir != "":


### PR DESCRIPTION
I have made a modification to resolve an issue where the completed image generated by running text2img in the Windows environment cannot be loaded in the UI. There is a problem with Windows not recognizing the suffix when it is in the form of "?time". To avoid browser caching, it seems necessary to add the suffix at a different step.

**Environment this was tested in**
Windows
NVIDIA RTX 2080 8GB