### PR TITLE
[README] Update keyboard shortcut instructions for MacOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A browser interface based on Gradio library for Stable Diffusion.
 - Attention, specify parts of text that the model should pay more attention to
     - a man in a `((tuxedo))` - will pay more attention to tuxedo
     - a man in a `(tuxedo:1.21)` - alternative syntax
-    - select text and press `Ctrl+Up` or `Ctrl+Down` to automatically adjust attention to selected text (code contributed by anonymous user)
+    - select text and press `Ctrl+Up` or `Ctrl+Down` (or `Command+Up` or `Command+Down` if you're on a MacOS) to automatically adjust attention to selected text (code contributed by anonymous user)
 - Loopback, run img2img processing multiple times
 - X/Y/Z plot, a way to draw a 3 dimensional plot of images with different parameters
 - Textual Inversion


### PR DESCRIPTION
Hello,

**Describe what this pull request is trying to achieve.**

During my usage, I noticed that the instructions for adjusting the attention to selected text are primarily focused on non-Mac users. As it currently stands, the instructions only mention the Ctrl+Up and Ctrl+Down shortcuts. This might cause a bit of confusion for Mac users, who are more accustomed to using the Command key for such actions.

I also would like to gently point out that there may be Mac users accessing this tool via platforms like Google Colab. My proposed change, though minor, might contribute to a more comfortable experience for those users by potentially reducing confusion and aiding in more intuitive interaction.

In light of this, I've taken the liberty of proposing a minor change to the instruction text to include "or Command+Up or Command+Down if you're on a MacOS". 
This slight modification could make the tool more intuitive for Mac users.

While I realize this is a minor point, I believe this change could contribute to a more inclusive user experience, particularly for Mac users.

Thank you for taking the time to review this proposal, and please feel free to let me know if there are any changes or adjustments you'd like me to make.


**Additional notes and description of your changes**

The only change is in the README text.

**Environment this was tested in**

Confirmed on GitHub.
(OS - MacOS, Browser - Chrome)