### PR TITLE
Fix Gateway Timeout by adding processed images to checkprogress endpoint

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -319,6 +319,7 @@ class Api:
             shared.state.end()
 
         b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        shared.state.current_processed_images = b64images
 
         return TextToImageResponse(images=b64images, parameters=vars(txt2imgreq), info=processed.js())
 
@@ -424,7 +425,7 @@ class Api:
         # copy from check_progress_call of ui.py
 
         if shared.state.job_count == 0:
-            return ProgressResponse(progress=0, eta_relative=0, state=shared.state.dict(), textinfo=shared.state.textinfo)
+            return ProgressResponse(progress=0, eta_relative=0, state=shared.state.dict(), textinfo=shared.state.textinfo, current_processed_images=shared.state.current_processed_images)
 
         # avoid dividing zero
         progress = 0.01

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -187,6 +187,7 @@ class ProgressResponse(BaseModel):
     state: dict = Field(title="State", description="The current state snapshot")
     current_image: str = Field(default=None, title="Current image", description="The current image in base64 format. opts.show_progress_every_n_steps is required for this to work.")
     textinfo: str = Field(default=None, title="Info text", description="Info text used by WebUI.")
+    current_processed_images: List[str] = Field(default=None, title="Images", description="The generated image in base64 format.")
 
 class InterrogateRequest(BaseModel):
     image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -110,6 +110,7 @@ class State:
     current_latent = None
     current_image = None
     current_image_sampling_step = 0
+    current_processed_images = None
     id_live_preview = 0
     textinfo = None
     time_start = None
@@ -153,6 +154,7 @@ class State:
         self.current_latent = None
         self.current_image = None
         self.current_image_sampling_step = 0
+        self.current_processed_images = None
         self.id_live_preview = 0
         self.skipped = False
         self.interrupted = False


### PR DESCRIPTION
# Please read the [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing) before submitting a pull request!

If you have a large change, pay special attention to this paragraph:

> Before making changes, if you think that your feature will result in more than 100 lines changing, find me and talk to me about the feature you are proposing. It pains me to reject the hard work someone else did, but I won't add everything to the repo, and it's better if the rejection happens before you have to waste time working on the feature.

Otherwise, after making sure you're following the rules described in wiki page, remove this section and continue on.

**Describe what this pull request is trying to achieve.**

A clear and concise description of what you're trying to accomplish with this, so your intent doesn't have to be extracted from your code.

**txt2img and img2img currently are endpoints that keep a connection open the entire time images are being generated. This is usually fine for generating a single image but if you're batching 4 images and selecting hires fix, it's easy for the generation to take over 100 seconds to complete. The problem is most gateways will not hold a connection to a post request open past 100 seconds so these requests eventually fail even though they were generated successfully.**

**My fix is to give api users the option to ignore the response of the txt2img and img2img post requests and instead fire and forget them allowing the checkprogress endpoint to eventually return the process images when the job has completed.**

**Additional notes and description of your changes**

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of.

**Environment this was tested in**

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: Windows local server with tunnel through cloud flare 
 - Browser: api only, did not touch webui
 - Graphics card: NVIDIA RTX 3080 10GB

**Screenshots or videos of your changes**

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.
Did not touch user interface but if accepted I would suggest updating the UI to use check progress as well.