### PR TITLE
Added target aware paste for images

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,15 +92,7 @@ document.addEventListener('keydown', function(e) {
  * checks that a UI element is not in another hidden element or tab content
  */
 function uiElementIsVisible(el) {
-    if (el === document) {
-        return true;
-    }
-
-    const computedStyle = getComputedStyle(el);
-    const isVisible = computedStyle.display !== 'none';
-
-    if (!isVisible) return false;
-    return uiElementIsVisible(el.parentNode);
+    return !!el.offsetParent;
 }
 
 function uiElementInSight(el) {


### PR DESCRIPTION
Hello,

**Describe what this pull request is trying to achieve.**

When we have multiple image inputs, it's quite annoying that you can paste only in the first one. With my changes, you can click on UI part where you want to paste and it will do that.

**Additional notes and description of your changes**

I also changed `uiElementIsVisible` function as it doesn't need to be so complicated.
According to [mdn docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent):

> offsetParent returns null in the following situations:
> 
> The element or any ancestor has the display property set to none.
> The element has the position property set to fixed (Firefox returns &lt;body&gt;).
> The element is &lt;body&gt; or &lt;html&gt;.

Also wan't to add that if user clicks on some inputs, the target is always &lt;body&gt;, so this logic will work only if you click on the container area.

**Environment this was tested in**

 - OS: MacOS
 - Browser: chrome, safari
 - Graphics card: M1 Pro

**Screenshots or videos of your changes**


https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28074308/fd7b6689-be65-450a-8d30-05860baa2345


https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28074308/a21821ac-c9a8-4332-a581-41d9cd563a94

