### PR TITLE
Bump gradio to 3.32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ blendmodes
 accelerate
 basicsr
 gfpgan
-gradio==3.31.0
+gradio==3.32.0
 numpy
 omegaconf
 opencv-contrib-python

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -3,7 +3,7 @@ transformers==4.25.1
 accelerate==0.18.0
 basicsr==1.4.2
 gfpgan==1.3.8
-gradio==3.31.0
+gradio==3.32.0
 numpy==1.23.5
 Pillow==9.5.0
 realesrgan==0.3.0

--- a/webui.py
+++ b/webui.py
@@ -370,17 +370,6 @@ def webui():
 
         gradio_auth_creds = list(get_gradio_auth_creds()) or None
 
-        # this restores the missing /docs endpoint
-        if launch_api and not hasattr(FastAPI, 'original_setup'):
-            # TODO: replace this with `launch(app_kwargs=...)` if https://github.com/gradio-app/gradio/pull/4282 gets merged
-            def fastapi_setup(self):
-                self.docs_url = "/docs"
-                self.redoc_url = "/redoc"
-                self.original_setup()
-
-            FastAPI.original_setup = FastAPI.setup
-            FastAPI.setup = fastapi_setup
-
         app, local_url, share_url = shared.demo.launch(
             share=cmd_opts.share,
             server_name=server_name,
@@ -393,6 +382,10 @@ def webui():
             inbrowser=cmd_opts.autolaunch,
             prevent_thread_lock=True,
             allowed_paths=cmd_opts.gradio_allowed_path,
+            app_kwargs={
+                "docs_url": "/docs",
+                "redoc_url": "/redoc",
+            },
         )
         if cmd_opts.add_stop_route:
             app.add_route("/_stop", stop_route, methods=["POST"])


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

Upgrades Gradio to be able to remove the docs URL hack.


**Environment this was tested in**

 - OS: macOS
 - Browser: Chrome
 - Graphics card: M2

**Screenshots or videos of your changes**

## yep it's 3.32

![Screenshot 2023-05-22 at 10 43 43](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/797dfcc1-9be7-4ab4-8dc9-a0f96033ab41)

## yep them's the docs

![Screenshot 2023-05-22 at 10 43 50](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/4429913b-4b86-4dd3-9420-4ff8fef0cd05)


