### PR TITLE
disable `timeout_keep_alive`: fixes #10625 #10510 #10474

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -682,4 +682,4 @@ class Api:
 
     def launch(self, server_name, port):
         self.app.include_router(self.router)
-        uvicorn.run(self.app, host=server_name, port=port)
+        uvicorn.run(self.app, host=server_name, port=port, timeout_keep_alive=0)


### PR DESCRIPTION
This fix disables uvicorn's `timeout_keep_alive` option, replacing the default value of 5 with 0.

**Additional notes and description of your changes**

We encountered a lot of errors where generations were being prematurely errored, when used through the API.

This fix is based off the comment posted on https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10625