### PR TITLE
Fix for #10643 (Inpainting mask sometimes not working)

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -92,7 +92,8 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
     elif mode == 2:  # inpaint
         image, mask = init_img_with_mask["image"], init_img_with_mask["mask"]
         alpha_mask = ImageOps.invert(image.split()[-1]).convert('L').point(lambda x: 255 if x > 0 else 0, mode='1')
-        mask = ImageChops.lighter(alpha_mask, mask.convert('L')).convert('L')
+        mask = mask.convert('L').point(lambda x: 255 if x > 128 else 0, mode='1')
+        mask = ImageChops.lighter(alpha_mask, mask).convert('L')
         image = image.convert("RGB")
     elif mode == 3:  # inpaint sketch
         image = inpaint_color_sketch


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**

A fix for #10643. Short summary: In the chrome webui the HTML canvas for painting the inpainting mask has some noise (on my machine :) ). The backend treats any non 0 pixel as white. As a result the entire mask map turns white and the entire image is changed. This PR fixes that.

**Additional notes and description of your changes**

The fix converts the initial painted mask to a pure black and white image, with no gradients. If there should be a need for a grayscale mask, this won't work. This doesn't affect the gaussian blur that is applied later on in the process.

**Environment this was tested in**

 - OS: Windows
 - Browser: chrome
 - Graphics card: NVIDIA RTX 4090 24GB

**Screenshots or videos of your changes**

N/A