### PR TITLE
Add second quicksettings area

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -53,6 +53,7 @@ ui_reorder_categories = [
     "seed",
     "batch",
     "override_settings",
+    'quicksettings_accordion',
     "scripts",
 ]
 
@@ -483,6 +484,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "keyedit_delimiters": OptionInfo(".,\\/!?%^*;:{}=`~()", "Ctrl+up/down word delimiters"),
     "quicksettings_list": OptionInfo(["sd_model_checkpoint"], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear at the top of page rather than in settings tab").needs_restart(),
+    "quicksettings_accordion": OptionInfo([], "Quicksettings accordion", ui_components.DropdownMulti, lambda: {"choices": [x for x in list(opts.data_labels.keys()) if x != 'sd_model_checkpoint']}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear in an accordion within the txt2img and img2img tabs").needs_restart(),
     "ui_tab_order": OptionInfo([], "UI tab order", ui_components.DropdownMulti, lambda: {"choices": list(tab_names)}).needs_restart(),
     "hidden_tabs": OptionInfo([], "Hidden UI tabs", ui_components.DropdownMulti, lambda: {"choices": list(tab_names)}).needs_restart(),
     "ui_reorder": OptionInfo(", ".join(ui_reorder_categories), "txt2img/img2img UI item order").needs_restart(),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -53,7 +53,7 @@ ui_reorder_categories = [
     "seed",
     "batch",
     "override_settings",
-    'quicksettings_accordion',
+    "quicksettings_accordion",
     "scripts",
 ]
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1718,9 +1718,12 @@ def create_ui():
                 if ifid in ['txt2img', 'img2img'] and len(quicksettings_accordion) > 0:
                     qs_rows = [x for x in [i[1] for i in interface.blocks.items()] if x.elem_id and 'quicksettings_row' in x.elem_id]
                     if len(qs_rows) == 1:
+                        separate_qs_rows = [quicksettings_accordion[i:i+3] for i in range(0, len(quicksettings_accordion), 3)]
                         with qs_rows[0]:
                             with gr.Accordion(label='Quicksettings', elem_id=f'quicksettings_accordion_{ifid}', open=False):
-                                setup_quicksettings(quicksettings_accordion, section=ifid)
+                                for row in separate_qs_rows:
+                                    with gr.Row():
+                                        setup_quicksettings(row, section=ifid)
                         qs_rows[0].visible = True
                 with gr.TabItem(label, id=ifid, elem_id=f"tab_{ifid}"):
                     interface.render()


### PR DESCRIPTION
## Description

Due to discussion in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10634, it seems desirable to want a form of quicksettings that does not clutter up the UI as much. This PR proposes **in addition to** the global quicksettings (which remains unchanged and still available), a quicksettings accordion in both the txt2img and img2img tabs. The settings will seamlessly sync between tabs and be maintained on page reloads when modified. All previous quicksettings functionality should be unaffected.

This is a bit of a hacky implementation, so feedback on how to improve it would be appreciated. ~~I haven't focused on how to possibly improve the layout yet either (everything will take up the full width of the accordion currently).~~ Settings are now displayed in rows of 3 (will automatically expand if less than 3).

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/639deca0-4c8f-4db3-a2ee-06cb40c8fb6e)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
