### PR TITLE
Tooltip fixes & optimizations

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -153,14 +153,27 @@ function processTooltipCheckNodes() {
 
 onUiUpdate(function(mutationRecords) {
     for (const record of mutationRecords) {
+        if (record.type === "childList" && record.target.classList.contains("options")) {
+            // This smells like a Gradio dropdown menu having changed,
+            // so let's enqueue an update for the input element that shows the current value.
+            let wrap = record.target.parentNode;
+            let input = wrap?.querySelector("input");
+            if (input) {
+                input.title = ""; // So we'll even have a chance to update it.
+                tooltipCheckNodes.add(input);
+            }
+        }
         for (const node of record.addedNodes) {
             if (node.nodeType === Node.ELEMENT_NODE && !node.classList.contains("hide")) {
-                if (
-                    node.tagName === "SPAN" ||
-                    node.tagName === "BUTTON" ||
-                    node.tagName === "P"
-                ) {
-                    tooltipCheckNodes.add(node);
+                if (!node.title) {
+                    if (
+                        node.tagName === "SPAN" ||
+                        node.tagName === "BUTTON" ||
+                        node.tagName === "P" ||
+                        node.tagName === "INPUT"
+                    ) {
+                        tooltipCheckNodes.add(node);
+                    }
                 }
                 node.querySelectorAll('span, button, p').forEach(n => tooltipCheckNodes.add(n));
             }

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -119,10 +119,18 @@ var titles = {
 function updateTooltip(element) {
     if (element.title) return; // already has a title
 
-    let tooltip = localization[titles[element.textContent]] || titles[element.textContent];
+    let text = element.textContent;
+    let tooltip = localization[titles[text]] || titles[text];
 
     if (!tooltip) {
-        tooltip = localization[titles[element.value]] || titles[element.value];
+        let value = element.value;
+        if (value) tooltip = localization[titles[value]] || titles[value];
+    }
+
+    if (!tooltip) {
+        // Gradio dropdown options have `data-value`.
+        let dataValue = element.dataset.value;
+        if (dataValue) tooltip = localization[titles[dataValue]] || titles[dataValue];
     }
 
     if (!tooltip) {
@@ -170,7 +178,8 @@ onUiUpdate(function(mutationRecords) {
                         node.tagName === "SPAN" ||
                         node.tagName === "BUTTON" ||
                         node.tagName === "P" ||
-                        node.tagName === "INPUT"
+                        node.tagName === "INPUT" ||
+                        (node.tagName === "LI" && node.classList.contains("item")) // Gradio dropdown item
                     ) {
                         tooltipCheckNodes.add(node);
                     }


### PR DESCRIPTION
Follows up on #10455

**Describe what this pull request is trying to achieve.**

* Optimize tooltip checking by
  * only looking at element nodes
  * deduplicating the elements to check
  * debouncing the actual work
* Restore support for dropdown value tooltips (that was gone with the Great Gradio Update)
* Add support for dropdown option tooltips

**Environment this was tested in**

 - OS: macOS
 - Browser: Chrome
 - Graphics card: I think it does at least 256 colors

**Screeny shooties**

Dropdown value tooltip:

<img width="391" alt="Screenshot 2023-05-24 at 20 44 45" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/cae67fd0-96b0-422b-a2bb-eab31c15b6f6">

Dropdown option tooltip:

<img width="384" alt="Screenshot 2023-05-24 at 20 44 52" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/8c207f1e-0f86-4df6-8045-128abdb5157d">

