### PR TITLE
Cleaner image metadata read

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -665,9 +665,13 @@ def read_info_from_image(image):
             items['exif comment'] = exif_comment
             geninfo = exif_comment
 
-        for field in ['jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
-                      'loop', 'background', 'timestamp', 'duration']:
+    for field in ['jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
+                    'loop', 'background', 'timestamp', 'duration', 'progressive', 'progression',
+                    'icc_profile', 'chromaticity']:
+        try:
             items.pop(field, None)
+        except KeyError:
+            pass
 
     if items.get("Software", None) == "NovelAI":
         try:

--- a/modules/images.py
+++ b/modules/images.py
@@ -668,10 +668,7 @@ def read_info_from_image(image):
     for field in ['jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
                     'loop', 'background', 'timestamp', 'duration', 'progressive', 'progression',
                     'icc_profile', 'chromaticity']:
-        try:
-            items.pop(field, None)
-        except KeyError:
-            pass
+        items.pop(field, None)
 
     if items.get("Software", None) == "NovelAI":
         try:


### PR DESCRIPTION
## Description

A few minor fixes to `read_info_from_image`.
- Actually remove keys (don't limit to when the image contains EXIF only)
- Add a few more common keys to the list

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
