### PR TITLE
Small fixes to prepare_tcmalloc for Debian/Ubuntu compatibility

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -183,7 +183,7 @@ fi
 # Try using TCMalloc on Linux
 prepare_tcmalloc() {
     if [[ "${OSTYPE}" == "linux"* ]] && [[ -z "${NO_TCMALLOC}" ]] && [[ -z "${LD_PRELOAD}" ]]; then
-        TCMALLOC="$(ldconfig -p | grep -Po "libtcmalloc.so.\d" | head -n 1)"
+        TCMALLOC="$(PATH=/usr/sbin:$PATH ldconfig -p | grep -Po "libtcmalloc(_minimal|)\.so\.\d" | head -n 1)"
         if [[ ! -z "${TCMALLOC}" ]]; then
             echo "Using TCMalloc: ${TCMALLOC}"
             export LD_PRELOAD="${TCMALLOC}"


### PR DESCRIPTION
**What this pull request is trying to achieve:**

The `prepare_tcmalloc` function in the `webui.sh` script does not correctly preload libtcmalloc on Debian and Ubuntu systems (and in addition, will not work by default for most people who don't have `/usr/sbin` on their PATH). I've made some small changes to ensure that it works correctly for Debian/Ubuntu users.

**Description of changes:**

- /usr/sbin (where ldconfig is usually located) is not typically on users' PATHs by default. We now include that in the `PATH` before trying to run ldconfig.
- The libtcmalloc library is called libtcmalloc_minimal on Debian/Ubuntu systems. We now check whether libtcmalloc_minimal exists when running prepare_tcmalloc.

**Environment this was tested in:** Tested on Debian 11 (Buster).