### PR TITLE
fix: also calc_resolution_hires on component.change for sliders

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -527,21 +527,22 @@ def create_ui():
             hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
 
             for component in hr_resolution_preview_inputs:
-                event = component.release if isinstance(component, gr.Slider) else component.change
+                events = [component.change, component.release] if isinstance(component, gr.Slider) else [component.change]
 
-                event(
-                    fn=calc_resolution_hires,
-                    inputs=hr_resolution_preview_inputs,
-                    outputs=[hr_final_resolution],
-                    show_progress=False,
-                )
-                event(
-                    None,
-                    _js="onCalcResolutionHires",
-                    inputs=hr_resolution_preview_inputs,
-                    outputs=[],
-                    show_progress=False,
-                )
+                for event in events:
+                    event(
+                        fn=calc_resolution_hires,
+                        inputs=hr_resolution_preview_inputs,
+                        outputs=[hr_final_resolution],
+                        show_progress=False,
+                    )
+                    event(
+                        None,
+                        _js="onCalcResolutionHires",
+                        inputs=hr_resolution_preview_inputs,
+                        outputs=[],
+                        show_progress=False,
+                    )
 
             txt2img_gallery, generation_info, html_info, html_log = create_output_panel("txt2img", opts.outdir_txt2img_samples)
 


### PR DESCRIPTION
in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/1a5b86ad65fd738eadea1ad72f4abad3a4aabf17
> rework hires fix preview for https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6437: movie it to where it takes less place, make it actually account for all relevant sliders and calculate dimensions correctly

in that commit, the `calc_resolution_hires` is change to calculate on the slider's release
this address is the issue that I have brought up previously about the display value may be incorrect

but changed to on release causes another issue
when the slider value is changed via other means such as `read generation parameters from prompt` or type in the value directly, the value is changed but the slider not release so `calc_resolution_hiresis` not triggered

this PR fixes the issue

now this vlaue will correctly update no matter if it's changed via user slider drag or other means

note: if the user drag the slider quickly and the user is holding on to the slider but not yet release, the slider may temporarily display the wrong values, the correct value will be displayed when thie slider is released