### PR TITLE
Add a zoom slider for img2img operations

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -702,6 +702,7 @@ def create_ui():
 
                 with gr.Tabs(elem_id="mode_img2img"):
                     img2img_selected_tab = gr.State(0)
+                    gr.Slider(label="Image zoom", interactive=True, elem_id="img2img_zoom_slider", value=1.0, maximum=2.5, minimum=0.5)
 
                     with gr.TabItem('img2img', id='img2img', elem_id="img2img_img2img_tab") as tab_img2img:
                         init_img = gr.Image(label="Image for img2img", elem_id="img2img_image", show_label=False, source="upload", interactive=True, type="pil", tool="editor", image_mode="RGBA").style(height=480)


### PR DESCRIPTION
**Describe what this pull request is trying to achieve.**
Adding a zoom slider to img2img tabs so inpainting and inspecting can be done more accurately.
Addresses: #1486 

**Environment this was tested in**
 - OS: Windows 11
 - Browser: Chrome

**Screenshots or videos of your changes**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/8643457/ab662945-09b2-4710-86ce-23ae7e307d70)