### PR TITLE
Mark caption_image_overlay's textfont as deprecated; fix #10778

### DIFF
--- a/modules/textual_inversion/image_embedding.py
+++ b/modules/textual_inversion/image_embedding.py
@@ -1,8 +1,10 @@
 import base64
 import json
+import warnings
+
 import numpy as np
 import zlib
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 import torch
 
 
@@ -129,14 +131,17 @@ def extract_image_data_embed(image):
 
 
 def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, textfont=None):
+    from modules.images import get_font
+    if textfont:
+        warnings.warn(
+            'passing in a textfont to caption_image_overlay is deprecated and does nothing',
+            DeprecationWarning,
+            stacklevel=2,
+        )
     from math import cos
 
     image = srcimage.copy()
     fontsize = 32
-    if textfont is None:
-        from modules.images import get_font
-        textfont = get_font(fontsize)
-
     factor = 1.5
     gradient = Image.new('RGBA', (1, image.size[1]), color=(0, 0, 0, 0))
     for y in range(image.size[1]):
@@ -147,12 +152,12 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
 
     draw = ImageDraw.Draw(image)
 
-    font = ImageFont.truetype(textfont, fontsize)
+    font = get_font(fontsize)
     padding = 10
 
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
     fontsize = min(int(fontsize * (((image.size[0]*0.75)-(padding*4))/w)), 72)
-    font = ImageFont.truetype(textfont, fontsize)
+    font = get_font(fontsize)
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
     draw.text((padding, padding), title, anchor='lt', font=font, fill=(255, 255, 255, 230))
 
@@ -163,7 +168,7 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
     _, _, w, h = draw.textbbox((0, 0), footerRight, font=font)
     fontsize_right = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
 
-    font = ImageFont.truetype(textfont, min(fontsize_left, fontsize_mid, fontsize_right))
+    font = get_font(min(fontsize_left, fontsize_mid, fontsize_right))
 
     draw.text((padding, image.size[1]-padding),               footerLeft, anchor='ls', font=font, fill=(255, 255, 255, 230))
     draw.text((image.size[0]/2, image.size[1]-padding),       footerMid, anchor='ms', font=font, fill=(255, 255, 255, 230))


### PR DESCRIPTION
## Description

* a simple description of what you're trying to accomplish: fix #10778 since it had inadvertently broken in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/df7070eca22278b25c921ef72d3f97a221d66242 due to me overlooking how it reuses variables such as `font` and `textfont`. 🙄 
* a summary of changes in code:
  * soft-disable the unused `textfont` argument
  * call `get_font()` correctly
* which issues it fixes, if any: #10778

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
