### PR TITLE
fix "hires. fix" prompt sharing same labels with txt2img_prompt

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -505,10 +505,10 @@ def create_ui():
                             with FormRow(elem_id="txt2img_hires_fix_row4", variant="compact", visible=opts.hires_fix_show_prompts) as hr_prompts_container:
                                 with gr.Column(scale=80):
                                     with gr.Row():
-                                        hr_prompt = gr.Textbox(label="Prompt", elem_id="hires_prompt", show_label=False, lines=3, placeholder="Prompt for hires fix pass.\nLeave empty to use the same prompt as in first pass.", elem_classes=["prompt"])
+                                        hr_prompt = gr.Textbox(label="Hires prompt", elem_id="hires_prompt", show_label=False, lines=3, placeholder="Prompt for hires fix pass.\nLeave empty to use the same prompt as in first pass.", elem_classes=["prompt"])
                                 with gr.Column(scale=80):
                                     with gr.Row():
-                                        hr_negative_prompt = gr.Textbox(label="Negative prompt", elem_id="hires_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt for hires fix pass.\nLeave empty to use the same negative prompt as in first pass.", elem_classes=["prompt"])
+                                        hr_negative_prompt = gr.Textbox(label="Hires negative prompt", elem_id="hires_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt for hires fix pass.\nLeave empty to use the same negative prompt as in first pass.", elem_classes=["prompt"])
 
                     elif category == "batch":
                         if not opts.dimensions_and_batch_together:


### PR DESCRIPTION
## Description

`hr_prompt` and `hr_negative_prompt` share the same gradio textbox labels with `txt2img_prompt` and `txt2img_negative_prompt` respectively, which caused them to load the same values from `ui-config.json`.

If user had previously saved some custom prompts in `ui-config.json`, the same values will be passed onto Hires prompts **even with `hires_fix_show_prompts` disabled/never enabled.** 

So when the user specifies some different prompt/negative prompt in the UI, the inadvertently synced `hr_prompt` and `hr_negative_prompt` remains in "default" state instead of being kept same with the current prompts, causing hires generations to deviate unexpectedly.

***

In addition, with the `hires_fix_show_prompts` enabled, the changes made to the hires prompts in the UI will not be detected by ui_loadsave.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
