### PR TITLE
fix launch_utlis to prevent uncommitted changes on third party repo

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -147,7 +147,7 @@ def git_clone(url, dir, name, commithash=None):
     run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
 
     if commithash is not None:
-        run(f'"{git}" -C "{dir}" checkout {commithash} --force', None, "Couldn't checkout {name}'s hash: {commithash}")
+        run(f'"{git}" -C "{dir}" checkout {commithash} --force', None, f"Couldn't checkout {name}'s hash: {commithash}")
 
 
 def git_pull_recursive(dir):

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -141,13 +141,13 @@ def git_clone(url, dir, name, commithash=None):
             return
 
         run(f'"{git}" -C "{dir}" fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
-        run(f'"{git}" -C "{dir}" checkout {commithash}', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
+        run(f'"{git}" -C "{dir}" checkout {commithash} --force', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
         return
 
     run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
 
     if commithash is not None:
-        run(f'"{git}" -C "{dir}" checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
+        run(f'"{git}" -C "{dir}" checkout {commithash} --force', None, "Couldn't checkout {name}'s hash: {commithash}")
 
 
 def git_pull_recursive(dir):


### PR DESCRIPTION
## Description
Running ./webui.sh --share --enable-insecure-extension-access on google colab.
During first init with launch.py, It will clone git repo like codeformer_repo, with has some issue at this moment while doing `git checkout` and break the init. Add `--force` would solve the problem. 

## Screenshots/videos:
before the changes, there is some issue on when git checking out CodeFormer
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/56169783/cf73c08d-5b77-46c4-907f-dfe12b84ee37)

problem solved after adding `--force` on git checkout
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/56169783/53c3ce9d-a937-43fc-9cf8-ac24e14c1db8)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
