### PR TITLE
Round down scale destination dimensions to nearest multiple of 8

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -53,8 +53,8 @@ class Upscaler:
 
     def upscale(self, img: PIL.Image, scale, selected_model: str = None):
         self.scale = scale
-        dest_w = int(img.width * scale)
-        dest_h = int(img.height * scale)
+        dest_w = round((img.width * scale - 4) / 8) * 8
+        dest_h = round((img.height * scale - 4) / 8) * 8
 
         for _ in range(3):
             shape = (img.width, img.height)


### PR DESCRIPTION
## Description

If an image is scaled with a fractional value, the dimensions of the resulting image can be indivisible by 8.
On a side note, when the result is pulled back into the UI, the dimensions would be rounded down to the nearest multiple of 8; even though the UI is showing the dimensions of the image as is.

Example:

Before fix: `int(512 * 1.7) = 870`
After fix: `round( ( 512 * 1.7 - 4 ) / 8 ) * 8 = 864`

I discovered the issue as I'm working on an API which uses Tiled Diffusion and it uses the built in upscaler under the hood.
I believe having this could help with third party integrations and loop-back scenarios, and it shouldn't have negative side effects.



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
