### PR TITLE
Refactor EmbeddingDatabase.register_embedding() to allow unregistering

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -120,16 +120,29 @@ class EmbeddingDatabase:
         self.embedding_dirs.clear()
 
     def register_embedding(self, embedding, model):
-        self.word_embeddings[embedding.name] = embedding
+        return self.register_embedding_by_name(embedding, model, embedding.name)
 
-        ids = model.cond_stage_model.tokenize([embedding.name])[0]
-
+    def register_embedding_by_name(self, embedding, model, name):
+        ids = model.cond_stage_model.tokenize([name])[0]
         first_id = ids[0]
         if first_id not in self.ids_lookup:
             self.ids_lookup[first_id] = []
-
-        self.ids_lookup[first_id] = sorted(self.ids_lookup[first_id] + [(ids, embedding)], key=lambda x: len(x[0]), reverse=True)
-
+        if name in self.word_embeddings:
+            # remove old one from the lookup list
+            lookup = [x for x in self.ids_lookup[first_id] if x[1].name!=name]
+        else:
+            lookup = self.ids_lookup[first_id]
+        if embedding is not None:
+            lookup += [(ids, embedding)]
+        self.ids_lookup[first_id] = sorted(lookup, key=lambda x: len(x[0]), reverse=True)
+        if embedding is None:
+            # unregister embedding with specified name
+            if name in self.word_embeddings:
+                del self.word_embeddings[name]
+            if len(self.ids_lookup[first_id])==0:
+                del self.ids_lookup[first_id]
+            return None
+        self.word_embeddings[name] = embedding
         return embedding
 
     def get_expected_shape(self):


### PR DESCRIPTION
In my [EmbeddingMerge](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/7659) extension I need to create and destroy TI embeddings at runtime.
I had to copy source code from `/modules/textual_inversion/textual_inversion.py` into my extension, because current `EmbeddingDatabase.register_embedding()` does not allow to:
- Re-register embedding with a name that was already registered
- Un-register any registered embedding

I feel wrong, because that function in essence is implementation detail of EmbeddingDatabase, and I should not mess with it like that. Instead, I would be happy if upstream function will be changed to allow unregistering older embeddings transparently.

Original code before modifications:
```python
    def register_embedding(self, embedding, model):
        self.word_embeddings[embedding.name] = embedding

        ids = model.cond_stage_model.tokenize([embedding.name])[0]

        first_id = ids[0]
        if first_id not in self.ids_lookup:
            self.ids_lookup[first_id] = []

        self.ids_lookup[first_id] = sorted(self.ids_lookup[first_id] + [(ids, embedding)], key=lambda x: len(x[0]), reverse=True)

        return embedding
```

My proposed changes:
```python
    def register_embedding(self, embedding, model):
        return self.register_embedding_by_name(embedding, model, embedding.name)

    def register_embedding_by_name(self, embedding, model, name):
        ids = model.cond_stage_model.tokenize([name])[0]
        first_id = ids[0]
        if first_id not in self.ids_lookup:
            self.ids_lookup[first_id] = []
        if name in self.word_embeddings:
            # remove old one from the lookup list
            lookup = [x for x in self.ids_lookup[first_id] if x[1].name!=name]
        else:
            lookup = self.ids_lookup[first_id]
        if embedding is not None:
            lookup += [(ids, embedding)]
        self.ids_lookup[first_id] = sorted(lookup, key=lambda x: len(x[0]), reverse=True)
        if embedding is None:
            # unregister embedding with specified name
            if name in self.word_embeddings:
                del self.word_embeddings[name]
            if len(self.ids_lookup[first_id])==0:
                del self.ids_lookup[first_id]
            return None
        self.word_embeddings[name] = embedding
        return embedding
```

For information, here is how the copied version currently looks like in extension:

https://github.com/klimaleksus/stable-diffusion-webui-embedding-merge/blob/56d4ac1fdc675cbc0001cb6d849c187a90a50899/scripts/embedding_merge.py#L753-L775

(I will use unregistering of created temporary embeddings in `on_script_unloaded()` handler; currently my code does not do that, and uses only re-registering them on-demand).

Actually, this can be considered as a bugfix for original `register_embedding()` which silently fails when called on the same embedding twice (it pollutes the cache `ids_lookup` and never frees its old records) and at least leaks memory, otherwise requiring to call `load_textual_inversion_embeddings()` to reload everything from disk again, which is overkill.

---

- [X] I have read contributing wiki page
- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines
- [x] My code passes tests `39 passed`