### PR TITLE
Fix get_conds_with_caching()

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -321,14 +321,13 @@ class StableDiffusionProcessing:
         have been used before. The second element is where the previously
         computed result is stored.
         """
-
-        if cache[0] is not None and (required_prompts, steps) == cache[0]:
+        if cache[0] is not None and (required_prompts, steps, opts.CLIP_stop_at_last_layers, shared.sd_model.sd_checkpoint_info) == cache[0]:
             return cache[1]
 
         with devices.autocast():
             cache[1] = function(shared.sd_model, required_prompts, steps)
 
-        cache[0] = (required_prompts, steps)
+        cache[0] = (required_prompts, steps, opts.CLIP_stop_at_last_layers, shared.sd_model.sd_checkpoint_info)
         return cache[1]
 
     def setup_conds(self):

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -94,7 +94,10 @@ def confirm_checkpoints(p, xs):
 
 
 def apply_clip_skip(p, x, xs):
-    opts.data["CLIP_stop_at_last_layers"] = x
+    if opts.data["CLIP_stop_at_last_layers"] != x:
+        opts.data["CLIP_stop_at_last_layers"] = x
+        p.cached_c = [None, None]
+        p.cached_uc = [None, None]
 
 
 def apply_upscale_latent_space(p, x, xs):

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -94,10 +94,7 @@ def confirm_checkpoints(p, xs):
 
 
 def apply_clip_skip(p, x, xs):
-    if opts.data["CLIP_stop_at_last_layers"] != x:
-        opts.data["CLIP_stop_at_last_layers"] = x
-        p.cached_c = [None, None]
-        p.cached_uc = [None, None]
+    opts.data["CLIP_stop_at_last_layers"] = x
 
 
 def apply_upscale_latent_space(p, x, xs):


### PR DESCRIPTION
## Description
Fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10777
Fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10819
Fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10854

xyz clip skip is not applyed due to `get_conds_with_caching()` https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/ff0e17174f8d93a71fdd5a4a80a4629bbf97f822
same for sd checkpoint
the old conds cache is use even after sd chackpoint change

add clip skip and model info into `cache[0]` for comparison

this issue could have very widespread influences
it will affect any script that has the ability to change the parameters that that necessitates `conds` recalculation
not sure if any other parameters needs be added to the `cache[0]`

issue #10854
> somehow the page becomes 404 after I tag it with `bug` tag (a github "`bug`" 🤔)
tldr: when using XYZ checkpoint with a mix of SD1.5 and 2.0 modles 
> ```py
> RuntimeError: mat1 and mat2 shapes cannot be multiplied (154x768 and 1024x320)
> ```
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
