### PR TITLE
Only poll gamepads while connected

### DIFF
--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -24,7 +24,10 @@ window.addEventListener('gamepadconnected', (e) => {
             isWaiting = false;
         }
     }, 10);
-    window.addEventListener('gamepaddisconnected', (e) => clearInterval(gamepads[e.gamepad.index]));
+});
+
+window.addEventListener('gamepaddisconnected', (e) => {
+    clearInterval(gamepads[e.gamepad.index]);
 });
 
 /*

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -1,7 +1,9 @@
+let gamepads = [];
+
 window.addEventListener('gamepadconnected', (e) => {
     const index = e.gamepad.index;
     let isWaiting = false;
-    setInterval(async() => {
+    gamepads[index] = setInterval(async() => {
         if (!opts.js_modal_lightbox_gamepad || isWaiting) return;
         const gamepad = navigator.getGamepads()[index];
         const xValue = gamepad.axes[0];
@@ -22,6 +24,7 @@ window.addEventListener('gamepadconnected', (e) => {
             isWaiting = false;
         }
     }, 10);
+    window.addEventListener('gamepaddisconnected', (e) => clearInterval(gamepads[e.gamepad.index]))
 });
 
 /*

--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -24,7 +24,7 @@ window.addEventListener('gamepadconnected', (e) => {
             isWaiting = false;
         }
     }, 10);
-    window.addEventListener('gamepaddisconnected', (e) => clearInterval(gamepads[e.gamepad.index]))
+    window.addEventListener('gamepaddisconnected', (e) => clearInterval(gamepads[e.gamepad.index]));
 });
 
 /*


### PR DESCRIPTION
A small fix to stop polling gamepads when they're disconnected.

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
