### PR TITLE
Exception Handling Of sdOptimizationXformers availabilty Check

### DIFF
--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -48,7 +48,12 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
+        try:
+            is_avail = shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
+        except Exception as e:
+            errors.display(e, "Error while checking torch cuda availability in SdOptimizationXformers")
+            return False
+        return is_avail
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -48,12 +48,7 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        try:
-            is_avail = shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
-        except Exception as e:
-            errors.display(e, "Error while checking torch cuda availability in SdOptimizationXformers")
-            return False
-        return is_avail
+        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward
@@ -67,7 +62,7 @@ class SdOptimizationSdpNoMem(SdOptimization):
     priority = 80
 
     def is_available(self):
-        return hasattr(torch.nn.functional, "scaled_dot_product_attention") and callable(torch.nn.functional.scaled_dot_product_attention)
+        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = scaled_dot_product_no_mem_attention_forward


### PR DESCRIPTION
Exception Handling Of sdOptimizationXformers availabilty Check

## Description

* Issue:
while running WebUI with below cmd.
`Launching Web UI with arguments: --lowvram --no-half --xformers --skip-torch-cuda-test`
`Warning: caught exception 'No CUDA GPUs are available', memory monitor disabled`
`Error in torch cuda version: RuntimeError`
`Traceback (most recent call last):`
  `File "D:\Personal\AI\stable-diffusion-webui\modules\sd_hijack_optimizations.py", line 52, in is_available`
    `     is_avail = shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 381, in get_device_capability`
  `        prop = get_device_properties(device)`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 395, in get_device_properties`
   `      _lazy_init()  # will define _get_device_properties`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 247, in _lazy_init` 
  `        torch._C._cuda_init()`
`RuntimeError: No CUDA GPUs are available`

* Changes in code : A Simple try and except statement to return False in case of error and logging error msg