### PR TITLE
Frontend: only look at top-level tabs, not nested tabs

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,12 +10,18 @@ function gradioApp() {
     return elem.shadowRoot ? elem.shadowRoot : elem;
 }
 
+/**
+ * Get the currently selected top-level UI tab button (e.g. the button that says "Extras").
+ */
 function get_uiCurrentTab() {
-    return gradioApp().querySelector('#tabs button.selected');
+    return gradioApp().querySelector('#tabs > .tab-nav > button.selected');
 }
 
+/**
+ * Get the first currently visible top-level UI tab content (e.g. the div hosting the "txt2img" UI).
+ */
 function get_uiCurrentTabContent() {
-    return gradioApp().querySelector('.tabitem[id^=tab_]:not([style*="display: none"])');
+    return gradioApp().querySelector('#tabs > .tabitem[id^=tab_]:not([style*="display: none"])');
 }
 
 var uiUpdateCallbacks = [];


### PR DESCRIPTION
Refs 
## Description

`get_uiCurrentTabContent()` would return the wrong tab if e.g. extensions such as https://github.com/bbc-mc/sdweb-merge-block-weighted-gui used nested tab strips. This fixes the selector to use `>`, the direct descendant selector instead of ``, the any descendant selector.

* which issues it fixes, if any: https://github.com/adieyal/sd-dynamic-prompts/issues/459#issuecomment-1568543926

## Screenshots/videos:

Not like it's a very interesting screenshot, but here!

![Screenshot 2023-05-30 at 17 56 16](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/e5950f06-9d2c-4bfc-8972-254a70a94ecd)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
