### PR TITLE
fix 10896 pnginfo parameters

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -503,8 +503,6 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
 
     image_format = Image.registered_extensions()[extension]
 
-    existing_pnginfo = existing_pnginfo or {}
-
     if extension.lower() == '.png':
         if opts.enable_pnginfo:
             pnginfo_data = PngImagePlugin.PngInfo()

--- a/modules/images.py
+++ b/modules/images.py
@@ -504,8 +504,6 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
     image_format = Image.registered_extensions()[extension]
 
     existing_pnginfo = existing_pnginfo or {}
-    if opts.enable_pnginfo:
-        existing_pnginfo['parameters'] = geninfo
 
     if extension.lower() == '.png':
         if opts.enable_pnginfo:


### PR DESCRIPTION
## Description
fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10896
remove the two lines that causes the parameters to be overwritten by upscaling

to be honest I don't know what the point of `existing_pnginfo['parameters'] = geninfo` it seems to only cause trouble
from what I can tell when generate images (txt2img)
`existing_pnginfo['parameters']` always equals `geninfo` so there's no point of reassigning it
and when you upscaling in extra tab, that lines essentially overrides the generation parameters

as far I can tell this change the final pnginfo back to what it was like in 1.2.1

you may want to do some testing yourself to make sure that I didn't overlook something

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
