### PR TITLE
New restart method for installing extensions

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -841,3 +841,9 @@ def walk_files(path, allowed_extensions=None):
                 continue
 
             yield os.path.join(root, filename)
+
+
+def restart_program():
+    """immediately stops the process with exit code 111, which webui.bat/webui.sh interpret as a command to start webui again"""
+
+    os._exit(111)

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -49,7 +49,7 @@ def apply_and_restart(disable_list, update_list, disable_all):
     shared.opts.disabled_extensions = disabled
     shared.opts.disable_all_extensions = disable_all
     shared.opts.save(shared.config_filename)
-    shared.state.request_restart()
+    shared.restart_program()
 
 
 def save_config_state(name):

--- a/webui.bat
+++ b/webui.bat
@@ -57,7 +57,7 @@ exit /b
 
 :accelerate_launch
 echo Accelerating
-%ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
+%ACCELERATE% launch --quiet --num_cpu_threads_per_process=6 launch.py
 if %ERRORLEVEL% == 1 goto :restart
 pause
 exit /b

--- a/webui.bat
+++ b/webui.bat
@@ -51,14 +51,20 @@ if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch
 %PYTHON% launch.py %*
+if %ERRORLEVEL% == 111 goto :restart
 pause
 exit /b
 
 :accelerate_launch
 echo Accelerating
 %ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
+if %ERRORLEVEL% == 111 goto :restart
 pause
 exit /b
+
+:restart
+echo Restarting...
+goto :accelerate
 
 :show_stdout_stderr
 

--- a/webui.bat
+++ b/webui.bat
@@ -58,7 +58,7 @@ exit /b
 :accelerate_launch
 echo Accelerating
 %ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
-if %ERRORLEVEL% == 111 goto :restart
+if %ERRORLEVEL% == 1 goto :restart
 pause
 exit /b
 

--- a/webui.sh
+++ b/webui.sh
@@ -203,17 +203,21 @@ prepare_tcmalloc() {
     fi
 }
 
-if [[ ! -z "${ACCELERATE}" ]] && [ ${ACCELERATE}="True" ] && [ -x "$(command -v accelerate)" ]
-then
-    printf "\n%s\n" "${delimiter}"
-    printf "Accelerating launch.py..."
-    printf "\n%s\n" "${delimiter}"
-    prepare_tcmalloc
-    exec accelerate launch --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
-else
-    printf "\n%s\n" "${delimiter}"
-    printf "Launching launch.py..."
-    printf "\n%s\n" "${delimiter}"
-    prepare_tcmalloc
-    exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
-fi
+return_code="111"
+while [[ "$return_code" -eq "111" ]]; do
+    if [[ ! -z "${ACCELERATE}" ]] && [ ${ACCELERATE}="True" ] && [ -x "$(command -v accelerate)" ]; then
+        printf "\n%s\n" "${delimiter}"
+        printf "Accelerating launch.py..."
+        printf "\n%s\n" "${delimiter}"
+        prepare_tcmalloc
+        accelerate launch --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
+        return_code=$?
+    else
+        printf "\n%s\n" "${delimiter}"
+        printf "Launching launch.py..."
+        printf "\n%s\n" "${delimiter}"
+        prepare_tcmalloc
+        "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        return_code=$?
+    fi
+done

--- a/webui.sh
+++ b/webui.sh
@@ -210,8 +210,10 @@ while [[ "$return_code" -eq "111" ]]; do
         printf "Accelerating launch.py..."
         printf "\n%s\n" "${delimiter}"
         prepare_tcmalloc
-        accelerate launch --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
-        return_code=$?
+        accelerate launch --quiet --num_cpu_threads_per_process=6 "${LAUNCH_SCRIPT}" "$@"
+        if [[ "$return_code" -eq "1" ]]; then
+            return_code="111"
+        fi
     else
         printf "\n%s\n" "${delimiter}"
         printf "Launching launch.py..."


### PR DESCRIPTION
## Description

* the big button in extensions UI exits the program with code `111`
* both `webui.bat` and `webui.sh` interpret exit code `111` as a command to restart the program rather then to stop execution
* tested both on Windows, seemingly no issues
* if button is pressed outside of` webui.bat`/`webui.sh`, the program just exits, which is fine by me
* if working with `ACCELERATE=True`, there's no way to detect `111` return code, so under accelerate the program isrestarted if it quits abnormally by other means too

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
