### PR TITLE
Round upscaled dimensions only when not divisible by 8

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -53,8 +53,8 @@ class Upscaler:
 
     def upscale(self, img: PIL.Image, scale, selected_model: str = None):
         self.scale = scale
-        dest_w = round((img.width * scale - 4) / 8) * 8
-        dest_h = round((img.height * scale - 4) / 8) * 8
+        dest_w = round((img.width * scale - 4) / 8) * 8 if img.width * scale % 8 != 0 else img.width * scale
+        dest_h = round((img.height * scale - 4) / 8) * 8 if img.height * scale % 8 != 0 else img.height * scale
 
         for _ in range(3):
             shape = (img.width, img.height)

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -53,8 +53,8 @@ class Upscaler:
 
     def upscale(self, img: PIL.Image, scale, selected_model: str = None):
         self.scale = scale
-        dest_w = round((img.width * scale - 4) / 8) * 8 if img.width * scale % 8 != 0 else img.width * scale
-        dest_h = round((img.height * scale - 4) / 8) * 8 if img.height * scale % 8 != 0 else img.height * scale
+        dest_w = int((img.width * scale) // 8 * 8)
+        dest_h = int((img.height * scale) // 8 * 8)
 
         for _ in range(3):
             shape = (img.width, img.height)


### PR DESCRIPTION
## Description

A small tweak to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10796, which returns the dimensions components as is if they're already divisible by 8 to prevent unnecessary reduction.

Tests:

Before tweak: `round((696 * 1 - 4) / 8) * 8 = 688`
After tweak: `696`

Before tweak: `round((697 * 1 - 4) / 8) * 8 = 696`
After tweak: `696`

Before tweak: `round((512 * 1 - 4) / 8) * 8 = 508`
After tweak: `508`

Before tweak: `round((512 * 1.5 - 4) / 8) * 8 = 768`
After tweak: `768`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
