### PR TITLE
Fix duplicate Cross attention optimization after UI reload

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -469,9 +469,6 @@ def webui():
         startup_timer.record("scripts unloaded callback")
         initialize_rest(reload_script_modules=True)
 
-        modules.sd_hijack.list_optimizers()
-        startup_timer.record("scripts list_optimizers")
-
 
 if __name__ == "__main__":
     if cmd_opts.nowebui:

--- a/webui.py
+++ b/webui.py
@@ -469,7 +469,6 @@ def webui():
         startup_timer.record("scripts unloaded callback")
         initialize_rest(reload_script_modules=True)
 
-        modules.script_callbacks.on_list_optimizers(modules.sd_hijack_optimizations.list_optimizers)
         modules.sd_hijack.list_optimizers()
         startup_timer.record("scripts list_optimizers")
 


### PR DESCRIPTION
## Description
after  webui is reloaded `Cross attention optimization` drop down list will be duplicated due to it's been populated twice

I classify this as a minor bug
as far as I can tell duplication does not cause any issues apart from visual confusion

I did not test this with the new proposed total [Restart ](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10916)


## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/3787747c-9256-4ab3-8761-e4788bc5259f)
current

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/0dd76711-3b7b-4d30-8833-a5965e63a352

fixed

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f93aa99b-75d2-40c4-b479-3c0413b70f66

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
