### PR TITLE
optimization: reduce cpu memory usage when loading models

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -198,13 +198,14 @@ def get_state_dict_from_checkpoint(pl_sd):
     pl_sd = pl_sd.pop("state_dict", pl_sd)
     pl_sd.pop("state_dict", None)
 
-    state_dict_keys = pl_sd.keys()
+    state_dict_keys = list(pl_sd.keys())
     for key in state_dict_keys:
         for text, replacement in checkpoint_dict_replacements.items():
             if key.startswith(text):
                 new_key = replacement + key[len(text):]
                 value = pl_sd.pop(key)
                 pl_sd[new_key] = value
+                break
 
     return pl_sd
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -194,27 +194,17 @@ checkpoint_dict_replacements = {
 }
 
 
-def transform_checkpoint_dict_key(k):
-    for text, replacement in checkpoint_dict_replacements.items():
-        if k.startswith(text):
-            k = replacement + k[len(text):]
-
-    return k
-
-
 def get_state_dict_from_checkpoint(pl_sd):
     pl_sd = pl_sd.pop("state_dict", pl_sd)
     pl_sd.pop("state_dict", None)
 
-    sd = {}
-    for k, v in pl_sd.items():
-        new_key = transform_checkpoint_dict_key(k)
-
-        if new_key is not None:
-            sd[new_key] = v
-
-    pl_sd.clear()
-    pl_sd.update(sd)
+    state_dict_keys = pl_sd.keys()
+    for key in state_dict_keys:
+        for text, replacement in checkpoint_dict_replacements.items():
+            if key.startswith(text):
+                new_key = replacement + key[len(text):]
+                value = pl_sd.pop(key)
+                pl_sd[new_key] = value
 
     return pl_sd
 


### PR DESCRIPTION
## Description

optimization: reduce cpu memory usage when loading models

When loading state_dict of model,_
- Old way: **copy the whole state_dict**, and modify the key
- New way: **just modify the key in place**, do not need copy the whole state_dict of model

Reduce the usage of cpu memory, when loading model.

In my computer, Macbook Pro M1:
- origin cpu memory usage: 5.8 GB
- in Old way, load a new model, peak cpu memory usage: 9.5 GB
- in New way, load a new model, peak cpu memory usage: 7.9 GB


