### PR TITLE
fallback version info form CHANGELOG.md

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -68,7 +68,8 @@ def git_tag():
     try:
         return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
     except Exception:
-        return "<none>"
+        with open(os.path.dirname(os.path.abspath(__file__)) + "/../CHANGELOG.md") as file:
+            return next((line.strip() for line in file if line.strip()), "<none>")
 
 
 def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live) -> str:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -69,7 +69,8 @@ def git_tag():
         return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
     except Exception:
         try:
-            changelog_md = pathlib.Path(__file__).parent.parent / "CHANGELOG.md"
+            from pathlib import Path
+            changelog_md = Path(__file__).parent.parent / "CHANGELOG.md"
             with changelog_md.open(encoding="utf-8") as file:
                 return next((line.strip() for line in file if line.strip()), "<none>")
         except Exception:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -68,8 +68,12 @@ def git_tag():
     try:
         return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
     except Exception:
-        with open(os.path.dirname(os.path.abspath(__file__)) + "/../CHANGELOG.md") as file:
-            return next((line.strip() for line in file if line.strip()), "<none>")
+        try:
+            changelog_md = pathlib.Path(__file__).parent.parent / "CHANGELOG.md"
+            with changelog_md.open(encoding="utf-8") as file:
+                return next((line.strip() for line in file if line.strip()), "<none>")
+        except Exception:
+            return "<none>"
 
 
 def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live) -> str:


### PR DESCRIPTION
## Description
fallback read version info from CHANGELOG.md if not repo
just find the first line and print it
as long as the first line of read me is version info it will work

I considered add extra parsing logic, but I think it's better this way as it will tell us that if it's a non repo install if we see `##1.3.1`

## Screenshots/videos:
tested with `assert False`
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/8318f0c4-85ce-4a52-93b1-da578d27648d)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/60c777c0-27d9-4295-9855-0507f883a074)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
