### PR TITLE
torch.cuda.is_available() check for SdOptimizationXformers

### DIFF
--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -48,7 +48,7 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)
+        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -48,7 +48,7 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
+        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward


### PR DESCRIPTION
`torch.cuda.is_available()` check for SdOptimizationXformers

## Description

* Issue:
while running WebUI with below cmd.
`Launching Web UI with arguments: --lowvram --no-half --xformers --skip-torch-cuda-test`
`Warning: caught exception 'No CUDA GPUs are available', memory monitor disabled`
`Error in torch cuda version: RuntimeError`
`Traceback (most recent call last):`
  `File "D:\Personal\AI\stable-diffusion-webui\modules\sd_hijack_optimizations.py", line 52, in is_available`
    `     is_avail = shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.version.cuda and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 381, in get_device_capability`
  `        prop = get_device_properties(device)`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 395, in get_device_properties`
   `      _lazy_init()  # will define _get_device_properties`
  `File "D:\Personal\AI\stable-diffusion-webui\venv\lib\site-packages\torch\cuda\__init__.py", line 247, in _lazy_init` 
  `        torch._C._cuda_init()`
`RuntimeError: No CUDA GPUs are available`

* Changes in code : ` torch.cuda.is_available() `worked instead of `torch.version.cuda ` it solve the problem of interruption of whole flow. It bypass this with false value.

Later the code works with `torch.version.cuda`, but this is needed to protect the flow from interruption.

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
