### PR TITLE
Made the zoom function global for other extensions

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -103,7 +103,14 @@ onUiLoaded(async() => {
 
     const elements = await getElements();
 
-    function applyZoomAndPan(targetElement, elemId) {
+    function applyZoomAndPan(elemId) {
+        const targetElement = gradioApp().querySelector(elemId);
+
+        if (!targetElement) {
+            console.log("Element not found");
+            return;
+        }
+
         targetElement.style.transformOrigin = "0 0";
         let [zoomLevel, panX, panY] = [1, 0, 0];
         let fullScreenMode = false;
@@ -558,7 +565,11 @@ onUiLoaded(async() => {
         gradioApp().addEventListener("mousemove", handleMoveByKey);
     }
 
-    applyZoomAndPan(elements.sketch, elementIDs.sketch);
-    applyZoomAndPan(elements.inpaint, elementIDs.inpaint);
-    applyZoomAndPan(elements.inpaintSketch, elementIDs.inpaintSketch);
+    applyZoomAndPan(elementIDs.sketch);
+    applyZoomAndPan(elementIDs.inpaint);
+    applyZoomAndPan(elementIDs.inpaintSketch);
+
+
+    // Make the function global so that other extensions can take advantage of this solution
+    window.applyZoomAndPan = applyZoomAndPan;
 });


### PR DESCRIPTION
## Description

It was suggested by the user [catboxanon](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10759#issuecomment-1574988219) to make the applyZoomAndPan function global, which would allow other extensions to take advantage of the zoom function for their canvases.

I also reworked the function a bit and now it accepts only item IDs.

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22278673/610fe9f5-ad55-4660-b3d5-05372e042510

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
