### PR TITLE
Make save_pil_to_file to have same parameters with gradio's function

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -31,7 +31,7 @@ def check_tmp_file(gradio, filename):
     return False
 
 
-def save_pil_to_file(self, pil_image, dir=None):
+def save_pil_to_file(self, pil_image, dir=None, format="png"):
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)


### PR DESCRIPTION
Make override function(save_pil_to_file in modules/ui_tempfile.py) to have the same input parameters with the original function(pil_to_temp_file in gradio/components.py)

## Description

* Currently, function `save_pil_to_file` overrides gradio's function `pil_to_temp_file`, but compared to `pil_to_temp_file`, function `save_pil_to_file` lacks one input parameter: `format`, which cause trouble in some situation. like this:
  ```
  Generating semantic segmentation with SAM
  Auto SAM strengthening semantic segmentation
  Auto SAM generated 140 masks
  Auto SAM strengthen process end
  Traceback (most recent call last):
    File "/home/ubuntu/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/routes.py", line 422, in run_predict
      output = await app.get_blocks().process_api(
    File "/home/ubuntu/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1326, in process_api
      data = self.postprocess_data(fn_index, result["prediction"], state)
    File "/home/ubuntu/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1260, in postprocess_data
      prediction_value = block.postprocess(prediction_value)
    File "/home/ubuntu/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/components.py", line 4457, in postprocess
      file = self.img_array_to_temp_file(img, dir=self.DEFAULT_TEMP_DIR)
    File "/home/ubuntu/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/components.py", line 355, in img_array_to_temp_file
      return self.pil_to_temp_file(pil_image, dir, format="png")
  TypeError: save_pil_to_file() got an unexpected keyword argument 'format'
  ```
* This PR add the `format` input parameter to function `save_pil_to_file` to make it have the same input parameters

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
