### PR TITLE
fix rework-disable-autolaunch for new restart method

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -247,7 +247,7 @@ def prepare_environment():
     try:
         # the existance of this file is a signal to webui.sh/bat that webui needs to be restarted when it stops execution
         os.remove(os.path.join(script_path, "tmp", "restart"))
-        os.environ.setdefault('SD_WEBUI_DISABLE_AUTOLAUNCH', '1')
+        os.environ.setdefault('SD_WEBUI_RESTARTING ', '1')
     except OSError:
         pass
 

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -247,6 +247,7 @@ def prepare_environment():
     try:
         # the existance of this file is a signal to webui.sh/bat that webui needs to be restarted when it stops execution
         os.remove(os.path.join(script_path, "tmp", "restart"))
+        os.environ.setdefault('SD_WEBUI_DISABLE_AUTOLAUNCH', '1')
     except OSError:
         pass
 

--- a/webui.py
+++ b/webui.py
@@ -407,6 +407,9 @@ def webui():
         if cmd_opts.add_stop_route:
             app.add_route("/_stop", stop_route, methods=["POST"])
 
+        # after initial launch, disable --autolaunch for subsequent restarts
+        cmd_opts.autolaunch = False
+
         startup_timer.record("gradio launch")
 
         # gradio uses a very open CORS policy via app.user_middleware, which makes it possible for

--- a/webui.py
+++ b/webui.py
@@ -396,7 +396,7 @@ def webui():
             ssl_verify=cmd_opts.disable_tls_verify,
             debug=cmd_opts.gradio_debug,
             auth=gradio_auth_creds,
-            inbrowser=cmd_opts.autolaunch,
+            inbrowser=cmd_opts.autolaunch and os.getenv('SD_WEBUI_DISABLE_AUTOLAUNCH') != '1',
             prevent_thread_lock=True,
             allowed_paths=cmd_opts.gradio_allowed_path,
             app_kwargs={
@@ -406,9 +406,6 @@ def webui():
         )
         if cmd_opts.add_stop_route:
             app.add_route("/_stop", stop_route, methods=["POST"])
-
-        # after initial launch, disable --autolaunch for subsequent restarts
-        cmd_opts.autolaunch = False
 
         startup_timer.record("gradio launch")
 

--- a/webui.py
+++ b/webui.py
@@ -396,7 +396,7 @@ def webui():
             ssl_verify=cmd_opts.disable_tls_verify,
             debug=cmd_opts.gradio_debug,
             auth=gradio_auth_creds,
-            inbrowser=cmd_opts.autolaunch and os.getenv('SD_WEBUI_DISABLE_AUTOLAUNCH') != '1',
+            inbrowser=cmd_opts.autolaunch and os.getenv('SD_WEBUI_RESTARTING ') != '1',
             prevent_thread_lock=True,
             allowed_paths=cmd_opts.gradio_allowed_path,
             app_kwargs={


### PR DESCRIPTION
## Description

due to the new restart method [A yet another method to restart webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10975)
the old disable `--autolaunch` dose not work any more

so a rework
if webui is launche via restart, it will set environment variable `disable_webui_autolaunch` to 1
at the launch of webui it also check if `disable_webui_autolaunch` is not 1, else disables autolaunch

why environment variable, two reasons
1. `launch_utils.py` happens too early and it's Troublesome to get a variable from there without making a mess
2. this allows a user that has special needs to override this behavior via setting `disable_webui_autolaunch` to anything other then `1`

note: `os.environ.setdefault` only set if the environment variable dose not exist it doesn't override

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
