### PR TITLE
handles exception when parsing generation parameters from png info

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -277,15 +277,18 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     res["Negative prompt"] = negative_prompt
 
     for k, v in re_param.findall(lastline):
-        if v[0] == '"' and v[-1] == '"':
-            v = unquote(v)
+        try:
+            if v[0] == '"' and v[-1] == '"':
+                v = unquote(v)
 
-        m = re_imagesize.match(v)
-        if m is not None:
-            res[f"{k}-1"] = m.group(1)
-            res[f"{k}-2"] = m.group(2)
-        else:
-            res[k] = v
+            m = re_imagesize.match(v)
+            if m is not None:
+                res[f"{k}-1"] = m.group(1)
+                res[f"{k}-2"] = m.group(2)
+            else:
+                res[k] = v
+        except Exception:
+            print(f"Error parsing \"{k}: {v}\"")
 
     # Missing CLIP skip means it was set to 1 (the default)
     if "Clip skip" not in res:


### PR DESCRIPTION
## Description
related https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11000
when when parsing generation parameters if it encounters an error in one of the keys
it will prints an errors continue to the next parameter, and returned all the correctly passed parameters

as opposed to the current behavior as opposed to leaving the web page to be stuck in a waiting state

example
when parsing the image form https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11000
```py
Error parsing "Face restoration: "
```

note: the issue with https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11000 goes a bit deeper
it's not a specific fix for that but does leave it the general situation if this happens
I will make another PR addressing the actual issue for https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11000

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
