### PR TITLE
Forcing Torch Version to 1.13.1 for RX 5000 series GPUs

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -122,7 +122,7 @@ case "$gpu_info" in
             # Navi users will still use torch 1.13 because 2.0 does not seem to work.
             export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
         else
-            printf "\e[1m\e[31mERROR: Navi GPUs must be using at max python 3.10, aborting...\e[0m"
+            printf "\e[1m\e[31mERROR: RX 5000 series GPUs must be using at max python 3.10, aborting...\e[0m"
             exit 1
         fi
     ;;

--- a/webui.sh
+++ b/webui.sh
@@ -114,16 +114,19 @@ fi
 # Check prerequisites
 gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")
 case "$gpu_info" in
-    *"Navi 1"*) 
-        pyv="$(${python_cmd} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
-        if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]] 
+    *"Navi 1"*)
+        export HSA_OVERRIDE_GFX_VERSION=10.3.0
+        if [[ -z "${TORCH_COMMAND}" ]]
         then
-            export HSA_OVERRIDE_GFX_VERSION=10.3.0
-            # Navi users will still use torch 1.13 because 2.0 does not seem to work.
-            export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
-        else
-            printf "\e[1m\e[31mERROR: RX 5000 series GPUs must be using at max python 3.10, aborting...\e[0m"
-            exit 1
+            pyv="$(${python_cmd} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
+            if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]] 
+            then
+                # Navi users will still use torch 1.13 because 2.0 does not seem to work.
+                export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
+            else
+                printf "\e[1m\e[31mERROR: RX 5000 series GPUs must be using at max python 3.10, aborting...\e[0m"
+                exit 1
+            fi
         fi
     ;;
     *"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0

--- a/webui.sh
+++ b/webui.sh
@@ -116,6 +116,7 @@ pyv="$(python -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
 gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")
 case "$gpu_info" in
     *"Navi 1"*|*"Navi 2"*) 
+        if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]] 
         then
             export HSA_OVERRIDE_GFX_VERSION=10.3.0
             # Navi users will still use torch 1.13 because 2.0 does not seem to work.

--- a/webui.sh
+++ b/webui.sh
@@ -112,10 +112,10 @@ then
 fi
 
 # Check prerequisites
-pyv="$(${python_cmd} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
 gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")
 case "$gpu_info" in
     *"Navi 1"*) 
+        pyv="$(${python_cmd} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
         if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]] 
         then
             export HSA_OVERRIDE_GFX_VERSION=10.3.0

--- a/webui.sh
+++ b/webui.sh
@@ -112,10 +112,10 @@ then
 fi
 
 # Check prerequisites
-pyv="$(python -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
+pyv="$(${python_cmd} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
 gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")
 case "$gpu_info" in
-    *"Navi 1"*|*"Navi 2"*) 
+    *"Navi 1"*) 
         if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]] 
         then
             export HSA_OVERRIDE_GFX_VERSION=10.3.0
@@ -126,19 +126,12 @@ case "$gpu_info" in
             exit 1
         fi
     ;;
-    *"Renoir"*) 
-        if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]]
-        then
-            export HSA_OVERRIDE_GFX_VERSION=9.0.0
-            # Renoir users will still use torch 1.13 because 2.0 does not seem to work.
-            export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
-            printf "\n%s\n" "${delimiter}"
-            printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
-            printf "\n%s\n" "${delimiter}"
-        else
-            printf "\e[1m\e[31mERROR: Renoir GPUs must be using at max python 3.10, aborting...\e[0m"
-            exit 1
-        fi
+    *"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
+    ;;
+    *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
+        printf "\n%s\n" "${delimiter}"
+        printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
+        printf "\n%s\n" "${delimiter}"
     ;;
     *)
     ;;

--- a/webui.sh
+++ b/webui.sh
@@ -112,14 +112,32 @@ then
 fi
 
 # Check prerequisites
+pyv="$(python -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')"
 gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")
 case "$gpu_info" in
-    *"Navi 1"*|*"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
+    *"Navi 1"*|*"Navi 2"*) 
+        then
+            export HSA_OVERRIDE_GFX_VERSION=10.3.0
+            # Navi users will still use torch 1.13 because 2.0 does not seem to work.
+            export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
+        else
+            printf "\e[1m\e[31mERROR: Navi GPUs must be using at max python 3.10, aborting...\e[0m"
+            exit 1
+        fi
     ;;
-    *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
-        printf "\n%s\n" "${delimiter}"
-        printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
-        printf "\n%s\n" "${delimiter}"
+    *"Renoir"*) 
+        if [[ $(bc <<< "$pyv <= 3.10") -eq 1 ]]
+        then
+            export HSA_OVERRIDE_GFX_VERSION=9.0.0
+            # Renoir users will still use torch 1.13 because 2.0 does not seem to work.
+            export TORCH_COMMAND="pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 --index-url https://download.pytorch.org/whl/rocm5.2"
+            printf "\n%s\n" "${delimiter}"
+            printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"
+            printf "\n%s\n" "${delimiter}"
+        else
+            printf "\e[1m\e[31mERROR: Renoir GPUs must be using at max python 3.10, aborting...\e[0m"
+            exit 1
+        fi
     ;;
     *)
     ;;


### PR DESCRIPTION
## Description

As described on the discussion under #10465, this is an attempt to make work the WebUI again on older AMD cards like the RX5000 series.

The code forces TORCH_COMMAND for Navi and Renoir GPUs.

Also, the older pytorch version requires python version <= 3.10. I added some code to check it, so the user gets a cleaner error message when trying to run it on python 3.11 or later

This is still intended as a workaround, to be removed as soon as someone finds a way to run the webui properly on these cards.

Should fix #10873

## Checklist:

* [x]  I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
* [x]  I have performed a self-review of my own code
* [x]  My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
* [x]  My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
