### PR TITLE
link footer API to Wiki when API is not active

### DIFF
--- a/html/footer.html
+++ b/html/footer.html
@@ -1,5 +1,5 @@
 <div>
-        <a href="/docs">API</a>
+        <a href="{api_docs}">API</a>
          • 
         <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">Github</a>
          • 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1501,7 +1501,7 @@ def create_ui():
             gr.Audio(interactive=False, value=os.path.join(script_path, "notification.mp3"), elem_id="audio_notification", visible=False)
 
         footer = shared.html("footer.html")
-        footer = footer.format(versions=versions_html())
+        footer = footer.format(versions=versions_html(), api_docs="/docs" if shared.cmd_opts.api else "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API")
         gr.HTML(footer, elem_id="footer")
 
         settings.add_functionality(demo)


### PR DESCRIPTION
## Description
[Feature Request]: API Button Should have explanation of how to enable the API feature #11025 

direct the footer API link to [wiki/api](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API) when api is not active
seems like a good idea, better then 404
## Screenshots/videos:
with api no change
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/5e7fd057-6c64-41df-9663-60d2476737e0)
no api link to wiki
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/7a4cd988-3eec-4208-bea5-fc4db54dbe93)
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
