### PR TITLE
Allow activation of Generate Forever during generation

### DIFF
--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -148,12 +148,18 @@ var addContextMenuEventListener = initResponse[2];
         500);
     };
 
-    appendContextMenuOption('#txt2img_generate', 'Generate forever', function() {
+    let generateOnRepeat_txt2img = function() {
         generateOnRepeat('#txt2img_generate', '#txt2img_interrupt');
-    });
-    appendContextMenuOption('#img2img_generate', 'Generate forever', function() {
+    };
+
+    let generateOnRepeat_img2img = function() {
         generateOnRepeat('#img2img_generate', '#img2img_interrupt');
-    });
+    };
+
+    appendContextMenuOption('#txt2img_generate', 'Generate forever', generateOnRepeat_txt2img);
+    appendContextMenuOption('#txt2img_interrupt', 'Generate forever', generateOnRepeat_txt2img);
+    appendContextMenuOption('#img2img_generate', 'Generate forever', generateOnRepeat_img2img);
+    appendContextMenuOption('#img2img_interrupt', 'Generate forever', generateOnRepeat_img2img);
 
     let cancelGenerateForever = function() {
         clearInterval(window.generateOnRepeatInterval);


### PR DESCRIPTION
## Description
Allow activation of Generate Forever during generation

currently for whatever reason they generate forever button cannot be activated during generation
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/fb1d10b3-e536-41f1-a4f9-d9ec75ff2bfa)

this change adds the option to activate during generation
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/339059cd-6f89-4a6e-b450-6a85efbaf7ef)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
