### PR TITLE
Don't die when a LoRA is a broken symlink

### DIFF
--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -448,7 +448,11 @@ def list_available_loras():
             continue
 
         name = os.path.splitext(os.path.basename(filename))[0]
-        entry = LoraOnDisk(name, filename)
+        try:
+            entry = LoraOnDisk(name, filename)
+        except OSError:  # should catch FileNotFoundError and PermissionError etc.
+            errors.report(f"Failed to load LoRA {name} from {filename}", exc_info=True)
+            continue
 
         available_loras[name] = entry
 


### PR DESCRIPTION
## Description

* a simple description of what you're trying to accomplish: when a LoRA is a broken symlink, it can be enumerated fine, but attempting to read it (for hashing) will crash.
* which issues it fixes, if any: Fixes #11098

## Screenshots/videos:

```
*** Failed to load LoRA moop from stable-diffusion-webui/models/Lora/moop.safetensors
    Traceback (most recent call last):
      File "stable-diffusion-webui/extensions-builtin/Lora/lora.py", line 452, in list_available_loras
        entry = LoraOnDisk(name, filename)
      File "stable-diffusion-webui/extensions-builtin/Lora/lora.py", line 101, in __init__
        hashes.sha256_from_cache(self.filename, "lora/" + self.name, use_addnet_hash=self.is_safetensors) or
      File "stable-diffusion-webui/modules/hashes.py", line 51, in sha256_from_cache
        ondisk_mtime = os.path.getmtime(filename)
      File "lib/python3.10/genericpath.py", line 55, in getmtime
        return os.stat(filename).st_mtime
    FileNotFoundError: [Errno 2] No such file or directory: 'stable-diffusion-webui/models/Lora/moop.safetensors'
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
