### PR TITLE
Converse Zoom extension use Alt instead of Shift for zoom

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -514,6 +514,11 @@ onUiLoaded(async() => {
                 event.preventDefault();
                 action(event);
             }
+
+            // Removing the default behavior in the browser for alt key when the handler is attached
+            if (event.altKey) {
+                event.preventDefault();
+            }
         }
 
         // Get Mouse position

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -131,7 +131,7 @@ onUiLoaded(async() => {
         canvas_show_tooltip: true,
         canvas_swap_controls: false
     };
-    // swap the actions for ctr + wheel and shift + wheel
+    // swap the actions for ctr + wheel and alt + wheel
     const hotkeysConfig = createHotkeyConfig(
         defaultHotkeysConfig,
         hotkeysConfigOpts
@@ -192,8 +192,8 @@ onUiLoaded(async() => {
             tooltipContent.className = "tooltip-content";
 
             // Add info about hotkeys
-            const zoomKey = hotkeysConfig.canvas_swap_controls ? "Ctrl" : "Shift";
-            const adjustKey = hotkeysConfig.canvas_swap_controls ? "Shift" : "Ctrl";
+            const zoomKey = hotkeysConfig.canvas_swap_controls ? "Ctrl" : "Alt";
+            const adjustKey = hotkeysConfig.canvas_swap_controls ? "Alt" : "Ctrl";
 
             const hotkeys = [
                 {key: `${zoomKey} + wheel`, action: "Zoom canvas"},
@@ -347,7 +347,7 @@ onUiLoaded(async() => {
         // Change the zoom level based on user interaction
         function changeZoomLevel(operation, e) {
             if (
-                (!hotkeysConfig.canvas_swap_controls && e.shiftKey) ||
+                (!hotkeysConfig.canvas_swap_controls && e.altKey) ||
                 (hotkeysConfig.canvas_swap_controls && e.ctrlKey)
             ) {
                 e.preventDefault();
@@ -565,7 +565,7 @@ onUiLoaded(async() => {
 
             // Handle brush size adjustment with ctrl key pressed
             if (
-                (hotkeysConfig.canvas_swap_controls && e.shiftKey) ||
+                (hotkeysConfig.canvas_swap_controls && e.altKey) ||
                 (!hotkeysConfig.canvas_swap_controls &&
                     (e.ctrlKey || e.metaKey))
             ) {


### PR DESCRIPTION
## Description
use Alt key for the modifier key instead of shift for canvas zoom

I don't think using shift + scroll wheel for zoom is a good choice
as this overrides the ability to scroll horizontally, this is a built-in function in most browsers I believe
I suggest using another key maybe alt as the modifier

as far as I know most application that I know of use
scroll wheel for vertical scrolling
shift + scroll wheel for horizontal scrolling
alt / ctrl + scroll wheel for zoom

@daswer123

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/cd8ad6a6-63c0-493d-a572-46daec661468)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
