### PR TITLE
show Git clone progress

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -147,10 +147,10 @@ def git_clone(url, dir, name, commithash=None):
             return
 
         run(f'"{git}" -C "{dir}" fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}")
-        run(f'"{git}" -C "{dir}" checkout {commithash}', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}")
+        run(f'"{git}" -C "{dir}" checkout {commithash}', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}", live=True)
         return
 
-    run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}")
+    run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
 
     if commithash is not None:
         run(f'"{git}" -C "{dir}" checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")


### PR DESCRIPTION
## Description
[[Feature Request]: give a progress bar while cloning git repositories on first setup ](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11224)

currently if a user wish to see the cloning process they will have to set `WEBUI_LAUNCH_LIVE_OUTPUT=1`
this is obviously not very intuitive and also gives too much information for regular users

I believe seeing the cleaning progress is beneficial especially for those who have slower internet
this does however make the initial setup more cluttered'

also show for `git checkout`

## initial install log after change:
```
venv "B:\GitHub\stable-diffusion-webui\venv\Scripts\Python.exe"
Python 3.10.6 (tags/v3.10.6:9c7b4bd, Aug  1 2022, 21:53:49) [MSC v.1932 64 bit (AMD64)]
Version: v1.3.2-RC-242-g59419bd6
Commit hash: 59419bd64a1581caccaac04dceb66c1c069a2db1
Installing xformers
Collecting xformers==0.0.20
  Using cached xformers-0.0.20-cp310-cp310-win_amd64.whl (97.6 MB)
Installing collected packages: xformers
Successfully installed xformers-0.0.17
Cloning Stable Diffusion into B:\GitHub\stable-diffusion-webui\repositories\stable-diffusion-stability-ai...
Cloning into 'B:\GitHub\stable-diffusion-webui\repositories\stable-diffusion-stability-ai'...
remote: Enumerating objects: 574, done.
remote: Counting objects: 100% (304/304), done.
remote: Compressing objects: 100% (88/88), done.
remote: Total 574 (delta 244), reused 216 (delta 216), pack-reused 270Receiving objects:  94% (540/574), 73.36 MiB | 6.0
Receiving objects: 100% (574/574), 73.43 MiB | 6.08 MiB/s, done.
Resolving deltas: 100% (276/276), done.
Cloning K-diffusion into B:\GitHub\stable-diffusion-webui\repositories\k-diffusion...
Cloning into 'B:\GitHub\stable-diffusion-webui\repositories\k-diffusion'...
remote: Enumerating objects: 731, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 731 (delta 1), reused 3 (delta 1), pack-reused 724
Receiving objects: 100% (731/731), 145.87 KiB | 4.29 MiB/s, done.
Resolving deltas: 100% (477/477), done.
Cloning CodeFormer into B:\GitHub\stable-diffusion-webui\repositories\CodeFormer...
Cloning into 'B:\GitHub\stable-diffusion-webui\repositories\CodeFormer'...
remote: Enumerating objects: 583, done.
remote: Counting objects: 100% (234/234), done.
remote: Compressing objects: 100% (90/90), done.
remote: Total 583 (delta 168), reused 166 (delta 144), pack-reused 349
Receiving objects: 100% (583/583), 17.31 MiB | 1.90 MiB/s, done.
Resolving deltas: 100% (279/279), done.
Cloning BLIP into B:\GitHub\stable-diffusion-webui\repositories\BLIP...
Cloning into 'B:\GitHub\stable-diffusion-webui\repositories\BLIP'...
remote: Enumerating objects: 277, done.
remote: Counting objects: 100% (277/277), done.
remote: Compressing objects: 100% (124/124), done.Receiving objects:   3% (9/277)
remote: Total 277 (delta 152), reused 247 (delta 150), pack-reused 0Receiving objects:  99% (275/277), 3.69 MiB | 7.34 MReceiving objects: 100% (277/277), 7.03 MiB | 7.54 MiB/s, done.

Resolving deltas: 100% (152/152), done.
Installing requirements



Launching Web UI with arguments: ...
......
irrelevant......
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
