### PR TITLE
WEBUI.SH Navi 3 Support

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -131,6 +131,10 @@ case "$gpu_info" in
     ;;
     *"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
     ;;
+    *"Navi 3"*) [[ -z "${TORCH_COMMAND}" ]] && \
+        export TORCH_COMMAND="pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm5.5"
+        # Navi 3 needs at least 5.5 which is only on the nightly chain
+    ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
         printf "\n%s\n" "${delimiter}"
         printf "Experimental support for Renoir: make sure to have at least 4GB of VRAM and 10GB of RAM or enable cpu mode: --use-cpu all --no-half"


### PR DESCRIPTION
Navi 3 card now defaults to nightly torch to utilize rocm 5.5 for out-of-the-box support.

https://download.pytorch.org/whl/nightly/

While its not yet on the main pytorch "get started" site, it still seems perfectly indexable via pip which is all we need.

With this I'm able to clone a fresh repo and immediately run ./webui.sh on my 7900 XTX without any problems.

![7900xtx](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/39478211/0032f2cd-d8f5-4c89-85f0-0e8753df866b)