### PR TITLE
fix very slow loading speed of .safetensors files

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -247,8 +247,11 @@ def read_metadata_from_safetensors(filename):
 def read_state_dict(checkpoint_file, print_global_state=False, map_location=None):
     _, extension = os.path.splitext(checkpoint_file)
     if extension.lower() == ".safetensors":
-        device = map_location or shared.weight_load_location or devices.get_optimal_device_name()
-        pl_sd = safetensors.torch.load_file(checkpoint_file, device=device)
+        if not shared.opts.disable_mmap_load_safetensors:
+            device = map_location or shared.weight_load_location or devices.get_optimal_device_name()
+            pl_sd = safetensors.torch.load_file(checkpoint_file, device=device)
+        else:
+            pl_sd = safetensors.torch.load(open(checkpoint_file, 'rb').read())
     else:
         pl_sd = torch.load(checkpoint_file, map_location=map_location or shared.weight_load_location)
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -376,6 +376,7 @@ options_templates.update(options_section(('system', "System"), {
     "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job."),
     "print_hypernet_extra": OptionInfo(False, "Print extra hypernetwork information to console."),
     "list_hidden_files": OptionInfo(True, "Load models/files in hidden directories").info("directory is hidden if its name starts with \".\""),
+    "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files (fixes very slow loading speed in some cases)."),
 }))
 
 options_templates.update(options_section(('training', "Training"), {


### PR DESCRIPTION
## Description

* This fixes very slow loading of .safetensors files which happens in some cases, e.g. in combination with running the WebUI on WSL2 and accessing the storage for models on a windows drive (https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11216)
* code adds a new option to Systems menu to allow the user to disable memmapping while loading the .safetensors file

## Screenshots/videos:
No

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
