### PR TITLE
Update mac_specific.py

### DIFF
--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -7,7 +7,7 @@ from packaging import version
 # has_mps is only available in nightly pytorch (for now) and macOS 12.3+.
 # check `getattr` and try it for compatibility
 def check_for_mps() -> bool:
-    if not getattr(torch, 'has_mps', False):
+    if not torch.backends.mps.is_built():
         return False
     try:
         torch.zeros(1).to(torch.device("mps"))


### PR DESCRIPTION
change has_mps to torch.backends.mps.is_built()

## Description

When I run the program, it prompts:
```shell
/Users/zhouwenzhe/stable-diffusion-webui/modules/mac_specific.py:10: UserWarning: 'has_mps' is deprecated, please use 'torch.backends.mps.is_built()'
  if not getattr(torch, 'has_mps', False):
```
I have modified the code from `if not getattr(torch, 'has_mps', False):` to `if not torch.backends.mps.is_built():`, in order to more accurately check whether the MPS backend has been built.

This change can solve the issue where the MPS backend may not have been correctly detected (if such an issue exists).

## Screenshots/videos:
### Warning:
<img width="897" alt="image" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/57127283/1e337742-e140-4288-9ce1-03eb3997898b">

### Effect:
<img width="735" alt="image" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/57127283/8647e801-39d3-48ab-a884-98c18ba96b33">

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
