### PR TITLE
catch errors when retrieving extension index

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -387,12 +387,15 @@ def refresh_available_extensions(url, hide_tags, sort_column):
     global available_extensions
 
     import urllib.request
-    with urllib.request.urlopen(url) as response:
-        text = response.read()
+    try:
+        with urllib.request.urlopen(url) as response:
+            text = response.read()
+        available_extensions = json.loads(text)
+        code, tags = refresh_available_extensions_from_data(hide_tags, sort_column)
 
-    available_extensions = json.loads(text)
-
-    code, tags = refresh_available_extensions_from_data(hide_tags, sort_column)
+    except Exception as e:
+        code, tags = (None, None)
+        print(e)
 
     return url, code, gr.CheckboxGroup.update(choices=tags), '', ''
 
@@ -629,6 +632,5 @@ def create_ui():
                     inputs=[config_states_list],
                     outputs=[config_states_table],
                 )
-
 
     return ui


### PR DESCRIPTION
## Description
if for whatever reason the extension index cannot be retrieved, webui will be left in a perpetual state of waiting
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/a59363fd-7ae8-44ec-89ff-f97006799a02)
a user will not be able to retry without a reload of web page

you can simulate the error by entering invalid URL or disconnecting the internet

this catches the error so that the user can retry

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
