### PR TITLE
revert use of gitpython hijack

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -2,7 +2,8 @@ import os
 import threading
 
 from modules import shared, errors
-from modules.gitpython_hack import Repo
+# from modules.gitpython_hack import Repo
+from git import Repo
 from modules.paths_internal import extensions_dir, extensions_builtin_dir, script_path  # noqa: F401
 
 extensions = []


### PR DESCRIPTION
## Description
under certain conditions extension information can fail to load
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/51689ba4-69e2-4484-bddc-8d4e26e0a2ae)
I have seen this issue being triggered in the real world under normal use, and it frequently enough in the real world to be of a concern
then condition can be easily triggered using a debugger by placing a breakpoint at https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/dev/webui.py#L371
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/293d09e3-bf70-4331-bbf2-1378ed5e4bc9)
let the code execute to the breakpoint wait for one second or two then continue and then it continue

the console error output you would see when the issue is triggered is something like the below
```py
fatal: unable to access 'C:B:\Stable Diffusion\Models\cache/.config/git/config': Invalid argument
*** Failed reading extension data from Git repository (sdweb-merge-board)
    Traceback (most recent call last):
      File "B:\GitHub\stable-diffusion-webui\modules\extensions.py", line 64, in do_read_info_from_repo
        commit = repo.head.commit
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\git\refs\symbolic.py", line 226, in _get_commit
        obj = self._get_object()
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\git\refs\symbolic.py", line 219, in _get_object
        return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\git\objects\base.py", line 94, in new_from_sha
        oinfo = repo.odb.info(sha1)
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\git\db.py", line 40, in info
        hexsha, typename, size = self._git.get_object_header(bin_to_hex(binsha))
      File "B:\GitHub\stable-diffusion-webui\modules\gitpython_hack.py", line 18, in get_object_header
        ret = subprocess.check_output(
      File "C:\Programs\Python\3.10.6\lib\subprocess.py", line 420, in check_output
        return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
      File "C:\Programs\Python\3.10.6\lib\subprocess.py", line 524, in run
        raise CalledProcessError(retcode, process.args,
    subprocess.CalledProcessError: Command '['git', 'cat-file', '--batch-check']' returned non-zero exit status 128.

---
```
I think we should revert the use of good python hijacked before this can be fixed
@akx like you input on this as I believe you're the one who added `gitpython hijack`
## my speculations
as far as I can tell it has to do with something within `import gradio`
(I've tried to find the root cause but wasn't able to as it goes very deep)
I suspect it launches some sub process of thread in the background and causing issues with our gitpython hijacke
and if that something is allowed to execute before `preload_extensions_git_metadata` is called "everything explodes"
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
