### PR TITLE
Update ui.py show megapixels calc

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -112,7 +112,7 @@ def calc_resolution_hires(enable, width, height, hr_scale, hr_resize_x, hr_resiz
     with devices.autocast():
         p.init([""], [0], [0])
 
-    return f"resize: from <span class='resolution'>{p.width}x{p.height}</span> to <span class='resolution'>{p.hr_resize_x or p.hr_upscale_to_x}x{p.hr_resize_y or p.hr_upscale_to_y}</span>"
+    return f"resize: from <span class='resolution'>{p.width}x{p.height}</span> to <span class='resolution'>{p.hr_resize_x or p.hr_upscale_to_x}x{p.hr_resize_y or p.hr_upscale_to_y} = {p.hr_upscale_to_x * p.hr_upscale_to_y / 1000000} MP</span>"
 
 
 def resize_from_to_html(width, height, scale_by):


### PR DESCRIPTION
just an idea i had and was able to actually make this work in my local UI.  I'm not proficient in any programming language though so i don't know about making this same change everywhere else in the code base as appropriate.

if this is even something anyone other than myself would like to see.

## Description

* add calculated megapixels value to hires fix info shown in ui
* added simple and i think correct multiply and divide code to get the expected megapixel vlaue after a hires "upscale by" setting change
* doesn't really fix any problem, just something i think would be neat to see

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6720184/5b47d0b3-1038-4101-aa0e-302dc19106da)


## Checklist:

- [x ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
