### PR TITLE
Optimize inpaint batch processing and address extension matching issue

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -22,6 +22,8 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
     if inpaint_mask_dir:
         inpaint_masks = shared.listfiles(inpaint_mask_dir)
         is_inpaint_batch = len(inpaint_masks) > 0
+        # Create a dictionary of masks, where the key is the filename without extension.
+        mask_dict = {os.path.splitext(os.path.basename(m))[0]: m for m in inpaint_masks}
     if is_inpaint_batch:
         print(f"\nInpaint batch is enabled. {len(inpaint_masks)} masks found.")
 
@@ -52,11 +54,9 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args):
         p.init_images = [img] * p.batch_size
 
         if is_inpaint_batch:
-            # try to find corresponding mask for an image using simple filename matching
-            mask_image_path = os.path.join(inpaint_mask_dir, os.path.basename(image))
-            # if not found use first one ("same mask for all images" use-case)
-            if mask_image_path not in inpaint_masks:
-                mask_image_path = inpaint_masks[0]
+            base_filename = os.path.splitext(os.path.basename(image))[0]
+            # try to find corresponding mask if not found, use the first mask ("same mask for all images" use-case)
+            mask_image_path = mask_dict.get(base_filename, inpaint_masks[0])
             mask_image = Image.open(mask_image_path)
             p.image_mask = mask_image
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -750,7 +750,7 @@ def create_ui():
                         )
                         img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs, elem_id="img2img_batch_input_dir")
                         img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs, elem_id="img2img_batch_output_dir")
-                        img2img_batch_inpaint_mask_dir = gr.Textbox(label="Inpaint batch mask directory (required for inpaint batch processing only)", **shared.hide_dirs, elem_id="img2img_batch_inpaint_mask_dir")
+                        img2img_batch_inpaint_mask_dir = gr.Textbox(label="Inpaint batch mask directory (required for inpaint batch processing only) (Provide masks with filenames matching input images. If no match, the first mask is used)", **shared.hide_dirs, elem_id="img2img_batch_inpaint_mask_dir")
 
                     img2img_tabs = [tab_img2img, tab_sketch, tab_inpaint, tab_inpaint_color, tab_inpaint_upload, tab_batch]
 


### PR DESCRIPTION
## Description
I used the Inpaint batch function, but in my case images were in .jpg format while masks are in .png format, or vice versa. This discrepancy was causing the system to fail at finding matching masks for input images

This pull request addresses two issues in the process_batch function: extension matching for image and mask files, and performance optimization for large batches.

Previously, the code expected image and mask files to have matching extensions. I updated it to pair images and masks based on base filenames, disregarding their extensions. 

Instead of iteratively searching for matching masks for each image, a dictionary (mask_dict) is now created beforehand.

Related issues/pulls:
- #7295
-  #11220 (maybe)

Let me know if there are any questions or additional modifications required.


