### PR TITLE
Fixing "TypeError: save_pil_to_file() got an unexpected keyword argum…

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -31,7 +31,11 @@ def check_tmp_file(gradio, filename):
     return False
 
 
-def save_pil_to_file(self, pil_image, dir=None):
+def save_pil_to_file(self, pil_image, dir=None, format=None):
+    # Temporary fix for:
+    # https://github.com/opparco/stable-diffusion-webui-two-shot/issues/54
+    del format
+    
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)


### PR DESCRIPTION
…ent 'format'"

The used library sends down a format parameter that is not recognized by save_pil_to_file(). As a temporary fix, I'm adding it again, but ignoring the value.

### How to reproduce the bug:
- Install the Latent Couple extension. Restart automatic1111 if needed
- Make sure this fix is NOT present.
- Enable the Latent Couple option in the img2img tab
- Click "Visualize"

Result: the error mentioned above happens.