### PR TITLE
[minor new feature] sort extensions by popularity (github stars)

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -415,6 +415,7 @@ sort_ordering = [
     (False, lambda x: x.get('name', 'z')),
     (True, lambda x: x.get('name', 'z')),
     (False, lambda x: 'z'),
+    (True, lambda x: x.get('stars', 0)),
 ]
 
 
@@ -546,7 +547,7 @@ def create_ui():
 
                 with gr.Row():
                     hide_tags = gr.CheckboxGroup(value=["ads", "localization", "installed"], label="Hide extensions with tags", choices=["script", "ads", "localization", "installed"])
-                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order", ], type="index")
+                    sort_column = gr.Radio(value="popularity", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order", "popularity" ], type="index")
 
                 with gr.Row():
                     search_extensions_text = gr.Text(label="Search").style(container=False)

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -473,8 +473,8 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
             <tr>
                 <td><a href="{html.escape(url)}" target="_blank">{html.escape(name)}</a><br />{tags_text}</td>
                 <td>{html.escape(description)}<p class="info">
-                    <span class="star_count"><a href="{html.escape(url)}" target="_blank"> Stars: <b>{stars}</b> ☆</a></span>
                     <span class="date_added">Added: {html.escape(added)}</span>
+                    <span class="star_count"><a href="{html.escape(url)}" target="_blank"> stars: <b>{stars:,} ☆</b></a></span>
                 </p></td>
                 <td>{install_code}</td>
             </tr>
@@ -546,7 +546,7 @@ def create_ui():
             with gr.TabItem("Available", id="available"):
                 with gr.Row():
                     refresh_available_extensions_button = gr.Button(value="Load from:", variant="primary")
-                    available_extensions_index = gr.Text(value="https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui-extensions/master/index.json", label="Extension index URL").style(container=False)
+                    available_extensions_index = gr.Text(value="https://raw.githubusercontent.com/GoulartNogueira/stable-diffusion-webui-extensions/master/index.json", label="Extension index URL").style(container=False)
                     extension_to_install = gr.Text(elem_id="extension_to_install", visible=False)
                     install_extension_button = gr.Button(elem_id="install_extension_button", visible=False)
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -432,7 +432,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         <thead>
             <tr>
                 <th>Extension</th>
-                <th>Description</th>
+                <th>Details</th>
                 <th>Action</th>
             </tr>
         </thead>
@@ -443,6 +443,8 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
 
     for ext in sorted(extlist, key=sort_function, reverse=sort_reverse):
         name = ext.get("name", "noname")
+        # assert stars are integers
+        stars = int(ext.get("stars", 0)) # forcing int to avoid XSS
         added = ext.get('added', 'unknown')
         url = ext.get("url", None)
         description = ext.get("description", "")
@@ -470,7 +472,10 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         code += f"""
             <tr>
                 <td><a href="{html.escape(url)}" target="_blank">{html.escape(name)}</a><br />{tags_text}</td>
-                <td>{html.escape(description)}<p class="info"><span class="date_added">Added: {html.escape(added)}</span></p></td>
+                <td>{html.escape(description)}<p class="info">
+                    <span class="star_count"><a href="{html.escape(url)}" target="_blank"> Stars: <b>{stars}</b> ☆</a></span>
+                    <span class="date_added">Added: {html.escape(added)}</span>
+                </p></td>
                 <td>{install_code}</td>
             </tr>
 

--- a/style.css
+++ b/style.css
@@ -678,26 +678,23 @@ table.settings-value-table td{
 }
 
 #available_extensions .info{
-    margin: 0;
+    margin: 0.5em 0;
     display: flex;
     margin-top: auto;
-}
-
-#available_extensions .star_count{
-    opacity: 0.85;
+    opacity: 0.80;
     font-size: 90%;
-    margin-left: auto;
-    margin-right: 0.5em;
-    display: inline-block;
 }
 
 #available_extensions .date_added{
-    opacity: 0.85;
-    font-size: 90%;
-    margin-left: auto;
-    margin-right: 0.5em;
+    margin-right: auto;
     display: inline-block;
 }
+
+#available_extensions .star_count{
+    margin-left: auto;
+    display: inline-block;
+}
+
 
 /* replace original footer with ours */
 

--- a/style.css
+++ b/style.css
@@ -679,11 +679,24 @@ table.settings-value-table td{
 
 #available_extensions .info{
     margin: 0;
+    display: flex;
+    margin-top: auto;
+}
+
+#available_extensions .star_count{
+    opacity: 0.85;
+    font-size: 90%;
+    margin-left: auto;
+    margin-right: 0.5em;
+    display: inline-block;
 }
 
 #available_extensions .date_added{
     opacity: 0.85;
     font-size: 90%;
+    margin-left: auto;
+    margin-right: 0.5em;
+    display: inline-block;
 }
 
 /* replace original footer with ours */


### PR DESCRIPTION
## Problem:
There are over 170 extensions. Some are popular and well maintained, others are still in early development.
So every time I need a new feature, I need to open the github page for each extension and check their quality and popularity.

## Solution:
Make it easier to find the most popular extensions.
This will also help new users to discover and try the most popular extensions.

## Method:
Sort each repo by their github stars and display the star count for comparison.

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7660643/9b8e1cb8-ff63-419b-b927-1c9e9dc1febf)

## Requirement:
To load the start count correctly, you must load a json with the data.
For now, you can get use the Extension index URL from my github: `https://raw.githubusercontent.com/GoulartNogueira/stable-diffusion-webui-extensions/master/index.json` but I've already submit [the update](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/98) to the official source.
I've also provided the script so they can run periodically and keep the star count up-to-date.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
