### PR TITLE
Strip whitespaces from URL and dirname prior to extension installation

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -325,6 +325,11 @@ def normalize_git_url(url):
 def install_extension_from_url(dirname, url, branch_name=None):
     check_access()
 
+    if isinstance(dirname, str):
+        dirname = dirname.strip()
+    if isinstance(url, str):
+        url = url.strip()
+
     assert url, 'No URL specified'
 
     if dirname is None or dirname == "":


### PR DESCRIPTION
## Description

* This avoid some cryptic errors brought by accidental spaces around urls by stripping them ahead

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
