### PR TITLE
add `before_hr` script callback

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1074,6 +1074,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
         sd_models.apply_token_merging(self.sd_model, self.get_token_merging_ratio(for_hr=True))
 
+        if self.scripts is not None:
+            self.scripts.before_hr(self)
+
         samples = self.sampler.sample_img2img(self, samples, noise, self.hr_c, self.hr_uc, steps=self.hr_second_pass_steps or self.steps, image_conditioning=image_conditioning)
 
         sd_models.apply_token_merging(self.sd_model, self.get_token_merging_ratio())

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -186,6 +186,11 @@ class Script:
 
         return f'script_{tabname}{title}_{item_id}'
 
+    def before_hr(self, p ,*args):
+        """
+        This function is called before hires fix start.
+        """
+        pass
 
 current_basedir = paths.script_path
 
@@ -546,6 +551,15 @@ class ScriptRunner:
                     self.scripts[si].filename = filename
                     self.scripts[si].args_from = args_from
                     self.scripts[si].args_to = args_to
+
+
+    def before_hr(self, p):
+        for script in self.alwayson_scripts:
+            try:
+                script_args = p.script_args[script.args_from:script.args_to]
+                script.before_hr(p, *script_args)
+            except Exception:
+                errors.report(f"Error running before_hr: {script.filename}", exc_info=True)
 
 
 scripts_txt2img: ScriptRunner = None


### PR DESCRIPTION
#### Describe what this pull request is trying to achieve.

Some features related to the hires fix have been added in the recent update. This includes prompts for hires fix, and it is assumed that the generation conditions will be different between the hires fix and normal generation. This has affected several scripts, particularly causing issues in relation to LoRA. This is because LoRA is reloaded before the hires fix. In the extension controlling LoRA, the problem is circumvented by setting p.disable_extra_networks = False after controlling LoRA, but I don't think this is the correct control. Therefore, a callback needs to be set up before the hires fix is executed, allowing for reconfiguration. I've added a callback for this purpose.

Environment this was tested in

    OS: Windows
    Browser: Firefox
    Graphics card: NVIDIA RTX 3060