### PR TITLE
Fixing --subpath on newer gradio version

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -359,7 +359,11 @@ def api_only():
     modules.script_callbacks.app_started_callback(None, app)
 
     print(f"Startup time: {startup_timer.summary()}.")
-    api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
+    api.launch(
+        server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1",
+        port=cmd_opts.port if cmd_opts.port else 7861,
+        root_path = f"/{cmd_opts.subpath}"
+    )
 
 
 def stop_route(request):
@@ -403,6 +407,7 @@ def webui():
                 "docs_url": "/docs",
                 "redoc_url": "/redoc",
             },
+            root_path = f"/{cmd_opts.subpath}",
         )
         if cmd_opts.add_stop_route:
             app.add_route("/_stop", stop_route, methods=["POST"])
@@ -435,11 +440,6 @@ def webui():
 
         timer.startup_record = startup_timer.dump()
         print(f"Startup time: {startup_timer.summary()}.")
-
-        if cmd_opts.subpath:
-            redirector = FastAPI()
-            redirector.get("/")
-            gradio.mount_gradio_app(redirector, shared.demo, path=f"/{cmd_opts.subpath}")
 
         try:
             while True:


### PR DESCRIPTION
## Description

`--subpath` got broken again after gradio 3.30, updated it to work with 3.30+

## Screenshots/videos:

before:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/89681913/dcfb7430-3d66-43d8-9751-2c083d0b107b)

after:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/89681913/4906d9ab-ec5b-4604-876a-b36bda386fa3)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
