### PR TITLE
add callback after_extra_networks_activate

### DIFF
--- a/modules/extra_networks.py
+++ b/modules/extra_networks.py
@@ -103,6 +103,9 @@ def activate(p, extra_network_data):
         except Exception as e:
             errors.display(e, f"activating extra network {extra_network_name}")
 
+    if p.scripts is not None:
+        p.scripts.after_extra_networks_activate(p, batch_number=p.iteration, prompts=p.prompts, seeds=p.seeds, subseeds=p.subseeds, extra_network_data=extra_network_data)
+
 
 def deactivate(p, extra_network_data):
     """call deactivate for extra networks in extra_network_data in specified order, then call

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -116,6 +116,21 @@ class Script:
 
         pass
 
+    def after_extra_networks_activate(self, p, *args, **kwargs):
+        """
+        Calledafter extra networks activation, before conds calculation
+        allow modification of the network after extra networks activation been applied
+        won't be call if p.disable_extra_networks
+
+        **kwargs will have those items:
+          - batch_number - index of current batch, from 0 to number of batches-1
+          - prompts - list of prompts for current batch; you can change contents of this list but changing the number of entries will likely break things
+          - seeds - list of seeds for current batch
+          - subseeds - list of subseeds for current batch
+          - extra_network_data - list of ExtraNetworkParams for current stage
+        """
+        pass
+
     def process_batch(self, p, *args, **kwargs):
         """
         Same as process(), but called for every batch.
@@ -482,6 +497,14 @@ class ScriptRunner:
                 script.before_process_batch(p, *script_args, **kwargs)
             except Exception:
                 errors.report(f"Error running before_process_batch: {script.filename}", exc_info=True)
+
+    def after_extra_networks_activate(self, p, **kwargs):
+        for script in self.alwayson_scripts:
+            try:
+                script_args = p.script_args[script.args_from:script.args_to]
+                script.after_extra_networks_activate(p, *script_args, **kwargs)
+            except Exception:
+                errors.report(f"Error running after_extra_networks_activate: {script.filename}", exc_info=True)
 
     def process_batch(self, p, **kwargs):
         for script in self.alwayson_scripts:


### PR DESCRIPTION
## Description
this mainly affected extensions that needs to modify extra network after it's been activated
such as [lora block weights](https://github.com/hako-mikan/sd-webui-lora-block-weight)
and in my opinion the actual solution to the issue that https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11477 describes
quote
> this has affected several scripts, particularly causing issues in relation to LoRA

the following is mostly a repost of my Discord message on this topic

we might need to add a an extra process_batch or a new call back for hi-pass
https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/10944 

I propose to add a new callback in `extra_network.activate`, a post `extra_network_activate` callback
I think this is the best place to add operations that need to happen after activation of extra network but before setup_conds()
normally for img2img process_batch is enough but the issue is that for txt2img with hirse-fix there are multiple activations of extra networks
extensions that need to inject themselves between extra network activation and conds shoud switch to use the new call back

the key difference between process_batch only proposed new callback post_extra_network_activate is that
process_batch called only once per batch
whiles post_extra_network_activate maybe called multiple times (when hires-fix) 

also some extensions actually activate after networks for ther own use
example https://github.com/pkuliyi2015/multidiffusion-upscaler-for-automatic1111/blob/main/tile_methods/multidiffusion.py#L206

if the this call back is implemented
process_batch should be moved after conds
and they can be a minor optimization for conds calculation for --lowvram mode
which would also entail moving `scripts.process_batch` after conds
this would cause a breaking change this is not implemented in this PR
this can be implemented later after this PR has been merged and those extension that would be affected has time to migrate to the new callback, making the migration more smooth

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
