### PR TITLE
fix can't get current hash

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -142,7 +142,7 @@ def git_clone(url, dir, name, commithash=None):
         if commithash is None:
             return
 
-        current_hash = run(f'"{git}" -C "{dir}" rev-parse HEAD', None, f"Couldn't determine {name}'s hash: {commithash}").strip()
+        current_hash = run(f'"{git}" -C "{dir}" rev-parse HEAD', None, f"Couldn't determine {name}'s hash: {commithash}", live=False).strip()
         if current_hash == commithash:
             return
 


### PR DESCRIPTION
## Description

When using WEBUI_LAUNCH_LIVE_OUTPUT, the default arg "live" for function "run" is set to True. This prevents getting stdout and stderr from return value, thereby making it impossible to get the current_hash. As a result, offline startup is not possible.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
