### PR TITLE
Extension metadata

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -424,6 +424,7 @@ sort_ordering = [
     (False, lambda x: x.get('name', 'z')),
     (True, lambda x: x.get('name', 'z')),
     (False, lambda x: 'z'),
+    (True, lambda x: x.get('stars', 0)),
 ]
 
 
@@ -451,6 +452,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
 
     for ext in sorted(extlist, key=sort_function, reverse=sort_reverse):
         name = ext.get("name", "noname")
+        stars = int(ext.get("stars", 0))
         added = ext.get('added', 'unknown')
         url = ext.get("url", None)
         description = ext.get("description", "")
@@ -478,7 +480,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         code += f"""
             <tr>
                 <td><a href="{html.escape(url)}" target="_blank">{html.escape(name)}</a><br />{tags_text}</td>
-                <td>{html.escape(description)}<p class="info"><span class="date_added">Added: {html.escape(added)}</span></p></td>
+                <td>{html.escape(description)}<p class="info"><span class="date_added">Added: {html.escape(added)}</span><span class="star_count">stars: <b>{stars:,}</b></a></p></td>
                 <td>{install_code}</td>
             </tr>
 
@@ -562,7 +564,7 @@ def create_ui():
 
                 with gr.Row():
                     hide_tags = gr.CheckboxGroup(value=["ads", "localization", "installed"], label="Hide extensions with tags", choices=["script", "ads", "localization", "installed"])
-                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order", ], type="index")
+                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order", "stars"], type="index")
 
                 with gr.Row():
                     search_extensions_text = gr.Text(label="Search").style(container=False)

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -424,8 +424,17 @@ sort_ordering = [
     (False, lambda x: x.get('name', 'z')),
     (True, lambda x: x.get('name', 'z')),
     (False, lambda x: 'z'),
+    (True, lambda x: x.get('commit_time', '')),
+    (True, lambda x: x.get('created_at', '')),
     (True, lambda x: x.get('stars', 0)),
 ]
+
+
+def get_date(info: dict, key):
+    try:
+        return datetime.strptime(info.get(key), "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return ''
 
 
 def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text=""):
@@ -454,6 +463,8 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         name = ext.get("name", "noname")
         stars = int(ext.get("stars", 0))
         added = ext.get('added', 'unknown')
+        update_time = get_date(ext, 'commit_time')
+        create_time = get_date(ext, 'created_at')
         url = ext.get("url", None)
         description = ext.get("description", "")
         extension_tags = ext.get("tags", [])
@@ -480,7 +491,8 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         code += f"""
             <tr>
                 <td><a href="{html.escape(url)}" target="_blank">{html.escape(name)}</a><br />{tags_text}</td>
-                <td>{html.escape(description)}<p class="info"><span class="date_added">Added: {html.escape(added)}</span><span class="star_count">stars: <b>{stars:,}</b></a></p></td>
+                <td>{html.escape(description)}<p class="info">
+                <span class="date_added">Update: {html.escape(update_time)}  Added: {html.escape(added)}  Created: {html.escape(create_time)}</span><span class="star_count">stars: <b>{stars}</b></a></p></td>
                 <td>{install_code}</td>
             </tr>
 
@@ -564,7 +576,7 @@ def create_ui():
 
                 with gr.Row():
                     hide_tags = gr.CheckboxGroup(value=["ads", "localization", "installed"], label="Hide extensions with tags", choices=["script", "ads", "localization", "installed"])
-                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order", "stars"], type="index")
+                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order",'update time', 'create time', "stars"], type="index")
 
                 with gr.Row():
                     search_extensions_text = gr.Text(label="Search").style(container=False)

--- a/style.css
+++ b/style.css
@@ -704,9 +704,22 @@ table.popup-table .link{
     margin: 0;
 }
 
-#available_extensions .date_added{
-    opacity: 0.85;
+#available_extensions .info{
+    margin: 0.5em 0;
+    display: flex;
+    margin-top: auto;
+    opacity: 0.80;
     font-size: 90%;
+}
+
+#available_extensions .date_added{
+    margin-right: auto;
+    display: inline-block;
+}
+
+#available_extensions .star_count{
+    margin-left: auto;
+    display: inline-block;
 }
 
 /* replace original footer with ours */


### PR DESCRIPTION
## Description
rework of [[minor new feature] sort extensions by popularity (github stars)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11370)

add `stars` `update date` `creation date`

use my test index for testing
~~https://raw.githubusercontent.com/w-e-w/temp_test/master/index.json~~ removed

workflow configured can be enabled at any time
### screenshot
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/actions/workflows/update_metadata.yml
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/8a3acbb6-e886-4bc9-a813-3e7241cf07d3)

### WIP / Future work if this gets pulled
instead of A-Z Z-A Newest Oldest
I like to separate them in ascending and descending order and sort category
currently have some trouble organizing the UI I'm not good with Gradio 
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c9fd1a5f-29ce-4664-b375-f45411ce9c63)
if someone wants to do it for me feel free
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
