### PR TITLE
fix for #11534: canvas zoom and pan extension hijacking shortcut keys

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -608,23 +608,29 @@ onUiLoaded(async() => {
 
         // Handle keydown events
         function handleKeyDown(event) {
-            const hotkeyActions = {
-                [hotkeysConfig.canvas_hotkey_reset]: resetZoom,
-                [hotkeysConfig.canvas_hotkey_overlap]: toggleOverlap,
-                [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen
-            };
+            // before activating shortcut, ensure user is not actively typing in an input field
+            if(event.target.nodeName === 'TEXTAREA' || event.target.nodeName === 'INPUT') {
+                event.preventDefault;
+            } else {
 
-            const action = hotkeyActions[event.code];
-            if (action) {
-                event.preventDefault();
-                action(event);
-            }
+                const hotkeyActions = {
+                    [hotkeysConfig.canvas_hotkey_reset]: resetZoom,
+                    [hotkeysConfig.canvas_hotkey_overlap]: toggleOverlap,
+                    [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen
+                };
 
-            if (
-                isModifierKey(event, hotkeysConfig.canvas_hotkey_zoom) ||
-                isModifierKey(event, hotkeysConfig.canvas_hotkey_adjust)
-            ) {
-                event.preventDefault();
+                const action = hotkeyActions[event.code];
+                if (action) {
+                    event.preventDefault();
+                    action(event);
+                }
+
+                if (
+                    isModifierKey(event, hotkeysConfig.canvas_hotkey_zoom) ||
+                    isModifierKey(event, hotkeysConfig.canvas_hotkey_adjust)
+                ) {
+                    event.preventDefault();
+                }
             }
         }
 
@@ -687,10 +693,15 @@ onUiLoaded(async() => {
         // Handle the move event for pan functionality. Updates the panX and panY variables and applies the new transform to the target element.
         function handleMoveKeyDown(e) {
             if (e.code === hotkeysConfig.canvas_hotkey_move) {
-                if (!e.ctrlKey && !e.metaKey && isKeyDownHandlerAttached) {
-                    e.preventDefault();
-                    document.activeElement.blur();
-                    isMoving = true;
+                // before activating shortcut, ensure user is not actively typing in an input field
+                if(e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'INPUT') {
+                    event.preventDefault;
+                } else {
+                    if (!e.ctrlKey && !e.metaKey && isKeyDownHandlerAttached) {
+                        e.preventDefault();
+                        document.activeElement.blur();
+                        isMoving = true;
+                    }
                 }
             }
         }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -608,29 +608,34 @@ onUiLoaded(async() => {
 
         // Handle keydown events
         function handleKeyDown(event) {
+            // Disable key locks to make pasting from the buffer work correctly
+            if ((event.ctrlKey && event.code === 'KeyV') || event.code === "F5") {
+                return;
+            }
+
             // before activating shortcut, ensure user is not actively typing in an input field
-            if(event.target.nodeName === 'TEXTAREA' || event.target.nodeName === 'INPUT') {
-                event.preventDefault;
-            } else {
+            if (event.target.nodeName === 'TEXTAREA' || event.target.nodeName === 'INPUT') {
+                return;
+            }
 
-                const hotkeyActions = {
-                    [hotkeysConfig.canvas_hotkey_reset]: resetZoom,
-                    [hotkeysConfig.canvas_hotkey_overlap]: toggleOverlap,
-                    [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen
-                };
 
-                const action = hotkeyActions[event.code];
-                if (action) {
-                    event.preventDefault();
-                    action(event);
-                }
+            const hotkeyActions = {
+                [hotkeysConfig.canvas_hotkey_reset]: resetZoom,
+                [hotkeysConfig.canvas_hotkey_overlap]: toggleOverlap,
+                [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen
+            };
 
-                if (
-                    isModifierKey(event, hotkeysConfig.canvas_hotkey_zoom) ||
-                    isModifierKey(event, hotkeysConfig.canvas_hotkey_adjust)
-                ) {
-                    event.preventDefault();
-                }
+            const action = hotkeyActions[event.code];
+            if (action) {
+                event.preventDefault();
+                action(event);
+            }
+
+            if (
+                isModifierKey(event, hotkeysConfig.canvas_hotkey_zoom) ||
+                isModifierKey(event, hotkeysConfig.canvas_hotkey_adjust)
+            ) {
+                event.preventDefault();
             }
         }
 
@@ -692,16 +697,22 @@ onUiLoaded(async() => {
 
         // Handle the move event for pan functionality. Updates the panX and panY variables and applies the new transform to the target element.
         function handleMoveKeyDown(e) {
+
+            // Disable key locks to make pasting from the buffer work correctly
+            if ((e.ctrlKey && e.code === 'KeyV') || e.code === "F5") {
+                return;
+            }
+
+            // before activating shortcut, ensure user is not actively typing in an input field
+            if (e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'INPUT') {
+                return;
+            }
+
             if (e.code === hotkeysConfig.canvas_hotkey_move) {
-                // before activating shortcut, ensure user is not actively typing in an input field
-                if(e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'INPUT') {
-                    event.preventDefault;
-                } else {
-                    if (!e.ctrlKey && !e.metaKey && isKeyDownHandlerAttached) {
-                        e.preventDefault();
-                        document.activeElement.blur();
-                        isMoving = true;
-                    }
+                if (!e.ctrlKey && !e.metaKey && isKeyDownHandlerAttached) {
+                    e.preventDefault();
+                    document.activeElement.blur();
+                    isMoving = true;
                 }
             }
         }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -200,7 +200,8 @@ onUiLoaded(async() => {
         canvas_hotkey_move: "KeyF",
         canvas_hotkey_overlap: "KeyO",
         canvas_disabled_functions: [],
-        canvas_show_tooltip: true
+        canvas_show_tooltip: true,
+        canvas_blur_prompt: false
     };
 
     const functionMap = {
@@ -609,13 +610,15 @@ onUiLoaded(async() => {
         // Handle keydown events
         function handleKeyDown(event) {
             // Disable key locks to make pasting from the buffer work correctly
-            if ((event.ctrlKey && event.code === 'KeyV') || event.code === "F5") {
+            if ((event.ctrlKey && event.code === 'KeyV') || (event.ctrlKey && event.code === 'KeyC') || event.code === "F5") {
                 return;
             }
 
             // before activating shortcut, ensure user is not actively typing in an input field
-            if (event.target.nodeName === 'TEXTAREA' || event.target.nodeName === 'INPUT') {
-                return;
+            if (!hotkeysConfig.canvas_blur_prompt) {
+                if (event.target.nodeName === 'TEXTAREA' || event.target.nodeName === 'INPUT') {
+                    return;
+                }
             }
 
 
@@ -699,14 +702,17 @@ onUiLoaded(async() => {
         function handleMoveKeyDown(e) {
 
             // Disable key locks to make pasting from the buffer work correctly
-            if ((e.ctrlKey && e.code === 'KeyV') || e.code === "F5") {
+            if ((e.ctrlKey && e.code === 'KeyV') || (e.ctrlKey && event.code === 'KeyC') || e.code === "F5") {
                 return;
             }
 
             // before activating shortcut, ensure user is not actively typing in an input field
-            if (e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'INPUT') {
-                return;
+            if (!hotkeysConfig.canvas_blur_prompt) {
+                if (e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'INPUT') {
+                    return;
+                }
             }
+
 
             if (e.code === hotkeysConfig.canvas_hotkey_move) {
                 if (!e.ctrlKey && !e.metaKey && isKeyDownHandlerAttached) {

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -9,5 +9,6 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_hotkey_reset": shared.OptionInfo("R", "Reset zoom and canvas positon"),
     "canvas_hotkey_overlap": shared.OptionInfo("O", "Toggle overlap").info("Technical button, neededs for testing"),
     "canvas_show_tooltip": shared.OptionInfo(True, "Enable tooltip on the canvas"),
+    "canvas_blur_prompt": shared.OptionInfo(False, "Take the focus off the prompt when working with a canvas"),
     "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom","Adjust brush size", "Moving canvas","Fullscreen","Reset Zoom","Overlap"]}),
 }))


### PR DESCRIPTION
## Description

* fix for #11534
* check DOM event target before activating canvas zoom/pan shortcuts
* only activate shortcut when an input or textarea element is not in active focus

There are many ways this issue could be remediated, with a different set of tradeoffs. The fix in this PR is straightforward and does not change the overall approach for this feature. 

## Screenshots/videos:
* see video attached to original issue

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
