### PR TITLE
postprocessing: use read_info_from_image

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -662,6 +662,13 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     return fullfn, txt_fullfn
 
 
+IGNORED_INFO_KEYS = {
+    'jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
+    'loop', 'background', 'timestamp', 'duration', 'progressive', 'progression',
+    'icc_profile', 'chromaticity', 'photoshop',
+}
+
+
 def read_info_from_image(image):
     items = image.info or {}
 
@@ -679,9 +686,7 @@ def read_info_from_image(image):
             items['exif comment'] = exif_comment
             geninfo = exif_comment
 
-    for field in ['jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
-                    'loop', 'background', 'timestamp', 'duration', 'progressive', 'progression',
-                    'icc_profile', 'chromaticity']:
+    for field in IGNORED_INFO_KEYS:
         items.pop(field, None)
 
     if items.get("Software", None) == "NovelAI":

--- a/modules/images.py
+++ b/modules/images.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 import pytz
@@ -669,7 +671,7 @@ IGNORED_INFO_KEYS = {
 }
 
 
-def read_info_from_image(image):
+def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
     items = image.info or {}
 
     geninfo = items.pop('parameters', None)

--- a/modules/images.py
+++ b/modules/images.py
@@ -672,7 +672,7 @@ IGNORED_INFO_KEYS = {
 
 
 def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
-    items = image.info or {}
+    items = (image.info or {}).copy()
 
     geninfo = items.pop('parameters', None)
 

--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -54,7 +54,9 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
     for image, name in zip(image_data, image_names):
         shared.state.textinfo = name
 
-        existing_pnginfo = image.info or {}
+        parameters, existing_pnginfo = images.read_info_from_image(image)
+        if parameters:
+            existing_pnginfo["parameters"] = parameters
 
         pp = scripts_postprocessing.PostprocessedImage(image.convert("RGB"))
 


### PR DESCRIPTION
## Description

Related to #11594: this makes `postprocessing` use `read_info_from_image` (which knows how to clean out keys we don't want to schlep along, see https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10697), so we don't end up accidentally splatting e.g. an `exif` key with an invalid (repr-of-bytes) value into a PNG.

Also, make that function not mutate the `.info` of the passed-in Image 🤫 