### PR TITLE
Correctly pass arguments to webui.bat

### DIFF
--- a/webui-user.bat
+++ b/webui-user.bat
@@ -5,4 +5,4 @@ set GIT=
 set VENV_DIR=
 set COMMANDLINE_ARGS=
 
-call webui.bat
+call webui.bat %*


### PR DESCRIPTION
## Description

fix a bug when run webui.bat will not pass the arguments to webui.bat

## Screenshots/videos:


## Checklist:

- [ x ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ x ] I have performed a self-review of my own code
- [ x ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ x ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
