### PR TITLE
fix extra network replace preview gen info

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -383,7 +383,7 @@ def setup_ui(ui, gallery):
 
         assert is_allowed, f'writing to {filename} is not allowed'
 
-        save_image_with_geninfo(image, geninfo, filename)
+        save_image_with_geninfo(image, geninfo, filename, existing_pnginfo={'parameters': geninfo})
 
         return [page.create_html(ui.tabname) for page in ui.stored_extra_pages]
 


### PR DESCRIPTION
## Description
consider as a patch more than a permanent fix
currently the extra networks tab replace preview image button does not save the previous image with gen info with PNG file type
this wasn't the case in the past

the cause of this was due to various changes overtime causes the function of to be scattered `save_image_with_geninfo`
main cause commits
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/a6b618d07248267de36f0e8f4a847d997285e272
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10905

before the PR correct info saved
| | txt/img 2 img| post processing | replace preivew |
| --- | --- | --- | --- |
| png | working | working | not working |
| jpg | working | not working | working  |

after the PR correct info saved
| | txt/img 2 img| post processing | replace preivew |
| --- | --- | --- | --- |
| png | working | working | working |
| jpg | working | not working | working |

the real fix is to rewrite `save_image_with_geninfo`
or rather deprecated the current one and replace with a new one
due to this function is extensively used by lots of extensions
if we just remove it or read write it it will cause extensions to break

there are some differences about how we save metadata in JPEG and PNG
I'm not happy about it
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
