### PR TITLE
Fix warning of 'has_mps' deprecated from PyTorch

### DIFF
--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -4,16 +4,21 @@ from modules.sd_hijack_utils import CondFunc
 from packaging import version
 
 
-# has_mps is only available in nightly pytorch (for now) and macOS 12.3+.
-# check `getattr` and try it for compatibility
+# before torch version 1.13, has_mps is only available in nightly pytorch and macOS 12.3+,
+# use check `getattr` and try it for compatibility.
+# in torch version 1.13, backends.mps.is_available() and backends.mps.is_built() are introduced in to check mps availabilty,
+# since torch 2.0.1+ nightly build, getattr(torch, 'has_mps', False) was deprecated, see https://github.com/pytorch/pytorch/pull/103279
 def check_for_mps() -> bool:
-    if not getattr(torch, 'has_mps', False):
-        return False
-    try:
-        torch.zeros(1).to(torch.device("mps"))
-        return True
-    except Exception:
-        return False
+    if version.parse(torch.__version__) <= version.parse("2.0.1"):
+        if not getattr(torch, 'has_mps', False):
+            return False
+        try:
+            torch.zeros(1).to(torch.device("mps"))
+            return True
+        except Exception:
+            return False
+    else:
+        return torch.backends.mps.is_available() and torch.backends.mps.is_built()
 has_mps = check_for_mps()
 
 


### PR DESCRIPTION
## Description

Before torch version 1.13, `has_mps` is only available in nightly pytorch and macOS 12.3+, use check `getattr` and try it for compatibility. In torch version 1.13, backends.mps.is_available() and backends.mps.is_built() are introduced in to check mps availabilty

since torch 2.0.1+ nightly build, getattr(torch, 'has_mps', False) was deprecated, due to this change https://github.com/pytorch/pytorch/pull/103279
and a warning info will display:

> UserWarning: 'has_mps' is deprecated, please use 'torch.backends.mps.is_built()'

This PR will fix this warning caused by the latest PyTorch nightly build (version > 2.0.1), as well as is compatible with the legacy version of PyTorch 1.x.

This fix has been tested with webui 1.4 + PyTorch 1.12.1 + torchvision 0.13.1 + Python3.10


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
