### PR TITLE
fix(api): convert to "RGB" if image mode is "RGBA" #11655

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -84,6 +84,8 @@ def encode_pil_to_base64(image):
             image.save(output_bytes, format="PNG", pnginfo=(metadata if use_metadata else None), quality=opts.jpeg_quality)
 
         elif opts.samples_format.lower() in ("jpg", "jpeg", "webp"):
+            if image.mode == "RGBA":
+                image = image.convert("RGB")
             parameters = image.info.get('parameters', None)
             exif_bytes = piexif.dump({
                 "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(parameters or "", encoding="unicode") }


### PR DESCRIPTION
## Description

* ControlNet (`preprocessor: inpaint_only+lama, model: control_v11p_sd15_inpaint [ebff9138]`)  is correctly called through the API.
* If the output image is in RGBA mode, convert it to RGB.
* Fix #11655

## Screenshots/videos:
N/A.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
