### PR TITLE
Revert #11244

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -391,7 +391,6 @@ options_templates.update(options_section(('system', "System"), {
     "print_hypernet_extra": OptionInfo(False, "Print extra hypernetwork information to console."),
     "list_hidden_files": OptionInfo(True, "Load models/files in hidden directories").info("directory is hidden if its name starts with \".\""),
     "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
-    "github_proxy": OptionInfo("None", "Github proxy", ui_components.DropdownEditable, lambda: {"choices": ["None", "ghproxy.com", "hub.yzuu.cf", "hub.njuu.cf", "hub.nuaa.cf"]}).info("for custom inputs will just replace github.com with the input"),
 }))
 
 options_templates.update(options_section(('training', "Training"), {

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -325,17 +325,6 @@ def normalize_git_url(url):
     return url
 
 
-def github_proxy(url):
-    proxy = shared.opts.github_proxy
-
-    if proxy == 'None':
-        return url
-    if proxy == 'ghproxy.com':
-        return "https://ghproxy.com/" + url
-
-    return url.replace('github.com', proxy)
-
-
 def install_extension_from_url(dirname, url, branch_name=None):
     check_access()
 
@@ -345,8 +334,6 @@ def install_extension_from_url(dirname, url, branch_name=None):
         url = url.strip()
 
     assert url, 'No URL specified'
-
-    url = github_proxy(url)
 
     if dirname is None or dirname == "":
         *parts, last_part = url.split('/')
@@ -367,12 +354,12 @@ def install_extension_from_url(dirname, url, branch_name=None):
         shutil.rmtree(tmpdir, True)
         if not branch_name:
             # if no branch is specified, use the default branch
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], verbose=False) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none']) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
         else:
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], branch=branch_name, verbose=False) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], branch=branch_name) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()


### PR DESCRIPTION
## Description

This reverts pull request #11244 by the reasons specified at https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11244#issuecomment-1627686913

> - The URL of mirrored extension is applied on the clone phase, and is recorded to the on-disk config, which means if a mirror is down for whatever reason, it would be hard for users without git knowledge to turn this off, or replace the already set URL other than reinstalling all extensions (which is the case for most of the Chinese user).
> - So far the normalize_git_url still considers the remote URL as a whole, which makes the extension index unable to match installed extensions.
> - The mirror should only be applied to GitHub urls, while a considerable part of users in China uses domestic Git repositories and a choice here would break them.
> - This PR works only on Install from URL tab, and it does no help in launching the webui itself as it stills access github on its launch (which makes the move to system config more inappropriate).
> - This PR does not fix the connection when an extension has a git submodule on GitHub as well.
> - As a voluntary public service provided by an individual, it might not be appropriate to be included in such manner.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
