### PR TITLE
fix: add queue lock for refresh-checkpoints

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -593,7 +593,8 @@ class Api:
         }
 
     def refresh_checkpoints(self):
-        shared.refresh_checkpoints()
+        with self.queue_lock:
+            shared.refresh_checkpoints()
 
     def create_embedding(self, args: dict):
         try:


### PR DESCRIPTION
## Description
Asynchronous call of **refresh-checkpoints** and **txt2img** has a certain probability of causing server crashes. This is because refresh-checkpoints is not locked via queue_lock. **refresh-checkpoints** clears the checkpoint list before rebuilding it. If txt2img is called at this moment, it will result in the following error:

```
self.run_forever ()
File "/opt/conda/1ib/python3 .10/asyncio/base_events.py", line 636, in run_until_complete
return loop.run_until_complete (main)
File "/opt/conda/lib/python3.10/asyncio/runners.py", line 44, in run ERROR:
Traceback (most recent call last):
Can't run without a checkpoint. Find and place a .ckpt or .safetensors file into any of th
- directory /s3/mount/sagemaker/model/diffusion_model/deploy/Stable-diffusion
- directory /content/stable-diffusion-webui/models/Stable-diffusion
- file /content/stable-diffusion-webui/model.ckpt
No checkpoints found. When searching for checkpoints, looked at:
```

And then, this error will cause the server to be stuck for a period of time.
```
unhandled exception during asyncio.run() shutdown
SystemExit: 1
raise SystemExit (code)
File "/opt/conda/lib/python3.10/_-sitebuiltins.py", line 26, in __call_-
exit (1)
File "/content/stable-diffusion-webui/modules/sd_models.py", line 171, in select_checkpo
checkpoint_info = info or select_checkpoint ()
```

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/394ffa7b0a7fff3ec484bcd084e673a8b301ccc8/modules/shared.py#L286-L288

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/394ffa7b0a7fff3ec484bcd084e673a8b301ccc8/modules/sd_models.py#L113-L135
