### PR TITLE
use url.<base>.insteadOf

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -325,15 +325,14 @@ def normalize_git_url(url):
     return url
 
 
-def github_proxy(url):
+def github_proxy_insteadof():
     proxy = shared.opts.github_proxy
-
     if proxy == 'None':
-        return url
-    if proxy == 'ghproxy.com':
-        return "https://ghproxy.com/" + url
+        return None
 
-    return url.replace('github.com', proxy)
+    if proxy == 'ghproxy.com':
+        return 'url.https://ghproxy.com/https://github.com/.insteadof=https://github.com/'
+    return f'url.https://{proxy}/.insteadof=https://github.com/'
 
 
 def install_extension_from_url(dirname, url, branch_name=None):
@@ -345,8 +344,6 @@ def install_extension_from_url(dirname, url, branch_name=None):
         url = url.strip()
 
     assert url, 'No URL specified'
-
-    url = github_proxy(url)
 
     if dirname is None or dirname == "":
         *parts, last_part = url.split('/')
@@ -367,12 +364,12 @@ def install_extension_from_url(dirname, url, branch_name=None):
         shutil.rmtree(tmpdir, True)
         if not branch_name:
             # if no branch is specified, use the default branch
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], verbose=False) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], c=[github_proxy_insteadof()]) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
         else:
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], branch=branch_name, verbose=False) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], c=[github_proxy_insteadof()], branch=branch_name) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()


### PR DESCRIPTION
## Description
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11707
writes url.<base>.insteadOf to local git conig before cloning

I did some simulation test seems to work but cannot truly test

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
