### PR TITLE
Fix MPS cache cleanup

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -54,8 +54,9 @@ def torch_gc():
         with torch.cuda.device(get_cuda_device_string()):
             torch.cuda.empty_cache()
             torch.cuda.ipc_collect()
-    elif has_mps() and hasattr(torch.mps, 'empty_cache'):
-        torch.mps.empty_cache()
+
+    if has_mps():
+        mac_specific.torch_mps_gc()
 
 
 def enable_tf32():

--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -1,7 +1,11 @@
+import logging
+
 import torch
 import platform
 from modules.sd_hijack_utils import CondFunc
 from packaging import version
+
+log = logging.getLogger()
 
 
 # before torch version 1.13, has_mps is only available in nightly pytorch and macOS 12.3+,
@@ -19,7 +23,17 @@ def check_for_mps() -> bool:
             return False
     else:
         return torch.backends.mps.is_available() and torch.backends.mps.is_built()
+
+
 has_mps = check_for_mps()
+
+
+def torch_mps_gc() -> None:
+    try:
+        from torch.mps import empty_cache
+        empty_cache()
+    except Exception:
+        log.warning("MPS garbage collection failed", exc_info=True)
 
 
 # MPS workaround for https://github.com/pytorch/pytorch/issues/89784


### PR DESCRIPTION
Importing torch does not import torch.mps so the call failed.

This moves the MPS specific cleanup to the `mac_specific` module too.

See https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/da8916f92649fc4d947cb46d9d8f8ea1621b2a59#commitcomment-121183933

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
  - in specific, it Works on My Mac