### PR TITLE
fix: timeout_keep_alive_handler error

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -715,4 +715,4 @@ class Api:
 
     def launch(self, server_name, port):
         self.app.include_router(self.router)
-        uvicorn.run(self.app, host=server_name, port=port, timeout_keep_alive=0)
+        uvicorn.run(self.app, host=server_name, port=port, timeout_keep_alive=shared.cmd_opts.timeout_keep_alive)

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -107,3 +107,4 @@ parser.add_argument("--no-hashing", action='store_true', help="disable sha256 ha
 parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
 parser.add_argument('--subpath', type=str, help='customize the subpath for gradio, use with reverse proxy')
 parser.add_argument('--add-stop-route', action='store_true', help='add /_stop route to stop server')
+parser.add_argument('--timeout-keep-alive', type=int, default=30, help='set timeout_keep_alive for uvicorn')


### PR DESCRIPTION
In this PR: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10635 
@montyanderson  try to fix the error: timeout_keep_alive.
But I am sure : when set timeout_keep_alive to 0, this error still happened.
There are some users's feedback, just like: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10625 

In my case, when I set timeout_keep_alive >= 20, there is not this error any more.

I guess this error is happen, because of the webui server can not to response to client. The reason is : 
The connection is termination by uvicorn, because uvicorn cannot reach client, 
so uvicorn think this connection is not alive because time is out.
And then this error is happened.

I am not aware of other users' network environments, therefore, I have set the default value to 30 seconds and added an option.

Note: this PR only can fix the mode with (--nowebui). because I have not find how to set gradio timeout_keep_alive.
So if you have this error, please add --nowebui, and try to set --timeout-keep-alive to a large number, like 60
