### PR TITLE
Allow using alt in the prompt fields again

### DIFF
--- a/javascript/edit-order.js
+++ b/javascript/edit-order.js
@@ -6,11 +6,11 @@ function keyupEditOrder(event) {
     let target = event.originalTarget || event.composedPath()[0];
     if (!target.matches("*:is([id*='_toprow'] [id*='_prompt'], .prompt) textarea")) return;
     if (!event.altKey) return;
-    event.preventDefault();
 
     let isLeft = event.key == "ArrowLeft";
     let isRight = event.key == "ArrowRight";
     if (!isLeft && !isRight) return;
+    event.preventDefault();
 
     let selectionStart = target.selectionStart;
     let selectionEnd = target.selectionEnd;


### PR DESCRIPTION
A keypress event being prevented when the alt key is down is not good for key layouts where you need alt to compose e.g. a bracket.

This also prevented using e.g. cmd+opt+i to open the inspector when that field was focused.

Regressed in 7a6abc59ea1ecd8bb311de1719b018fb5960cd80.