### PR TITLE
Don't do MPS GC when there's a latent

### DIFF
--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -5,7 +5,7 @@ import platform
 from modules.sd_hijack_utils import CondFunc
 from packaging import version
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 # before torch version 1.13, has_mps is only available in nightly pytorch and macOS 12.3+,

--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -30,6 +30,10 @@ has_mps = check_for_mps()
 
 def torch_mps_gc() -> None:
     try:
+        from modules.shared import state
+        if state.current_latent is not None:
+            log.debug("`current_latent` is set, skipping MPS garbage collection")
+            return
         from torch.mps import empty_cache
         empty_cache()
     except Exception:


### PR DESCRIPTION
## Description

I got a bunch of
```
failed assertion `commit an already committed command buffer'
```
post da8916f92649fc4d947cb46d9d8f8ea1621b2a59 – running with `python -X faulthandler` reveals these happen when there's another thread doing the in-progress preview.

This _should_ work around that issue by not allowing the GC to occur if there's a current latent tensor, but this might not be enough.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
