### PR TITLE
Use submit and blur for quick settings textbox

### DIFF
--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -260,13 +260,20 @@ class UiSettings:
             component = self.component_dict[k]
             info = opts.data_labels[k]
 
-            change_handler = component.release if hasattr(component, 'release') else component.change
-            change_handler(
-                fn=lambda value, k=k: self.run_settings_single(value, key=k),
-                inputs=[component],
-                outputs=[component, self.text_settings],
-                show_progress=info.refresh is not None,
-            )
+            if isinstance(component, gr.Textbox):
+                methods = [component.submit, component.blur]
+            elif hasattr(component, 'release'):
+                methods = [component.release]
+            else:
+                methods = [component.change]
+
+            for method in methods:
+                method(
+                    fn=lambda value, k=k: self.run_settings_single(value, key=k),
+                    inputs=[component],
+                    outputs=[component, self.text_settings],
+                    show_progress=info.refresh is not None,
+                )
 
         button_set_checkpoint = gr.Button('Change checkpoint', elem_id='change_checkpoint', visible=False)
         button_set_checkpoint.click(


### PR DESCRIPTION
## Description
[[Bug]: Can't normal edit Directory name pattern after add it to Quicksettings list ! ](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11740)
when textbox is in quick settings fit one typing too fast can cause the textbox to glitch
the issue is caused by the settings update speed is unable to keep up with the typing speed

my solution
switch to `blur`  `submit` https://www.gradio.app/docs/textbox
only update settings when textbook is released or when Enter is pressed

it was using `change` since `release` is not available

`submit` is a bit redundant, but I suppose someone could press `Enter` then press `Ctrl Enter` to generate something
unfortunately `submit` doesn't trigger on `control enter`

maybe a better solution could be achieved by buffer the input using JavaScript
but I am bad with JavaScript and I don't want to add any complications

## Screenshots/videos:
issue example in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11740


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
