### PR TITLE
Added [none] filename token.

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -380,6 +380,7 @@ class FilenameGenerator:
         'denoising': lambda self: self.p.denoising_strength if self.p and self.p.denoising_strength else NOTHING_AND_SKIP_PREVIOUS_TEXT,
         'user': lambda self: self.p.user,
         'vae_filename': lambda self: self.get_vae_filename(),
+        'none': lambda self: '', # Overrides the default so you can get just the sequence number
     }
     default_time_format = '%Y%m%d%H%M%S'
 
@@ -601,12 +602,12 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         else:
             file_decoration = opts.samples_filename_pattern or "[seed]-[prompt_spaces]"
 
+        file_decoration = namegen.apply(file_decoration) + suffix
+
         add_number = opts.save_images_add_number or file_decoration == ''
 
         if file_decoration != "" and add_number:
             file_decoration = f"-{file_decoration}"
-
-        file_decoration = namegen.apply(file_decoration) + suffix
 
         if add_number:
             basecount = get_next_sequence_number(path, basename)


### PR DESCRIPTION
## Description

* Added [none] filename token
* Shouldn't be used with any other token
* Allows the user to override the default tokens of [seed] or [seed]-[prompt] to use just the sequence number
* Users need to be able to generate files with sequence numbers only in order to be able to automatically import as a sequence into NLE software such as Adobe Premiere

## Screenshots/videos:


## Checklist:

- [X ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X ] I have performed a self-review of my own code
- [X ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
One test failed, but it's the same as on dev. "test_watermark.py" with "ModuleNotFoundError: No module named 'fire'". Not related.