### PR TITLE
Warns merge into master

### DIFF
--- a/.github/workflows/warns_merge_master.yml
+++ b/.github/workflows/warns_merge_master.yml
@@ -1,0 +1,19 @@
+name: Pull requests can't target master branch
+
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warning marge into master
+        run: |
+          echo -e "::warning::This pull request directly merge into \"master\" branch, normally development happens on \"dev\" branch."
+          exit 1


### PR DESCRIPTION
## Description
Attempt to address a bug known as `AUTOMATIC1111`
unfortunately I can only speculate on the cause of the bug as this mysterious entity is stroud in mystery
we only know that the bug happened sporadically, more research is needed

run a action that deliberately fails when a pull request targets master branch
it doesn't prevent it but it makes it obvious that a pull request is going into master

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/be45f858-44c1-4858-b37b-d867dcc740f4)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
