### PR TITLE
404 when thumb file not found

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -8,6 +8,7 @@ from modules.ui import up_down_symbol
 import gradio as gr
 import json
 import html
+from fastapi.exceptions import HTTPException
 
 from modules.generation_parameters_copypaste import image_from_url_text
 
@@ -25,6 +26,9 @@ def register_page(page):
 
 def fetch_file(filename: str = ""):
     from starlette.responses import FileResponse
+
+    if not os.path.isfile(filename):
+        raise HTTPException(status_code=404, detail="File not found")
 
     if not any(Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs):
         raise ValueError(f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages.")


### PR DESCRIPTION
## Description
Response 404 instead of crash when thumb file is not found.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
