### PR TITLE
cached_data_for_file() it's not just used used safesensor

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -94,4 +94,4 @@ def cached_data_for_file(subsection, title, filename, func):
 
         dump_cache()
 
-    return entry['value']
+    return entry


### PR DESCRIPTION
## Description
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/ccd97886da1f659472cdca3de8731f59a70bbc28 breaks extension
cached_data_for_file is broken for extension

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
