### PR TITLE
Bring the "Always discard next-to-last sigma" setting to the X/Y/Z sc…

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -98,9 +98,9 @@ def apply_clip_skip(p, x, xs):
 
 
 def apply_always_discard_next_to_last_sigma(p, x, xs):
-    if len(x) == 0: 
+    if len(x) == 0:
         p.override_settings['always_discard_next_to_last_sigma'] = False
-    if 'True' in x: 
+    if 'True' in x:
         p.override_settings['always_discard_next_to_last_sigma'] = True
     else:
         p.override_settings['always_discard_next_to_last_sigma'] = False

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -97,6 +97,15 @@ def apply_clip_skip(p, x, xs):
     opts.data["CLIP_stop_at_last_layers"] = x
 
 
+def apply_always_discard_next_to_last_sigma(p, x, xs):
+    if len(x) == 0: 
+        p.override_settings['always_discard_next_to_last_sigma'] = False
+    if 'True' in x: 
+        p.override_settings['always_discard_next_to_last_sigma'] = True
+    else:
+        p.override_settings['always_discard_next_to_last_sigma'] = False
+
+
 def apply_upscale_latent_space(p, x, xs):
     if x.lower().strip() != '0':
         opts.data["use_scale_latent_for_hires_fix"] = True
@@ -226,6 +235,7 @@ axis_options = [
     AxisOption("Schedule rho", float, apply_override("rho")),
     AxisOption("Eta", float, apply_field("eta")),
     AxisOption("Clip skip", int, apply_clip_skip),
+    AxisOption("Always discard next-to-last sigma", str, apply_always_discard_next_to_last_sigma, choices=lambda: ["False", "True"]),
     AxisOption("Denoising", float, apply_field("denoising_strength")),
     AxisOptionTxt2Img("Hires upscaler", str, apply_field("hr_upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
     AxisOptionImg2Img("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")),


### PR DESCRIPTION
Just a quick entry to the type list of the X/Y/Z script to be able to target the "Always discard next-to-last sigma" setting.

## Description

* An entry in the list with strings "True" and "False"
* A new function to process True & False as I couldn't make it work with boolean choices
* The function defaults to False if no entry is passed (shouldn't happen but you never know)

## Screenshots/videos:
![xyz](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4924572/ec66b0a3-0025-4be8-8471-db10e52e9d5e)

Makes running the same prompt against Clip skip for instance easier.

![xyz_grid-0010-realisian_v50-2916047939-action shot 1girl extremely detailed book](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4924572/cd053b8e-807e-4dc6-ac71-e945a4420a9c)

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
