### PR TITLE
XYZ always_discard_next_to_last_sigma

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -147,7 +147,7 @@ def apply_face_restore(p, opt, x):
 def apply_override(field, boolean: bool = False):
     def fun(p, x, xs):
         if boolean:
-            x = True if x == "True" else False
+            x = True if x.lower() == "true" else False
         p.override_settings[field] = x
     return fun
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -144,10 +144,17 @@ def apply_face_restore(p, opt, x):
     p.restore_faces = is_active
 
 
-def apply_override(field):
+def apply_override(field, boolean: bool = False):
     def fun(p, x, xs):
+        if boolean:
+            x = True if x == "True" else False
         p.override_settings[field] = x
     return fun
+
+
+def boolean_choice():
+    return ["True", "False"]
+
 
 def format_value_add_label(p, opt, x):
     if type(x) == float:
@@ -235,6 +242,7 @@ axis_options = [
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
     AxisOption("Token merging ratio", float, apply_override('token_merging_ratio')),
     AxisOption("Token merging ratio high-res", float, apply_override('token_merging_ratio_hr')),
+    AxisOption("Always discard next-to-last sigma", str, apply_override('always_discard_next_to_last_sigma', boolean=True), choices=boolean_choice),
 ]
 
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -152,8 +152,10 @@ def apply_override(field, boolean: bool = False):
     return fun
 
 
-def boolean_choice():
-    return ["True", "False"]
+def boolean_choice(reverse: bool = False):
+    def choice():
+        return ["False", "True"] if reverse else ["True", "False"]
+    return choice
 
 
 def format_value_add_label(p, opt, x):
@@ -242,7 +244,7 @@ axis_options = [
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
     AxisOption("Token merging ratio", float, apply_override('token_merging_ratio')),
     AxisOption("Token merging ratio high-res", float, apply_override('token_merging_ratio_hr')),
-    AxisOption("Always discard next-to-last sigma", str, apply_override('always_discard_next_to_last_sigma', boolean=True), choices=boolean_choice),
+    AxisOption("Always discard next-to-last sigma", str, apply_override('always_discard_next_to_last_sigma', boolean=True), choices=boolean_choice(reverse=True)),
 ]
 
 


### PR DESCRIPTION
## Description
alternative implementation of https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11817

key difference of implementation
the functions can be reused for other fields

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
