### PR TITLE
Add support for using `--upcast-sampling` with SD XL

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -326,7 +326,7 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
 
         timer.record("apply half()")
 
-    devices.dtype_unet = model.model.diffusion_model.dtype
+    devices.dtype_unet = torch.float16 if model.is_sdxl and not shared.cmd_opts.no_half else model.model.diffusion_model.dtype
     devices.unet_needs_upcast = shared.cmd_opts.upcast_sampling and devices.dtype == torch.float16 and devices.dtype_unet == torch.float16
 
     model.first_stage_model.to(devices.dtype_vae)


### PR DESCRIPTION
## Description
- Fix the `apply_model` hijack for upcast sampling so that it does not convert all of the `cond` dictionary values into lists
- Add the upcast sampling hijacks for SD XL
- `model.model.diffusion_model.dtype` is always `torch.float32` for SD XL (likely due to the removal of `use_fp16`), so assume float16 if `.half()` was applied

This fixes the crashes when using SD XL on macOS without `--no-half`.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

## Environment this was tested in:

 - OS: macOS 13.4.1 (c)
 - Browser: Safari
 - Graphics card: M1 Max 64 GB