### PR TITLE
Only start timer when actually starting

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -1,4 +1,4 @@
-from modules import launch_utils, timer
+from modules import launch_utils
 
 
 args = launch_utils.args
@@ -26,6 +26,7 @@ start = launch_utils.start
 
 
 def main():
+    from modules import timer
     timer.startup_timer.record("start")
 
     if not args.skip_prepare_environment:

--- a/launch.py
+++ b/launch.py
@@ -1,4 +1,4 @@
-from modules import launch_utils
+from modules import launch_utils, timer
 
 
 args = launch_utils.args
@@ -25,6 +25,8 @@ start = launch_utils.start
 
 
 def main():
+    timer.startup_timer.record("start")
+
     if not args.skip_prepare_environment:
         prepare_environment()
 

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -213,7 +213,7 @@ for key, metadata in opts.data_labels.items():
         value = None
     optType = opts.typemap.get(type(metadata.default), type(value))
 
-    if optType == types.NoneType:
+    if isinstance(optType, types.NoneType):
         pass
     elif metadata is not None:
         fields.update({key: (Optional[optType], Field(default=metadata.default, description=metadata.label))})

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -10,9 +10,6 @@ from functools import lru_cache
 
 from modules import cmd_args, errors
 from modules.paths_internal import script_path, extensions_dir
-from modules import timer
-
-timer.startup_timer.record("start")
 
 args, _ = cmd_args.parser.parse_known_args()
 


### PR DESCRIPTION
## Description

move the start timer to the actual entrypoint

prevent actually starting a timer (on the comfy extension)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
