### PR TITLE
Fix missing p save_image before-highres-fix

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1029,7 +1029,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 image = sd_samplers.sample_to_image(image, index, approximation=0)
 
             info = create_infotext(self, self.all_prompts, self.all_seeds, self.all_subseeds, [], iteration=self.iteration, position_in_batch=index)
-            images.save_image(image, self.outpath_samples, "", seeds[index], prompts[index], opts.samples_format, info=info, suffix="-before-highres-fix")
+            images.save_image(image, self.outpath_samples, "", seeds[index], prompts[index], opts.samples_format, info=info, p=self, suffix="-before-highres-fix")
 
         if latent_scale_mode is not None:
             for i in range(samples.shape[0]):


### PR DESCRIPTION
## Description
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/b010eea520caa90d2a31d98ec7c4a9d9d540c9ad/modules/processing.py#L1032
fix missing p for images.save_image `before-highres-fix`
the missing p case all filename patterns that use p to not work

the other 2 intermediate saves `before-color-correction` `before-face-restoration` all have p
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/b010eea520caa90d2a31d98ec7c4a9d9d540c9ad/modules/processing.py#L786
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/b010eea520caa90d2a31d98ec7c4a9d9d540c9ad/modules/processing.py#L803

I have no idea how this bug survive 7 months without being noticed
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/4d66bf2c0d27702cc83b9cc57ebb1f359d18d938
## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
