### PR TITLE
Restart sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Licenses for borrowed code can be found in `Settings -> Licenses` screen, and al
 
 - Stable Diffusion - https://github.com/CompVis/stable-diffusion, https://github.com/CompVis/taming-transformers
 - k-diffusion - https://github.com/crowsonkb/k-diffusion.git
+- Restart sampling - https://github.com/Newbeeer/diffusion_restart_sampling
 - GFPGAN - https://github.com/TencentARC/GFPGAN.git
 - CodeFormer - https://github.com/sczhou/CodeFormer
 - ESRGAN - https://github.com/xinntao/ESRGAN

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -89,11 +89,12 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
             restart_steps, restart_times, restart_max = restart_list[i + 1]
             min_idx = i + 1
             max_idx = int(torch.argmin(abs(sigmas - restart_max), dim=0))
-            sigma_restart = get_sigmas_karras(restart_steps, sigmas[min_idx], sigmas[max_idx], device=sigmas.device)[:-1] # remove the zero at the end
-            for times in range(restart_times):
-                x = x + torch.randn_like(x) * s_noise * (sigmas[max_idx] ** 2 - sigmas[min_idx] ** 2) ** 0.5
-                for (old_sigma, new_sigma) in zip(sigma_restart[:-1], sigma_restart[1:]):
-                    x = heun_step(x, old_sigma, new_sigma)
+            if max_idx < min_idx:
+                sigma_restart = get_sigmas_karras(restart_steps, sigmas[min_idx], sigmas[max_idx], device=sigmas.device)[:-1] # remove the zero at the end
+                for times in range(restart_times):
+                    x = x + torch.randn_like(x) * s_noise * (sigmas[max_idx] ** 2 - sigmas[min_idx] ** 2) ** 0.5
+                    for (old_sigma, new_sigma) in zip(sigma_restart[:-1], sigma_restart[1:]):
+                        x = heun_step(x, old_sigma, new_sigma)
     return x
 
 samplers_data_k_diffusion = [

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -43,7 +43,7 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     step_id = 0
-    from k_diffusion.sampling import to_d, append_zero, get_sigmas_karras
+    from k_diffusion.sampling import to_d, get_sigmas_karras
     def heun_step(x, old_sigma, new_sigma, second_order = True):
         nonlocal step_id
         denoised = model(x, old_sigma * s_in, **extra_args)

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -67,7 +67,10 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
     if restart_list is None:
         if steps >= 20:
             restart_steps = 9
-            restart_times = 2 if steps >= 36 else 1
+            restart_times = 1
+            if steps >= 36:
+                restart_steps = steps // 4
+                restart_times = 2
             sigmas = get_sigmas_karras(steps - restart_steps * restart_times, sigmas[-2].item(), sigmas[0].item(), device=sigmas.device)
             restart_list = {0.1: [restart_steps + 1, restart_times, 2]}
         else:

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -1,5 +1,3 @@
-# export PIP_CACHE_DIR=/scratch/dengm/cache
-# export XDG_CACHE_HOME=/scratch/dengm/cache
 from collections import deque
 import torch
 import inspect


### PR DESCRIPTION
## Description

Added the restart sampler as described in https://arxiv.org/pdf/2306.14878.pdf. The changes are made in sd_samplers_kdiffusion.py. Also added credit in README.md. 

Since last pull request, tuned the parameters so there won't be 18 additional steps. 

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/46507649/7a7744d7-aaa5-4f81-9d8e-24224185fc34)


## Checklist:

- [Y] I have read [[contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [Y] I have performed a self-review of my own code
- [Y] My code follows the [[style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [Y] My code passes [[tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)](