### PR TITLE
fix webui with subpath return 404

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -387,6 +387,9 @@ def webui():
 
         gradio_auth_creds = list(get_gradio_auth_creds()) or None
 
+        root_path = ""
+        if cmd_opts.subpath:
+            root_path = f"/{cmd_opts.subpath}"
         app, local_url, share_url = shared.demo.launch(
             share=cmd_opts.share,
             server_name=server_name,
@@ -403,6 +406,7 @@ def webui():
                 "docs_url": "/docs",
                 "redoc_url": "/redoc",
             },
+            root_path = root_path,
         )
         if cmd_opts.add_stop_route:
             app.add_route("/_stop", stop_route, methods=["POST"])


### PR DESCRIPTION
## Description

* I deploy some diffusion instances in a Kubernetes cluster and access these instances by a domain name。
* in my case, the domain name is test.com, I want `test.com/diffusion-0` to access the `diffusion-0` pod, `test.com/diffusion-1` to access the `diffusion-1` pod, etc...
* pod's entrypoint command is: `./webui.sh -f --listen --theme dark --api --xformers --enable-insecure-extension-access --subpath ${HOSTNAME} `
* ingress yaml is:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
    nginx.ingress.kubernetes.io/configuration-snippet: |
      rewrite /[^/]+/(.*) /$1 break;
    nginx.ingress.kubernetes.io/proxy-body-size: 10m
  name: diffusion
  namespace: default
spec:
  rules:
  - host: test.com
    http:
      paths:
      - backend:
          service:
            name: diffusion-0
            port:
              number: 7860
        path: /diffusion-0/
        pathType: ImplementationSpecific
```
* When accessing `test.com/diffusion-0/`, the browser sends requests to "/info" and "/theme.css", and returns 404, it should send requests to `/diffusion-0/info` and `/diffusion-0/theme.css`.
## Screenshots/videos:

## Checklist:

- [ Y ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ Y ] I have performed a self-review of my own code
- [ Y ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ Y ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
