### PR TITLE
Adding support for FlashAttention (flash-attn) optimization

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -53,6 +53,7 @@ parser.add_argument("--clip-models-path", type=str, help="Path to directory with
 parser.add_argument("--xformers", action='store_true', help="enable xformers for cross attention layers")
 parser.add_argument("--force-enable-xformers", action='store_true', help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work")
 parser.add_argument("--xformers-flash-attention", action='store_true', help="enable xformers with Flash Attention to improve reproducibility (supported for SD2.x or variant only)")
+parser.add_argument("--flash-attn", action='store_true', help="use FlashAttention(-2) for cross attention layers (flash_attn package required)")
 parser.add_argument("--deepdanbooru", action='store_true', help="does not do anything")
 parser.add_argument("--opt-split-attention", action='store_true', help="prefer Doggettx's cross-attention layer optimization for automatic choice of optimization")
 parser.add_argument("--opt-sub-quad-attention", action='store_true', help="prefer memory efficient sub-quadratic cross-attention layer optimization for automatic choice of optimization")


### PR DESCRIPTION
## Description

Adding support for FlashAttention (flash-attn) optimization, which FlashAttention-2 has missive performance improvement over --xformers (current version) or --opt-sdp-attention on large images.

### Usage
To use this PR, you need to manually install the `flash-attn` package (version 2.0+ for FlashAttention-2), following https://github.com/Dao-AILab/flash-attention#installation-and-features. (Note: set MAX_JOBS=1 if you run out of memory during pip install)

Note that for now flash-attn 2.0+ will break `transformers`, which is one of sd webui's dependency.  
(a simple hack is add a line of `flash_attn_unpadded_func = flash_attn_varlen_func` to the end of `<python's lib dir>/site-packages/flash_attn/flash_attn_interface.py`)

Then add `--flash-attn` to the launch arguments to activate this.

More info: see discussion #11884 

## Screenshots/videos:
See discussion #11884 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
