### PR TITLE
fix vae loading order

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -240,6 +240,8 @@ def initialize():
     modelloader.cleanup_models()
     configure_opts_onchange()
 
+    modules.sd_vae.refresh_vae_list()
+    startup_timer.record("refresh VAE")
     modules.sd_models.setup_model()
     startup_timer.record("setup SD model")
 
@@ -283,8 +285,6 @@ def initialize_rest(*, reload_script_modules=False):
     modelloader.load_upscalers()
     startup_timer.record("load upscalers")
 
-    modules.sd_vae.refresh_vae_list()
-    startup_timer.record("refresh VAE")
     modules.textual_inversion.textual_inversion.list_textual_inversion_templates()
     startup_timer.record("refresh textual inversion templates")
 


### PR DESCRIPTION
## Description

* fix vae loading order: call `sd_vae.refresh_vae_list()` before `modules.sd_models.setup_model()`

## Screenshots:
before
~~~bash
...
venv "F:\webui\webui\stable-diffusion-webui\venv\Scripts\Python.exe"
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)]
Version: v1.4.1
Commit hash: f865d3e11647dfd6c7b2cdf90dde24680e58acd8
Installing requirements
...
Loading weights [xxxxxxxxxx] from F:\webui\webui\stable-diffusion-webui\models\Stable-diffusion\foobar.safetensors
Creating model from config: F:\webui\webui\stable-diffusion-webui\configs\v1-inference.yaml
LatentDiffusion: Running in eps-prediction mode
DiffusionWrapper has 859.52 M params.
Couldn't find VAE named kl-f8-anime2.ckpt; using None instead
Textual inversion embeddings loaded(26):...
~~~
after
~~~bash
...
Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\kl-f8-anime2.ckpt
~~~
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
