### PR TITLE
Fix composable diffusion weight parsing

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -153,7 +153,7 @@ def get_learned_conditioning(model, prompts, steps):
 
 
 re_AND = re.compile(r"\bAND\b")
-re_weight = re.compile(r"^(\s*.*?)(?:\s*:\s*([-+]?(?:\d+\.?|\d*\.\d+)))?\s*$")
+re_weight = re.compile(r"^((?:\s|.)*?)(?:\s*:\s*([-+]?(?:\d+\.?|\d*\.\d+)))?\s*$")
 
 def get_multicond_prompt_list(prompts):
     res_indexes = []

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -153,7 +153,7 @@ def get_learned_conditioning(model, prompts, steps):
 
 
 re_AND = re.compile(r"\bAND\b")
-re_weight = re.compile(r"^(.*?)(?:\s*:\s*([-+]?(?:\d+\.?|\d*\.\d+)))?\s*$")
+re_weight = re.compile(r"^(\s*.*?)(?:\s*:\s*([-+]?(?:\d+\.?|\d*\.\d+)))?\s*$")
 
 def get_multicond_prompt_list(prompts):
     res_indexes = []


### PR DESCRIPTION
## Description

Putting a newline anywhere in any prompt when using composable diffusion with prompt weighting breaks the parsing: weights are not taken into account and become a part of the prompt. This is because the regex for the `: float` weight matches text with `.` (`.*?`), which does not include `\s`.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
