### PR TITLE
fix: allow to resize images and change batch size before saving images to disk

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -753,6 +753,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             devices.torch_gc()
 
             if p.scripts is not None:
+                x_samples_ddim = list(x_samples_ddim)
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
 
             for i, x_sample in enumerate(x_samples_ddim):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -752,11 +752,12 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             devices.torch_gc()
 
-            x_samples_ddim_list = list(x_samples_ddim)
             if p.scripts is not None:
+                x_samples_ddim_list = list(x_samples_ddim)
                 p.scripts.postprocess_batch(p, x_samples_ddim, x_samples_ddim_list, batch_number=n)
+                x_samples_ddim = x_samples_ddim_list
 
-            for i, x_sample in enumerate(x_samples_ddim_list):
+            for i, x_sample in enumerate(x_samples_ddim):
                 p.batch_index = i
 
                 x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -753,10 +753,10 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             devices.torch_gc()
 
             if p.scripts is not None:
-                x_samples_ddim = list(x_samples_ddim)
-                p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
+                x_samples_ddim_list = list(x_samples_ddim)
+                p.scripts.postprocess_batch(p, x_samples_ddim, x_samples_ddim_list, batch_number=n)
 
-            for i, x_sample in enumerate(x_samples_ddim):
+            for i, x_sample in enumerate(x_samples_ddim_list):
                 p.batch_index = i
 
                 x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -752,8 +752,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             devices.torch_gc()
 
+            x_samples_ddim_list = list(x_samples_ddim)
             if p.scripts is not None:
-                x_samples_ddim_list = list(x_samples_ddim)
                 p.scripts.postprocess_batch(p, x_samples_ddim, x_samples_ddim_list, batch_number=n)
 
             for i, x_sample in enumerate(x_samples_ddim_list):


### PR DESCRIPTION
## Description

In https://github.com/ModelSurge/sd-webui-comfyui/pull/63 we're making it possible to run a comfyui workflow that runs automatically as a postprocessing step. We're having trouble making it possible to save a different number of images than what the webui has generated, while also allowing to resize the images. Basically, we need to be able to save a completely different set of images than what the webui generates.

If the workflow has multiple output nodes, then it returns new images. Here's an example:

<details>

<summary>duplicate images postprocessing example (click to open)</summary>

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/32277961/99c6ff8c-7e4d-40cd-9b4d-70a4d4a09dac)

</details>

To do achieve this, there are multiple callbacks at our disposal:

- `scripts.Script.postprocess_image`
    - this hook does not work because we have to return exactly 1:1 image as output. We also cannot keep the batch size in comfyui, it is forced to be one image at a time here because we can only process 1 image at a time
- `scripts.Script.postprocess_batch`
    - this hook does not work because on top of having to return exactly 1 image as output, it is not possible to change the shape of the images. a single tensor of the whole batch is passed to this callback, which only makes it possible to apply in-place tensor operations, which in turn don't allow to resize the tensor
- `scripts.Script.postprocess`
    - this is the least bad option we found as it allows to return a different number of images and resize them as we need
    - however, this requires extensive copy pasting of the image saving logic, and does not future proof any possible implementation by the extension

As a solution, passing a list to `scripts.Script.postprocess_batch` instead of a tensor of the entire batch makes it possible for extension code to mutate the list in place before it is iterated over in `modules.postprocessing.process_images_inner` to save each image.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
