### PR TITLE
Add postprocess_batch_list script callback

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -718,24 +718,26 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
     def infotext(iteration=0, position_in_batch=0, use_main_prompt=False):
         all_prompts = p.all_prompts[:]
+        all_negative_prompts = p.all_negative_prompts[:]
         all_seeds = p.all_seeds[:]
         all_subseeds = p.all_subseeds[:]
 
         # apply changes to generation data
         all_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.prompts
+        all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.negative_prompts
         all_seeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.seeds
         all_subseeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.subseeds
 
         # update p.all_negative_prompts in case extensions changed the size of the batch
         # create_infotext below uses it
-        old_negative_prompts = p.all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size]
-        p.all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.negative_prompts
+        old_negative_prompts = p.all_negative_prompts
+        p.all_negative_prompts = all_negative_prompts
 
         try:
             return create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration, position_in_batch, use_main_prompt)
         finally:
             # restore p.all_negative_prompts in case extensions changed the size of the batch
-            p.all_negative_prompts[iteration * p.batch_size:iteration * p.batch_size + len(p.negative_prompts)] = old_negative_prompts
+            p.all_negative_prompts = old_negative_prompts
 
     if os.path.exists(cmd_opts.embeddings_dir) and not p.do_not_reload_embeddings:
         model_hijack.embedding_db.load_textual_inversion_embeddings()

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -722,20 +722,20 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         all_subseeds = p.all_subseeds[:]
 
         # apply changes to generation data
-        all_prompts[n * p.batch_size:(n + 1) * p.batch_size] = p.prompts
-        all_seeds[n * p.batch_size:(n + 1) * p.batch_size] = p.seeds
-        all_subseeds[n * p.batch_size:(n + 1) * p.batch_size] = p.subseeds
+        all_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.prompts
+        all_seeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.seeds
+        all_subseeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.subseeds
 
         # update p.all_negative_prompts in case extensions changed the size of the batch
         # create_infotext below uses it
-        old_negative_prompts = p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size]
-        p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size] = p.negative_prompts
+        old_negative_prompts = p.all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size]
+        p.all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.negative_prompts
 
         try:
             return create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration, position_in_batch, use_main_prompt)
         finally:
             # restore p.all_negative_prompts in case extensions changed the size of the batch
-            p.all_negative_prompts[n * p.batch_size:n * p.batch_size + len(p.negative_prompts)] = old_negative_prompts
+            p.all_negative_prompts[iteration * p.batch_size:iteration * p.batch_size + len(p.negative_prompts)] = old_negative_prompts
 
     if os.path.exists(cmd_opts.embeddings_dir) and not p.do_not_reload_embeddings:
         model_hijack.embedding_db.load_textual_inversion_embeddings()

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -16,6 +16,11 @@ class PostprocessImageArgs:
         self.image = image
 
 
+class PostprocessBatchListArgs:
+    def __init__(self, images):
+        self.images = images
+
+
 class Script:
     name = None
     """script's internal name derived from title"""
@@ -152,6 +157,25 @@ class Script:
         **kwargs will have same items as process_batch, and also:
           - batch_number - index of current batch, from 0 to number of batches-1
           - images - torch tensor with all generated images, with values ranging from 0 to 1;
+        """
+
+        pass
+
+    def postprocess_batch_list(self, p, pp: PostprocessBatchListArgs, *args, **kwargs):
+        """
+        Same as postprocess_batch(), but receives batch images as a list of 3D tensors instead of a 4D tensor.
+        This is useful when you want to update the entire batch instead of individual images.
+
+        You can modify the postprocessing object (pp) to update the images in the batch, remove images, add images, etc.
+        If the number of images is different from the batch size when returning,
+        then the script has the responsibility to also update the following attributes in the processing object (p):
+          - p.prompts
+          - p.negative_prompts
+          - p.seeds
+          - p.subseeds
+
+        **kwargs will have same items as process_batch, and also:
+          - batch_number - index of current batch, from 0 to number of batches-1
         """
 
         pass
@@ -535,6 +559,14 @@ class ScriptRunner:
                 script.postprocess_batch(p, *script_args, images=images, **kwargs)
             except Exception:
                 errors.report(f"Error running postprocess_batch: {script.filename}", exc_info=True)
+
+    def postprocess_batch_list(self, p, pp: PostprocessBatchListArgs, **kwargs):
+        for script in self.alwayson_scripts:
+            try:
+                script_args = p.script_args[script.args_from:script.args_to]
+                script.postprocess_batch_list(p, pp, *script_args, **kwargs)
+            except Exception:
+                errors.report(f"Error running postprocess_batch_list: {script.filename}", exc_info=True)
 
     def postprocess_image(self, p, pp: PostprocessImageArgs):
         for script in self.alwayson_scripts:


### PR DESCRIPTION
Follow-up of #11933

## Description

In sd-webui-comfyui, we need to be able to replace all images in a batch with a completely unrelated set of images before saving. A possible candidate solution for this is to implement a new script callback that receives the batch images as a list instead of a single tensor.

Feedback welcome on the implementation and docstrings.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
