### PR TITLE
Fix parsing text encoder blocks in some LoRAs

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -161,7 +161,7 @@ def load_network(name, network_on_disk):
             sd_module = shared.sd_model.network_layer_mapping.get(key, None)
         elif sd_module is None and "lora_te1_text_model" in key_network_without_network_parts:
             key = key_network_without_network_parts.replace("lora_te1_text_model", "0_transformer_text_model")
-            sd_module = shared.sd_model.network_layer_mapping.get(key, None)
+            sd_module = shared.sd_model.network_layer_mapping.get(key, None) or shared.sd_model.network_layer_mapping.get(key[2:], None)
 
         if sd_module is None:
             keys_failed_to_match[key_network] = key


### PR DESCRIPTION
## Description

Title. ~~I feel like the current code is actually wrong (what's the point of the `0_` prefix?) but~~ I don't have any other LoRAs or models to test with that match this behavior, so I'm allowing both of keys like these to be parsed:
- `0_transformer_text_model_encoder_layers_0_mlp_fc1` (orginally accounted for)
- `transformer_text_model_encoder_layers_0_mlp_fc1` (this PR)

If you want a LoRA to try this with, go to /hdg/ thread `#350` on 4chan and Ctrl+F for `Qm41TZbD`. I can't link directly here since it's NSFW and this is the only example I have for this. In it's current state without this PR applied, it spits out a huge dict for `Failed to match keys when loading network`. 

**Edit:** I'm guessing the current code is only accounting for SDXL which has two TEs, so that would make sense. I'm not sure why this LoRA in particular has the index in it's key names, since it's trained on an SD1 model, but at least it solves the issue.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
