### PR TITLE
TypeError: Api.launch() got an unexpected keyword argument 'root_path'

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -373,8 +373,7 @@ def api_only():
     print(f"Startup time: {startup_timer.summary()}.")
     api.launch(
         server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1",
-        port=cmd_opts.port if cmd_opts.port else 7861,
-        root_path = f"/{cmd_opts.subpath}"
+        port=cmd_opts.port if cmd_opts.port else 7861
     )
 
 


### PR DESCRIPTION
## Description

* Can't run at API `--nowebui`

## Screenshots/videos:

```
Startup time: 47.5s (launcher: 12.4s, import torch: 4.7s, import gradio: 0.8s, setup paths: 1.1s, other imports: 2.0s, setup codeformer: 0.4s, load scripts: 2.1s, hijack-middleware.py: 0.1s, started-opts.py: 23.9s).
Traceback (most recent call last):
  File "./stable-diffusion-webui/launch.py", line 39, in <module>
    main()
  File "./stable-diffusion-webui/launch.py", line 35, in main
    start()
  File "./stable-diffusion-webui/modules/launch_utils.py", line 392, in start
    webui.api_only()
  File "./stable-diffusion-webui/webui.py", line 374, in api_only
    api.launch(
TypeError: Api.launch() got an unexpected keyword argument 'root_path'


```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
