### PR TITLE
catch exception for non git extensions

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -56,9 +56,11 @@ class Extension:
                 self.do_read_info_from_repo()
 
                 return self.to_dict()
-
-        d = cache.cached_data_for_file('extensions-git', self.name, os.path.join(self.path, ".git"), read_from_repo)
-        self.from_dict(d)
+        try:
+            d = cache.cached_data_for_file('extensions-git', self.name, os.path.join(self.path, ".git"), read_from_repo)
+            self.from_dict(d)
+        except FileNotFoundError:
+            pass
         self.status = 'unknown'
 
     def do_read_info_from_repo(self):


### PR DESCRIPTION
## Description
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11975
catch fire not found exception for non-git extensions
since cache info might be incorrect it won't use the existing cache if `.git` is not found
## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/0abcbbd6-8630-4fec-a8bb-7c26810deb51)
_information is left blank_

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
