### PR TITLE
api only subpath (rootpath)

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -724,9 +724,9 @@ class Api:
             cuda = {'error': f'{err}'}
         return models.MemoryResponse(ram=ram, cuda=cuda)
 
-    def launch(self, server_name, port):
+    def launch(self, server_name, port, root_path):
         self.app.include_router(self.router)
-        uvicorn.run(self.app, host=server_name, port=port, timeout_keep_alive=shared.cmd_opts.timeout_keep_alive)
+        uvicorn.run(self.app, host=server_name, port=port, timeout_keep_alive=shared.cmd_opts.timeout_keep_alive, root_path=root_path)
 
     def kill_webui(self):
         restart.stop_program()

--- a/webui.py
+++ b/webui.py
@@ -374,7 +374,7 @@ def api_only():
     api.launch(
         server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1",
         port=cmd_opts.port if cmd_opts.port else 7861,
-        root_path = f"/{cmd_opts.subpath}"
+        root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else ""
     )
 
 


### PR DESCRIPTION
## Description
passing subpath as root_path for api when launching in api only mode
related PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11976

NOTE
I didn't actually test this but based on the [documentation ](https://www.uvicorn.org/settings/#http)and the `uvicorn.run()` function definition this should function correctly
another [doc](https://fastapi.tiangolo.com/advanced/behind-a-proxy/)

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
