### PR TITLE
automatically apply some settings from images dragged into prompt

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -732,19 +732,22 @@ def image_data(data):
     try:
         image = Image.open(io.BytesIO(data))
         textinfo, _ = read_info_from_image(image)
-        return textinfo, None
+        print("\n")
+        print(textinfo)
+        print("\n")
+        return textinfo, True
     except Exception:
         pass
 
     try:
         text = data.decode('utf8')
         assert len(text) < 10000
-        return text, None
+        return text, False
 
     except Exception:
         pass
 
-    return gr.update(), None
+    return gr.update(), False
 
 
 def flatten(img, bgcolor):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -429,8 +429,8 @@ def apply_image_settings(txt_prompt_img):
             img_data['img_prompt'] = ""
         if img_data['img_negative_prompt'] is None:
             img_data['img_negative_prompt'] = ""
-    
-    except:
+
+    except Exception:
         for key in img_data.keys():
             img_data[key] = gr.update()
 


### PR DESCRIPTION

## Description
* Currently the webui replaces the prompt with image information when an output image is dragged onto the prompt. This change instead prints that image info to the terminal and attempts to set information taken from image info. 

## Changes
* Added an extra function in ui.py that returns the values of the information taken from the dragged in output image, and connected it to the prompt call. Slight change to called function in image.py to pass back needed information for the function in ui.py.

## Which issues it fixes, if any
* None that I know of



