### PR TITLE
Revert "Add postprocess_batch_list script callback"

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -717,27 +717,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         p.all_subseeds = [int(subseed) + x for x in range(len(p.all_prompts))]
 
     def infotext(iteration=0, position_in_batch=0, use_main_prompt=False):
-        all_prompts = p.all_prompts[:]
-        all_negative_prompts = p.all_negative_prompts[:]
-        all_seeds = p.all_seeds[:]
-        all_subseeds = p.all_subseeds[:]
-
-        # apply changes to generation data
-        all_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.prompts
-        all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.negative_prompts
-        all_seeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.seeds
-        all_subseeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.subseeds
-
-        # update p.all_negative_prompts in case extensions changed the size of the batch
-        # create_infotext below uses it
-        old_negative_prompts = p.all_negative_prompts
-        p.all_negative_prompts = all_negative_prompts
-
-        try:
-            return create_infotext(p, all_prompts, all_seeds, all_subseeds, comments, iteration, position_in_batch, use_main_prompt)
-        finally:
-            # restore p.all_negative_prompts in case extensions changed the size of the batch
-            p.all_negative_prompts = old_negative_prompts
+        return create_infotext(p, p.all_prompts, p.all_seeds, p.all_subseeds, comments, iteration, position_in_batch, use_main_prompt)
 
     if os.path.exists(cmd_opts.embeddings_dir) and not p.do_not_reload_embeddings:
         model_hijack.embedding_db.load_textual_inversion_embeddings()
@@ -825,10 +805,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             if p.scripts is not None:
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
-
-                postprocess_batch_list_args = scripts.PostprocessBatchListArgs(list(x_samples_ddim))
-                p.scripts.postprocess_batch_list(p, postprocess_batch_list_args, batch_number=n)
-                x_samples_ddim = postprocess_batch_list_args.images
 
             for i, x_sample in enumerate(x_samples_ddim):
                 p.batch_index = i

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -16,11 +16,6 @@ class PostprocessImageArgs:
         self.image = image
 
 
-class PostprocessBatchListArgs:
-    def __init__(self, images):
-        self.images = images
-
-
 class Script:
     name = None
     """script's internal name derived from title"""
@@ -157,25 +152,6 @@ class Script:
         **kwargs will have same items as process_batch, and also:
           - batch_number - index of current batch, from 0 to number of batches-1
           - images - torch tensor with all generated images, with values ranging from 0 to 1;
-        """
-
-        pass
-
-    def postprocess_batch_list(self, p, pp: PostprocessBatchListArgs, *args, **kwargs):
-        """
-        Same as postprocess_batch(), but receives batch images as a list of 3D tensors instead of a 4D tensor.
-        This is useful when you want to update the entire batch instead of individual images.
-
-        You can modify the postprocessing object (pp) to update the images in the batch, remove images, add images, etc.
-        If the number of images is different from the batch size when returning,
-        then the script has the responsibility to also update the following attributes in the processing object (p):
-          - p.prompts
-          - p.negative_prompts
-          - p.seeds
-          - p.subseeds
-
-        **kwargs will have same items as process_batch, and also:
-          - batch_number - index of current batch, from 0 to number of batches-1
         """
 
         pass
@@ -559,14 +535,6 @@ class ScriptRunner:
                 script.postprocess_batch(p, *script_args, images=images, **kwargs)
             except Exception:
                 errors.report(f"Error running postprocess_batch: {script.filename}", exc_info=True)
-
-    def postprocess_batch_list(self, p, pp: PostprocessBatchListArgs, **kwargs):
-        for script in self.alwayson_scripts:
-            try:
-                script_args = p.script_args[script.args_from:script.args_to]
-                script.postprocess_batch_list(p, pp, *script_args, **kwargs)
-            except Exception:
-                errors.report(f"Error running postprocess_batch_list: {script.filename}", exc_info=True)
 
     def postprocess_image(self, p, pp: PostprocessImageArgs):
         for script in self.alwayson_scripts:


### PR DESCRIPTION
## Description
extra networks info gets deleted due to the changes done in that that
I think this can be considered as a major bug as this will cause every single information generated using that version to not have extra networks info and thus are not reproducible
as opposed to reverting if we can sort out the correct logic within the short time then this doesn't need to be reverted and instead would need to be patched
but if not reverting it then reintroducing it later is faster

## Screenshots/videos:
1.5.0 no extra networks info
```
parameters

1girl, miku
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 3816423551, Size: 512x512, Model hash: 099e07547a, Model: darkSushiMixMix_brighterPruned, Clip skip: 2, Lora hashes: "hatsunemiku1-000006: 8ccb2b9adc0a", Version: v1.5.0-38-gd0bf509f
```
1.4.1 normal with extra networks info
```
parameters

1girl, <lora:hatsunemiku1-000006:1> miku
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^    <---- this line is manuel highlight
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 3816423551, Size: 512x512, Model hash: 099e07547a, Model: Anime_Dark Sushi Mix 大颗寿司Mix_darkSushiMixMix_brighterPruned, Clip skip: 2, Lora hashes: "hatsunemiku1-000006: 8ccb2b9adc0a", Version: v1.4.1
```

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
