### PR TITLE
Fix TypeError: unsupported operand type

### DIFF
--- a/extensions-builtin/Lora/network.py
+++ b/extensions-builtin/Lora/network.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 from collections import namedtuple
 import enum
 
@@ -99,7 +100,7 @@ class Network:  # LoraModule
 
 
 class ModuleType:
-    def create_module(self, net: Network, weights: NetworkWeights) -> Network | None:
+    def create_module(self, net: Network, weights: NetworkWeights) -> Optional[Network]:
         return None
 
 


### PR DESCRIPTION


## Description

*  Fix TypeError: unsupported operand type(s) for |: 'type' and 'NoneType' in `create_module()` method in `extensions-builtin/Lora/network.py`
* The `create_module()` method returns a Network object or None. The return None statement is causing the | operator to be used on the type of the Network object and the NoneType value. To fix this error,  changed the return type of the `create_module()` method to `Optional[Network]`.
* Changed return type of `create_module()` method to `Optional[Network]`.
* Updated `return None` statement to return a `None` value of type `Optional[Network]`.

* Full error below:
``` 
.....
Installing requirements
Launching Web UI with arguments: --share --skip-torch-cuda-test --no-gradio-queue --precision full --no-half
no module 'xformers'. Processing without...
no module 'xformers'. Processing without...
No module 'xformers'. Proceeding without it.
Warning: caught exception 'Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx', memory monitor disabled
Downloading: "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors" to /home/rpanchum/stable-diffusion-webui/models/Stable-diffusion/v1-5-pruned-emaonly.safetensors
100%|██████████| 3.97G/3.97G [00:38<00:00, 112MB/s]
*** Error loading script: lora_script.py
    Traceback (most recent call last):
      File "/home/rpanchum/stable-diffusion-webui/modules/scripts.py", line 295, in load_scripts
        script_module = script_loading.load_module(scriptfile.path)
      File "/home/rpanchum/stable-diffusion-webui/modules/script_loading.py", line 10, in load_module
        module_spec.loader.exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 843, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/home/rpanchum/stable-diffusion-webui/extensions-builtin/Lora/scripts/lora_script.py", line 7, in <module>
        import network
      File "/home/rpanchum/stable-diffusion-webui/extensions-builtin/Lora/network.py", line 101, in <module>
        class ModuleType:
      File "/home/rpanchum/stable-diffusion-webui/extensions-builtin/Lora/network.py", line 102, in ModuleType
        def create_module(self, net: Network, weights: NetworkWeights) -> Network | None:
    TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

---
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
