### PR TITLE
fix extra networks overwritten by postprocess_batch_list

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -716,8 +716,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     else:
         p.all_subseeds = [int(subseed) + x for x in range(len(p.all_prompts))]
 
-    prompts_with_extra_network_data = []
-
     def infotext(iteration=0, position_in_batch=0, use_main_prompt=False):
         all_prompts = p.all_prompts[:]
         all_negative_prompts = p.all_negative_prompts[:]
@@ -832,7 +830,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                 postprocess_batch_list_args = scripts.PostprocessBatchListArgs(list(x_samples_ddim), p.prompts[:], prompts_with_extra_network_data[:], p.negative_prompts[:], p.seeds[:], p.subseeds[:])
                 p.scripts.postprocess_batch_list(p, postprocess_batch_list_args, batch_number=n)
-                x_samples_ddim, p.prompts, prompts_with_extra_network_data, p.negative_prompts, p.seeds, p.subseeds = postprocess_batch_list_args.as_tuple()
+                x_samples_ddim, p.prompts, prompts_with_extra_network_data, p.negative_prompts, p.seeds, p.subseeds = postprocess_batch_list_args.get_lists()
 
             for i, x_sample in enumerate(x_samples_ddim):
                 p.batch_index = i

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -771,7 +771,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 break
 
             p.prompts = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
-            p.prompts_with_extra_network_data = p.prompts[:]
             p.negative_prompts = p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size]
             p.seeds = p.all_seeds[n * p.batch_size:(n + 1) * p.batch_size]
             p.subseeds = p.all_subseeds[n * p.batch_size:(n + 1) * p.batch_size]
@@ -824,6 +823,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             devices.torch_gc()
 
+            p.prompts_with_extra_network_data = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
             if p.scripts is not None:
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -723,7 +723,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         all_subseeds = p.all_subseeds[:]
 
         # apply changes to generation data
-        all_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.prompts
+        all_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.prompts_with_extra_network_data
         all_negative_prompts[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.negative_prompts
         all_seeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.seeds
         all_subseeds[iteration * p.batch_size:(iteration + 1) * p.batch_size] = p.subseeds
@@ -771,6 +771,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 break
 
             p.prompts = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
+            p.prompts_with_extra_network_data = p.prompts[:]
             p.negative_prompts = p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size]
             p.seeds = p.all_seeds[n * p.batch_size:(n + 1) * p.batch_size]
             p.subseeds = p.all_subseeds[n * p.batch_size:(n + 1) * p.batch_size]

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -17,8 +17,23 @@ class PostprocessImageArgs:
 
 
 class PostprocessBatchListArgs:
-    def __init__(self, images):
+    def __init__(self, images, prompts, prompts_with_extra_network_data, negative_prompts, seeds, subseeds):
         self.images = images
+        self.prompts = prompts
+        self.prompts_with_extra_network_data = prompts_with_extra_network_data
+        self.negative_prompts = negative_prompts
+        self.seeds = seeds
+        self.subseeds = subseeds
+
+    def as_tuple(self):
+        return (
+            self.images,
+            self.prompts,
+            self.prompts_with_extra_network_data,
+            self.negative_prompts,
+            self.seeds,
+            self.subseeds,
+        )
 
 
 class Script:
@@ -167,13 +182,12 @@ class Script:
         This is useful when you want to update the entire batch instead of individual images.
 
         You can modify the postprocessing object (pp) to update the images in the batch, remove images, add images, etc.
-        If the number of images is different from the batch size when returning,
-        then the script has the responsibility to also update the following attributes in the processing object (p):
-          - p.prompts
-          - p.prompts_with_extra_network_data
-          - p.negative_prompts
-          - p.seeds
-          - p.subseeds
+        If the size of pp.images is changed, then the following attributes on pp must also all be resized accordingly:
+          - pp.prompts
+          - pp.prompts_with_extra_network_data
+          - pp.negative_prompts
+          - pp.seeds
+          - pp.subseeds
 
         **kwargs will have same items as process_batch, and also:
           - batch_number - index of current batch, from 0 to number of batches-1

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -25,7 +25,7 @@ class PostprocessBatchListArgs:
         self.seeds = seeds
         self.subseeds = subseeds
 
-    def as_tuple(self):
+    def get_lists(self):
         return (
             self.images,
             self.prompts,

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -170,6 +170,7 @@ class Script:
         If the number of images is different from the batch size when returning,
         then the script has the responsibility to also update the following attributes in the processing object (p):
           - p.prompts
+          - p.prompts_with_extra_network_data
           - p.negative_prompts
           - p.seeds
           - p.subseeds


### PR DESCRIPTION
## Description

This should fix the extra network issue, at the cost of an extra attribute `p.prompts_with_extra_network_data`. I'm testing this actively as we speak but I'm not familiar enough with the code to be sure that p.negative_prompts or other p attributes are not modified after the slicing of p.prompts, p.negative_prompts etc. and before the new callback.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
