### PR TITLE
fix check for updates status always "unknown"

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -61,7 +61,7 @@ class Extension:
             self.from_dict(d)
         except FileNotFoundError:
             pass
-        self.status = 'unknown'
+        self.status = 'unknown' if self.status == '' else self.status
 
     def do_read_info_from_repo(self):
         repo = None


### PR DESCRIPTION
## Description
Fix check for updates status always unknown 
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12021
this seems like a bug caused by the cache rework, not entirely sure how it worked before but this should fix it
## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
