### PR TITLE
api /sdapi/v1/options use "Any" type when default type is None

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -208,11 +208,9 @@ class PreprocessResponse(BaseModel):
 fields = {}
 for key, metadata in opts.data_labels.items():
     value = opts.data.get(key)
-    optType = opts.typemap.get(type(metadata.default), type(metadata.default))
+    optType = opts.typemap.get(type(metadata.default), type(metadata.default)) if metadata.default else Any
 
-    if metadata.default is None:
-        pass
-    elif metadata is not None:
+    if metadata is not None:
         fields.update({key: (Optional[optType], Field(default=metadata.default, description=metadata.label))})
     else:
         fields.update({key: (Optional[optType], Field())})


### PR DESCRIPTION
## Description
[Bug]: sd_model_checkpoint removed from GET /sdapi/v1/options? https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12025
if I'm understanding correctly
what happens is that if the default value is None type
then the model that the API returns don't even include that field

so I changed that if the default is none it would use `Any` type 

Note I'm never used pydantic, and not entirely sure what the intended response should be
but this fix seems to work

the issue was caused by a series of changes you did around
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/b270ded268c92950a35a7a326da54496ef4151c8#diff-f4032708024d08a8ae417cd5e4f6a3e7e06d7a567704b86c8874edc7d7b5937b

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
