### PR TITLE
IMG2IMG TIF batch fix img2img.py

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -20,7 +20,7 @@ import modules.scripts
 def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=False, scale_by=1.0, use_png_info=False, png_info_props=None, png_info_dir=None):
     processing.fix_seed(p)
 
-    images = list(shared.walk_files(input_dir, allowed_extensions=(".png", ".jpg", ".jpeg", ".webp")))
+    images = list(shared.walk_files(input_dir, allowed_extensions=(".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff")))
 
     is_inpaint_batch = False
     if inpaint_mask_dir:


### PR DESCRIPTION
[Bug]: IMG2IMG Batch will not locate TIF images #12106

## Description

* a simple description of what you're trying to accomplish
get img2img batching to process tifs again

* a summary of changes in code
Adjusted line 20 to include .tif and .tiff

* which issues it fixes, if any:
In my tests, it is working, now

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
The last instruction on the wiki/Tests says "Once the server is running, you can run tests with just py.test."
@akx How do I do that? Console? From within the WebUI? Please provide clearer instructions for me to be able to confidently say I've run the test for pull request submission. I understand installing via the requirements.txt and added the argument to my command_args with the launcher, but otherwise I don't know what to do from there.
