### PR TITLE
Add total_tqdm clear in the end of txt2img & img2img api.

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -343,6 +343,7 @@ class Api:
                         processed = process_images(p)
                 finally:
                     shared.state.end()
+                    shared.total_tqdm.clear()
 
         b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
 
@@ -402,6 +403,7 @@ class Api:
                         processed = process_images(p)
                 finally:
                     shared.state.end()
+                    shared.total_tqdm.clear()
 
         b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
 


### PR DESCRIPTION
## Description
I'm using web ui api, and found total progress tqdm bar is increase infinitely. This may lead to oom.

## Screenshots/videos:
<img width="403" alt="image" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28686889/f1c5dc0f-0858-402c-84ab-2f8a0a6a7c6a">

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
