### PR TITLE
updated `import_hook.py` to enable xformers load by `sd_hijacking.py` and other routines

### DIFF
--- a/modules/import_hook.py
+++ b/modules/import_hook.py
@@ -1,5 +1,7 @@
 import sys
 
-# this will break any attempt to import xformers which will prevent stability diffusion repo from trying to use it
+# solution to load xformers by @liuzimo https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/6594#discussioncomment-5216054
+# sd_hijack will fail to load xformers because sys.modules cannot find i. This solution solves the problem. 
 if "--xformers" not in "".join(sys.argv):
-    sys.modules["xformers"] = None
+    import xformers
+sys.modules["xformers"] = xformers


### PR DESCRIPTION
implementation of @liuzimo's solution to enable `sys.modules` to find the `xformers` package in `sd_hijacking` routines. The change is described in https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/6594#discussioncomment-5216054. I tested it;  it works. 

## Description

* solve a problem where `sd_hijack` and related routines would fail to load `xformers.ops` because sys.modules could not find it in site packages.  
* solves issues https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12142 and https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5993

## Checklist:

- [ x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ x] I have performed a self-review of my own code
- [ x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
