### PR TITLE
fix: infotext using index 0

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -115,7 +115,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
 
         for n, processed_image in enumerate(proc.images):
             filename = image_path.stem
-            infotext = proc.infotext(p, n)
+            infotext = proc.infotext(p, 0)
             relpath = os.path.dirname(os.path.relpath(image, input_dir))
 
             if n > 0:


### PR DESCRIPTION
## Description

As I mentioned issue #12149 , I found that `infotext` function using index when controlnet included, but seed array only contains just one value. So I modified that infotext funtion uses index 0 during batch processing.

## Screenshots/videos:


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
