### PR TITLE
Rework img2img batch image save

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -10,7 +10,6 @@ from modules import sd_samplers, images as imgutil
 from modules.generation_parameters_copypaste import create_override_settings_dict, parse_generation_parameters
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 from modules.shared import opts, state
-from modules.images import save_image
 import modules.shared as shared
 import modules.processing as processing
 from modules.ui import plaintext_to_html

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -17,6 +17,7 @@ import modules.scripts
 
 
 def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=False, scale_by=1.0, use_png_info=False, png_info_props=None, png_info_dir=None):
+    output_dir = output_dir.strip()
     processing.fix_seed(p)
 
     images = list(shared.walk_files(input_dir, allowed_extensions=(".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff")))

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -32,11 +32,6 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
 
     print(f"Will process {len(images)} images, creating {p.n_iter * p.batch_size} new images for each.")
 
-    save_normally = output_dir == ''
-
-    p.do_not_save_grid = True
-    p.do_not_save_samples = not save_normally
-
     state.job_count = len(images) * p.n_iter
 
     # extract "default" params to use in case getting png info fails
@@ -111,21 +106,13 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
         if proc is None:
-            proc = process_images(p)
-
-        for n, processed_image in enumerate(proc.images):
-            filename = image_path.stem
-            infotext = proc.infotext(p, n)
-            relpath = os.path.dirname(os.path.relpath(image, input_dir))
-
-            if n > 0:
-                filename += f"-{n}"
-
-            if not save_normally:
-                os.makedirs(os.path.join(output_dir, relpath), exist_ok=True)
-                if processed_image.mode == 'RGBA':
-                    processed_image = processed_image.convert("RGB")
-                save_image(processed_image, os.path.join(output_dir, relpath), None, extension=opts.samples_format, info=infotext, forced_filename=filename, save_to_dirs=False)
+            p.outpath_samples = output_dir
+            p.override_settings['save_to_dirs'] = False
+            if p.n_iter > 1 or p.batch_size > 1:
+                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
+            else:
+                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
+            process_images(p)
 
 
 def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_index: int, mask_blur: int, mask_alpha: float, inpainting_fill: int, restore_faces: bool, tiling: bool, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, seed: int, subseed: int, subseed_strength: float, seed_resize_from_h: int, seed_resize_from_w: int, seed_enable_extras: bool, selected_scale_tab: int, height: int, width: int, scale_by: float, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, img2img_batch_use_png_info: bool, img2img_batch_png_info_props: list, img2img_batch_png_info_dir: str, request: gr.Request, *args):

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -105,12 +105,13 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
         if proc is None:
-            p.outpath_samples = output_dir
-            p.override_settings['save_to_dirs'] = False
-            if p.n_iter > 1 or p.batch_size > 1:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
-            else:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
+            if output_dir:
+                p.outpath_samples = output_dir
+                p.override_settings['save_to_dirs'] = False
+                if p.n_iter > 1 or p.batch_size > 1:
+                    p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
+                else:
+                    p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
             process_images(p)
 
 


### PR DESCRIPTION
## Description
fix issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12149 introduced by PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11747

instead of having a dedicated image saving sequence just reuse everything
should make maintain easier

since the image save file name is parsed by `FilenameGenerator` it could cause potential issues if they are special sequences in the file name
I have mentioned past that we shouldn't use valid file name characters for as pattern (square brackets `[xxx]`)

I propose we switch to using `<xxx>`
it should be possible to make the transition without breaking change

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
