### PR TITLE
Edit styles UI and function added

### DIFF
--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -24,6 +24,9 @@ var titles = {
     "\u{1f4d2}": "Paste available values into the field",
     "\u{1f3b4}": "Show/hide extra networks",
     "\u{1f300}": "Restore progress",
+    "\u{1f527}": "Edit Style",
+    "\u{0270f}\ufe0f": "Save Style",
+    "\u{0274c}\ufe0f": "Delete Style",
 
     "Inpaint a part of image": "Draw a mask over an image, and the script will regenerate the masked area with content according to prompt",
     "SD upscale": "Upscale image normally, split result into tiles, improve each tile using img2img, merge whole image back",

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -247,6 +247,13 @@ function confirm_clear_prompt(prompt, negative_prompt) {
     return [prompt, negative_prompt];
 }
 
+function confirm_delete_style(...args) {
+    if (confirm("Delete style?")) {
+        return args;
+    }
+    return null;
+}
+
 
 var opts = {};
 onAfterUiUpdate(function() {

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -106,7 +106,7 @@ class StyleDatabase:
         if os.path.exists(path):
             shutil.copy(path, f"{path}.bak")
 
-        fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
         with os.fdopen(fd, "w", encoding="utf-8-sig", newline='') as file:
             # _fields is actually part of the public API: typing.NamedTuple is a replacement for collections.NamedTuple,
             # and collections.NamedTuple has explicit documentation for accessing _fields. Same goes for _asdict()

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -112,6 +112,7 @@ class StyleDatabase:
             # and collections.NamedTuple has explicit documentation for accessing _fields. Same goes for _asdict()
             writer = csv.DictWriter(file, fieldnames=PromptStyle._fields)
             writer.writeheader()
+            writer.writerow({})
             writer.writerows(style._asdict() for k, style in self.styles.items())
 
     def extract_styles_from_prompt(self, prompt, negative_prompt):


### PR DESCRIPTION
## Description
This change adds a small button next to the styles toolbar that enables a dropdown to allow the user to edit or delete saved styles. The selected style is determined by the last style in the dropdown, which is also the last selected style. The style prompt and negative prompt is loaded and the user can edit and save the style, as well as delete it entirely.

## Changes in code
Added UI elements to upper shell, passes 4 new parameters into text2img and img2img sections for the 2 new prompts and 2 new buttons. Functions added at the top of ui.py to hook to these 2 new buttons as well as to apply the prompts from the last style in the dropdown.

## Screenshots/videos:


https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125175965/c6b75ad1-6fdc-4c16-95f0-de38ecc3b025

## Checklist:

- [y] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [y] I have performed a self-review of my own code
- [y] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [y] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
