### PR TITLE
xyz_grid: allow varying the seed along an axis separate from axis options

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -417,6 +417,10 @@ class Script(scripts.Script):
                 include_lone_images = gr.Checkbox(label='Include Sub Images', value=False, elem_id=self.elem_id("include_lone_images"))
                 include_sub_grids = gr.Checkbox(label='Include Sub Grids', value=False, elem_id=self.elem_id("include_sub_grids"))
             with gr.Column():
+                vary_seeds_x = gr.Checkbox(label='Vary seed on X axis', value=False, elem_id=self.elem_id("vary_seeds_x"))
+                vary_seeds_y = gr.Checkbox(label='Vary seed on Y axis', value=False, elem_id=self.elem_id("vary_seeds_y"))
+                vary_seeds_z = gr.Checkbox(label='Vary seed on Z axis', value=False, elem_id=self.elem_id("vary_seeds_z"))
+            with gr.Column():
                 margin_size = gr.Slider(label="Grid margins (px)", minimum=0, maximum=500, value=0, step=2, elem_id=self.elem_id("margin_size"))
 
         with gr.Row(variant="compact", elem_id="swap_axes"):
@@ -475,9 +479,9 @@ class Script(scripts.Script):
             (z_values_dropdown, lambda params:get_dropdown_update_from_params("Z",params)),
         )
 
-        return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size]
+        return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, vary_seeds_x, vary_seeds_y, vary_seeds_z, margin_size]
 
-    def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size):
+    def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, vary_seeds_x, vary_seeds_y, vary_seeds_z, margin_size):
         if not no_fixed_seeds:
             modules.processing.fix_seed(p)
 
@@ -647,6 +651,16 @@ class Script(scripts.Script):
             x_opt.apply(pc, x, xs)
             y_opt.apply(pc, y, ys)
             z_opt.apply(pc, z, zs)
+
+            xdim = len(xs) if vary_seeds_x else 1
+            ydim = len(ys) if vary_seeds_y else 1
+
+            if vary_seeds_x:
+               pc.seed += ix
+            if vary_seeds_y:
+               pc.seed += iy * xdim
+            if vary_seeds_z:
+               pc.seed += iz * xdim * ydim
 
             res = process_images(pc)
 


### PR DESCRIPTION
## Description

* in some scenarios with xyz grid, you might want a set of different images along an axis, but the same one on the other axes. currently, you can either change the seed, or you can use prompt SR to change the prompt. this PR allows you to specify a fixed seed but then vary it along one or more axes so the seed can vary at the same time as the prompt. this may be kinda weird; i use it now and then, but it may not be worth the added UI complexity
* a summary of changes in code:
* * three checkboxes are provided, allowing the seed to vary along each axis independently
* * each selected checkbox effectively causes the seed to increment along that axis
* * if multiple axes are selected, 2D/3D array-indexing computation is performed so all seeds are unique
* an alternative implementation would be to have a switch that just forces varying seeds if there's a prompt SR, but it's possible you might have more than one prompt SR but only want seed variation along one of them; or there might be some other axis option where incrementing seeds is useful, so I went with more general functionality
* if you should choose to accept this PR, please suggest how you would prefer the UI to be laid out and I'll fix it

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/6344fd68-2d63-4af0-a241-c688259a18c7)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/21624104-196f-4e42-82b2-1d3c1e0c8d04)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
