### PR TITLE
sort VAE

### DIFF
--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -50,6 +50,7 @@ def get_filename(filepath):
 
 
 def refresh_vae_list():
+    global vae_dict
     vae_dict.clear()
 
     paths = [
@@ -82,6 +83,8 @@ def refresh_vae_list():
     for filepath in candidates:
         name = get_filename(filepath)
         vae_dict[name] = filepath
+
+    vae_dict = dict(sorted(vae_dict.items(), key=lambda item: shared.natural_sort_key(item[0])))
 
 
 def find_vae_near_checkpoint(checkpoint_file):


### PR DESCRIPTION
## Description
alternative to PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12281
but instead sort VAE dictionary at the source
this way that the it's applied across the UI

remaks
to be honest I think the VAE is left or needs to be revamped
irrc currently one can accidentally use a 1.x VAE on a XL model
unless one is deliberately trying to create a bad image one should never do that
## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
