### PR TITLE
Fix Gradio 3.39.0 textbox overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,6 +140,10 @@ div.styler{
     background: var(--background-fill-primary);
 }
 
+.block.gradio-textbox{
+    overflow: visible !important;
+}
+
 
 /* general styled components */
 


### PR DESCRIPTION
## Description

More Gradio shenanigans. Fixes `overflow` to return back back to `visible` (3.39.0 overrides it to `hidden` by default). I think it's safe to assume if it was always like this in the past then this won't introduce any new issues.

In particular this resolves an issue with the autocomplete extension. https://github.com/DominikDoom/a1111-sd-webui-tagcomplete/issues/213

## Screenshots/videos:
n/a, visually identical

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
