### PR TITLE
Add styling for script components

### DIFF
--- a/style.css
+++ b/style.css
@@ -190,6 +190,13 @@ button.custom-button{
     text-align: center;
 }
 
+.gradio-group[id$="_script_container"] > div .gradio-group > div > div:is(.gradio-accordion, .form) {
+    border: 1px solid var(--block-border-color) !important;
+    border-radius: 8px !important;
+    margin: 2px 0;
+    padding: 8px 8px;
+}
+
 
 /* txt2img/img2img specific */
 


### PR DESCRIPTION
## Description

Makes component styles for alwayson scripts/extensions more distinct within the UI. This was similar to how the UI was styled in the past and disappeared after another Gradio update I assume. If this change isn't wanted feel free to close.

## Screenshots/videos:

<details>
<summary>Before</summary>

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/3e12edc2-86d5-4b22-a4d5-dac2d6a35c42)
</details>

<details>
<summary>After</summary>

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/c03e9f29-3f46-4ce5-87aa-0e98a9928322)
</details>


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-stye)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
