### PR TITLE
Remove legacy temp dir implementation

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -60,8 +60,6 @@ def image_from_url_text(filedata):
 
     if type(filedata) == dict and filedata.get("is_file", False):
         filename = filedata["name"]
-        is_in_right_dir = ui_tempdir.check_tmp_file(shared.demo, filename)
-        assert is_in_right_dir, 'trying to open image file outside of allowed directories'
 
         filename = filename.rsplit('?', 1)[0]
         return Image.open(filename)

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -6,7 +6,7 @@ import re
 
 import gradio as gr
 from modules.paths import data_path
-from modules import shared, ui_tempdir, script_callbacks
+from modules import shared, script_callbacks
 from PIL import Image
 
 re_param_code = r'\s*([\w ]+):\s*("(?:\\"[^,]|\\"|\\|[^\"])+"|[^,]*)(?:,|$)'

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -353,8 +353,8 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "save_init_img": OptionInfo(False, "Save init images when using img2img"),
 
-    "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),
-    "clean_temp_dir_at_start": OptionInfo(False, "Cleanup non-default temporary directory when starting webui"),
+    "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default").needs_restart(),
+    "clean_temp_dir_at_start": OptionInfo(False, "Cleanup Gradio temporary directory when starting webui").needs_restart(),
 
 }))
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -353,7 +353,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
     "save_init_img": OptionInfo(False, "Save init images when using img2img"),
 
-    "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default").needs_restart(),
+    "temp_dir":  OptionInfo("", "Does nothing -- use the environment variable GRADIO_TEMP_DIR to change this"),
     "clean_temp_dir_at_start": OptionInfo(False, "Cleanup Gradio temporary directory when starting webui").needs_restart(),
 
 }))

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -1,77 +1,12 @@
 import os
-import tempfile
-from collections import namedtuple
-from pathlib import Path
 
-import gradio.components
-
-from PIL import PngImagePlugin
+from gradio_client.client import DEFAULT_TEMP_DIR
 
 from modules import shared
 
 
-Savedfile = namedtuple("Savedfile", ["name"])
-
-
-def register_tmp_file(gradio, filename):
-    if hasattr(gradio, 'temp_file_sets'):  # gradio 3.15
-        gradio.temp_file_sets[0] = gradio.temp_file_sets[0] | {os.path.abspath(filename)}
-
-    if hasattr(gradio, 'temp_dirs'):  # gradio 3.9
-        gradio.temp_dirs = gradio.temp_dirs | {os.path.abspath(os.path.dirname(filename))}
-
-
-def check_tmp_file(gradio, filename):
-    if hasattr(gradio, 'temp_file_sets'):
-        return any(filename in fileset for fileset in gradio.temp_file_sets)
-
-    if hasattr(gradio, 'temp_dirs'):
-        return any(Path(temp_dir).resolve() in Path(filename).resolve().parents for temp_dir in gradio.temp_dirs)
-
-    return False
-
-
-def save_pil_to_file(self, pil_image, dir=None, format="png"):
-    already_saved_as = getattr(pil_image, 'already_saved_as', None)
-    if already_saved_as and os.path.isfile(already_saved_as):
-        register_tmp_file(shared.demo, already_saved_as)
-        filename = already_saved_as
-
-        if not shared.opts.save_images_add_number:
-            filename += f'?{os.path.getmtime(already_saved_as)}'
-
-        return filename
-
-    if shared.opts.temp_dir != "":
-        dir = shared.opts.temp_dir
-
-    use_metadata = False
-    metadata = PngImagePlugin.PngInfo()
-    for key, value in pil_image.info.items():
-        if isinstance(key, str) and isinstance(value, str):
-            metadata.add_text(key, value)
-            use_metadata = True
-
-    file_obj = tempfile.NamedTemporaryFile(delete=False, suffix=".png", dir=dir)
-    pil_image.save(file_obj, pnginfo=(metadata if use_metadata else None))
-    return file_obj.name
-
-
-# override save to file function so that it also writes PNG info
-gradio.components.IOComponent.pil_to_temp_file = save_pil_to_file
-
-
-def on_tmpdir_changed():
-    if shared.opts.temp_dir == "" or shared.demo is None:
-        return
-
-    os.makedirs(shared.opts.temp_dir, exist_ok=True)
-
-    register_tmp_file(shared.demo, os.path.join(shared.opts.temp_dir, "x"))
-
-
 def cleanup_tmpdr():
-    temp_dir = shared.opts.temp_dir
+    temp_dir = shared.opts.temp_dir or DEFAULT_TEMP_DIR
     if temp_dir == "" or not os.path.isdir(temp_dir):
         return
 

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -2,11 +2,9 @@ import os
 
 from gradio_client.client import DEFAULT_TEMP_DIR
 
-from modules import shared
-
 
 def cleanup_tmpdr():
-    temp_dir = shared.opts.temp_dir or DEFAULT_TEMP_DIR
+    temp_dir = DEFAULT_TEMP_DIR
     if temp_dir == "" or not os.path.isdir(temp_dir):
         return
 

--- a/webui.py
+++ b/webui.py
@@ -65,7 +65,7 @@ if not shared.cmd_opts.skip_version_check:
 
 import modules.codeformer_model as codeformer
 import modules.gfpgan_model as gfpgan
-from modules import sd_samplers, upscaler, extensions, localization, ui_tempdir, ui_extra_networks, config_states
+from modules import sd_samplers, upscaler, extensions, localization, ui_extra_networks, config_states
 import modules.face_restoration
 import modules.img2img
 

--- a/webui.py
+++ b/webui.py
@@ -212,7 +212,6 @@ def configure_opts_onchange():
     shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: modules.sd_models.reload_model_weights()), call=False)
     shared.opts.onchange("sd_vae", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
     shared.opts.onchange("sd_vae_as_default", wrap_queued_call(lambda: modules.sd_vae.reload_vae_weights()), call=False)
-    shared.opts.onchange("temp_dir", ui_tempdir.on_tmpdir_changed)
     shared.opts.onchange("gradio_theme", shared.reload_gradio_theme)
     shared.opts.onchange("cross_attention_optimization", wrap_queued_call(lambda: modules.sd_hijack.model_hijack.redo_hijack(shared.sd_model)), call=False)
     startup_timer.record("opts onchange")

--- a/webui.py
+++ b/webui.py
@@ -65,7 +65,7 @@ if not shared.cmd_opts.skip_version_check:
 
 import modules.codeformer_model as codeformer
 import modules.gfpgan_model as gfpgan
-from modules import sd_samplers, upscaler, extensions, localization, ui_extra_networks, config_states
+from modules import sd_samplers, upscaler, extensions, localization, ui_tempdir, ui_extra_networks, config_states
 import modules.face_restoration
 import modules.img2img
 


### PR DESCRIPTION
## Description

Closes #3278 #11040 #11185

A lot of this code is legacy and no longer needed, as Gradio has fixed all these items. This would also resolve the long standing issue of the temp folder never being cleared, which is now doable since all Gradio related files are stored separately under `gradio` now. 

Some related info:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/3278#issuecomment-1666383929
https://github.com/gradio-app/gradio/blob/34f6b22efbfedfa569d452f3f99ed2e6593e3c21/gradio/components/base.py#L310-L316
https://github.com/gradio-app/gradio/pull/3523
https://github.com/gradio-app/gradio/issues/3597
https://github.com/gradio-app/gradio/pull/4256

This would also prevent any edge cases like this being encountered in the future when Gradio updates. https://github.com/Mikubill/sd-webui-controlnet/issues/1563

This is however a bit of a breaking change in it's current state, as it makes the `temp_dir` setting obsolete. It should be preferred to use the `GRADIO_TEMP_DIR` environment variable now. I'm open for suggestions on how to make this more easily accessible to the user though if this is desired.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
