### PR TITLE
don't save incomplete images

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -356,6 +356,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),
     "clean_temp_dir_at_start": OptionInfo(False, "Cleanup non-default temporary directory when starting webui"),
 
+    "dont_save_interrupted_images": OptionInfo(False, "Don't save incomplete images").info("Don't save images that has been interrupted in mid-generation, they will still show up in webui output."),
 }))
 
 options_templates.update(options_section(('saving-paths', "Paths for saving"), {


### PR DESCRIPTION
## Description
[[Feature Request]: Option setting to not save a skipped image #12335](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12335) 
> not exactly what the feature request asked, he's asking for interactive implementation....


new opt `Saving images/grids` > `Don't save incomplete images`
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/cb49cc35-1822-4641-8184-276222673944)
if enabled will skip saving to storage when the image is interrupted or skipped
default not enabled

saving of image grid is not affected it's not governed under this setting
and even if the images are not saved the result was still show up in web UI
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
