### PR TITLE
Add option to try to use last latent, force for LMS sampler

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -329,6 +329,7 @@ infotext_to_setting_name_mapping = [
     ('Eta', 'eta_ancestral'),
     ('Eta DDIM', 'eta_ddim'),
     ('Discard penultimate sigma', 'always_discard_next_to_last_sigma'),
+    ('Use last stored latent', 'use_last_stored_latent'),
     ('UniPC variant', 'uni_pc_variant'),
     ('UniPC skip type', 'uni_pc_skip_type'),
     ('UniPC order', 'uni_pc_order'),

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -13,7 +13,7 @@ from modules.script_callbacks import AfterCFGCallbackParams, cfg_after_cfg_callb
 samplers_k_diffusion = [
     ('Euler a', 'sample_euler_ancestral', ['k_euler_a', 'k_euler_ancestral'], {"uses_ensd": True}),
     ('Euler', 'sample_euler', ['k_euler'], {}),
-    ('LMS', 'sample_lms', ['k_lms'], {}),
+    ('LMS', 'sample_lms', ['k_lms'], {'discard_next_to_last_sigma': True, 'use_last_stored_latent': True}),
     ('Heun', 'sample_heun', ['k_heun'], {"second_order": True}),
     ('DPM2', 'sample_dpm_2', ['k_dpm_2'], {'discard_next_to_last_sigma': True}),
     ('DPM2 a', 'sample_dpm_2_ancestral', ['k_dpm_2_a'], {'discard_next_to_last_sigma': True, "uses_ensd": True}),
@@ -475,5 +475,12 @@ class KDiffusionSampler:
         if self.model_wrap_cfg.padded_cond_uncond:
             p.extra_generation_params["Pad conds"] = True
 
-        return samples
+        use_last_stored_latent = self.config is not None and self.config.options.get('use_last_stored_latent', False)
+        if opts.use_last_stored_latent and not use_last_stored_latent:
+            use_last_stored_latent = True
+            p.extra_generation_params["Use last stored latent"] = True
 
+        if use_last_stored_latent:
+            return self.last_latent
+        else:
+            return samples

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -615,7 +615,7 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
     'rho':  OptionInfo(0.0, "rho", gr.Number).info("0 = default (7 for karras, 1 for polyexponential); higher values result in a more steep noise schedule (decreases faster)"),
     'eta_noise_seed_delta': OptionInfo(0, "Eta noise seed delta", gr.Number, {"precision": 0}).info("ENSD; does not improve anything, just produces different results for ancestral samplers - only useful for reproducing images"),
     'always_discard_next_to_last_sigma': OptionInfo(False, "Always discard next-to-last sigma").link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6044"),
-    'use_last_stored_latent': OptionInfo(False, "Always try to use the last stored latent").info("Used by default for LMS (non-Karras) to work around an issue with k-diffusion").link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/TODO"),
+    'use_last_stored_latent': OptionInfo(False, "Always try to use the last stored latent").info("Used by default for LMS (non-Karras) to work around an issue with k-diffusion").link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12349"),
     'uni_pc_variant': OptionInfo("bh1", "UniPC variant", gr.Radio, {"choices": ["bh1", "bh2", "vary_coeff"]}),
     'uni_pc_skip_type': OptionInfo("time_uniform", "UniPC skip type", gr.Radio, {"choices": ["time_uniform", "time_quadratic", "logSNR"]}),
     'uni_pc_order': OptionInfo(3, "UniPC order", gr.Slider, {"minimum": 1, "maximum": 50, "step": 1}).info("must be < sampling steps"),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -615,6 +615,7 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
     'rho':  OptionInfo(0.0, "rho", gr.Number).info("0 = default (7 for karras, 1 for polyexponential); higher values result in a more steep noise schedule (decreases faster)"),
     'eta_noise_seed_delta': OptionInfo(0, "Eta noise seed delta", gr.Number, {"precision": 0}).info("ENSD; does not improve anything, just produces different results for ancestral samplers - only useful for reproducing images"),
     'always_discard_next_to_last_sigma': OptionInfo(False, "Always discard next-to-last sigma").link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6044"),
+    'use_last_stored_latent': OptionInfo(False, "Always try to use the last stored latent").info("Used by default for LMS (non-Karras) to work around an issue with k-diffusion").link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/TODO"),
     'uni_pc_variant': OptionInfo("bh1", "UniPC variant", gr.Radio, {"choices": ["bh1", "bh2", "vary_coeff"]}),
     'uni_pc_skip_type': OptionInfo("time_uniform", "UniPC skip type", gr.Radio, {"choices": ["time_uniform", "time_quadratic", "logSNR"]}),
     'uni_pc_order': OptionInfo(3, "UniPC order", gr.Slider, {"minimum": 1, "maximum": 50, "step": 1}).info("must be < sampling steps"),

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -241,6 +241,7 @@ axis_options = [
     AxisOption("Token merging ratio", float, apply_override('token_merging_ratio')),
     AxisOption("Token merging ratio high-res", float, apply_override('token_merging_ratio_hr')),
     AxisOption("Always discard next-to-last sigma", str, apply_override('always_discard_next_to_last_sigma', boolean=True), choices=boolean_choice(reverse=True)),
+    AxisOption("Use last stored latent", str, apply_override('use_last_stored_latent', boolean=True), choices=boolean_choice(reverse=True)),
 ]
 
 


### PR DESCRIPTION
## Description

This PR aims to hopefully resolve, or at least bring to further light, a long-standing issue in #7244, particularly with the LMS sampler.

[For LMS, k-diffusion runs the callback before doing more work on the latent](https://github.com/crowsonkb/k-diffusion/blob/d79351ac29bcaa73b1de5039197a60109470382e/k_diffusion/sampling.py#L272-L276). The very last step of LMS, after the last callback, has notably caused issues, for some unknown reason to me as I don't know the intricacies of the sampler, but users have found that the penultimate step does _not_ have this issue. However, there was no way previously to obtain this last step other than working off the callback k-diffusion provides, so this PR adds the option to now use that last callback (stored in `last_latent`) and return that for the final result instead. I also don't believe this applies to every sampler so I worded the option in that it tries to use the last latent -- basically whatever k-diffusion last returns in it's callback.

This PR now forces this for LMS, along with discarding the penultimate sigma for it. Using the Karras scheduler with LMS (available in the sampler selection as LMS Karras) does not seem to have this issue so I'm leaving that as-is.

## Screenshots/videos:

(PNG info included for replication, though note the `Before` will need the change before this PR to be replicated ofc)

**Before**
![before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/cecbedb7-2f05-4966-b3fe-607a9cdb9a18)

**After**
![after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/9bcb431f-4e1e-4773-a8e6-47dbfd99874e)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
