### PR TITLE
provide an option so hires fix uses the final step (sort of) of the prompt schedule

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -514,6 +514,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "ui_reorder_list": OptionInfo([], "txt2img/img2img UI item order", ui_components.DropdownMulti, lambda: {"choices": list(shared_items.ui_reorder_categories())}).info("selected items appear first").needs_restart(),
     "hires_fix_show_sampler": OptionInfo(False, "Hires fix: show hires sampler selection").needs_restart(),
     "hires_fix_show_prompts": OptionInfo(False, "Hires fix: show hires prompt and negative prompt").needs_restart(),
+    "hires_fix_use_final_prompt": OptionInfo(False, "Hires fix: use final state of prompt for whole duration"),
     "disable_token_counters": OptionInfo(False, "Disable prompt token counters").needs_restart(),
 }))
 


### PR DESCRIPTION
## Description

**The UI option for this is not in the right place, please tell me where to put it.**

* when using prompt editing, sometimes you don't want the hires fix to apply the full prompt editing schedule, you just want to continue refining the final result using the final editing state of the prompt
  * for example, if your prompt is `[something that sets up the composition:something that produces the real result:0.35]`, then during the hires fix pass, you really only want the hires fix to use `something that produces the real result`, you don't want it to go back temporarily and apply `something that sets up the composition` for a while
  * while you can use separate hires prompt to achieve this, that doesn't work if you're using something like Dynamic Prompts or Wildcards to create prompts dynamically; those extensions would need to provide some mechanism to generate a special hires prompt, and it would be pretty tedious, whereas doing it here handles anything which modifies the prompt, whether it's an extension or a script like xyz-grid prompt SR. Even without using extensions and scripts, I know some people specifically want this behavior, so it saves them from having to manually make a hires prompt just to get this effect
  * this PR provides an optional setting that forces the highres fix to build the schedule specially and only use the final part of the prompt
  * There is special handling for `[foo|bar]` so it still happens during highres fix, but only if it was active at the final step. so `[[foo|bar]::0.5]` is treated as ` `, but `[[foo|bar]:0.5]` is treated as `[foo|bar]`
* a summary of changes in code
  * a new option in shared.py settings
  *  `get_learned_conditioning_prompt_schedule` takes a new "use final state" boolean parameter that causes it to produce a "final state" schedule by only ever generating the "after" of a `scheduled` expression
  * `get_conds_with_caching` takes an optional "use final state" parameter and includes it as part of the cache key
  * normal prompts are unchanged; hires fix prompts optionally set the "use final state" parameter to True
  * plumbing to pass "use final state" parameter through
* Addresses #9281, but in a more sophisticated way

* **Things that maybe should get changed before this is merged**
  * Where should the option go? It's not actually User Interface, maybe under Stable Diffusion? Personally if this was just for me I'd put it in the txt2img hires fix controls themselves (e.g. where you set the scale), but personally I think this should be the default behavior that everyone gets out of the box, so my judgement is suspect, which is why I put it in settings
  * Should I make it so even if you set this option, it's ignored if you explicitly set a non-empty hires prompt?
  * Need to save this option into the png-info and make it an override so that people can reproduce the results without manually changing the setting to the correct value?
  * The new parameter in `get_learned_conditioning_prompt_schedule` defaults to `False` so extensions calling it won't break. But I didn't do that for `get_conds_with_caching`, should I?
## Screenshots/videos:

The effect is not easily discernable in normal use, so I just made some exaggerated examples with the hires fix denoising set to 0.8, scale=1, so that the hires fix pass basically recomputes the whole image, just so you can see the effect happening.

The prompt is `[man on a street:woman in a forest:0.99] with a [cat|cow|sheep|horse]`. The expected behavior is that the old code will produce a man on a street, and the new code will produce a woman in a forest, and that we get a cat-cow-sheep-horse regardless, and not just a horse (which would happen if we naively just used the final prompt schedule step).

before hires fix:
![00399-v1-5-pruned-2023-08-05-7-30-3127545016-before-highres-fix](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/777b534c-b383-4a2a-b762-6677a89b4025)

hires fix before this change:
![00400-v1-5-pruned-2023-08-05-7-30-3127545016](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/3723c2f1-68a3-4a66-8368-4efa48a791d2)

hires fix with the option provided by this PR enabled:
![00408-v1-5-pruned-2023-08-05-7-30-3127545016](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/33d79220-3ce3-4a85-903a-61412f021411)

I put the UI option to control it here with the other hires fix options, but this is actually the **User Interface** options panel, and this option is not User Interface, so this doesn't seem like the right choice. (None of the options panels really seemed like a good fit, and at least here it's next to some related choices.)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/125328806/f5217a88-fc27-4ba2-9b01-b88920af8a93)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
