### PR TITLE
Update extra_networks_lora.py

### DIFF
--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -25,7 +25,7 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
             te_multiplier = float(params.positional[1]) if len(params.positional) > 1 else 1.0
             te_multiplier = float(params.named.get("te", te_multiplier))
 
-            unet_multiplier = float(params.positional[2]) if len(params.positional) > 2 else te_multiplier
+            unet_multiplier = float(params.positional[2]) if len(params.positional) > 2 and type(params.positional[2]) is not str else te_multiplier
             unet_multiplier = float(params.named.get("unet", unet_multiplier))
 
             dyn_dim = int(params.positional[3]) if len(params.positional) > 3 else None


### PR DESCRIPTION
Add type check for params.positional[2]

## Description

* A simple fix for compatibility with loRA block weight extension, which use params.positional[2] in string.
* Prevent doing float(params.positional[2]) without checking the type of params.positional[2] (if its str).


## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
