### PR TITLE
default save_incomplete_images True

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -385,7 +385,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),
     "clean_temp_dir_at_start": OptionInfo(False, "Cleanup non-default temporary directory when starting webui"),
 
-    "save_incomplete_images": OptionInfo(False, "Save incomplete images").info("save images that has been interrupted in mid-generation; even if not saved, they will still show up in webui output."),
+    "save_incomplete_images": OptionInfo(True, "Save incomplete images").info("save images that has been interrupted in mid-generation; even if not saved, they will still show up in webui output."),
 }))
 
 options_templates.update(options_section(('saving-paths', "Paths for saving"), {


### PR DESCRIPTION
## Description
in your rework [`d86d12e`](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/d86d12e9117772f041682124badc7baac7c57911#diff-15faa364afc7fd40ccc1e6a38893b2dac62c846715710dfbe44f25fb65205440L388-R388) you flip the logic / wording but didn't flip the value
to preserve old behavior by default which is `save` then that should be `True`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
