### PR TITLE
add explicit content-type header for image/webp

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -41,6 +41,9 @@ warnings.filterwarnings("default" if opts.show_gradio_deprecation_warnings else 
 mimetypes.init()
 mimetypes.add_type('application/javascript', '.js')
 
+# Likewise, add explicit content-type header for certain missing image types
+mimetypes.add_type('image/webp', '.webp')
+
 if not cmd_opts.share and not cmd_opts.listen:
     # fix gradio phoning home
     gradio.utils.version_check = lambda: None


### PR DESCRIPTION
## Description

Python 10.x does lack the "image/webp" mime-type, so opening those files directly in the browser does yield to render them as text/plain

Python 11.x does support it, so these changes will need to go away whenever the version being used here is upgraded.

See: https://github.com/python/cpython/issues/83083


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
