### PR TITLE
Update outdated pytorch_lightning import to prevent boot crash

### DIFF
--- a/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
+++ b/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma

--- a/modules/models/diffusion/ddpm_edit.py
+++ b/modules/models/diffusion/ddpm_edit.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma


### PR DESCRIPTION
Given this environment: 
- Python 3.10.11 (main, Apr 20 2023, 19:02:41) [GCC 11.2.0]
- stable-diffusion-webui: v1.5.1

The imports prior to the changes in this PR results in this error:
> ModuleNotFoundError: No module named 'pytorch_lightning.utilities.distributed'

Full stack trace: 

```
Traceback (most recent call last):
  File "/workspace/sd/launch.py", line 39, in <module>
    main()
  File "/workspace/sd/launch.py", line 35, in main
    start()
  File "/workspace/sd/modules/launch_utils.py", line 390, in start
    import webui
  File "/workspace/sd/webui.py", line 54, in <module>
    from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, queue_lock  # noqa: F401
  File "/workspace/sd/modules/call_queue.py", line 6, in <module>
    from modules import shared, progress, errors
  File "/workspace/sd/modules/shared.py", line 21, in <module>
    from ldm.models.diffusion.ddpm import LatentDiffusion
  File "/workspace/sd/repositories/stable-diffusion-stability-ai/ldm/models/diffusion/ddpm.py", line 20, in <module>
    from pytorch_lightning.utilities.distributed import rank_zero_only
ModuleNotFoundError: No module named 'pytorch_lightning.utilities.distributed'
```

This addresses #11458 which documents the bug but no fix was made to the repo itself (yet).

I'm not sure it's a safe change but it never hurts to ask. For instance I don't know if this is a backward-compatible change.

## Importantly this does not resolve the issue fully

Even after this change, a crash occurs due to: 

```
Traceback (most recent call last):
  File "/workspace/sd/launch.py", line 39, in <module>
    main()
  File "/workspace/sd/launch.py", line 35, in main
    start()
  File "/workspace/sd/modules/launch_utils.py", line 390, in start
    import webui
  File "/workspace/sd/webui.py", line 54, in <module>
    from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, queue_lock  # noqa: F401
  File "/workspace/sd/modules/call_queue.py", line 6, in <module>
    from modules import shared, progress, errors
  File "/workspace/sd/modules/shared.py", line 21, in <module>
    from ldm.models.diffusion.ddpm import LatentDiffusion
  File "/workspace/sd/repositories/stable-diffusion-stability-ai/ldm/models/diffusion/ddpm.py", line 20, in <module>
    from pytorch_lightning.utilities.distributed import rank_zero_only
ModuleNotFoundError: No module named 'pytorch_lightning.utilities.distributed'
```

AFAIK that's a downloaded file, so perhaps the version of `stable-diffusion-stability-ai` needs to be updated? Not sure.

It looks like the current (as of today [culprit code in the stablediffusion repository](https://github.com/Stability-AI/stablediffusion/blob/cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf/ldm/models/diffusion/ddpm.py#L20) still uses this outdated namespace as well.

Manually editing this code to also use `rank_only` in the import namespace manages to get the boot process to the next stage: 

```
Downloading: "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors" to /workspace/sd/models/Stable-diffusion/v1-5-pruned-emaonly.safetensors

 22%|████████████████████
```

It's likely this PR might need to wait for a while and a better temporary solution would be to pin down the pytorch-lightning dependency to an earlier version that still offers `distributed` in the import namespace. Since [pytorch-lightning 2.0.0](https://github.com/Lightning-AI/lightning/releases)(which gets installed with the existing requirements.txt) is major version bump I'm guessing 1.9.x could be safe? 