### PR TITLE
Fix mismatch between shared.sd_model & shared.opts

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -623,6 +623,8 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         timer.record("send model to device")
 
         model_data.set_sd_model(already_loaded)
+        shared.opts.data["sd_model_checkpoint"] = already_loaded.sd_checkpoint_info.title
+        shared.opts.data["sd_checkpoint_hash"] = already_loaded.sd_checkpoint_info.sha256
         print(f"Using already loaded model {already_loaded.sd_checkpoint_info.title}: done in {timer.summary()}")
         return model_data.sd_model
     elif shared.opts.sd_checkpoints_limit > 1 and len(model_data.loaded_sd_models) < shared.opts.sd_checkpoints_limit:


### PR DESCRIPTION
## Description

* Fix mismatch between shared.sd_model and shard.opts causing runtime error after switching models.
* Added processing to update shared.opts after model_data.set_sd_model function call.
* This problem occurs when `Maximum number of checkpoints loaded at the same time` setting is greater than or equal to 2.

## How to reproduce this bug

The mismatch arises when calling the `reload_model_weights` function internally.

1. When calling `reload_model_weights(info=A_info)`, A_info is loaded and both `shared.sd_model` and `shared.opts` are updated (Note that A_info and B_info are models with different `checkpoint_config`).
2. Calling `reload_model_weights(info=B_info)` next, B_info is loaded, and again, `shared.sd_model` and `shared.opts` are updated.
3. When `reload_model_weights(info=A_info)` is called again, A_info is reused and only `shared.sd_model` is updated. At this point, `shared.opts` remains B_info.

After this process, when calling processing.process_images, even though I want to use the A_info model, it unintentionally switches to the B_info model instead.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)