### PR TITLE
Use error code 1111 to trigger restart

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -316,13 +316,6 @@ def prepare_environment():
     codeformer_commit_hash = os.environ.get('CODEFORMER_COMMIT_HASH', "c5b4593074ba6214284d6acd5f1719b6c5d739af")
     blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
 
-    try:
-        # the existance of this file is a signal to webui.sh/bat that webui needs to be restarted when it stops execution
-        os.remove(os.path.join(script_path, "tmp", "restart"))
-        os.environ.setdefault('SD_WEBUI_RESTARTING', '1')
-    except OSError:
-        pass
-
     if not args.skip_python_version_check:
         check_python_version()
 

--- a/modules/restart.py
+++ b/modules/restart.py
@@ -1,7 +1,4 @@
 import os
-from pathlib import Path
-
-from modules.paths_internal import script_path
 
 
 def is_restartable() -> bool:
@@ -12,11 +9,8 @@ def is_restartable() -> bool:
 
 
 def restart_program() -> None:
-    """creates file tmp/restart and immediately stops the process, which webui.bat/webui.sh interpret as a command to start webui again"""
-
-    (Path(script_path) / "tmp" / "restart").touch()
-
-    stop_program()
+    """exit process with errorcode 1111, which webui.bat/webui.sh interpret as a command to start webui again"""
+    os._exit(1111)
 
 
 def stop_program() -> None:

--- a/webui.bat
+++ b/webui.bat
@@ -51,14 +51,21 @@ if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch
 %PYTHON% launch.py %*
-if EXIST tmp/restart goto :skip_venv
+if %errorlevel% == 1111 (
+    if [%SD_WEBUI_RESTARTING%] == [] set SD_WEBUI_RESTARTING=1
+    goto :skip_venv
+)
 pause
 exit /b
 
 :accelerate_launch
 echo Accelerating
 %ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
-if EXIST tmp/restart goto :skip_venv
+if %errorlevel% == 1111 (
+    if [%1] == [] set SD_WEBUI_RESTARTING=1
+    goto :skip_venv
+)
+
 pause
 exit /b
 

--- a/webui.sh
+++ b/webui.sh
@@ -248,7 +248,11 @@ while [[ "$KEEP_GOING" -eq "1" ]]; do
         "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
     fi
 
-    if [[ ! -f tmp/restart ]]; then
+    if [ $? -ne 1111 ]; then
         KEEP_GOING=0
+    fi
+
+    if [[ -z "$SD_WEBUI_RESTARTING" ]]; then
+        export SD_WEBUI_RESTARTING="1"
     fi
 done


### PR DESCRIPTION
## Description
Use error code 1111 to trigger restart

writing a file to be detected as a trigger restart works but is there a reason why we don't use error code?

only tested using with windwos webui.bat
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
