### PR TITLE
extra network metadata inherit old description

### DIFF
--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -36,12 +36,10 @@ class UserMetadataEditor:
         item = self.page.items.get(name, {})
 
         user_metadata = item.get('user_metadata', None)
-        if user_metadata is None:
-            user_metadata = {}
+        if not user_metadata:
+            user_metadata = {'description': item.get('description', '')}
             item['user_metadata'] = user_metadata
 
-        if len(user_metadata) == 0:
-            user_metadata = {'description': item.get('description', '')}
         return user_metadata
 
     def create_extra_default_items_in_left_column(self):

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -40,6 +40,8 @@ class UserMetadataEditor:
             user_metadata = {}
             item['user_metadata'] = user_metadata
 
+        if len(user_metadata) == 0:
+            user_metadata = {'description': item.get('description', '')}
         return user_metadata
 
     def create_extra_default_items_in_left_column(self):


### PR DESCRIPTION
## Description
on initial creation of the new metadata.json
inherits the old description.txt

this way if someone already has the description in the old format it will not be created blank and overwritten by the new json metadata

ease the transition between old and new metadata system

test / scenario

have some extra network, beside the fireplace if I was the same name but.txt
in the text file enter some description and it will show up in the extra networks tab

currently now if you press the metadata button and edit and save it
this will create a new Json file without but the old description
you will see that the card will no longer have the description

after this PR
when did Json file is created for the first time
it will inherit whatever it is in the current description.txt

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
