### PR TITLE
Zoom and pan: fix auto-expand

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -42,6 +42,11 @@ onUiLoaded(async() => {
         }
     }
 
+    // Detect whether the element has a horizontal scroll bar
+    function hasHorizontalScrollbar(element) {
+        return element.scrollWidth > element.clientWidth;
+    }
+
     // Function for defining the "Ctrl", "Shift" and "Alt" keys
     function isModifierKey(event, key) {
         switch (key) {
@@ -650,16 +655,14 @@ onUiLoaded(async() => {
         }
 
         // Simulation of the function to put a long image into the screen.
-        // We define the size of the canvas, make a fullscreen to reveal the image, then reduce it to fit into the element.
+        // We detect if an image has a scroll bar or not, make a fullscreen to reveal the image, then reduce it to fit into the element.
         // We hide the image and show it to the user when it is ready.
         function autoExpand(e) {
             const canvas = document.querySelector(`${elemId} canvas[key="interface"]`);
             const isMainTab = activeElement === elementIDs.inpaint || activeElement === elementIDs.inpaintSketch || activeElement === elementIDs.sketch;
+
             if (canvas && isMainTab) {
-                if (canvas && parseInt(targetElement.style.width) > 862 || parseInt(canvas.width) < 862) {
-                    return;
-                }
-                if (canvas) {
+                if (hasHorizontalScrollbar(targetElement)) {
                     targetElement.style.visibility = "hidden";
                     setTimeout(() => {
                         fitToScreen();


### PR DESCRIPTION
## Description

After receiving feedback from users of the extension, I made a fix that completely fixes possible problems with this setting.

The problem was that there were no proper checks and the picture was blinking.

I fixed that, and now it checks for a scroll bar, if there is one, the image will expand.

## Screenshots/videos:

<details><summary>Before</summary>

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22278673/25cdb9bc-20bf-48a2-bdcf-bcc30585bfbb

</details>
<details><summary>After</summary>

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22278673/a7c62be4-1739-4e1b-81d2-ce0cb9dacdac

</details>

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
