### PR TITLE
Add slerp import for extension backwards compat

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List
 
 import modules.sd_hijack
 from modules import devices, prompt_parser, masking, sd_samplers, lowvram, generation_parameters_copypaste, extra_networks, sd_vae_approx, scripts, sd_samplers_common, sd_unet, errors, rng
+from modules.rng import slerp # noqa: F401
 from modules.sd_hijack import model_hijack
 from modules.sd_samplers_common import images_tensor_to_samples, decode_first_stage, approximation_indexes
 from modules.shared import opts, cmd_opts, state


### PR DESCRIPTION
## Description

Follow-up to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12426. Fixes extension compatbility with [sd-webui-llul](https://github.com/hnmr293/sd-webui-llul)

https://github.com/hnmr293/sd-webui-llul/blob/aa47b3eeb45c53f0d6ccaae59abf36e8ed6731f5/scripts/llul_hooker.py#L10

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
