### PR TITLE
Use better symbol for extra networks sort

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -78,7 +78,6 @@ extra_networks_symbol = '\U0001F3B4'  # 🎴
 switch_values_symbol = '\U000021C5' # ⇅
 restore_progress_symbol = '\U0001F300' # 🌀
 detect_image_size_symbol = '\U0001F4D0'  # 📐
-up_down_symbol = '\u2195\ufe0f' # ↕️
 
 
 plaintext_to_html = ui_common.plaintext_to_html

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -347,7 +347,7 @@ def pages_in_preferred_order(pages):
 
 
 def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
-    from modules.ui import up_down_symbol
+    from modules.ui import switch_values_symbol
 
     ui = ExtraNetworksUi()
     ui.pages = []
@@ -374,7 +374,7 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
 
     edit_search = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", elem_classes="search", placeholder="Search...", visible=False, interactive=True)
     dropdown_sort = gr.Dropdown(choices=['Default Sort', 'Date Created', 'Date Modified', 'Name'], value='Default Sort', elem_id=tabname+"_extra_sort", elem_classes="sort", multiselect=False, visible=False, show_label=False, interactive=True, label=tabname+"_extra_sort_order")
-    button_sortorder = ToolButton(up_down_symbol, elem_id=tabname+"_extra_sortorder", elem_classes="sortorder", visible=False)
+    button_sortorder = ToolButton(switch_values_symbol, elem_id=tabname+"_extra_sortorder", elem_classes="sortorder", visible=False)
     button_refresh = gr.Button('Refresh', elem_id=tabname+"_extra_refresh", visible=False)
     checkbox_show_dirs = gr.Checkbox(True, label='Show dirs', elem_id=tabname+"_extra_show_dirs", elem_classes="show-dirs", visible=False)
 


### PR DESCRIPTION
## Description

Follow-up to my own PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10943. I somehow didn't realize this character exists, let alone in the UI already.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
