### PR TITLE
Add extra infotext option

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -581,6 +581,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
         "RNG": opts.randn_source if opts.randn_source != "GPU" and opts.randn_source != "NV" else None,
         "NGMS": None if p.s_min_uncond == 0 else p.s_min_uncond,
         **p.extra_generation_params,
+        **{opt: getattr(opts, opt) for opt in opts.extra_infotext},
         "Version": program_version() if opts.add_version_to_infotext else None,
         "User": p.user if opts.add_user_name_to_info else None,
     }

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -266,7 +266,7 @@ options_templates.update(options_section(('infotext', "Infotext"), {
 <li>Discard: remove style text from prompt, keep styles dropdown as it is.</li>
 <li>Apply if any: remove style text from prompt; if any styles are found in prompt, put them into styles dropdown, otherwise keep it as it is.</li>
 </ul>"""),
-
+    "extra_infotext": shared.OptionInfo([], "Additional infotext", ui_components.DropdownMulti, lambda: {"choices": list(shared.opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("extra settings to appear in infotext; not added to override settings, only for informational purposes").needs_reload_ui(),
 }))
 
 options_templates.update(options_section(('ui', "Live previews"), {


### PR DESCRIPTION
## Description

Allows adding any arbitrary option to infotext. Closes a bunch of feature requests.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/4969
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6031
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/8345
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9562
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10599

We may want to prefix the settings keys or put it all under a JSON-encoded string instead, but this at least gets that discussion going.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
