### PR TITLE
Catch float value error default to -1

### DIFF
--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -51,7 +51,10 @@ class UiLoadsave:
                 if isinstance(x, gr.Textbox) and field == 'value':  # due to an undersirable behavior of gr.Textbox, if you give it an int value instead of str, everything dies
                     saved_value = str(saved_value)
                 elif isinstance(x, gr.Number) and field == 'value':
-                    saved_value = float(saved_value)
+                    try:
+                        saved_value = float(saved_value)
+                    except ValueError:
+                        saved_value = -1
 
                 setattr(obj, field, saved_value)
                 if init_field is not None:


### PR DESCRIPTION
## Description
it's a value can't be converted to a float it will throw an error
like when the value is a blank string

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
