### PR TITLE
Fix to make `Lora/Networks: use old method` setting work

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -357,7 +357,13 @@ def network_forward(module, input, original_forward):
         if module is None:
             continue
 
-        y = module.forward(y, input)
+        if shared.opts.lora_functional:
+            module.up_model.to(device=devices.device)
+            module.down_model.to(device=devices.device)
+
+            y = y + module.up_model(module.down_model(input)) * module.multiplier() * module.calc_scale()
+        else:
+            y = module.forward(y, input)
 
     return y
 


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12104

Fixes a regression introduced by https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/b75b004fe62826455f1aa77e849e7da13902cb17 as part of the extra networks rework (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11821). I honestly don't understand why this works, as to me it looks identical to this code below, but it does in fact fix the RuntimeError and produce an image that is identical to one before this regression.

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/68f336bd994bed5442ad95bad6b6ad5564a5409a/extensions-builtin/Lora/network_lora.py#L80-L84

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
