### PR TITLE
Fix broken `Lora/Networks: use old method` option

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -357,7 +357,7 @@ def network_forward(module, input, original_forward):
         if module is None:
             continue
 
-        y = module.forward(y, input)
+        y = module.forward(input, y)
 
     return y
 


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12104

Fixes a regression introduced by https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/b75b004fe62826455f1aa77e849e7da13902cb17 as part of the extra networks rework (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11821). As far as I can tell this was just an oversight during refactoring. This fixes the `RuntimeError` and produces an image identical to one before this regression.

Note that this function is only ever used when the option is enabled, so it doesn't affect the "new normal" for LoRA operation.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/68f336bd994bed5442ad95bad6b6ad5564a5409a/extensions-builtin/Lora/networks.py#L323-L327

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
