### PR TITLE
Make `StableDiffusionProcessingImg2Img.mask_blur` a property, make more inline with PIL `GaussianBlur`

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1275,13 +1275,13 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
             if self.mask_blur_x > 0:
                 np_mask = np.array(image_mask)
-                kernel_size = 2 * int(4 * self.mask_blur_x + 0.5) + 1
+                kernel_size = 2 * int(2.5 * self.mask_blur_x + 0.5) + 1
                 np_mask = cv2.GaussianBlur(np_mask, (kernel_size, 1), self.mask_blur_x)
                 image_mask = Image.fromarray(np_mask)
 
             if self.mask_blur_y > 0:
                 np_mask = np.array(image_mask)
-                kernel_size = 2 * int(4 * self.mask_blur_y + 0.5) + 1
+                kernel_size = 2 * int(2.5 * self.mask_blur_y + 0.5) + 1
                 np_mask = cv2.GaussianBlur(np_mask, (1, kernel_size), self.mask_blur_y)
                 image_mask = Image.fromarray(np_mask)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1232,11 +1232,10 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.image_mask = mask
         self.latent_mask = None
         self.mask_for_overlay = None
-        if mask_blur is not None:
-            mask_blur_x = mask_blur
-            mask_blur_y = mask_blur
         self.mask_blur_x = mask_blur_x
         self.mask_blur_y = mask_blur_y
+        if mask_blur is not None:
+            self.mask_blur = mask_blur
         self.inpainting_fill = inpainting_fill
         self.inpaint_full_res = inpaint_full_res
         self.inpaint_full_res_padding = inpaint_full_res_padding
@@ -1245,6 +1244,22 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         self.mask = None
         self.nmask = None
         self.image_conditioning = None
+
+    @property
+    def mask_blur(self):
+        if self.mask_blur_x == self.mask_blur_y:
+            return self.mask_blur_x
+        return None
+
+    @mask_blur.setter
+    def mask_blur(self, value):
+        self.mask_blur_x = value
+        self.mask_blur_y = value
+
+    @mask_blur.deleter
+    def mask_blur(self):
+        del self.mask_blur_x
+        del self.mask_blur_y
 
     def init(self, all_prompts, all_seeds, all_subseeds):
         self.sampler = sd_samplers.create_sampler(self.sampler_name, self.sd_model)


### PR DESCRIPTION
I don't exactly know why GitHub allows me to do this, but I'm opening this PR on @Splendide-Imaginarius's behalf now since it's a pretty intrusive issue.

This fixes an issue where the `mask_blur` property isn't set in img2img, which has caused problems for Ultimate Upscale and ControlNet, both for a few months now. It was a regression introduced by https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10295.
https://github.com/Coyote-A/ultimate-upscale-for-automatic1111/issues/111
https://github.com/Mikubill/sd-webui-controlnet/discussions/1888
https://github.com/Mikubill/sd-webui-controlnet/pull/1907

Also makes the sigma values match closer to the old behavior of using PIL's `GaussianBlur` to reduce seams. 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
