### PR TITLE
Fix color correction by converting image to RGB

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -57,7 +57,7 @@ def apply_color_correction(correction, original_image):
 
     image = blendLayers(image, original_image, BlendType.LUMINOSITY)
 
-    return image
+    return image.convert('RGB')
 
 
 def apply_overlay(image, paste_loc, index, overlays):


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7021, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7560, https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9499

Caused by `blendLayers` returning an RGBA image, specifically a regression of [this commit](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/2e8b5418e3cd4e9212f2fcdb36305d7a40f97916) back in December. Since we don't override the opacity via that function (default being `1`) it's safe to convert this back to RGB.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
