### PR TITLE
pathc: also disable extensions installer with arg

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -243,7 +243,7 @@ def list_extensions(settings_file):
     disabled_extensions = set(settings.get('disabled_extensions', []))
     disable_all_extensions = settings.get('disable_all_extensions', 'none')
 
-    if disable_all_extensions != 'none':
+    if disable_all_extensions != 'none' or args.disable_extra_extensions or args.disable_all_extensions:
         return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]


### PR DESCRIPTION
## Description
I forgot to also disable the installer extension installer using args
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12294#issuecomment-1675628445

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
