### PR TITLE
Add Norm Module to lora ext and add "bias" support

### DIFF
--- a/extensions-builtin/Lora/network.py
+++ b/extensions-builtin/Lora/network.py
@@ -133,7 +133,7 @@ class NetworkModule:
 
         return 1.0
 
-    def finalize_updown(self, updown, orig_weight, output_shape):
+    def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
         if self.bias is not None:
             updown = updown.reshape(self.bias.shape)
             updown += self.bias.to(orig_weight.device, dtype=orig_weight.dtype)
@@ -145,7 +145,10 @@ class NetworkModule:
         if orig_weight.size().numel() == updown.size().numel():
             updown = updown.reshape(orig_weight.shape)
 
-        return updown * self.calc_scale() * self.multiplier()
+        if ex_bias is None:
+            ex_bias = 0
+
+        return updown * self.calc_scale() * self.multiplier(), ex_bias * self.multiplier()
 
     def calc_updown(self, target):
         raise NotImplementedError()

--- a/extensions-builtin/Lora/network.py
+++ b/extensions-builtin/Lora/network.py
@@ -145,10 +145,10 @@ class NetworkModule:
         if orig_weight.size().numel() == updown.size().numel():
             updown = updown.reshape(orig_weight.shape)
 
-        if ex_bias is None:
-            ex_bias = 0
+        if ex_bias is not None:
+            ex_bias = ex_bias * self.multiplier()
 
-        return updown * self.calc_scale() * self.multiplier(), ex_bias * self.multiplier()
+        return updown * self.calc_scale() * self.multiplier(), ex_bias
 
     def calc_updown(self, target):
         raise NotImplementedError()

--- a/extensions-builtin/Lora/network_norm.py
+++ b/extensions-builtin/Lora/network_norm.py
@@ -12,7 +12,6 @@ class ModuleTypeNorm(network.ModuleType):
 class NetworkModuleNorm(network.NetworkModule):
     def __init__(self,  net: network.Network, weights: network.NetworkWeights):
         super().__init__(net, weights)
-        print("NetworkModuleNorm")
 
         self.w_norm = weights.w.get("w_norm")
         self.b_norm = weights.w.get("b_norm")

--- a/extensions-builtin/Lora/network_norm.py
+++ b/extensions-builtin/Lora/network_norm.py
@@ -1,0 +1,29 @@
+import network
+
+
+class ModuleTypeNorm(network.ModuleType):
+    def create_module(self, net: network.Network, weights: network.NetworkWeights):
+        if all(x in weights.w for x in ["w_norm", "b_norm"]):
+            return NetworkModuleNorm(net, weights)
+
+        return None
+
+
+class NetworkModuleNorm(network.NetworkModule):
+    def __init__(self,  net: network.Network, weights: network.NetworkWeights):
+        super().__init__(net, weights)
+        print("NetworkModuleNorm")
+
+        self.w_norm = weights.w.get("w_norm")
+        self.b_norm = weights.w.get("b_norm")
+
+    def calc_updown(self, orig_weight):
+        output_shape = self.w_norm.shape
+        updown = self.w_norm.to(orig_weight.device, dtype=orig_weight.dtype)
+
+        if self.b_norm is not None:
+            ex_bias = self.b_norm.to(orig_weight.device, dtype=orig_weight.dtype)
+        else:
+            ex_bias = None
+
+        return self.finalize_updown(updown, orig_weight, output_shape, ex_bias)

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -322,7 +322,7 @@ def network_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn
                         updown = torch.nn.functional.pad(updown, (0, 0, 0, 0, 0, 5))
 
                     self.weight += updown
-                    if getattr(self, 'bias', None) is not None:
+                    if ex_bias is not None and getattr(self, 'bias', None) is not None:
                         self.bias += ex_bias
                     continue
 

--- a/extensions-builtin/Lora/scripts/lora_script.py
+++ b/extensions-builtin/Lora/scripts/lora_script.py
@@ -40,6 +40,18 @@ if not hasattr(torch.nn, 'Conv2d_forward_before_network'):
 if not hasattr(torch.nn, 'Conv2d_load_state_dict_before_network'):
     torch.nn.Conv2d_load_state_dict_before_network = torch.nn.Conv2d._load_from_state_dict
 
+if not hasattr(torch.nn, 'GroupNorm_forward_before_network'):
+    torch.nn.GroupNorm_forward_before_network = torch.nn.GroupNorm.forward
+
+if not hasattr(torch.nn, 'GroupNorm_load_state_dict_before_network'):
+    torch.nn.GroupNorm_load_state_dict_before_network = torch.nn.GroupNorm._load_from_state_dict
+
+if not hasattr(torch.nn, 'LayerNorm_forward_before_network'):
+    torch.nn.LayerNorm_forward_before_network = torch.nn.LayerNorm.forward
+
+if not hasattr(torch.nn, 'LayerNorm_load_state_dict_before_network'):
+    torch.nn.LayerNorm_load_state_dict_before_network = torch.nn.LayerNorm._load_from_state_dict
+
 if not hasattr(torch.nn, 'MultiheadAttention_forward_before_network'):
     torch.nn.MultiheadAttention_forward_before_network = torch.nn.MultiheadAttention.forward
 
@@ -50,6 +62,10 @@ torch.nn.Linear.forward = networks.network_Linear_forward
 torch.nn.Linear._load_from_state_dict = networks.network_Linear_load_state_dict
 torch.nn.Conv2d.forward = networks.network_Conv2d_forward
 torch.nn.Conv2d._load_from_state_dict = networks.network_Conv2d_load_state_dict
+torch.nn.GroupNorm.forward = networks.network_GroupNorm_forward
+torch.nn.GroupNorm._load_from_state_dict = networks.network_GroupNorm_load_state_dict
+torch.nn.LayerNorm.forward = networks.network_LayerNorm_forward
+torch.nn.LayerNorm._load_from_state_dict = networks.network_LayerNorm_load_state_dict
 torch.nn.MultiheadAttention.forward = networks.network_MultiheadAttention_forward
 torch.nn.MultiheadAttention._load_from_state_dict = networks.network_MultiheadAttention_load_state_dict
 


### PR DESCRIPTION
## Description

Since LyCORIS have added "train norm module" options and some trainer also support that.
I add "norm module" into lora ext.

Since the author of [HCP-Diffusion](https://github.com/7eu7d7/HCP-Diffusion) claims that bias also have siginificant effect on style when training norm layer, I also add "bias support" for network modules in lora ext. (May not be best practice, need review)

Since the "bias" in network module is actually for "bias directly add into updown), I use "ex_bias" here to refer to the "bias" in the module(LayerNorm/GroupNorm, or Linear/Conv2d, I have plan to support "train bias" in LyCORIS)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
