### PR TITLE
Add sliced encoding to significantly improve VRAM usage for batches

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -92,7 +92,15 @@ def images_tensor_to_samples(image, approximation=None, model=None):
             model = shared.sd_model
         image = image.to(shared.device, dtype=devices.dtype_vae)
         image = image * 2 - 1
-        x_latent = model.get_first_stage_encoding(model.encode_first_stage(image))
+        if opts.sd_vae_sliced_encoding:
+            x_latent = torch.stack([
+                model.get_first_stage_encoding(
+                    model.encode_first_stage(torch.unsqueeze(img, 0))
+                )[0]
+                for img in image
+            ])
+        else:
+            x_latent = model.get_first_stage_encoding(model.encode_first_stage(image))
 
     return x_latent
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -186,6 +186,7 @@ options_templates.update(options_section(('optimizations', "Optimizations"), {
     "token_merging_ratio_hr": OptionInfo(0.0, "Token merging ratio for high-res pass", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}, infotext='Token merging ratio hr').info("only applies if non-zero and overrides above"),
     "pad_cond_uncond": OptionInfo(False, "Pad prompt/negative prompt to be same length", infotext='Pad conds').info("improves performance when prompt and negative prompt have different lengths; changes seeds"),
     "persistent_cond_cache": OptionInfo(True, "Persistent cond cache").info("Do not recalculate conds from prompts if prompts have not changed since previous calculation"),
+    "sd_vae_sliced_encoding": OptionInfo(True, "Encode each image of a batch separately").info("reduces VRAM at the cost of latency"),
 }))
 
 options_templates.update(options_section(('compatibility', "Compatibility"), {


### PR DESCRIPTION
## Description

Title. This makes encoding more inline with [how decoding currently functions](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/da80d649fd6a6083be02aca5695367bd25abf0d5/modules/processing.py#L530). In my tests this reduces peak VRAM usage during the encode phase of hires fix (right before the diffusion process on the larger res begins) for a batch size of 4 from a bit over 16GB to just under 8GB. I've enabled this by default since it's such a huge improvement for VRAM and I didn't notice any regression in speed. If there's no issue with this we may just want to remove the option entirely and always use it.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
