### PR TITLE
Encode batch items individually to significantly reduce VRAM

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -92,7 +92,15 @@ def images_tensor_to_samples(image, approximation=None, model=None):
             model = shared.sd_model
         image = image.to(shared.device, dtype=devices.dtype_vae)
         image = image * 2 - 1
-        x_latent = model.get_first_stage_encoding(model.encode_first_stage(image))
+        if len(image) > 1:
+            x_latent = torch.stack([
+                model.get_first_stage_encoding(
+                    model.encode_first_stage(torch.unsqueeze(img, 0))
+                )[0]
+                for img in image
+            ])
+        else:
+            x_latent = model.get_first_stage_encoding(model.encode_first_stage(image))
 
     return x_latent
 


### PR DESCRIPTION
## Description

Title. This makes encoding batches (used during hires fix) more inline with [how decoding currently functions](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/da80d649fd6a6083be02aca5695367bd25abf0d5/modules/processing.py#L530). In my tests this reduces peak VRAM usage during the encode phase of hires fix (right before the diffusion process on the larger res begins) for a batch size of 4 (512x512 -> 1024x1024) from a bit over 16GB to just under 8GB (this is also without any optimizations and using `--no-half-vae`). Only utilized if we're infact doing a batch so `stack` and `unsqueeze` aren't used if it's just a single image.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
