### PR TITLE
Clear sampler and garbage collect before decoding images to reduce VRAM

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1192,6 +1192,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
         sd_models.apply_token_merging(self.sd_model, self.get_token_merging_ratio())
 
+        self.sampler = None
+        devices.torch_gc()
+
         decoded_samples = decode_latent_batch(self.sd_model, samples, target_device=devices.cpu, check_for_nans=True)
 
         self.is_hr_pass = False


### PR DESCRIPTION
## Description

Follow-up to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12514, more significant VRAM reduction. For a batch size of 4 with hires fix (512x512 -> 1024x1024) this cut off around 2GB of VRAM for me. For a **single** 512x512 @ hr = 2 image (not part of a batch), it cut off around 750MB, and 512x768 @ hr = 2 a bit over 1GB.
This was being done [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/da80d649fd6a6083be02aca5695367bd25abf0d5/modules/processing.py#L1105-L1108) but it can be performed even earlier and should be since decoding the latents is pretty heavy.

~~I hadn't tested this with SDXL yet, not sure if this causes any issue for the refiner. I'm assuming it doesn't but I haven't taken the time to review how that's implemented yet. Probably will reduce VRAM usage for SDXL in general though too if this works as I expect.~~ Occurred to me this is not related to SDXL code at all, so this doesn't affect it.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
