### PR TITLE
Support CLIP skip for SDXL (see description)

### DIFF
--- a/modules/sd_hijack_open_clip.py
+++ b/modules/sd_hijack_open_clip.py
@@ -55,7 +55,10 @@ class FrozenOpenCLIPEmbedder2WithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWi
 
     def encode_with_transformers(self, tokens):
         d = self.wrapped.encode_with_transformer(tokens)
-        z = d[self.wrapped.layer]
+        if opts.CLIP_stop_at_last_layers == 1:
+            z = d['last']
+        else:
+            z = d[self.wrapped.layer]
 
         pooled = d.get("pooled")
         if pooled is not None:


### PR DESCRIPTION
## Description

**Note: making this PR just to bring this to discussion.**

This PR adds a form of supporting CLIP skip with SDXL. I added this since scripts like the XYZ plot support changing this and I don't think users should be mislead to believe all the CLIP layers behave the same, but this does have several issues:

- SDXL/Stability trained with the penultimate clip layer in mind (CLIP skip = 2)
- Most users likely don't know the aforementioned, and the webui defaults to CLIP skip = 1. This would basically cause a lot of users to produce much worse results than the model is capable of.
	- (the webui forces the penultimate layer currently so for current users reading this there is nothing to worry about)
- This only allows for the last layer or penultimate layer to be used. The return value of `encode_with_transformer` only returns `last`, `penultimate`, and `pooled` (I don't know enough about SDXL's arch to know what this is honestly). The way Stability handles this also implies the last and penultimate are the only layers that should ever be used. https://github.com/Stability-AI/generative-models/blob/45c443b316737a4ab6e40413d7794a7f5657c19f/sgm/modules/encoders/modules.py#L442-L447

Also some potentially useful info, courtesy of Anonymous: https://boards.4channel.org/g/thread/95329616#p95329692

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
