### PR TITLE
Restore `extra_params` that was lost in merge

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -67,6 +67,8 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
     def __init__(self, funcname, sd_model, options=None):
         super().__init__(funcname)
 
+        self.extra_params = sampler_extra_params.get(funcname, [])
+
         self.options = options or {}
         self.func = funcname if callable(funcname) else getattr(k_diffusion.sampling, self.funcname)
 


### PR DESCRIPTION
## Description

Fixes regression in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/f8ff8c0638997fd0aef217db1505598846f14782, where the `sampler_extra_params` dict was no longer set up in the `KDiffusionSampler` class.
I haven't reviewed that commit fully but it'd be a good idea to make sure this isn't the only thing that got messed up due to it.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
