### PR TITLE
Add extra noise param for img2img operations

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -145,6 +145,10 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
 
         xi = x + noise * sigma_sched[0]
 
+        if opts.img2img_extra_noise > 0:
+            p.extra_generation_params["Extra noise"] = opts.img2img_extra_noise
+            xi += noise * opts.img2img_extra_noise
+
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 

--- a/modules/sd_samplers_timesteps.py
+++ b/modules/sd_samplers_timesteps.py
@@ -103,6 +103,10 @@ class CompVisSampler(sd_samplers_common.Sampler):
 
         xi = x * sqrt_alpha_cumprod + noise * sqrt_one_minus_alpha_cumprod
 
+        if opts.img2img_extra_noise > 0:
+            p.extra_generation_params["Extra noise"] = opts.img2img_extra_noise
+            xi += noise * opts.img2img_extra_noise * sqrt_alpha_cumprod
+
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -166,7 +166,8 @@ For img2img, VAE is used to process user's input image before the sampling, and 
 
 options_templates.update(options_section(('img2img', "img2img"), {
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Conditional mask weight'),
-    "initial_noise_multiplier": OptionInfo(1.0, "Noise multiplier for img2img", gr.Slider, {"minimum": 0.5, "maximum": 1.5, "step": 0.01}, infotext='Noise multiplier'),
+    "initial_noise_multiplier": OptionInfo(1.0, "Noise multiplier for img2img", gr.Slider, {"minimum": 0.0, "maximum": 1.5, "step": 0.001}, infotext='Noise multiplier'),
+    "img2img_extra_noise": OptionInfo(0.0, "Extra noise multiplier for img2img and hires fix", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Extra noise').info("0 = disabled (default); should be lower than denoising strength"),
     "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
     "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies.").info("normally you'd do less with less denoising"),
     "img2img_background_color": OptionInfo("#ffffff", "With img2img, fill transparent parts of the input image with this color.", ui_components.FormColorPicker, {}),

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -241,6 +241,8 @@ axis_options = [
     AxisOption("Eta", float, apply_field("eta")),
     AxisOption("Clip skip", int, apply_clip_skip),
     AxisOption("Denoising", float, apply_field("denoising_strength")),
+    AxisOption("Initial noise multiplier", float, apply_field("initial_noise_multiplier")),
+    AxisOption("Extra noise", float, apply_override("img2img_extra_noise")),
     AxisOptionTxt2Img("Hires upscaler", str, apply_field("hr_upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
     AxisOptionImg2Img("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")),
     AxisOption("VAE", str, apply_vae, cost=0.7, choices=lambda: ['None'] + list(sd_vae.vae_dict)),


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12085 and properly resolves https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/5351.

This gives the ability to add additional noise during img2img. This is technically identical functionality to `initial_noise_multiplier`, but because of how sensitive that parameter is, this expands the range to be more finely controlled. The aforementioned is really only useable up to a value of `1.1` (and defaulting to `1`), as shown in the PR it was implemented (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/5373), whereas this can take on the full range from `0` to `1` (depending on denoise strength used).

This also makes adding finer details to hires fix possible (something the other parameter cannot do directly [as it's only used strictly in the img2img tab](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/45be87afc6b173ebda94f427b8d396a2842ddf3c/modules/processing.py#L1507-L1509), not hires fix).

I believe this might make more sense to introduce directly into the hires fix and img2img UI, but for now [users can use the built-in extension to add it there if they wish](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/a2e213bc7ba29495559c9e53b734047ea879b343/extensions-builtin/extra-options-section/scripts/extra_options_section.py#L68-L69).

## Screenshots/videos:

The below example is for hires fix of a 512x512 image with denoising @ 0.45.

Extra noise = 0             |  Extra noise = 0.2
:-------------------------:|:-------------------------:
[![without](https://user-images.githubusercontent.com/122327233/260556373-9257aa18-dfc8-49f6-9984-a0a1f430c029.png)](https://user-images.githubusercontent.com/122327233/260556373-9257aa18-dfc8-49f6-9984-a0a1f430c029.png)  |  [![with](https://user-images.githubusercontent.com/122327233/260556387-0c6df12c-7412-43d5-84d2-2a69ad6152c4.png)](https://user-images.githubusercontent.com/122327233/260556387-0c6df12c-7412-43d5-84d2-2a69ad6152c4.png)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
