### PR TITLE
Add NoCrypt/miku gradio theme

### DIFF
--- a/modules/shared_gradio_themes.py
+++ b/modules/shared_gradio_themes.py
@@ -36,7 +36,8 @@ gradio_hf_hub_themes = [
     "step-3-profit/Midnight-Deep",
     "Taithrah/Minimal",
     "ysharma/huggingface",
-    "ysharma/steampunk"
+    "ysharma/steampunk",
+    "NoCrypt/miku"
 ]
 
 


### PR DESCRIPTION
## Description

* Add my custom gradio theme
* Here's the hf spaces link: https://huggingface.co/spaces/NoCrypt/miku
* Works with both dark and light mode

## Screenshots/videos:
![chrome_23-08-15 073055](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/57245077/746ed1f4-5101-4fb1-8fb5-6134d0335d25)
![chrome_23-08-15 074056](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/57245077/dd615598-5897-482d-afc6-79d26b0acbf6)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
