### PR TITLE
Fix `sd_vae_as_default` being accessed instead of `sd_vae_overrides_per_model_preferences`

### DIFF
--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -160,7 +160,7 @@ def resolve_vae_from_user_metadata(checkpoint_file) -> VaeResolution:
 
 def resolve_vae_near_checkpoint(checkpoint_file) -> VaeResolution:
     vae_near_checkpoint = find_vae_near_checkpoint(checkpoint_file)
-    if vae_near_checkpoint is not None and (shared.opts.sd_vae_as_default or is_automatic):
+    if vae_near_checkpoint is not None and (not shared.opts.sd_vae_overrides_per_model_preferences or is_automatic):
         return VaeResolution(vae_near_checkpoint, 'found near the checkpoint')
 
     return VaeResolution(resolved=False)


### PR DESCRIPTION
## Description
The setting `sd_vae_as_default` is still being used in `sd_vae.py`, which can cause an exception with new installs of web UI:
```
loading stable diffusion model: AttributeError
Traceback (most recent call last):
  File "/Users/brkirch/Desktop/stable-diffusion-webui/python/3.10.10/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/python/3.10.10/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/python/3.10.10/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/initialize.py", line 147, in load_model
    shared.sd_model  # noqa: B018
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/shared_items.py", line 110, in sd_model
    return modules.sd_models.model_data.get_sd_model()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/sd_models.py", line 475, in get_sd_model
    load_model()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/sd_models.py", line 583, in load_model
    load_model_weights(sd_model, checkpoint_info, state_dict, timer)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/sd_models.py", line 384, in load_model_weights
    vae_file, vae_source = sd_vae.resolve_vae(checkpoint_info.filename).tuple()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/sd_vae.py", line 180, in resolve_vae
    res = resolve_vae_near_checkpoint(checkpoint_file)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/sd_vae.py", line 163, in resolve_vae_near_checkpoint
    if vae_near_checkpoint is not None and (shared.opts.sd_vae_as_default or is_automatic):
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/options.py", line 114, in __getattr__
    return super(Options, self).__getattribute__(item)
AttributeError: 'Options' object has no attribute 'sd_vae_as_default'
```

This PR fixes the exception by using `not shared.opts.sd_vae_overrides_per_model_preferences` instead. The existing value of `sd_vae_as_default` is already being migrated for existing installs in `option.py`:
```Python
# 1.6.0 VAE defaults
if self.data.get('sd_vae_as_default') is not None and self.data.get('sd_vae_overrides_per_model_preferences') is None:
    self.data['sd_vae_overrides_per_model_preferences'] = not self.data.get('sd_vae_as_default')
```

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
