### PR TITLE
CSS: Remove forced visible overflow for Gradio group child divs

### DIFF
--- a/style.css
+++ b/style.css
@@ -138,7 +138,7 @@ a{
 }
 
 /* gradio 3.39 puts a lot of overflow: hidden all over the place for an unknown reqasaon. */
-.block.gradio-textbox, div.gradio-group, div.gradio-group div, div.gradio-dropdown{
+.block.gradio-textbox, div.gradio-group, div.gradio-dropdown{
     overflow: visible !important;
 }
 


### PR DESCRIPTION
## Description

Title. This is most noticeable with the progress bar in the extras tab and in the gallery view when generating a batch of images. Removing this doesn't seem to break anything else in my tests.

## Screenshots/videos:

<details>
<summary>Before</summary>

![before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/acc71120-6e2a-4e97-8e41-425565573bf5)
</details>

<details>
<summary>After</summary>

![after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/f2dbfa57-1864-4f36-bc23-7e9232b486f2)
</details>

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
