### PR TITLE
Remove wrong TAESD Latent scale

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -44,8 +44,7 @@ def samples_to_images_tensor(sample, approximation=None, model=None):
     elif approximation == 1:
         x_sample = sd_vae_approx.model()(sample.to(devices.device, devices.dtype)).detach()
     elif approximation == 3:
-        x_sample = sample * 1.5
-        x_sample = sd_vae_taesd.decoder_model()(x_sample.to(devices.device, devices.dtype)).detach()
+        x_sample = sd_vae_taesd.decoder_model()(sample.to(devices.device, devices.dtype)).detach()
         x_sample = x_sample * 2 - 1
     else:
         if model is None:


### PR DESCRIPTION
## Description
Title, when trying latest TAESD weight, it looks like I have wrong scale when send latent into taesd decoder.
So I just remove it now.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
