### PR TITLE
Fix exception that can sometimes occur when generating the Checkpoints tab

### DIFF
--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -30,8 +30,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        for index, name in enumerate(sd_models.checkpoints_list):
-            yield self.create_item(name, index)
+        with sd_models.checkpoints_list_lock:
+            for index, name in enumerate(sd_models.checkpoints_list):
+                yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]


### PR DESCRIPTION
## Description

Update:
35db3665b39c55bfc0ef37e25fe23897ce7345df sometimes produces exceptions due to copying incomplete data:
```
Traceback (most recent call last):
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/routes.py", line 442, in run_predict
    output = await app.get_blocks().process_api(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1392, in process_api
    result = await self.call_function(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1097, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/utils.py", line 703, in wrapper
    response = f(*args, **kwargs)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 392, in pages_html
    return refresh()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 400, in refresh
    ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 400, in <listcomp>
    ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 162, in create_html
    self.items = {x["name"]: x for x in self.list_items()}
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 162, in <dictcomp>
    self.items = {x["name"]: x for x in self.list_items()}
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks_checkpoints.py", line 35, in list_items
    yield self.create_item(name, index)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks_checkpoints.py", line 18, in create_item
    path, ext = os.path.splitext(checkpoint.filename)
AttributeError: 'NoneType' object has no attribute 'filename'
```

Normally this wouldn't be too difficult to fix; just save a copy of `sd_models.checkpoints_list` into a different variable at the beginning of the `list_models()` function in `sd_models.py` and then have `list_items()` in `ui_extra_networks_checkpoints.py` use that value if set.

The problem is that when I was testing when `list_models()` and `list_items()` started relative to each other, I found that `list_models()` can end up running on multiple threads at the same time. This leaves two options: either exit `list_models()` immediately if it is running in a different thread or use a lock to wait for it to finish in the other thread. The problem with exiting immediately is that it produces a window of time that can result in exceptions due to `checkpoints_list` being in an incomplete state. The latter however should still take less time than before this PR due to the lock waiting for the function to complete rather than the function running multiple times and starting over again each time from the beginning.

## Previous Description

Sometimes when launching web UI there will be an exception that looks like this:
```
Traceback (most recent call last):
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/routes.py", line 442, in run_predict
    output = await app.get_blocks().process_api(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1392, in process_api
    result = await self.call_function(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1097, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/utils.py", line 703, in wrapper
    response = f(*args, **kwargs)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 392, in pages_html
    return refresh()
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 400, in refresh
    ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 400, in <listcomp>
    ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 162, in create_html
    self.items = {x["name"]: x for x in self.list_items()}
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks.py", line 162, in <dictcomp>
    self.items = {x["name"]: x for x in self.list_items()}
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_extra_networks_checkpoints.py", line 33, in list_items
    for index, name in enumerate(sd_models.checkpoints_list):
RuntimeError: dictionary changed size during iteration
```

As the exception shows, the problem is that `sd_models.checkpoints_list` changes size while still in the for loop. This can happen because `list_items()` starts running in `ui_extra_networks_checkpoints.py` and then `list_models()` in `sd_models.py` clears `checkpoints_list` before the for loop in `list_items()` is completed. To prevent this, this PR creates a lock object and uses it so that `list_models()` and `list_items()` can't run at the same time.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
