### PR TITLE
fix Return empty list if extensions dir not exist 

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -246,7 +246,7 @@ def list_extensions(settings_file):
     disabled_extensions = set(settings.get('disabled_extensions', []))
     disable_all_extensions = settings.get('disable_all_extensions', 'none')
 
-    if disable_all_extensions != 'none' or args.disable_extra_extensions or args.disable_all_extensions:
+    if disable_all_extensions != 'none' or args.disable_extra_extensions or args.disable_all_extensions or not os.path.isdir(extensions_dir):
         return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]


### PR DESCRIPTION
## Description
if extension does not exist this will cause fatal error

this can happen if I just specify a new `--data-dir`

note as extension directory is created somewhere else (I'm not sure where) I did not opt to create a directory again if not exist

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
