### PR TITLE
Revert VAE to fp16 after (now temporarily) reverting to fp32

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -608,6 +608,12 @@ def decode_latent_batch(model, batch, target_device=None, check_for_nans=False):
 
         samples.append(sample)
 
+    # Revert VAE back to half precision incase user changes to a more stable VAE later
+    if devices.dtype_vae == torch.float32 and not cmd_opts.no_half and not cmd_opts.no_half_vae:
+        devices.dtype_vae = torch.float16
+        model.first_stage_model.to(devices.dtype_vae)
+        batch = batch.to(devices.dtype_vae)
+
     return samples
 
 


### PR DESCRIPTION
## Description

Title. This is incase the user were to later switch to a more stable VAE, and does not need the extra precision (notably only the NovelAI VAE seems to ever causes these issues in the first place).

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
