### PR TITLE
Attempt to resolve NaN issue with unstable VAEs while utilizing full precision (`--no-half-vae`)

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1242,7 +1242,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         self.sampler = None
         devices.torch_gc()
 
-        decoded_samples = decode_latent_batch(self.sd_model, samples, target_device=devices.cpu, check_for_nans=True)
+        try:
+            decoded_samples = decode_latent_batch(self.sd_model, samples, target_device=devices.cpu, check_for_nans=True)
+        except devices.NansException:
+            decoded_samples = samples
 
         self.is_hr_pass = False
 


### PR DESCRIPTION
**Update**: I believe https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12630 fixes this properly -- I will close this PR when that one or another is merged to resolve this.

## Description

Attempts to solve a regression in cc53db6652b11e6f7bca42c3aa93bd6761ed3d3f  (the previous commit a64fbe89288802f8b5ec8ca7bcab5aaf2c7bfea5 does not have this issue). I think this is also related to https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12611. PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12599 also still has this issue.

To preface: this only ever seems to happen with `animevae.pt`, and only for certain prompts. As such, it's difficult to find an easily reproducible scenario. This one is consistent for me, and I've verified it also works on somebody else's system. Also, **this is absolutely not the correct way to fix this**, because now it wastes time trying to decode the latent potentially twice, but I'm trying to wrap my head around what's going wrong here, and hopefully opening this PR brings that to discussion.

<details>
<summary>How to reproduce</summary>

1) Checkout cc53db6652b11e6f7bca42c3aa93bd6761ed3d3f or later, launch with `--no-half-vae`
Get this VAE, model, and these LoRAs
**VAE**: https://huggingface.co/a1079602570/animefull-final-pruned/blob/main/animevae.pt
**Model**: https://huggingface.co/AnonymousM/Based-mixes/blob/main/Based64mix-V3.safetensors
**LoRAs**:
~~(removed)~~

2) Download and use the metadata from this image to set up the params
![74wkie](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/294c1c5f-d536-4cc8-b826-6e287c143052)

3) (optionally) verify the image can be generated without hires fix.

4) Attempt to generate the image with hires fix enabled. These are the settings I usually use but I tested this several other times and the only factor that seems to matter is the `Upscale by` value must be `1.15` or more.
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/9c04a14e-695d-49d6-87d4-2b676fe62e40)

5) (optionally) take the above image, and use the exact same parameters to upscale in the img2img tab. This will _not_ produce the NaNs exception.

---

Side note: I got into the weeds and did some debugging, and this is why I'm also suspicious if this is related to the issue I linked above. This is the part of the code that produces the NaNs: https://github.com/Stability-AI/stablediffusion/blob/cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf/ldm/modules/diffusionmodules/model.py#L634-L641

If I attempt to upscale the image in img2img, and use the initial value of `z` (the upscaled latent, before [this line](https://github.com/Stability-AI/stablediffusion/blob/cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf/ldm/modules/diffusionmodules/model.py#L621) is executed), store that latent, and then attempt to use hires fix in txt2img, but with that value of `z` I stored earlier, it _still_ produces NaNs in that function. However, if I do it the other way around, storing the upscaled latent from txt2img, and using that in img2img, I instead get the below:

```
RuntimeError: Input type (struct c10::Half) and bias type (float) should be the same
```

</details>

Just noting my specs here as well, incase this is somehow some pytorch bug.

```
python: 3.10.6  •  torch: 2.0.1+cu118  •  xformers: 0.0.20
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
