### PR TITLE
Improve interrupt speed

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1155,6 +1155,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             devices.torch_gc()
 
     def sample_hr_pass(self, samples, decoded_samples, seeds, subseeds, subseed_strength, prompts):
+        if shared.state.interrupted:
+            return samples
+
         self.is_hr_pass = True
 
         target_width = self.hr_upscale_to_x

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -36,7 +36,7 @@ approximation_indexes = {"Full": 0, "Approx NN": 1, "Approx cheap": 2, "TAESD": 
 
 def samples_to_images_tensor(sample, approximation=None, model=None):
     '''latents -> images [-1, 1]'''
-    if approximation is None:
+    if approximation is None or (shared.state.interrupted and opts.live_preview_fast_interrupt):
         approximation = approximation_indexes.get(opts.show_progress_type, 0)
 
     if approximation == 2:

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -281,6 +281,7 @@ options_templates.update(options_section(('ui', "Live previews"), {
     "show_progress_type": OptionInfo("Approx NN", "Live preview method", gr.Radio, {"choices": ["Full", "Approx NN", "Approx cheap", "TAESD"]}).info("Full = slow but pretty; Approx NN and TAESD = fast but low quality; Approx cheap = super fast but terrible otherwise"),
     "live_preview_content": OptionInfo("Prompt", "Live preview subject", gr.Radio, {"choices": ["Combined", "Prompt", "Negative prompt"]}),
     "live_preview_refresh_period": OptionInfo(1000, "Progressbar and preview update period").info("in milliseconds"),
+    "live_preview_fast_interrupt": OptionInfo(False, "Return image with chosen live preview method on interrupt").info("makes interrupts faster"),
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7834

1) Adds option to use chosen live preview method on interrupt to save an extra second or two on interrupts. Defaults to false.
2) When hires fix is used, if we interrupt before going into hires fix, immediately return the given samples instead. This prevents wasting time on upscaling.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
