### PR TITLE
Make image viewer actually fit the whole page

### DIFF
--- a/style.css
+++ b/style.css
@@ -609,13 +609,19 @@ table.popup-table .link{
     display: flex;
     gap: 1em;
     padding: 1em;
-    background-color: rgba(0,0,0,0.2);
+    background-color:rgba(0,0,0,0);
+    z-index: 1;
+    transition: 0.2s ease background-color;
+}
+.modalControls:hover {
+    background-color:rgba(0,0,0,0.9);
 }
 .modalClose {
     margin-left: auto;
 }
 .modalControls span{
     color: white;
+    text-shadow: 0px 0px 0.25em black;
     font-size: 35px;
     font-weight: bold;
     cursor: pointer;
@@ -638,6 +644,13 @@ table.popup-table .link{
     height: 100%;
     width: 100%;
     min-height: 0;
+}
+
+#modalImage{
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
 }
 
 .modalPrev,


### PR DESCRIPTION
## Description

Makes this comment actually true. :^)
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/68f336bd994bed5442ad95bad6b6ad5564a5409a/style.css#L577

Text shadow added under the icons to make sure they never blend in, and the toolbar has the background color fade in on hover.

## Screenshots/videos:

Before             |  After
:-------------------------:|:-------------------------:
![before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/2aa13fd7-f640-4ab6-bf3d-0b0961002f7e)  |  ![after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/25cc694d-2659-49bc-b3fd-2956059903e6)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
