### PR TITLE
More hash filename patterns

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -368,7 +368,8 @@ class FilenameGenerator:
         'denoising': lambda self: self.p.denoising_strength if self.p and self.p.denoising_strength else NOTHING_AND_SKIP_PREVIOUS_TEXT,
         'user': lambda self: self.p.user,
         'vae_filename': lambda self: self.get_vae_filename(),
-        'none': lambda self: '', # Overrides the default so you can get just the sequence number
+        'none': lambda self: '',  # Overrides the default, so you can get just the sequence number
+        'image_hash': lambda self, *args: self.image_hash(*args)  # accepts formats: [image_hash<length>] default full hash
     }
     default_time_format = '%Y%m%d%H%M%S'
 
@@ -447,6 +448,10 @@ class FilenameGenerator:
             formatted_time = time_zone_time.strftime(self.default_time_format)
 
         return sanitize_filename_part(formatted_time, replace_spaces=False)
+
+    def image_hash(self, *args):
+        length = int(args[0]) if (args and args[0] != "") else None
+        return hashlib.sha256(self.image.tobytes()).hexdigest()[0:length]
 
     def apply(self, x):
         res = ''

--- a/modules/images.py
+++ b/modules/images.py
@@ -355,7 +355,9 @@ class FilenameGenerator:
         'date': lambda self: datetime.datetime.now().strftime('%Y-%m-%d'),
         'datetime': lambda self, *args: self.datetime(*args),  # accepts formats: [datetime], [datetime<Format>], [datetime<Format><Time Zone>]
         'job_timestamp': lambda self: getattr(self.p, "job_timestamp", shared.state.job_timestamp),
-        'prompt_hash': lambda self: hashlib.sha256(self.prompt.encode()).hexdigest()[0:8],
+        'prompt_hash': lambda self, *args: self.string_hash(self.prompt, *args),
+        'negative_prompt_hash': lambda self, *args: self.string_hash(self.p.negative_prompt, *args),
+        'full_prompt_hash': lambda self, *args: self.string_hash(f"{self.p.prompt} {self.p.negative_prompt}", *args),  # a space in between to create a unique string
         'prompt': lambda self: sanitize_filename_part(self.prompt),
         'prompt_no_styles': lambda self: self.prompt_no_style(),
         'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),
@@ -452,6 +454,10 @@ class FilenameGenerator:
     def image_hash(self, *args):
         length = int(args[0]) if (args and args[0] != "") else None
         return hashlib.sha256(self.image.tobytes()).hexdigest()[0:length]
+
+    def string_hash(self, text, *args):
+        length = int(args[0]) if (args and args[0] != "") else 8
+        return hashlib.sha256(text.encode()).hexdigest()[0:length]
 
     def apply(self, x):
         res = ''


### PR DESCRIPTION
## Summary
added new `[negative_prompt_hash]` and `[full_prompt_hash]` and [image_hash]
and make hash length customizable 

## Description
not really a bug but someone wants to prompt hash to contain the entire hash I supposed to just be positive prompts
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12637

I don't want to change the original so I add in a 2 new patterns, `negative_prompt_hash` and `full_prompt_hash`
`full_prompt_hash` is the `sha256(positive_prompt + " " + negative_prompt)`
> the space is there to create a unique string

in addition a new `image_hash` pattern which is the `sha256(image.tobytes())`
it is the hash of the output image itself not including the metadata
it can be used as a unique identifier, or a quick pixel perfect comparison check

I also made the hash length customizable through file pattern

`[prompt_hash<4>]` `[negative_prompt_hash<16>]` and `[full_prompt_hash<64>]`
default length of 8 is unchanged

`prompt_hash` length is also customizable but by default it uses the full hash which is equivalent to `[image_hash<64>]`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
