### PR TITLE
fix model override logic

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -702,11 +702,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     stored_opts = {k: opts.data[k] for k in p.override_settings.keys()}
 
     try:
-        # after running refiner, the refiner model is not unloaded - webui swaps back to main model here
-        if shared.sd_model.sd_checkpoint_info.title != opts.sd_model_checkpoint:
-            sd_models.reload_model_weights()
-
         # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint
+        # and if after running refiner, the refiner model is not unloaded - webui swaps back to main model here, if model over is present it will be reloaded afterwards
         if sd_models.checkpoint_aliases.get(p.override_settings.get('sd_model_checkpoint')) is None:
             p.override_settings.pop('sd_model_checkpoint', None)
             sd_models.reload_model_weights()


### PR DESCRIPTION
## Description
fix issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12641
fix model override logic
do not need extra logic to unload refine model
my model overall logic should automatically handle that unloading of refine model

did some test the results seems correct but I'm unsure if there's any aspects that I missed
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
