### PR TITLE
Make results column sticky

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,8 +137,8 @@ a{
     cursor: pointer;
 }
 
-/* gradio 3.39 puts a lot of overflow: hidden all over the place for an unknown reqasaon. */
-.block.gradio-textbox, div.gradio-group, div.gradio-dropdown{
+/* gradio 3.39 puts a lot of overflow: hidden all over the place for an unknown reason. */
+div.gradio-container, .block.gradio-textbox, div.gradio-group, div.gradio-dropdown{
     overflow: visible !important;
 }
 
@@ -1034,3 +1034,10 @@ div.accordions > div.input-accordion.input-accordion-open{
     flex-flow: column;
 }
 
+
+/* sticky right hand columns */
+
+#img2img_results, #txt2img_results, #extras_results {
+    position: sticky;
+    top: 0.5em;
+}


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7896, per suggestion of @missionfloyd 

Makes results column sticky, with a fix to make it work with Gradio 3.39.0. This will still function properly if the column happens to extend further towards the bottom, and will still always let you scroll to the bottom.

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/8beeaf90-ff29-4e57-b155-6c08007ec2ef

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
