### PR TITLE
api support get image from url

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -57,6 +57,15 @@ def setUpscalers(req: dict):
 
 
 def decode_base64_to_image(encoding):
+    if encoding.startswith("http://") or encoding.startswith("https://"):
+        import requests
+        response = requests.get(encoding, timeout=30, headers={'user-agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'})
+        try:
+            image = Image.open(BytesIO(response.content))
+            return image
+        except Exception as e:
+            raise HTTPException(status_code=500, detail="Invalid image url") from e
+
     if encoding.startswith("data:image/"):
         encoding = encoding.split(";")[1].split(",")[1]
     try:


### PR DESCRIPTION
## Description

I have added the functionality to the 'decode_base64_to_image' function in the API to get images from a URL. In many cases, in the API's usage scenarios, the upstream does not directly transmit base64 data but uploads the image to an object storage service (OSS) and then sends the URL of the image from OSS. Therefore, I believe it is necessary to add the ability to get images from a URL in the API.

```python
if encoding.startswith("http://") or encoding.startswith("https://"):
        import requests
        response = requests.get(encoding, timeout=30, headers={'user-agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'})
        try:
            image = Image.open(BytesIO(response.content))
            return image
        except Exception as e:
            raise HTTPException(status_code=500, detail="Invalid image url") from e
```

## Screenshots/videos:

![截图 2023-08-19 12-18-11](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25168945/aecb1844-deb1-4846-bd7c-4f1216b819dd)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
