### PR TITLE
switch to PNG when images too large

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -600,6 +600,11 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     """
     namegen = FilenameGenerator(p, seed, prompt, image)
 
+    # WebP and JPG formats have maximum dimension limits of 16383 and 65535 respectively. switch to PNG which has a much higher limit
+    if (image.height > 65535 or image.width > 65535) and extension.lower() in ("jpg", "jpeg") or (image.height > 16383 or image.width > 16383) and extension.lower() == "webp":
+        print('Image dimensions too large; saving as PNG')
+        extension = ".png"
+
     if save_to_dirs is None:
         save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
 


### PR DESCRIPTION
## Description
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12642
swap to png if image dimension exceeds the limit of jpeg or webp

go with swap format approach as opposed to downscale (as suggested by the issue) because
one can downscale and conver format later if they wish but they cannot upscale image back

my little experiment
```py
from PIL import Image
Image.new("RGB", (2**31-1, 1), "black").save('temp.png')
```
if my information is correct, maximum dimension for PNG is 2^32-1
since 2^32-1 cause OverflowError: Python int too large to convert to C long
so I try 2^31-1 and I got MemoryError just trying to create the black image
I don't think we need to worry about the limit of PNG format
I was able to save up to 2^26-1
but my image viewer was only able to open images lesser then 2^18~

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
