### PR TITLE
Fix Runtime Error  on MacOS cpu only. --no-half config

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -17,3 +17,4 @@ export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"
 export PYTORCH_ENABLE_MPS_FALLBACK=1
 
 ####################################################################
+1`

--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -10,7 +10,7 @@ then
 fi
 
 export install_dir="$HOME"
-export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half-vae --use-cpu interrogate"
+export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half --no-half-vae --use-cpu interrogate"
 export TORCH_COMMAND="pip install torch==2.0.1 torchvision==0.15.2"
 export K_DIFFUSION_REPO="https://github.com/brkirch/k-diffusion.git"
 export K_DIFFUSION_COMMIT_HASH="51c9778f269cedb55a4d88c79c0246d35bdadb71"


### PR DESCRIPTION
## Description

Fix Runtim error of using "Half" function when loading model when running on MacOS with CPU only.
Add "--no-half" config in COMMANDLINE_ARGS in webui-macos-env.sh file

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/17061986/2fc3218b-a930-4004-b778-61ba9fdc0d36)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/17061986/a2a27c70-d8b4-46ec-8dfb-82a6f11eebee)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
