### PR TITLE
Fix SD VAE switch error after model reuse

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -498,8 +498,8 @@ class SdModelData:
             pass
 
         if v is not None:
-            setattr(v, "base_vae", sd_vae.base_vae)
-            setattr(v, "loaded_vae_file", sd_vae.loaded_vae_file)
+            v.base_vae = sd_vae.base_vae
+            v.loaded_vae_file = sd_vae.loaded_vae_file
             self.loaded_sd_models.insert(0, v)
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -462,7 +462,6 @@ class SdModelData:
     def __init__(self):
         self.sd_model = None
         self.loaded_sd_models = []
-        self.loaded_vae_states = {}
         self.was_loaded_at_least_once = False
         self.lock = threading.Lock()
 
@@ -489,24 +488,19 @@ class SdModelData:
     def set_sd_model(self, v, already_loaded=False):
         self.sd_model = v
         if already_loaded:
-            sd_vae_state = self.loaded_vae_states.get(v.sd_model_hash, {})
-            sd_vae.base_vae = sd_vae_state.get("base_vae", None)
-            sd_vae.loaded_vae_file = sd_vae_state.get("loaded_vae_file", None)
-            sd_vae.checkpoint_info = sd_vae_state.get("checkpoint_info", None)
+            sd_vae.base_vae = getattr(v, "base_vae", None)
+            sd_vae.loaded_vae_file = getattr(v, "loaded_vae_file", None)
+            sd_vae.checkpoint_info = v.sd_checkpoint_info
 
         try:
             self.loaded_sd_models.remove(v)
-            self.loaded_vae_states.pop(v.sd_model_hash, {}).clear()
         except ValueError:
             pass
 
         if v is not None:
+            setattr(v, "base_vae", sd_vae.base_vae)
+            setattr(v, "loaded_vae_file", sd_vae.loaded_vae_file)
             self.loaded_sd_models.insert(0, v)
-            self.loaded_vae_states[v.sd_model_hash] = dict(
-                base_vae=sd_vae.base_vae,
-                loaded_vae_file=sd_vae.loaded_vae_file,
-                checkpoint_info=sd_vae.checkpoint_info,
-            )
 
 
 model_data = SdModelData()
@@ -661,7 +655,6 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         if len(model_data.loaded_sd_models) > shared.opts.sd_checkpoints_limit > 0:
             print(f"Unloading model {len(model_data.loaded_sd_models)} over the limit of {shared.opts.sd_checkpoints_limit}: {loaded_model.sd_checkpoint_info.title}")
             model_data.loaded_sd_models.pop()
-            model_data.loaded_vae_states.pop(loaded_model.sd_model_hash, {}).clear()
             send_model_to_trash(loaded_model)
             timer.record("send model to trash")
 
@@ -691,10 +684,9 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         sd_model = model_data.loaded_sd_models.pop()
         model_data.sd_model = sd_model
 
-        sd_vae_state = model_data.loaded_vae_states.pop(sd_model.sd_model_hash, {})
-        sd_vae.base_vae = sd_vae_state.get("base_vae", None)
-        sd_vae.loaded_vae_file = sd_vae_state.get("loaded_vae_file", None)
-        sd_vae.checkpoint_info = sd_vae_state.get("checkpoint_info", None)
+        sd_vae.base_vae = getattr(sd_model, "base_vae", None)
+        sd_vae.loaded_vae_file = getattr(sd_model, "loaded_vae_file", None)
+        sd_vae.checkpoint_info = sd_model.sd_checkpoint_info
 
         print(f"Reusing loaded model {sd_model.sd_checkpoint_info.title} to load {checkpoint_info.title}")
         return sd_model

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -671,6 +671,7 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
             shared.opts.data["sd_checkpoint_hash"] = already_loaded.sd_checkpoint_info.sha256
 
         print(f"Using already loaded model {already_loaded.sd_checkpoint_info.title}: done in {timer.summary()}")
+        sd_vae.reload_vae_weights(already_loaded)
         return model_data.sd_model
     elif shared.opts.sd_checkpoints_limit > 1 and len(model_data.loaded_sd_models) < shared.opts.sd_checkpoints_limit:
         print(f"Loading model {checkpoint_info.title} ({len(model_data.loaded_sd_models) + 1} out of {shared.opts.sd_checkpoints_limit})")

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -498,8 +498,6 @@ class SdModelData:
             pass
 
         if v is not None:
-            v.base_vae = sd_vae.base_vae
-            v.loaded_vae_file = sd_vae.loaded_vae_file
             self.loaded_sd_models.insert(0, v)
 
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -192,7 +192,7 @@ def load_vae_dict(filename, map_location):
 
 
 def load_vae(model, vae_file=None, vae_source="from unknown source"):
-    global vae_dict, loaded_vae_file
+    global vae_dict, base_vae, loaded_vae_file
     # save_settings = False
 
     cache_enabled = shared.opts.sd_vae_checkpoint_cache > 0
@@ -230,6 +230,8 @@ def load_vae(model, vae_file=None, vae_source="from unknown source"):
         restore_base_vae(model)
 
     loaded_vae_file = vae_file
+    model.base_vae = base_vae
+    model.loaded_vae_file = loaded_vae_file
 
 
 # don't call this from outside


### PR DESCRIPTION
## Description

* Error occurs when switching within "SD VAE" after using another VAE then reusing a model.
* Introduced `loaded_vae_states` to store VAE states. This is synchronized with `loaded_sd_models` to track VAE states.
* Resolves the error observed after reusing model during a VAE switch in "SD VAE".

## How to reproduce this bug:

1. In "Settings", set "Maximum number of checkpoints loaded at the same time" under "Stable Diffusion" to 2 or more.
2. Load "Model A" in the "Stable Diffusion checkpoint".
3. In "SD VAE", load "VAE A".
4. Switch to another model, "Model B", in the "Stable Diffusion checkpoint".
5. Switch to another VAE, "VAE B", in the "SD VAE".
6. Return to "Model A" in the "Stable Diffusion checkpoint". Note: "Model A" is reused from memory.
7. Switch to a different VAE, in "SD VAE". 

At this point, the following error occurs:
```bash
Loading VAE weights specified in settings: /stable-diffusion-webui/models/VAE/vae-ft-mse-840000-ema-pruned.safetensors
changing setting sd_vae to vae-ft-mse-840000-ema-pruned.safetensors: AssertionError
Traceback (most recent call last):
  File "/stable-diffusion-webui/modules/options.py", line 133, in set
    self.data_labels[key].onchange()
  File "/stable-diffusion-webui/modules/call_queue.py", line 14, in f
    res = func(*args, **kwargs)
  File "/stable-diffusion-webui/modules/initialize_util.py", line 152, in <lambda>
    shared.opts.onchange("sd_vae", wrap_queued_call(lambda: sd_vae.reload_vae_weights()), call=False)
  File "/stable-diffusion-webui/modules/sd_vae.py", line 271, in reload_vae_weights
    load_vae(sd_model, vae_file, vae_source)
  File "/stable-diffusion-webui/modules/sd_vae.py", line 209, in load_vae
    store_base_vae(model)
  File "/stable-diffusion-webui/modules/sd_vae.py", line 48, in store_base_vae
    assert not loaded_vae_file, "Trying to store non-base VAE!"
AssertionError: Trying to store non-base VAE!
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
