### PR TITLE
Consider folders when sorting checkpoint dropdown list

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -108,7 +108,11 @@ def checkpoint_tiles():
     def alphanumeric_key(key):
         return [convert(c) for c in re.split('([0-9]+)', key)]
 
-    return sorted([x.title for x in checkpoints_list.values()], key=alphanumeric_key)
+    def pathsort_key(path):
+        folders, file_name = os.path.split(path)
+        return ([alphanumeric_key(folder) for folder in folders.split(os.sep)], alphanumeric_key(file_name))
+
+    return sorted([x.title for x in checkpoints_list.values()], key=pathsort_key)
 
 
 def list_models():


### PR DESCRIPTION
With this change, sorting of the dropdown list of checkpoints will take into account folders and subfolders. In my opinion, sorting has become more correct.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
