### PR TITLE
Add resize-handle (built-in extension)

### DIFF
--- a/extensions-builtin/resize-handle/javascript/resize-handle.js
+++ b/extensions-builtin/resize-handle/javascript/resize-handle.js
@@ -1,0 +1,106 @@
+onUiLoaded(async() => {
+    const GRADIO_MIN_WIDTH = 320;
+    const GRID_TEMPLATE_COLUMNS = '1fr 16px 1fr';
+    const PAD = 16;
+    const DEBOUNCE_TIME = 100;
+
+    const R = {
+        tracking: false,
+        parent: null,
+        parentWidth: null,
+        leftCol: null,
+        leftColStartWidth: null,
+        screenX: null,
+    };
+
+    let resizeTimer;
+
+    const leftCols = [
+        gradioApp().querySelector('#txt2img_settings'),
+        gradioApp().querySelector('#img2img_settings'),
+    ];
+
+    function setLeftColGridTemplate(el, width) {
+        el.style.gridTemplateColumns = `${width}px 16px 1fr`;
+    }
+
+    function displayResizeHandle(parent) {
+        if (window.innerWidth < GRADIO_MIN_WIDTH * 2 + PAD * 4) {
+            parent.style.display = 'flex';
+            if (R.handle != null) {
+                R.handle.style.opacity = '0';
+            }
+            return false;
+        } else {
+            parent.style.display = 'grid';
+            if (R.handle != null) {
+                R.handle.style.opacity = '100';
+            }
+            return true;
+        }
+    }
+
+    function setup() {
+        for (const leftCol of leftCols) {
+            const parent = leftCol.parentElement;
+            const rightCol = parent.lastElementChild;
+
+            if (!displayResizeHandle(parent)) {
+                return;
+            }
+
+            parent.style.display = 'grid';
+            parent.style.gap = '0';
+            parent.style.gridTemplateColumns = GRID_TEMPLATE_COLUMNS;
+
+            const resizeHandle = document.createElement('div');
+            resizeHandle.classList.add('resize-handle');
+            parent.insertBefore(resizeHandle, rightCol);
+
+            resizeHandle.addEventListener('mousedown', (evt) => {
+                R.tracking = true;
+                R.parent = parent;
+                R.parentWidth = parent.offsetWidth;
+                R.handle = resizeHandle;
+                R.leftCol = leftCol;
+                R.leftColStartWidth = leftCol.offsetWidth;
+                R.screenX = evt.screenX;
+            });
+        }
+    }
+
+    window.addEventListener('mousemove', (evt) => {
+        if (R.tracking) {
+            const delta = R.screenX - evt.screenX;
+            const leftColWidth = Math.max(Math.min(R.leftColStartWidth - delta, R.parent.offsetWidth - GRADIO_MIN_WIDTH - PAD), GRADIO_MIN_WIDTH);
+            setLeftColGridTemplate(R.parent, leftColWidth);
+        }
+    });
+
+    window.addEventListener('mouseup', () => R.tracking = false);
+
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+
+        resizeTimer = setTimeout(() => {
+            for (const leftCol of leftCols) {
+                const parent = leftCol.parentElement;
+
+                if (displayResizeHandle(parent) && parent.style.gridTemplateColumns != GRID_TEMPLATE_COLUMNS) {
+                    const oldParentWidth = R.parentWidth;
+                    const newParentWidth = parent.offsetWidth;
+                    const widthL = parseInt(parent.style.gridTemplateColumns.split(' ')[0]);
+
+                    const ratio = newParentWidth / oldParentWidth;
+
+                    const newWidthL = Math.max(Math.floor(ratio * widthL), GRADIO_MIN_WIDTH);
+                    setLeftColGridTemplate(parent, newWidthL);
+
+                    R.parentWidth = newParentWidth;
+                }
+            }
+        }, DEBOUNCE_TIME);
+    });
+
+    setup();
+});

--- a/extensions-builtin/resize-handle/style.css
+++ b/extensions-builtin/resize-handle/style.css
@@ -1,0 +1,10 @@
+.resize-handle{
+	cursor: col-resize;
+	grid-column: 2 / 3;
+	min-width: 8px !important;
+	max-width: 8px !important;
+	height: 100%;
+	border-left: 1px dashed var(--border-color-primary);
+	user-select: none;
+	margin-left: 8px;
+}


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/2699

Adds a basic built-in extension to make the left and right columns of the txt2img and img2img tabs resizeable. This works by overriding the parent container in these tabs to use a grid layout, inserting a resize tool, and setting up their respective event handlers. Reflow is handled automatically by using the grid layout, and the grid layout is reverted to the flex layout when the browser width is too small (important for mobile).

I believe this is basic but useful enough to merit it being made available as a built-in extension, but if not I'll throw it up as a separate extension.

## Screenshots/videos:

![resize-handle](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/970311bb-3d4c-483d-bdeb-9195fad560ec)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
