### PR TITLE
Add option to move toprow to settings

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -232,6 +232,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "localization": OptionInfo("None", "Localization", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)).needs_reload_ui(),
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
+    "move_toprow_to_settings_column": OptionInfo(False, "Move top row (prompt, generate button) to settings column").needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("an be any valid CSS value").needs_reload_ui(),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -326,7 +326,8 @@ def create_ui():
     scripts.scripts_txt2img.initialize_scripts(is_img2img=False)
 
     with gr.Blocks(analytics_enabled=False) as txt2img_interface:
-        toprow = Toprow(is_img2img=False)
+        if not opts.move_toprow_to_settings_column:
+            toprow = Toprow(is_img2img=False)
 
         dummy_component = gr.Label(visible=False)
 
@@ -335,6 +336,9 @@ def create_ui():
 
         with gr.Tab("Generation", id="txt2img_generation") as txt2img_generation_tab, gr.Row(equal_height=False):
             with gr.Column(variant='compact', elem_id="txt2img_settings"):
+                if opts.move_toprow_to_settings_column:
+                    toprow = Toprow(is_img2img=False)
+
                 scripts.scripts_txt2img.prepare_ui()
 
                 for category in ordered_ui_categories():
@@ -544,13 +548,17 @@ def create_ui():
     scripts.scripts_img2img.initialize_scripts(is_img2img=True)
 
     with gr.Blocks(analytics_enabled=False) as img2img_interface:
-        toprow = Toprow(is_img2img=True)
+        if not opts.move_toprow_to_settings_column:
+            toprow = Toprow(is_img2img=True)
 
         extra_tabs = gr.Tabs(elem_id="img2img_extra_tabs")
         extra_tabs.__enter__()
 
         with gr.Tab("Generation", id="img2img_generation") as img2img_generation_tab, FormRow(equal_height=False):
             with gr.Column(variant='compact', elem_id="img2img_settings"):
+                if opts.move_toprow_to_settings_column:
+                    toprow = Toprow(is_img2img=True)
+
                 copy_image_buttons = []
                 copy_image_destinations = {}
 


### PR DESCRIPTION
(see https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12691 for an alternative, and my personally preferred, design)

## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12681

Adds an option to move the top row (prompt, generate button, action buttons) to the settings (left) column. Disabled by default.

This also makes a good compliment to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12648 and https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12687 as now the image preview can be made a larger focus of the interface if the user so desires.

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/0c21ad80-35b8-4ff3-8386-6d1051d9ff5e)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
