### PR TITLE
Patch config status handle corrupted files

### DIFF
--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -28,10 +28,13 @@ def list_config_states():
     for filename in os.listdir(config_states_dir):
         if filename.endswith(".json"):
             path = os.path.join(config_states_dir, filename)
-            with open(path, "r", encoding="utf-8") as f:
-                j = json.load(f)
-                j["filepath"] = path
-                config_states.append(j)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    j = json.load(f)
+                    j["filepath"] = path
+                    config_states.append(j)
+            except Exception as e:
+                print(f'[ERROR]{path}, {e}')
 
     config_states = sorted(config_states, key=lambda cs: cs["created_at"], reverse=True)
 

--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -8,14 +8,12 @@ import time
 import tqdm
 
 from datetime import datetime
-from collections import OrderedDict
 import git
 
 from modules import shared, extensions, errors
 from modules.paths_internal import script_path, config_states_dir
 
-
-all_config_states = OrderedDict()
+all_config_states = {}
 
 
 def list_config_states():

--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -31,10 +31,11 @@ def list_config_states():
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     j = json.load(f)
+                    assert "created_at" in j, '"created_at" does not exist'
                     j["filepath"] = path
                     config_states.append(j)
             except Exception as e:
-                print(f'[ERROR]{path}, {e}')
+                print(f'[ERROR]: Config states {path}, {e}')
 
     config_states = sorted(config_states, key=lambda cs: cs["created_at"], reverse=True)
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -200,119 +200,129 @@ def update_config_states_table(state_name):
     created_date = time.asctime(time.gmtime(config_state["created_at"]))
     filepath = config_state.get("filepath", "<unknown>")
 
-    code = f"""<!-- {time.time()} -->"""
-
-    webui_remote = config_state["webui"]["remote"] or ""
-    webui_branch = config_state["webui"]["branch"]
-    webui_commit_hash = config_state["webui"]["commit_hash"] or "<unknown>"
-    webui_commit_date = config_state["webui"]["commit_date"]
-    if webui_commit_date:
-        webui_commit_date = time.asctime(time.gmtime(webui_commit_date))
-    else:
-        webui_commit_date = "<unknown>"
-
-    remote = f"""<a href="{html.escape(webui_remote)}" target="_blank">{html.escape(webui_remote or '')}</a>"""
-    commit_link = make_commit_link(webui_commit_hash, webui_remote)
-    date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
-
-    current_webui = config_states.get_webui_config()
-
-    style_remote = ""
-    style_branch = ""
-    style_commit = ""
-    if current_webui["remote"] != webui_remote:
-        style_remote = STYLE_PRIMARY
-    if current_webui["branch"] != webui_branch:
-        style_branch = STYLE_PRIMARY
-    if current_webui["commit_hash"] != webui_commit_hash:
-        style_commit = STYLE_PRIMARY
-
-    code += f"""<h2>Config Backup: {config_name}</h2>
-      <div><b>Filepath:</b> {filepath}</div>
-      <div><b>Created at:</b> {created_date}</div>"""
-
-    code += f"""<h2>WebUI State</h2>
-      <table id="config_state_webui">
-        <thead>
-            <tr>
-                <th>URL</th>
-                <th>Branch</th>
-                <th>Commit</th>
-                <th>Date</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><label{style_remote}>{remote}</label></td>
-                <td><label{style_branch}>{webui_branch}</label></td>
-                <td><label{style_commit}>{commit_link}</label></td>
-                <td><label{style_commit}>{date_link}</label></td>
-            </tr>
-        </tbody>
-      </table>
-    """
-
-    code += """<h2>Extension State</h2>
-      <table id="config_state_extensions">
-        <thead>
-            <tr>
-                <th>Extension</th>
-                <th>URL</th>
-                <th>Branch</th>
-                <th>Commit</th>
-                <th>Date</th>
-            </tr>
-        </thead>
-        <tbody>
-    """
-
-    ext_map = {ext.name: ext for ext in extensions.extensions}
-
-    for ext_name, ext_conf in config_state["extensions"].items():
-        ext_remote = ext_conf["remote"] or ""
-        ext_branch = ext_conf["branch"] or "<unknown>"
-        ext_enabled = ext_conf["enabled"]
-        ext_commit_hash = ext_conf["commit_hash"] or "<unknown>"
-        ext_commit_date = ext_conf["commit_date"]
-        if ext_commit_date:
-            ext_commit_date = time.asctime(time.gmtime(ext_commit_date))
+    try:
+        webui_remote = config_state["webui"]["remote"] or ""
+        webui_branch = config_state["webui"]["branch"]
+        webui_commit_hash = config_state["webui"]["commit_hash"] or "<unknown>"
+        webui_commit_date = config_state["webui"]["commit_date"]
+        if webui_commit_date:
+            webui_commit_date = time.asctime(time.gmtime(webui_commit_date))
         else:
-            ext_commit_date = "<unknown>"
+            webui_commit_date = "<unknown>"
 
-        remote = f"""<a href="{html.escape(ext_remote)}" target="_blank">{html.escape(ext_remote or '')}</a>"""
-        commit_link = make_commit_link(ext_commit_hash, ext_remote)
-        date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
+        remote = f"""<a href="{html.escape(webui_remote)}" target="_blank">{html.escape(webui_remote or '')}</a>"""
+        commit_link = make_commit_link(webui_commit_hash, webui_remote)
+        date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
 
-        style_enabled = ""
+        current_webui = config_states.get_webui_config()
+
         style_remote = ""
         style_branch = ""
         style_commit = ""
-        if ext_name in ext_map:
-            current_ext = ext_map[ext_name]
-            current_ext.read_info_from_repo()
-            if current_ext.enabled != ext_enabled:
-                style_enabled = STYLE_PRIMARY
-            if current_ext.remote != ext_remote:
-                style_remote = STYLE_PRIMARY
-            if current_ext.branch != ext_branch:
-                style_branch = STYLE_PRIMARY
-            if current_ext.commit_hash != ext_commit_hash:
-                style_commit = STYLE_PRIMARY
+        if current_webui["remote"] != webui_remote:
+            style_remote = STYLE_PRIMARY
+        if current_webui["branch"] != webui_branch:
+            style_branch = STYLE_PRIMARY
+        if current_webui["commit_hash"] != webui_commit_hash:
+            style_commit = STYLE_PRIMARY
 
-        code += f"""
-            <tr>
-                <td><label{style_enabled}><input class="gr-check-radio gr-checkbox" type="checkbox" disabled="true" {'checked="checked"' if ext_enabled else ''}>{html.escape(ext_name)}</label></td>
-                <td><label{style_remote}>{remote}</label></td>
-                <td><label{style_branch}>{ext_branch}</label></td>
-                <td><label{style_commit}>{commit_link}</label></td>
-                <td><label{style_commit}>{date_link}</label></td>
-            </tr>
-    """
+        code = f"""<!-- {time.time()} -->
+<h2>Config Backup: {config_name}</h2>
+<div><b>Filepath:</b> {filepath}</div>
+<div><b>Created at:</b> {created_date}</div>
+<h2>WebUI State</h2>
+<table id="config_state_webui">
+    <thead>
+        <tr>
+            <th>URL</th>
+            <th>Branch</th>
+            <th>Commit</th>
+            <th>Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <label{style_remote}>{remote}</label>
+            </td>
+            <td>
+                <label{style_branch}>{webui_branch}</label>
+            </td>
+            <td>
+                <label{style_commit}>{commit_link}</label>
+            </td>
+            <td>
+                <label{style_commit}>{date_link}</label>
+            </td>
+        </tr>
+    </tbody>
+</table>
+<h2>Extension State</h2>
+<table id="config_state_extensions">
+    <thead>
+        <tr>
+            <th>Extension</th>
+            <th>URL</th>
+            <th>Branch</th>
+            <th>Commit</th>
+            <th>Date</th>
+        </tr>
+    </thead>
+    <tbody>
+"""
 
-    code += """
-        </tbody>
-    </table>
-    """
+        ext_map = {ext.name: ext for ext in extensions.extensions}
+
+        for ext_name, ext_conf in config_state["extensions"].items():
+            ext_remote = ext_conf["remote"] or ""
+            ext_branch = ext_conf["branch"] or "<unknown>"
+            ext_enabled = ext_conf["enabled"]
+            ext_commit_hash = ext_conf["commit_hash"] or "<unknown>"
+            ext_commit_date = ext_conf["commit_date"]
+            if ext_commit_date:
+                ext_commit_date = time.asctime(time.gmtime(ext_commit_date))
+            else:
+                ext_commit_date = "<unknown>"
+
+            remote = f"""<a href="{html.escape(ext_remote)}" target="_blank">{html.escape(ext_remote or '')}</a>"""
+            commit_link = make_commit_link(ext_commit_hash, ext_remote)
+            date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
+
+            style_enabled = ""
+            style_remote = ""
+            style_branch = ""
+            style_commit = ""
+            if ext_name in ext_map:
+                current_ext = ext_map[ext_name]
+                current_ext.read_info_from_repo()
+                if current_ext.enabled != ext_enabled:
+                    style_enabled = STYLE_PRIMARY
+                if current_ext.remote != ext_remote:
+                    style_remote = STYLE_PRIMARY
+                if current_ext.branch != ext_branch:
+                    style_branch = STYLE_PRIMARY
+                if current_ext.commit_hash != ext_commit_hash:
+                    style_commit = STYLE_PRIMARY
+
+            code += f"""        <tr>
+            <td><label{style_enabled}><input class="gr-check-radio gr-checkbox" type="checkbox" disabled="true" {'checked="checked"' if ext_enabled else ''}>{html.escape(ext_name)}</label></td>
+            <td><label{style_remote}>{remote}</label></td>
+            <td><label{style_branch}>{ext_branch}</label></td>
+            <td><label{style_commit}>{commit_link}</label></td>
+            <td><label{style_commit}>{date_link}</label></td>
+        </tr>
+"""
+
+        code += """    </tbody>
+</table>"""
+
+    except Exception as e:
+        print(f"[ERROR]: Config states {filepath}, {e}")
+        code = f"""<!-- {time.time()} -->
+<h2>Config Backup: {config_name}</h2>
+<div><b>Filepath:</b> {filepath}</div>
+<div><b>Created at:</b> {created_date}</div>
+<h2>This file is corrupted</h2>"""
 
     return code
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -65,7 +65,7 @@ def save_config_state(name):
     filename = os.path.join(config_states_dir, f"{timestamp}_{name}.json")
     print(f"Saving backup of webui/extension state to {filename}.")
     with open(filename, "w", encoding="utf-8") as f:
-        json.dump(current_config_state, f)
+        json.dump(current_config_state, f, indent=4)
     config_states.list_config_states()
     new_value = next(iter(config_states.all_config_states.keys()), "Current")
     new_choices = ["Current"] + list(config_states.all_config_states.keys())


### PR DESCRIPTION
## Description
Patch config status handle corrupted files
config status
currently if even if just one of `conflict status json` file is corrupted webui will failed to launch
this happened to a user https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/12682

at the loading stage I get rid of obviously corrupted files
> file with syntax errors or missing the `created_at` key

in the UI also add a second layer that tries to protect the user
making it more obvious that a certain conflict is corrupted "IF Detected"
by showing that this file is corrupted in the UI
as opposed to just a relatively nondescript `ERROR` from gradio
> this basically only catches missing keys
and since not all keys are used and key values might be still wrong it's not foolproof but it's better than nothing

note if the user insist, they can still click the `Restore Selected Config` button even after an error is detected

### minor changes
- I also took the chance to reformat the HTML removing some unnecessary text blocks
- fix indent to the HTML
- also save `config status json` with indent 4
## Screenshots/videos:
### current when thers an error
imo hard to notice
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/38ef9e06-3565-4c6d-9e8a-6ab6489efeef)
### now: imo obvious
![2023-08-20 17_35_59_054 chrome](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/535616b5-f536-4fc5-aa1a-71cb780044fb)


## Checklist:


- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
