### PR TITLE
Add option to move toprow to settings - alternative design

### DIFF
--- a/extensions-builtin/mobile/javascript/mobile.js
+++ b/extensions-builtin/mobile/javascript/mobile.js
@@ -18,7 +18,13 @@ function reportWindowSize() {
 
     for (var tab of ["txt2img", "img2img"]) {
         var button = gradioApp().getElementById(tab + '_generate_box');
-        var target = gradioApp().getElementById(currentlyMobile ? tab + '_results' : tab + '_actions_column');
+        var target = null;
+        if (currentlyMobile) {
+            target = gradioApp().getElementById(tab + '_results');
+        } else {
+            target = gradioApp().getElementById(tab + '_actions_column') || gradioApp().getElementById(tab + '_generate_row');
+        }
+
         target.insertBefore(button, target.firstElementChild);
     }
 }

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -233,6 +233,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
     "move_toprow_to_settings_column": OptionInfo(False, "Move top row (prompt, generate button) to settings column").needs_reload_ui(),
+    "move_generate_button_outside_toprow": OptionInfo(False, "Make generate button stick during scroll").info("only applies when the setting above is ticked").needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("an be any valid CSS value").needs_reload_ui(),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -232,6 +232,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "localization": OptionInfo("None", "Localization", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)).needs_reload_ui(),
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
+    "move_toprow_to_settings_column": OptionInfo(False, "Move top row (prompt, generate button) to settings column").needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("an be any valid CSS value").needs_reload_ui(),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -233,7 +233,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
     "move_toprow_to_settings_column": OptionInfo(False, "Move top row (prompt, generate button) to settings column").needs_reload_ui(),
-    "move_generate_button_outside_toprow": OptionInfo(False, "Make generate button stick during scroll").info("only applies when the setting above is ticked").needs_reload_ui(),
+    "sticky_generate_button": OptionInfo(False, "Make generate button stick during scroll").info("only applies when the setting above is ticked").needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("an be any valid CSS value").needs_reload_ui(),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -188,12 +188,12 @@ class Toprow:
         self.negative_prompt = toprow_prompt.negative_prompt
         self.flex_revert = ["flex-basis-revert"] if in_settings_column else []
 
-        if in_settings_column and opts.move_generate_button_outside_toprow:
+        if in_settings_column and opts.sticky_generate_button:
             with gr.Row(elem_id=f"{id_part}_generate_row", elem_classes=["generate-sticky"] + self.flex_revert):
                 self._create_generate_box()
 
         with gr.Row(elem_id=f"{id_part}_toprow", variant="compact"):
-            if in_settings_column and not opts.move_generate_button_outside_toprow:
+            if in_settings_column and not opts.sticky_generate_button:
                 with gr.Row(elem_id=f"{id_part}_generate_row", elem_classes=self.flex_revert):
                     self._create_generate_box()
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -326,7 +326,8 @@ def create_ui():
     scripts.scripts_txt2img.initialize_scripts(is_img2img=False)
 
     with gr.Blocks(analytics_enabled=False) as txt2img_interface:
-        toprow = Toprow(is_img2img=False)
+        if not opts.move_toprow_to_settings_column:
+            toprow = Toprow(is_img2img=False)
 
         dummy_component = gr.Label(visible=False)
 
@@ -335,6 +336,9 @@ def create_ui():
 
         with gr.Tab("Generation", id="txt2img_generation") as txt2img_generation_tab, gr.Row(equal_height=False):
             with gr.Column(variant='compact', elem_id="txt2img_settings"):
+                if opts.move_toprow_to_settings_column:
+                    toprow = Toprow(is_img2img=False)
+
                 scripts.scripts_txt2img.prepare_ui()
 
                 for category in ordered_ui_categories():
@@ -544,13 +548,17 @@ def create_ui():
     scripts.scripts_img2img.initialize_scripts(is_img2img=True)
 
     with gr.Blocks(analytics_enabled=False) as img2img_interface:
-        toprow = Toprow(is_img2img=True)
+        if not opts.move_toprow_to_settings_column:
+            toprow = Toprow(is_img2img=True)
 
         extra_tabs = gr.Tabs(elem_id="img2img_extra_tabs")
         extra_tabs.__enter__()
 
         with gr.Tab("Generation", id="img2img_generation") as img2img_generation_tab, FormRow(equal_height=False):
             with gr.Column(variant='compact', elem_id="img2img_settings"):
+                if opts.move_toprow_to_settings_column:
+                    toprow = Toprow(is_img2img=True)
+
                 copy_image_buttons = []
                 copy_image_destinations = {}
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -190,7 +190,7 @@ class Toprow:
 
         with gr.Row(elem_id=f"{id_part}_toprow", variant="compact"):
             if in_settings_column:
-                with gr.Row(elem_classes=self.flex_revert):
+                with gr.Row(elem_id=f"{id_part}_generate_row", elem_classes=self.flex_revert):
                     self._create_generate_box()
 
             with gr.Column(elem_id=f"{id_part}_prompt_container", scale=6):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -188,8 +188,12 @@ class Toprow:
         self.negative_prompt = toprow_prompt.negative_prompt
         self.flex_revert = ["flex-basis-revert"] if in_settings_column else []
 
+        if in_settings_column and opts.move_generate_button_outside_toprow:
+            with gr.Row(elem_id=f"{id_part}_generate_row", elem_classes=["generate-sticky"] + self.flex_revert):
+                self._create_generate_box()
+
         with gr.Row(elem_id=f"{id_part}_toprow", variant="compact"):
-            if in_settings_column:
+            if in_settings_column and not opts.move_generate_button_outside_toprow:
                 with gr.Row(elem_id=f"{id_part}_generate_row", elem_classes=self.flex_revert):
                     self._create_generate_box()
 

--- a/modules/ui_prompt_styles.py
+++ b/modules/ui_prompt_styles.py
@@ -50,12 +50,14 @@ def refresh_styles():
 
 
 class UiPromptStyles:
-    def __init__(self, tabname, main_ui_prompt, main_ui_negative_prompt):
+    def __init__(self, tabname, main_ui_prompt, main_ui_negative_prompt, extra_buttons=None):
         self.tabname = tabname
 
         with gr.Row(elem_id=f"{tabname}_styles_row"):
             self.dropdown = gr.Dropdown(label="Styles", show_label=False, elem_id=f"{tabname}_styles", choices=list(shared.prompt_styles.styles), value=[], multiselect=True, tooltip="Styles")
             edit_button = ui_components.ToolButton(value=styles_edit_symbol, elem_id=f"{tabname}_styles_edit_button", tooltip="Edit styles")
+            if extra_buttons is not None:
+                extra_buttons()
 
         with gr.Box(elem_id=f"{tabname}_styles_dialog", elem_classes="popup-dialog") as styles_dialog:
             with gr.Row():

--- a/style.css
+++ b/style.css
@@ -142,6 +142,10 @@ div.gradio-container, .block.gradio-textbox, div.gradio-group, div.gradio-dropdo
     overflow: visible !important;
 }
 
+.flex-basis-revert {
+    flex-basis: revert !important;
+}
+
 
 /* general styled components */
 

--- a/style.css
+++ b/style.css
@@ -326,6 +326,12 @@ div.block.gradio-accordion {
     right: 0;
     border-radius: 0 0.5rem 0.5rem 0;
 }
+.generate-sticky{
+    position: sticky;
+    z-index: 500;
+    top: 0.5em;
+    margin-bottom: 1em;
+}
 
 #img2img_scale_resolution_preview.block{
     display: flex;


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12681, alternative to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12688 (see description there for more info)

In addition to the other PR, this adds an option to make the generate button sticky.

I personally prefer this layout over the other PR. However, this does introduce much more code refactor, with a lot of usage of `if` and `nullcontext` to determine component layout. One thing in particular this has to do now is create the prompt components outside the `gr.Blocks` scope so we can manually invoke `render` of them where we want.

I think ideally everything should be created outside the `gr.Blocks` scope to begin with and then invoked with a single function, as this would make doing a few more refactor jobs simpler and open up more possible layout changes, but that's for a separate PR.

## Screenshots/videos:

**Layout**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/349c9c5c-87ff-4dda-adcd-ca97fe215232)

**Sticky generate button**
![sticky](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/d180fa69-c23c-4e1a-b159-acf665a31910)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
