### PR TITLE
Add option to make tabs sticky

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -232,6 +232,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "localization": OptionInfo("None", "Localization", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)).needs_reload_ui(),
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
+    "sticky_tabs": OptionInfo(False, "Make tabs stick to top of browser window during scroll").needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("an be any valid CSS value").needs_reload_ui(),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "do_not_show_images": OptionInfo(False, "Do not show any images in results for web"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1269,7 +1269,7 @@ def create_ui():
 
         parameters_copypaste.connect_paste_params_buttons()
 
-        with gr.Tabs(elem_id="tabs") as tabs:
+        with gr.Tabs(elem_id="tabs", elem_classes="tabs-sticky" if opts.sticky_tabs else []) as tabs:
             tab_order = {k: i for i, k in enumerate(opts.ui_tab_order)}
             sorted_interfaces = sorted(interfaces, key=lambda x: tab_order.get(x[1], 9999))
 

--- a/style.css
+++ b/style.css
@@ -1048,9 +1048,28 @@ div.accordions > div.input-accordion.input-accordion-open{
 }
 
 
-/* sticky right hand columns */
-
-#img2img_results, #txt2img_results, #extras_results {
+/* sticky behavior */
+.tabs-sticky > div.tab-nav{
     position: sticky;
+    top: 0;
+    z-index: 999;
+    background-color: var(--background-fill-primary);
+}
+
+#img2img_results, #txt2img_results, #extras_results{
+    position: sticky;
+}
+
+.generate-sticky{
+    position: sticky;
+    z-index: 500;
+    margin-bottom: 1em;
+}
+
+div#tabs:not(.tabs-sticky) :is(#img2img_results, #txt2img_results, #extras_results, .generate-sticky){
     top: 0.5em;
+}
+
+div#tabs.tabs-sticky :is(#img2img_results, #txt2img_results, #extras_results, .generate-sticky){
+    top: 3em;
 }


### PR DESCRIPTION
Currently a draft as this is accounting for some sticky behavior in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12691 (particularly the generate button)

## Description

Adds an option to make tabs sticky (stay on the top of the browser window on scroll).

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
