### PR TITLE
use fake-useragent for UserAgent

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -58,7 +58,7 @@ def setUpscalers(req: dict):
 def decode_base64_to_image(encoding):
     if encoding.startswith("http://") or encoding.startswith("https://"):
         import requests
-        response = requests.get(encoding, timeout=30, headers={'user-agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'})
+        response = requests.get(encoding, timeout=30, headers={'user-agent': shared.user_agent})
         try:
             image = Image.open(BytesIO(response.content))
             return image

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -6,6 +6,7 @@ from modules import shared_cmd_options, shared_gradio_themes, options, shared_it
 from modules.paths_internal import models_path, script_path, data_path, sd_configs_path, sd_default_config, sd_model_file, default_sd_model_file, extensions_dir, extensions_builtin_dir  # noqa: F401
 from ldm.models.diffusion.ddpm import LatentDiffusion
 from modules import util
+from fake_useragent import FakeUserAgent
 
 cmd_opts = shared_cmd_options.cmd_opts
 parser = shared_cmd_options.parser
@@ -86,3 +87,5 @@ list_checkpoint_tiles = shared_items.list_checkpoint_tiles
 refresh_checkpoints = shared_items.refresh_checkpoints
 list_samplers = shared_items.list_samplers
 reload_hypernetworks = shared_items.reload_hypernetworks
+
+user_agent = FakeUserAgent(min_percentage=1.0).random

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,5 @@ torch
 torchdiffeq
 torchsde
 transformers==4.30.2
+
+fake-useragent

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -29,3 +29,4 @@ torch
 torchdiffeq==0.2.3
 torchsde==0.2.5
 transformers==4.30.2
+fake-useragent==1.2.1


### PR DESCRIPTION
## Description

@SpenserCai
as opposed to hard coding a relatively outdated user agent
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/4760c3c0b58059e9c655a6ea8360c65a4586a71b/modules/api/api.py#L62
> chrome 62.0.3202 is from 2017-10-17, it screams bot

we can use a library like `fake-useragent` https://pypi.org/project/fake-useragent

kind of related PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12698

a test script
```py
from fake_useragent import FakeUserAgent
ua = user_agent = FakeUserAgent(min_percentage=1.0).random
print(ua)
```

### another method would be to just expose the user method make it editable

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
