### PR TITLE
Update torch for Navi 31 (7900 XT/XTX)

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -141,8 +141,9 @@ case "$gpu_info" in
     *"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
     ;;
     *"Navi 3"*) [[ -z "${TORCH_COMMAND}" ]] && \
-        export TORCH_COMMAND="pip install --pre torch==2.1.0.dev-20230614+rocm5.5 torchvision==0.16.0.dev-20230614+rocm5.5 --index-url https://download.pytorch.org/whl/nightly/rocm5.5"
-        # Navi 3 needs at least 5.5 which is only on the nightly chain
+         export TORCH_COMMAND="pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm5.6"
+        # Navi 3 needs at least 5.5 which is only on the nightly chain, previous versions are no longer online (torch==2.1.0.dev-20230614+rocm5.5 torchvision==0.16.0.dev-20230614+rocm5.5 torchaudio==2.1.0.dev-20230614+rocm5.5)
+        # so switch to nightly rocm5.6 without explicit versions this time
     ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
         printf "\n%s\n" "${delimiter}"


### PR DESCRIPTION
## Description
Navi 3 needs at least 5.5 which is only on the nightly chain, previous versions are no longer online (torch==2.1.0.dev-20230614+rocm5.5 torchvision==0.16.0.dev-20230614+rocm5.5). 
so switch to nightly rocm5.6 without explicit versions this time


* a simple description of what you're trying to accomplish
update TORCH_COMMAND for Navi 31
* a summary of changes in code
`export` TORCH_COMMAND="pip install --pre torch torchvision --index-url `"https://download.pytorch.org/whl/nightly/rocm5.6"`
* which issues it fixes, if any
`ERROR: No matching distribution found for torch==2.1.0.dev-20230614+rocm5.5`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
