### PR TITLE
Add CMP 40HX graphics card support

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -117,7 +117,6 @@ def autocast(disable=False):
         return contextlib.nullcontext()
     
     if "40HX" in torch.cuda.get_device_name(0):
-        print("检测到40HX  停用半精度,使用单精度")
         return torch.autocast("cuda",dtype=torch.float32,enabled=True)
 
     return torch.autocast("cuda")

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -115,6 +115,10 @@ def autocast(disable=False):
 
     if dtype == torch.float32 or shared.cmd_opts.precision == "full":
         return contextlib.nullcontext()
+    
+    if "40HX" in torch.cuda.get_device_name(0):
+        print("检测到40HX  停用半精度,使用单精度")
+        return torch.autocast("cuda",dtype=torch.float32,enabled=True)
 
     return torch.autocast("cuda")
 


### PR DESCRIPTION
## Description
Add CMP 40HX graphics card support
CMP 40HX does not have semi precision and can only use single precision

40hx 半精度被老黄砍了, 只能用单精度
## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
