### PR TITLE
Create Gradio temp directory if necessary

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -44,6 +44,8 @@ def save_pil_to_file(self, pil_image, dir=None, format="png"):
 
     if shared.opts.temp_dir != "":
         dir = shared.opts.temp_dir
+    else:
+        os.makedirs(dir, exist_ok=True)
 
     use_metadata = False
     metadata = PngImagePlugin.PngInfo()


### PR DESCRIPTION
## Description
In Gradio, `pil_to_temp_file()` [creates the Gradio temp directory](https://github.com/gradio-app/gradio/blob/861d752a83da0f95e9f79173069b69eababeed39/gradio/components/base.py#L313). Currently `save_pil_to_file()` (which replaces `pil_to_temp_file()`) doesn't do this, which can result in exceptions like this:
```
Traceback (most recent call last):
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/routes.py", line 442, in run_predict
    output = await app.get_blocks().process_api(
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1395, in process_api
    data = self.postprocess_data(fn_index, result["prediction"], state)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1329, in postprocess_data
    prediction_value = block.postprocess(prediction_value)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/venv/lib/python3.10/site-packages/gradio/components/gallery.py", line 185, in postprocess
    file = self.pil_to_temp_file(img, dir=self.DEFAULT_TEMP_DIR)
  File "/Users/brkirch/Desktop/stable-diffusion-webui/modules/ui_tempdir.py", line 55, in save_pil_to_file
    file_obj = tempfile.NamedTemporaryFile(delete=False, suffix=".png", dir=dir)
  File "/opt/homebrew/Cellar/python@3.10/3.10.12/Frameworks/Python.framework/Versions/3.10/lib/python3.10/tempfile.py", line 559, in NamedTemporaryFile
    file = _io.open(dir, mode, buffering=buffering,
  File "/opt/homebrew/Cellar/python@3.10/3.10.12/Frameworks/Python.framework/Versions/3.10/lib/python3.10/tempfile.py", line 556, in opener
    fd, name = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
  File "/opt/homebrew/Cellar/python@3.10/3.10.12/Frameworks/Python.framework/Versions/3.10/lib/python3.10/tempfile.py", line 256, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/21/syzrtch121bbf_w20437c96r0000gn/T/gradio/tmpkhsntxoz.png'
```
To resolve this issue this PR emulates the behavior of Gradio, and creates the temp directory for Gradio in `save_pil_to_file()` if the temp directory setting is empty.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
