### PR TITLE
Resize handle improvements and bug fixes

### DIFF
--- a/javascript/resizeHandle.js
+++ b/javascript/resizeHandle.js
@@ -66,6 +66,8 @@
         parent.insertBefore(resizeHandle, rightCol);
 
         resizeHandle.addEventListener('mousedown', (evt) => {
+            if (evt.button !== 0) return;
+
             evt.preventDefault();
             evt.stopPropagation();
 
@@ -91,6 +93,8 @@
     }
 
     window.addEventListener('mousemove', (evt) => {
+        if (evt.button !== 0) return;
+
         if (R.tracking) {
             evt.preventDefault();
             evt.stopPropagation();
@@ -102,6 +106,8 @@
     });
 
     window.addEventListener('mouseup', (evt) => {
+        if (evt.button !== 0) return;
+
         if (R.tracking) {
             evt.preventDefault();
             evt.stopPropagation();

--- a/javascript/resizeHandle.js
+++ b/javascript/resizeHandle.js
@@ -66,6 +66,11 @@
         parent.insertBefore(resizeHandle, rightCol);
 
         resizeHandle.addEventListener('mousedown', (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+
+            document.body.classList.add('resizing');
+
             R.tracking = true;
             R.parent = parent;
             R.parentWidth = parent.offsetWidth;
@@ -75,20 +80,37 @@
             R.screenX = evt.screenX;
         });
 
-        resizeHandle.addEventListener('dblclick', () => parent.style.gridTemplateColumns = GRID_TEMPLATE_COLUMNS);
+        resizeHandle.addEventListener('dblclick', (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+
+            parent.style.gridTemplateColumns = GRID_TEMPLATE_COLUMNS;
+        });
 
         afterResize(parent);
     }
 
     window.addEventListener('mousemove', (evt) => {
         if (R.tracking) {
+            evt.preventDefault();
+            evt.stopPropagation();
+
             const delta = R.screenX - evt.screenX;
             const leftColWidth = Math.max(Math.min(R.leftColStartWidth - delta, R.parent.offsetWidth - GRADIO_MIN_WIDTH - PAD), GRADIO_MIN_WIDTH);
             setLeftColGridTemplate(R.parent, leftColWidth);
         }
     });
 
-    window.addEventListener('mouseup', () => R.tracking = false);
+    window.addEventListener('mouseup', (evt) => {
+        if (R.tracking) {
+            evt.preventDefault();
+            evt.stopPropagation();
+
+            R.tracking = false;
+
+            document.body.classList.remove('resizing');
+        }
+    });
 
 
     window.addEventListener('resize', () => {

--- a/style.css
+++ b/style.css
@@ -1062,13 +1062,20 @@ div.accordions > div.input-accordion.input-accordion-open{
 }
 
 
-.resize-handle{
+.resize-handle {
+    position: relative;
 	cursor: col-resize;
 	grid-column: 2 / 3;
-	min-width: 8px !important;
-	max-width: 8px !important;
+	min-width: 16px !important;
+	max-width: 16px !important;
 	height: 100%;
-	border-left: 1px dashed var(--border-color-primary);
-	user-select: none;
-	margin-left: 8px;
+}
+
+.resize-handle::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 7.5px;
+    border-left: 1px dashed var(--border-color-primary);
 }

--- a/style.css
+++ b/style.css
@@ -1065,8 +1065,12 @@ body.resizing {
     cursor: col-resize !important;
 }
 
-body.resizing :not(.resize-handle) {
+body.resizing * {
     pointer-events: none !important;
+}
+
+body.resizing .resize-handle {
+    pointer-events: initial !important;
 }
 
 .resize-handle {

--- a/style.css
+++ b/style.css
@@ -1062,7 +1062,7 @@ div.accordions > div.input-accordion.input-accordion-open{
 }
 
 body.resizing {
-	cursor: col-resize !important;
+    cursor: col-resize !important;
 }
 
 body.resizing :not(.resize-handle) {
@@ -1071,11 +1071,11 @@ body.resizing :not(.resize-handle) {
 
 .resize-handle {
     position: relative;
-	cursor: col-resize;
-	grid-column: 2 / 3;
-	min-width: 16px !important;
-	max-width: 16px !important;
-	height: 100%;
+    cursor: col-resize;
+    grid-column: 2 / 3;
+    min-width: 16px !important;
+    max-width: 16px !important;
+    height: 100%;
 }
 
 .resize-handle::after {

--- a/style.css
+++ b/style.css
@@ -142,6 +142,11 @@ div.gradio-container, .block.gradio-textbox, div.gradio-group, div.gradio-dropdo
     overflow: visible !important;
 }
 
+/* align-items isn't enough and elements may overflow in Safari. */
+.unequal-height {
+    align-content: flex-start;
+}
+
 
 /* general styled components */
 

--- a/style.css
+++ b/style.css
@@ -1061,6 +1061,13 @@ div.accordions > div.input-accordion.input-accordion-open{
     top: 0.5em;
 }
 
+body.resizing {
+	cursor: col-resize !important;
+}
+
+body.resizing :not(.resize-handle) {
+    pointer-events: none !important;
+}
 
 .resize-handle {
     position: relative;


### PR DESCRIPTION
## Description

* Fix resize handle overflowing in Safari
* Expand the hit area of resize handle
* Prevent text selection and cursor changes while dragging resize handles
* Limit mouse detection for resize handles to primary (left) button only

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/3db20cce-11c0-445f-b1e6-eca0a5fa81b3

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/62b1f12a-8858-48b2-a41d-5747c0691230

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
