### PR TITLE
Zoom and pan: Improved integration

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/style.css
+++ b/extensions-builtin/canvas-zoom-and-pan/style.css
@@ -61,3 +61,6 @@
   to {opacity: 1;}
 }
 
+.styler {
+  overflow:inherit !important;
+}


### PR DESCRIPTION
## Description

With the new version of gradio the integration broke, so I fixed it and improved it a bit.

Added `applyZoomAndPanIntegration` function which can be conveniently applied to integrate with any extension, briefly described how to use it in the code

## Screenshots/videos:

<details><summary>Before</summary>

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22278673/98aa18c0-9d6b-4f51-9537-957c53ed8b46

</details>

<details><summary>After</summary>

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22278673/860f833b-a8d5-4f0b-8e9d-519a77af88a8

</details>

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
