### PR TITLE
tell RealESRGANer which device to run on, could be cuda, M1, or other…

### DIFF
--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -55,6 +55,7 @@ class UpscalerRealESRGAN(Upscaler):
             half=not cmd_opts.no_half and not cmd_opts.upcast_sampling,
             tile=opts.ESRGAN_tile,
             tile_pad=opts.ESRGAN_tile_overlap,
+            device=self.device,
         )
 
         upsampled = upsampler.enhance(np.array(img), outscale=info.scale)[0]


### PR DESCRIPTION
tell RealESRGANer which device to run on, could be cuda, M1, or other GPU

## Description

* RealESRGANer will check if you have cuda device, otherwise, it will run on CPU. For Apple Silicon users, it takes a long time
* By telling RealESRGANer which device to run on, it could use GPU other than CPU, and consume much less time
* code: add the params: 'device=self.device' when calling the function

## Screenshots/videos:
before: 35s
[https://github.com/yajunzhng/sd-extension-system-info/blob/main/R-ESRGAN4x.jpg](url)
after: 5s
[https://github.com/yajunzhng/sd-extension-system-info/blob/main/After.png](url)
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
