### PR TITLE
draw extra network buttons above description

### DIFF
--- a/style.css
+++ b/style.css
@@ -863,6 +863,7 @@ footer {
     position: absolute;
     color: white;
     right: 0;
+    z-index: 1
 }
 .extra-network-cards .card:hover .button-row{
     display: flex;


### PR DESCRIPTION
## Description
draw extra network buttons above description so that it's always clickable even when the card is extremely small
solves issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12743

before
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/561336f5-41bd-41db-999f-96c5cd7df177)
after
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/cf682210-3bd2-4ebb-93dd-5f488a46e08a)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
