### PR TITLE
Some UI style improvements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,6 @@ Licenses for borrowed code can be found in `Settings -> Licenses` screen, and al
 - TAESD - Ollin Boer Bohan - https://github.com/madebyollin/taesd
 - LyCORIS - KohakuBlueleaf
 - Restart sampling - lambertae - https://github.com/Newbeeer/diffusion_restart_sampling
-- Initial Gradio script - posted on 4chan by an Anonymous user. Thank you Anonymous user.
 - feather - Cole Bemis - https://github.com/feathericons/feather
+- Initial Gradio script - posted on 4chan by an Anonymous user. Thank you Anonymous user.
 - (You)

--- a/README.md
+++ b/README.md
@@ -174,4 +174,5 @@ Licenses for borrowed code can be found in `Settings -> Licenses` screen, and al
 - LyCORIS - KohakuBlueleaf
 - Restart sampling - lambertae - https://github.com/Newbeeer/diffusion_restart_sampling
 - Initial Gradio script - posted on 4chan by an Anonymous user. Thank you Anonymous user.
+- feather - Cole Bemis - https://github.com/feathericons/feather
 - (You)

--- a/extensions-builtin/Lora/ui_edit_user_metadata.py
+++ b/extensions-builtin/Lora/ui_edit_user_metadata.py
@@ -159,7 +159,7 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
         self.create_default_editor_elems()
 
         self.taginfo = gr.HighlightedText(label="Training dataset tags")
-        self.edit_activation_text = gr.Text(label='Activation text', info="Will be added to prompt along with Lora")
+        self.edit_activation_text = gr.Textbox(label='Activation text', info="Will be added to prompt along with Lora")
         self.slider_preferred_weight = gr.Slider(label='Preferred weight', info="Set to 0 to disable", minimum=0.0, maximum=2.0, step=0.01)
 
         with gr.Row() as row_random_prompt:

--- a/html/footer.html
+++ b/html/footer.html
@@ -1,7 +1,7 @@
 <div>
         <a href="{api_docs}">API</a>
          • 
-        <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">Github</a>
+        <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">GitHub</a>
          • 
         <a href="https://gradio.app">Gradio</a>
          • 

--- a/html/licenses.html
+++ b/html/licenses.html
@@ -688,3 +688,29 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
+
+<h2><a href="https://github.com/feathericons/feather/blob/main/LICENSE">feather</a></h2>
+<small>Some icon SVGs borrowed.</small>
+<pre>
+The MIT License (MIT)
+
+Copyright (c) 2013-2023 Cole Bemis
+   
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -229,6 +229,7 @@ function popup(contents) {
 
         var close = document.createElement('div');
         close.classList.add('global-popup-close');
+        close.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
         close.onclick = closePopup;
         close.title = "Close";
         globalPopup.appendChild(close);

--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -195,31 +195,31 @@ document.addEventListener("DOMContentLoaded", function() {
     modalControls.className = 'modalControls gradio-container';
     modal.append(modalControls);
 
-    const modalZoom = document.createElement('span');
+    const modalZoom = document.createElement('a');
     modalZoom.className = 'modalZoom cursor';
-    modalZoom.innerHTML = '&#10529;';
+    modalZoom.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>';
     modalZoom.addEventListener('click', modalZoomToggle, true);
     modalZoom.title = "Toggle zoomed view";
     modalControls.appendChild(modalZoom);
 
-    const modalTileImage = document.createElement('span');
+    const modalTileImage = document.createElement('a');
     modalTileImage.className = 'modalTileImage cursor';
-    modalTileImage.innerHTML = '&#8862;';
+    modalTileImage.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>';
     modalTileImage.addEventListener('click', modalTileImageToggle, true);
     modalTileImage.title = "Preview tiling";
     modalControls.appendChild(modalTileImage);
 
-    const modalSave = document.createElement("span");
+    const modalSave = document.createElement("a");
     modalSave.className = "modalSave cursor";
     modalSave.id = "modal_save";
-    modalSave.innerHTML = "&#x1F5AB;";
+    modalSave.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>';
     modalSave.addEventListener("click", modalSaveImage, true);
-    modalSave.title = "Save Image(s)";
+    modalSave.title = "Save image(s)";
     modalControls.appendChild(modalSave);
 
-    const modalClose = document.createElement('span');
+    const modalClose = document.createElement('a');
     modalClose.className = 'modalClose cursor';
-    modalClose.innerHTML = '&times;';
+    modalClose.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
     modalClose.onclick = closeModal;
     modalClose.title = "Close image viewer";
     modalControls.appendChild(modalClose);
@@ -233,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     const modalPrev = document.createElement('a');
     modalPrev.className = 'modalPrev';
-    modalPrev.innerHTML = '&#10094;';
+    modalPrev.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>';
     modalPrev.tabIndex = 0;
     modalPrev.addEventListener('click', modalPrevImage, true);
     modalPrev.addEventListener('keydown', modalKeyHandler, true);
@@ -241,7 +241,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     const modalNext = document.createElement('a');
     modalNext.className = 'modalNext';
-    modalNext.innerHTML = '&#10095;';
+    modalNext.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>';
     modalNext.tabIndex = 0;
     modalNext.addEventListener('click', modalNextImage, true);
     modalNext.addEventListener('keydown', modalKeyHandler, true);

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1085,7 +1085,7 @@ def create_ui():
                 script_callbacks.ui_train_tabs_callback(params)
 
             with gr.Column(elem_id='ti_gallery_container'):
-                ti_output = gr.Text(elem_id="ti_output", value="", show_label=False)
+                ti_output = gr.Textbox(elem_id="ti_output", value="", show_label=False)
                 gr.Gallery(label='Output', show_label=False, elem_id='ti_gallery', columns=4)
                 gr.HTML(elem_id="ti_progress", value="")
                 ti_outcome = gr.HTML(elem_id="ti_error", value="")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -303,12 +303,12 @@ def ordered_ui_categories():
 
 
 def create_override_settings_dropdown(tabname, row):
-    dropdown = gr.Dropdown([], label="Override settings", visible=False, elem_id=f"{tabname}_override_settings", multiselect=True)
+    dropdown = gr.Dropdown([], label="Override settings", elem_id=f"{tabname}_override_settings", multiselect=True)
 
     dropdown.change(
-        fn=lambda x: gr.Dropdown.update(visible=bool(x)),
+        fn=lambda x: gr.update(visible=bool(x)),
         inputs=[dropdown],
-        outputs=[dropdown],
+        outputs=[row],
     )
 
     return dropdown
@@ -403,7 +403,7 @@ def create_ui():
                                 batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="txt2img_batch_size")
 
                     elif category == "override_settings":
-                        with FormRow(elem_id="txt2img_override_settings_row") as row:
+                        with FormRow(elem_id="txt2img_override_settings_row", visible=False) as row:
                             override_settings = create_override_settings_dropdown('txt2img', row)
 
                     elif category == "scripts":
@@ -720,7 +720,7 @@ def create_ui():
                                 batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="img2img_batch_size")
 
                     elif category == "override_settings":
-                        with FormRow(elem_id="img2img_override_settings_row") as row:
+                        with FormRow(elem_id="img2img_override_settings_row", visible=False) as row:
                             override_settings = create_override_settings_dropdown('img2img', row)
 
                     elif category == "scripts":

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -543,8 +543,8 @@ def create_ui():
                     apply = gr.Button(value=apply_label, variant="primary")
                     check = gr.Button(value="Check for updates")
                     extensions_disable_all = gr.Radio(label="Disable all extensions", choices=["none", "extra", "all"], value=shared.opts.disable_all_extensions, elem_id="extensions_disable_all")
-                    extensions_disabled_list = gr.Text(elem_id="extensions_disabled_list", visible=False, container=False)
-                    extensions_update_list = gr.Text(elem_id="extensions_update_list", visible=False, container=False)
+                    extensions_disabled_list = gr.Textbox(elem_id="extensions_disabled_list", visible=False, show_label=False)
+                    extensions_update_list = gr.Textbox(elem_id="extensions_update_list", visible=False, show_label=False)
 
                 html = ""
 
@@ -579,8 +579,8 @@ def create_ui():
                 with gr.Row():
                     refresh_available_extensions_button = gr.Button(value="Load from:", variant="primary")
                     extensions_index_url = os.environ.get('WEBUI_EXTENSIONS_INDEX', "https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui-extensions/master/index.json")
-                    available_extensions_index = gr.Text(value=extensions_index_url, label="Extension index URL", container=False)
-                    extension_to_install = gr.Text(elem_id="extension_to_install", visible=False)
+                    available_extensions_index = gr.Textbox(value=extensions_index_url, label="Extension index URL", show_label=False)
+                    extension_to_install = gr.Textbox(elem_id="extension_to_install", visible=False)
                     install_extension_button = gr.Button(elem_id="install_extension_button", visible=False)
 
                 with gr.Row():
@@ -588,7 +588,7 @@ def create_ui():
                     sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order",'update time', 'create time', "stars"], type="index")
 
                 with gr.Row():
-                    search_extensions_text = gr.Text(label="Search", container=False)
+                    search_extensions_text = gr.Textbox(label="Search", placeholder="Search...", show_label=False)
 
                 install_result = gr.HTML()
                 available_extensions_table = gr.HTML()
@@ -624,9 +624,9 @@ def create_ui():
                 )
 
             with gr.TabItem("Install from URL", id="install_from_url"):
-                install_url = gr.Text(label="URL for extension's git repository")
-                install_branch = gr.Text(label="Specific branch name", placeholder="Leave empty for default main branch")
-                install_dirname = gr.Text(label="Local directory name", placeholder="Leave empty for auto")
+                install_url = gr.Textbox(label="URL for extension's git repository")
+                install_branch = gr.Textbox(label="Specific branch name", placeholder="Leave empty for default main branch")
+                install_dirname = gr.Textbox(label="Local directory name", placeholder="Leave empty for auto")
                 install_button = gr.Button(value="Install", variant="primary")
                 install_result = gr.HTML(elem_id="extension_install_result")
 

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -213,9 +213,11 @@ class ExtraNetworksPage:
         metadata_button = ""
         metadata = item.get("metadata")
         if metadata:
-            metadata_button = f"<div class='metadata-button card-button' title='Show internal metadata' onclick='extraNetworksRequestMetadata(event, {quote_js(self.name)}, {quote_js(item['name'])})'></div>"
+            info_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>'
+            metadata_button = f"<div class='metadata-button card-button' title='Show internal metadata' onclick='extraNetworksRequestMetadata(event, {quote_js(self.name)}, {quote_js(item['name'])})'>{info_icon}</div>"
 
-        edit_button = f"<div class='edit-button card-button' title='Edit metadata' onclick='extraNetworksEditUserMetadata(event, {quote_js(tabname)}, {quote_js(self.id_page)}, {quote_js(item['name'])})'></div>"
+        tool_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>'
+        edit_button = f"<div class='edit-button card-button' title='Edit metadata' onclick='extraNetworksEditUserMetadata(event, {quote_js(tabname)}, {quote_js(self.id_page)}, {quote_js(item['name'])})'>{tool_icon}</div>"
 
         local_path = ""
         filename = item.get("filename", "")

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -40,13 +40,9 @@ def create_setting_component(key, is_quicksettings=False):
     elem_id = f"setting_{key}"
 
     if info.refresh is not None:
-        if is_quicksettings:
+        with FormRow():
             res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
             ui_common.create_refresh_button(res, info.refresh, info.component_args, f"refresh_{key}")
-        else:
-            with FormRow():
-                res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
-                ui_common.create_refresh_button(res, info.refresh, info.component_args, f"refresh_{key}")
     else:
         res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
 

--- a/style.css
+++ b/style.css
@@ -177,6 +177,10 @@ a{
     cursor: pointer;
 }
 
+.gradio-container-3-41-0 .prose * {
+    --body-text-color: 'inherit';
+}
+
 /* align-items isn't enough and elements may overflow in Safari. */
 .unequal-height {
     align-content: flex-start;
@@ -627,17 +631,21 @@ table.popup-table .link{
     box-sizing: border-box;
 }
 
-.global-popup-close:before {
-    content: "×";
-}
-
 .global-popup-close{
     position: fixed;
-    right: 0.25em;
-    top: 0;
+    right: 8px;
+    top: 8px;
     cursor: pointer;
     color: white;
-    font-size: 32pt;
+}
+.global-popup-close:hover {
+    color: #999;
+}
+.global-popup-close svg {
+    padding: 8px;
+    box-sizing: content-box;
+    width: 32px;
+    height: 32px;
 }
 
 .global-popup-inner{
@@ -917,6 +925,7 @@ footer {
 .extra-network-cards .card .button-row{
     display: none;
     position: absolute;
+    margin: 6px;
     color: white;
     right: 0;
     z-index: 1
@@ -925,26 +934,19 @@ footer {
     display: flex;
 }
 
-.extra-network-cards .card .card-button{
-    color: white;
-}
-
-.extra-network-cards .card .metadata-button:before{
-    content: "🛈";
-}
-
-.extra-network-cards .card .edit-button:before{
-    content: "🛠";
-}
-
 .extra-network-cards .card .card-button {
+    color: white;
     text-shadow: 2px 2px 3px black;
-    padding: 0.25em 0.1em;
-    font-size: 200%;
-    width: 1.5em;
+    
 }
-.extra-network-cards .card .card-button:hover{
+.extra-network-cards .card .card-button:hover {
     color: red;
+}
+.extra-network-cards .card .card-button svg {
+    padding: 6px;
+    box-sizing: content-box;
+    width: 24px;
+    height: 24px;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -662,11 +662,12 @@ table.popup-table .link{
     -webkit-user-select: none;
     flex-direction: column;
 }
+#lightboxModal svg {
+    display: block;
+}
 
 .modalControls {
     display: flex;
-    gap: 1em;
-    padding: 1em;
     background-color:rgba(0,0,0,0);
     z-index: 1;
     transition: 0.2s ease background-color;
@@ -677,18 +678,23 @@ table.popup-table .link{
 .modalClose {
     margin-left: auto;
 }
-.modalControls span{
+.modalControls a{
     color: white;
     text-shadow: 0px 0px 0.25em black;
     font-size: 35px;
     font-weight: bold;
     cursor: pointer;
-    width: 1em;
 }
 
-.modalControls span:hover, .modalControls span:focus{
+.modalControls a:hover, .modalControls a:focus{
     color: #999;
     text-decoration: none;
+}
+
+.modalControls svg {
+    padding: 16px;
+    width: 32px;
+    height: 32px;
 }
 
 #lightboxModal > img {
@@ -718,11 +724,9 @@ table.popup-table .link{
   top: 50%;
   width: auto;
   padding: 16px;
-  margin-top: -50px;
+  margin-top: -32px;
   color: white;
-  font-weight: bold;
-  font-size: 20px;
-  transition: 0.6s ease;
+  transition: 0.6s ease background-color;
   border-radius: 0 3px 3px 0;
   user-select: none;
   -webkit-user-select: none;

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
 
 }
 
-.dark {
+:root:has(> .dark), .dark {
     color-scheme: dark;
 }
 

--- a/style.css
+++ b/style.css
@@ -177,7 +177,7 @@ a{
     cursor: pointer;
 }
 
-.gradio-container-3-41-0 .prose * {
+.gradio-container .prose * {
     --body-text-color: 'inherit';
 }
 

--- a/style.css
+++ b/style.css
@@ -936,11 +936,10 @@ footer {
 
 .extra-network-cards .card .card-button {
     color: white;
-    text-shadow: 2px 2px 3px black;
-    
+    filter: drop-shadow(0 0 4px black);
 }
 .extra-network-cards .card .card-button:hover {
-    color: red;
+    color: var(--color-accent);
 }
 .extra-network-cards .card .card-button svg {
     padding: 6px;

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@
 
 }
 
+.dark {
+    color-scheme: dark;
+}
+
 .block.padded:not(.gradio-accordion) {
     padding: 0 !important;
 }
@@ -26,6 +30,9 @@ div.gradio-container{
 .compact{
     background: transparent !important;
     padding: 0 !important;
+}
+.compact > *, .compact .box {
+    border-radius: inherit !important;
 }
 
 div.form{
@@ -46,11 +53,27 @@ div.form{
 .block.gradio-colorpicker {
     border-width: 0 !important;
     box-shadow: none !important;
+
+    /* gradio 3.39 puts a lot of overflow: hidden all over the place for an unknown reason. */
+    overflow: visible !important;
+}
+div.gradio-group:not([id$=_container]) {
+    overflow: visible !important;
 }
 
 div.gradio-group, div.styler{
     border-width: 0 !important;
     background: none;
+}
+/* button/radio groups broken in gradio 3.37 */
+div.styler {
+    --block-radius: inherit !important;
+    --block-border-width: inherit !important;
+    --layout-gap: inherit !important;
+    --form-gap-width: inherit !important;
+    --button-border-width: inherit !important;
+    --button-large-radius: inherit !important;
+    --button-small-radius: inherit !important;
 }
 .gap.compact{
     padding: 0;
@@ -127,19 +150,31 @@ div.gradio-html.min{
     background: var(--input-background-fill);
 }
 
-.gradio-container .prose a, .gradio-container .prose a:visited{
-    color: unset;
+.gradio-container .prose a {
     text-decoration: none;
+}
+.gradio-container .prose a,
+.gradio-container .prose a:visited {
+    color: var(--body-text-color);
+}
+.gradio-container .prose a:hover {
+    color: var(--link-text-color-hover);
+}
+.gradio-container .prose a:active {
+    color: var(--link-text-color-active);
+}
+
+div.styler > .gradio-gallery:not(.absolute) {
+    border-width: 0 !important;
+}
+
+.gradio-row {
+    row-gap: inherit !important;
 }
 
 a{
     font-weight: bold;
     cursor: pointer;
-}
-
-/* gradio 3.39 puts a lot of overflow: hidden all over the place for an unknown reason. */
-div.gradio-container, .block.gradio-textbox, div.gradio-group, div.gradio-dropdown{
-    overflow: visible !important;
 }
 
 /* align-items isn't enough and elements may overflow in Safari. */
@@ -149,14 +184,20 @@ div.gradio-container, .block.gradio-textbox, div.gradio-group, div.gradio-dropdo
 
 
 /* general styled components */
+:root {
+    --font-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Android Emoji", EmojiSymbols, "EmojiOne Mozilla", "Twemoji Mozilla", "Segoe UI Symbol", emoji, var(--font);
+    --button-tool-size: calc(var(--input-text-size) * var(--line-sm) + var(--spacing-xl) * 2 + var(--button-border-width) * 2);
+}
 
 .gradio-button.tool{
-    max-width: 2.2em;
-    min-width: 2.2em !important;
-    height: 2.4em;
+    font-size: 20px;
+    font-family: var(--font-emoji);
+    padding: 0;
+    min-width: var(--button-tool-size) !important;
+    max-width: var(--button-tool-size);
+    height: var(--button-tool-size);
     align-self: end;
-    line-height: 1em;
-    border-radius: 0.5em;
+    border-radius: var(--button-large-radius);
 }
 
 .gradio-button.secondary-down{
@@ -503,32 +544,31 @@ table.popup-table .link{
 
 
 /* live preview */
+:root {
+    --progress-value-fill: #0060df;
+    --progress-bar-fill: #b4c0cc;
+    --progress-radius: var(--radius-sm);
+}
+
+.dark {
+    --progress-bar-fill: #424c5b;
+}
+
 .progressDiv{
-    position: absolute;
-    height: 20px;
-    background: #b4c0cc;
-    border-radius: 3px !important;
-    top: -20px;
-}
-
-[id$=_results].mobile{
-    margin-top: 28px;
-}
-
-.dark .progressDiv{
-    background: #424c5b;
+    height: var(--size-5);
+    background: var(--progress-bar-fill);
+    border-radius: var(--progress-radius) !important;
+    overflow: hidden;
 }
 
 .progressDiv .progress{
     width: 0%;
-    height: 20px;
-    background: #0060df;
+    height: 100%;
+    background: var(--progress-value-fill);
     color: white;
     font-weight: bold;
-    line-height: 20px;
-    padding: 0 8px 0 0;
+    line-height: var(--size-5);
     text-align: right;
-    border-radius: 3px;
     overflow: visible;
     white-space: nowrap;
     padding: 0 0.5em;
@@ -546,7 +586,19 @@ table.popup-table .link{
     position: absolute;
     object-fit: contain;
     width: 100%;
-    height: calc(100% - 60px);  /* to match gradio's height */
+    height: 100%;
+}
+
+.gradio-group[id$=_gallery_container] {
+    border-width: var(--block-border-width) !important;
+}
+
+#img2img_results, #txt2img_results, #extras_results {
+    gap: 0.5em;
+}
+
+[id$=_results].mobile{
+    margin-top: 28px;
 }
 
 /* fullscreen popup (ie in Lora's (i) button) */
@@ -1056,6 +1108,10 @@ div.accordions > div.input-accordion.input-accordion-open{
 
 
 /* sticky right hand columns */
+
+.gradio-container {
+    overflow: visible;
+}
 
 #img2img_results, #txt2img_results, #extras_results {
     position: sticky;


### PR DESCRIPTION
## Description

* Fix progress bar layout
* Adjust the height of tool buttons to match neighboring input fields and dropdowns
* Explicitly specify the fonts for tool buttons to prevent them from being rendered as non-emoji symbols on some browsers
* Fix some button/radio group border radius being 0
* Fix broken styled TextBoxes (use `show_label=False` instead of `container=False`)
* Replace environment-dependent Unicode symbols with [feather icons](https://github.com/feathericons/feather) (same as Gradio)

## Screenshots/videos:

### Main
| Before | After |
| ------ | ----- |
| ![main_before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/b18fdfb5-f101-40f1-a1c2-afe0fb59899e) | ![main_after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/b448c859-4dc3-4533-9068-19774ac48f71) |

### Image preview modal
| Before | After |
| ------ | ----- |
| ![modal_before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/8a0d8f60-d38d-4ca4-aad3-5ea86b0e1a10) | ![modal_after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/178ef2b2-c8f5-4ac1-87cb-cfd89eeee8ee) |

### Model card
| Before | After |
| ------ | ----- |
| ![card_before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/dbef04e4-beac-4784-931b-ab9a48ab62b0) | ![card_after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/28616020/712ea24c-fc0a-4ba7-a7d8-aafb218d8fa6) |

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
