### PR TITLE
support installed extensions list api

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -770,7 +770,7 @@ class Api:
         except Exception as err:
             cuda = {'error': f'{err}'}
         return models.MemoryResponse(ram=ram, cuda=cuda)
-    
+
     def get_extensions_list(self):
         from modules import extensions
         extensions.list_extensions()

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -311,3 +311,12 @@ class ScriptInfo(BaseModel):
     is_alwayson: bool = Field(default=None, title="IsAlwayson", description="Flag specifying whether this script is an alwayson script")
     is_img2img: bool = Field(default=None, title="IsImg2img", description="Flag specifying whether this script is an img2img script")
     args: List[ScriptArg] = Field(title="Arguments", description="List of script's arguments")
+
+class ExtensionItem(BaseModel):
+    name: str = Field(title="Name", description="Extension name")
+    remote: str = Field(title="Remote", description="Extension Repository URL")
+    branch: str = Field(title="Branch", description="Extension Repository Branch")
+    commit_hash: str = Field(title="Commit Hash", description="Extension Repository Commit Hash")
+    version: str = Field(title="Version", description="Extension Version")
+    commit_date: str = Field(title="Commit Date", description="Extension Repository Commit Date")
+    enabled: bool = Field(title="Enabled", description="Flag specifying whether this extension is enabled")


### PR DESCRIPTION
## Description

I have added an API endpoint to get the list of installed extensions
```python
self.add_api_route("/sdapi/v1/extensions", self.get_extensions_list, methods=["GET"], response_model=List[models.ExtensionItem])
```

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25168945/de430ab7-2103-4d97-b669-e904f6866afc)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25168945/58c314cf-14ca-4375-aeee-8b5b1a6d7915)



## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25168945/e916e264-3c03-4816-a16d-c3c817eea385)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
