### PR TITLE
Fix styles dialog being removed from DOM

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -219,9 +219,14 @@ var globalPopupInner = null;
 function closePopup() {
     if (!globalPopup) return;
 
+    if (globalPopupInner && Object.hasOwn(globalPopupInner.firstElementChild, 'originalParent')) {
+        globalPopupInner.firstElementChild.style.display = "none";
+        globalPopupInner.firstElementChild.originalParent.appendChild(globalPopupInner.firstElementChild);
+    }
+
     globalPopup.style.display = "none";
 }
-function popup(contents) {
+function popup(contents, returnToParentOnClose = false) {
     if (!globalPopup) {
         globalPopup = document.createElement('div');
         globalPopup.onclick = closePopup;
@@ -241,6 +246,11 @@ function popup(contents) {
         globalPopup.appendChild(globalPopupInner);
 
         gradioApp().querySelector('.main').appendChild(globalPopup);
+    }
+
+    if (returnToParentOnClose) {
+        contents.originalParent = contents.parentElement;
+        contents.style.display = "block";
     }
 
     globalPopupInner.innerHTML = '';

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -252,7 +252,7 @@ def create_refresh_button(refresh_component, refresh_method, refreshed_args, ele
     return refresh_button
 
 
-def setup_dialog(button_show, dialog, *, button_close=None):
+def setup_dialog(button_show, dialog, *, button_close=None, return_to_parent_on_close=False):
     """Sets up the UI so that the dialog (gr.Box) is invisible, and is only shown when buttons_show is clicked, in a fullscreen modal window."""
 
     dialog.visible = False
@@ -261,7 +261,7 @@ def setup_dialog(button_show, dialog, *, button_close=None):
         fn=lambda: gr.update(visible=True),
         inputs=[],
         outputs=[dialog],
-    ).then(fn=None, _js="function(){ popup(gradioApp().getElementById('" + dialog.elem_id + "')); }")
+    ).then(fn=None, _js="function(){ popup(gradioApp().getElementById('" + dialog.elem_id + "'), returnToParentOnClose=" + ("true" if return_to_parent_on_close else "false") + "); }")
 
     if button_close:
         button_close.click(fn=None, _js="closePopup")

--- a/modules/ui_prompt_styles.py
+++ b/modules/ui_prompt_styles.py
@@ -103,7 +103,7 @@ class UiPromptStyles:
             show_progress=False,
         ).then(fn=None, _js="function(){update_"+tabname+"_tokens(); closePopup();}", show_progress=False)
 
-        ui_common.setup_dialog(button_show=edit_button, dialog=styles_dialog, button_close=self.close)
+        ui_common.setup_dialog(button_show=edit_button, dialog=styles_dialog, button_close=self.close, return_to_parent_on_close=True)
 
 
 


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12721

This was happening because `appendChild` [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/72ee347eabf04d1a238a738a03e7973cc2a46ca3/javascript/extraNetworks.js#L247) moves the styles dialog to the popup element, which gets overwritten once the styles dialog is opened in another tab. Once it's then attempted to be opened in the previous tab again, both then fail to work.

This works around it by returning the styles dialog to the original parent on close. I don't feel like this is the cleanest solution, so if there is a better one then by all means I'm open to suggestions.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
