### PR TITLE
Hide broken image crop tool

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,8 +2,8 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
 
-/* temporary fix to hide gradio crop tool until it's fixed https://github.com/gradio-app/gradio/issues/3810 */
 
+/* temporary fix to hide gradio crop tool until it's fixed https://github.com/gradio-app/gradio/issues/3810 */
 
 div.gradio-image button[aria-label="Edit"] {
     display: none;

--- a/style.css
+++ b/style.css
@@ -2,6 +2,14 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
 
+/* temporary fix to hide gradio crop tool until it's fixed https://github.com/gradio-app/gradio/issues/3810 */
+
+
+div.gradio-image button[aria-label="Edit"] {
+    display: none;
+}
+
+
 /* general gradio fixes */
 
 :root, .dark{


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10504 and clears up some confusion, like in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12789.

This is an upstream issue with Gradio that's been unresolved for several months, and there doesn't seem to be a way to replace or hide the tool on the Python side, so probably just best for now to hide it on the frontend until it's fixed. https://github.com/gradio-app/gradio/issues/3810

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
