### PR TITLE
Prevent duplicate resize handler

### DIFF
--- a/javascript/resizeHandle.js
+++ b/javascript/resizeHandle.js
@@ -134,6 +134,8 @@
 
 onUiLoaded(function() {
     for (var elem of gradioApp().querySelectorAll('.resize-handle-row')) {
-        setupResizeHandle(elem);
+        if (!elem.querySelector('.resize-handle')) {
+            setupResizeHandle(elem);
+        }
     }
 });


### PR DESCRIPTION
## Description

Title. Fixes an edge case where a user may somehow have a duplicate of the script lying around somewhere, which would result in two divs being added and pushing the results div down.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
