### PR TITLE
Vanilla image noise generator option

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -827,7 +827,12 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             p.seeds = p.all_seeds[n * p.batch_size:(n + 1) * p.batch_size]
             p.subseeds = p.all_subseeds[n * p.batch_size:(n + 1) * p.batch_size]
 
-            p.rng = rng.ImageRNG((opt_C, p.height // opt_f, p.width // opt_f), p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, seed_resize_from_h=p.seed_resize_from_h, seed_resize_from_w=p.seed_resize_from_w)
+            if opts.use_vanilla_random_number_generator:
+                rng_maker = rng.VanillaImageRNG
+            else:
+                rng_maker = rng.ImageRNG
+
+            p.rng = rng_maker((opt_C, p.height // opt_f, p.width // opt_f), p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, seed_resize_from_h=p.seed_resize_from_h, seed_resize_from_w=p.seed_resize_from_w)
 
             if p.scripts is not None:
                 p.scripts.before_process_batch(p, batch_number=n, prompts=p.prompts, seeds=p.seeds, subseeds=p.subseeds)

--- a/modules/rng.py
+++ b/modules/rng.py
@@ -1,4 +1,5 @@
 import torch
+import torchsde
 
 from modules import devices, rng_philox, shared
 

--- a/modules/rng.py
+++ b/modules/rng.py
@@ -1,5 +1,4 @@
 import torch
-import torchsde
 
 from modules import devices, rng_philox, shared
 

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -197,7 +197,11 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
 
         sigmas = self.get_sigmas(p, steps)
 
-        x = x * sigmas[0]
+        if opts.use_vanilla_random_number_generator:
+            # https://github.com/comfyanonymous/ComfyUI/blob/a57b0c797b0670e6fd48ff3cf1f37dbf0d0a67b5/comfy/samplers.py#L716
+            x = x * torch.sqrt(1.0 + sigmas[0] ** 2.0)
+        else:
+            x = x * sigmas[0]
 
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -197,6 +197,7 @@ options_templates.update(options_section(('optimizations', "Optimizations"), {
 }))
 
 options_templates.update(options_section(('compatibility', "Compatibility"), {
+    "use_vanilla_random_number_generator": OptionInfo(False, "Use vanilla random number generator. Can reproduce other UI's results (Fooocus/ComfyUI). Require full restart."),
     "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
     "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
     "no_dpmpp_sde_batch_determinism": OptionInfo(False, "Do not make DPM++ SDE deterministic across different batch sizes."),


### PR DESCRIPTION
# Description

Right now webui’s noise generating system is very powerful yet convoluted, making it difficult to produce consistent results with other software.

This pull request add an option “use_vanilla_random_number_generator” to temporarily disable some webui hackings to the noise generators. 

The result is that now we can perfectly reproduce results from other software like comfyui, fooocus, etc. This pull request also include a minor fix in the dpm++’s first sigmas for the noise processing so that the results are even more consistent.

My recommendation is that the option “use_vanilla_random_number_generator” should only be targeted to code development, since introducing this to users will cause some confusing about reproducing results from old seeds. 

This option is very useful when we want to implement extensions and check those extensions’ behaviors across different software.

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/edab50e4-d4f6-4bba-8b1c-4df4feb37fe1)


# Example 1

cinematic film still, a car in the city street . shallow depth of field, vignette, highly detailed, high budget, bokeh, cinemascope, moody, epic, gorgeous, film grain, grainy
Negative prompt: anime, cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed, mutated, ugly, disfigured
Steps: 20, Sampler: DPM++ 2M SDE Karras, CFG scale: 8, Seed: 123456, Size: 1024x1024, Model hash: e6bb9ea85b, Model: sd_xl_base_1.0_0.9vae, Version: v1.6.0-RC-32-gde0db85f

### Webui

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/74500a74-862d-44b4-a80c-8b4e09a4dbbe)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/bbd1fc04-970c-491c-a94b-b3dbddd328b7)

### Comfy

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/eccd9d2e-0f6a-4082-8fee-0b9b93ae54e1)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/af1afb1d-dcf6-4e55-96b5-80ed3c281c28)

### Fooocus (all tricks disabled)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/9be3350d-06f3-49b8-ba43-4e419727e546)

### Webui (with "use_vanilla_random_number_generator")

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/589cea4d-7fe0-4bec-931f-46907b103c14)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/a5975580-72a2-48c2-883b-d3a8d8018bf8)


# Example 2

professional 3d model of a cute cat. octane render, highly detailed, volumetric, dramatic lighting
Negative prompt: ugly, deformed, noisy, low poly, blurry, painting
Steps: 20, Sampler: DPM++ 2M SDE Karras, CFG scale: 8, Seed: 123456, Size: 1024x1024, Model hash: e6bb9ea85b, Model: sd_xl_base_1.0_0.9vae, Version: v1.6.0-RC-33-gc8f0b780

### Webui

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/6afeb2d4-9fea-4ced-8152-e699f266282e)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/766dd216-3f4d-40b9-9995-4fb3c810ac9e)

### Comfy

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/e30666ba-d017-4e3b-8299-ada3a2dc589f)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/32f7c333-9f55-4ac0-9abd-368b4737a5d7)


### Fooocus (all tricks disabled)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/4e4f2fe8-c5d0-49c0-87de-a806e6e1941a)


### Webui (with "use_vanilla_random_number_generator")

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/d68f533b-4ac0-4be1-9dab-0f7764cb3007)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19834515/43164662-8375-45d8-83f6-2495dd9b8d1c)


# Minor

If you may still see some minor difference between these results, my guess is that this is caused by other software using cpu to process clip text encoding. Nevertheless, we do not think it is necessary to perfectly reproduce that.

# Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
