### PR TITLE
Honor `--skip-install` for extension installers

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -404,7 +404,8 @@ def prepare_environment():
         run_pip(f"install -r \"{requirements_file}\"", "requirements")
         startup_timer.record("install requirements")
 
-    run_extensions_installers(settings_file=args.ui_settings_file)
+    if not args.skip_install:
+        run_extensions_installers(settings_file=args.ui_settings_file)
 
     if args.update_check:
         version_check(commit)


### PR DESCRIPTION
## Description

Make the `--skip-install` argument actually skip all package installations, in this case for extension installers. Resolves scenarios like in https://github.com/picobyte/stable-diffusion-webui-wd14-tagger/issues/56 where the user may want to save a bit of extra startup time.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
