### PR TITLE
Don't print blank stdout in extension installers

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -228,7 +228,9 @@ def run_extension_installer(extension_dir):
         env = os.environ.copy()
         env['PYTHONPATH'] = f"{os.path.abspath('.')}{os.pathsep}{env.get('PYTHONPATH', '')}"
 
-        print(run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env))
+        stdout = run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env)
+        if stdout:
+            print(stdout)
     except Exception as e:
         errors.report(str(e))
 


### PR DESCRIPTION
## Description

Fixes a long-standing minor annoyance where this previously printed a bunch of blank lines depending on how many `install.py` files the user has as part of extensions.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
