### PR TITLE
Fix raises duplicated tracebacks

### DIFF
--- a/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
+++ b/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
@@ -161,7 +161,8 @@ class DDPMV1(pl.LightningModule):
         elif self.parameterization == "x0":
             lvlb_weights = 0.5 * np.sqrt(torch.Tensor(alphas_cumprod)) / (2. * 1 - torch.Tensor(alphas_cumprod))
         else:
-            raise NotImplementedError("mu not supported")
+            msg = 'mu not supported'
+            raise NotImplementedError(msg)
         # TODO how to choose this term
         lvlb_weights[0] = lvlb_weights[1]
         self.register_buffer('lvlb_weights', lvlb_weights, persistent=False)
@@ -286,7 +287,8 @@ class DDPMV1(pl.LightningModule):
             else:
                 loss = torch.nn.functional.mse_loss(target, pred, reduction='none')
         else:
-            raise NotImplementedError("unknown loss type '{loss_type}'")
+            msg = "unknown loss type '{loss_type}'"
+            raise NotImplementedError(msg)
 
         return loss
 
@@ -301,7 +303,8 @@ class DDPMV1(pl.LightningModule):
         elif self.parameterization == "x0":
             target = x_start
         else:
-            raise NotImplementedError(f"Paramterization {self.parameterization} not yet supported")
+            msg = f'Paramterization {self.parameterization} not yet supported'
+            raise NotImplementedError(msg)
 
         loss = self.get_loss(model_out, target, mean=False).mean(dim=[1, 2, 3])
 
@@ -544,7 +547,8 @@ class LatentDiffusionV1(DDPMV1):
         elif isinstance(encoder_posterior, torch.Tensor):
             z = encoder_posterior
         else:
-            raise NotImplementedError(f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented")
+            msg = f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented"
+            raise NotImplementedError(msg)
         return self.scale_factor * z
 
     def get_learned_conditioning(self, c):
@@ -1075,7 +1079,8 @@ class LatentDiffusionV1(DDPMV1):
                                        return_x0=return_x0,
                                        score_corrector=score_corrector, corrector_kwargs=corrector_kwargs)
         if return_codebook_ids:
-            raise DeprecationWarning("Support dropped.")
+            msg = 'Support dropped.'
+            raise DeprecationWarning(msg)
             model_mean, _, model_log_variance, logits = outputs
         elif return_x0:
             model_mean, _, model_log_variance, x0 = outputs

--- a/extensions-builtin/Lora/network_lora.py
+++ b/extensions-builtin/Lora/network_lora.py
@@ -48,7 +48,8 @@ class NetworkModuleLora(network.NetworkModule):
         elif is_conv and key == "lora_up.weight" or key == "dyn_down":
             module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], (1, 1), bias=False)
         else:
-            raise AssertionError(f'Lora layer {self.network_key} matched a layer with unsupported type: {type(self.sd_module).__name__}')
+            msg = f"Lora layer {self.network_key} matched a layer with unsupported type: {type(self.sd_module).__name__}"
+            raise AssertionError(msg)
 
         with torch.no_grad():
             if weight.shape != module.weight.shape:

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -191,7 +191,8 @@ def load_network(name, network_on_disk):
                 break
 
         if net_module is None:
-            raise AssertionError(f"Could not find a module type (out of {', '.join([x.__class__.__name__ for x in module_types])}) that would accept those keys: {', '.join(weights.w)}")
+            msg = f"Could not find a module type (out of {', '.join([x.__class__.__name__ for x in module_types])}) that would accept those keys: {', '.join(weights.w)}"
+            raise AssertionError(msg)
 
         net.modules[key] = net_module
 
@@ -306,7 +307,8 @@ def network_apply_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn
     weights_backup = getattr(self, "network_weights_backup", None)
     if weights_backup is None and wanted_names != ():
         if current_names != ():
-            raise RuntimeError("no backup weights found and current weights are not unchanged")
+            msg = "no backup weights found and current weights are not unchanged"
+            raise RuntimeError(msg)
 
         if isinstance(self, torch.nn.MultiheadAttention):
             weights_backup = (self.in_proj_weight.to(devices.cpu, copy=True), self.out_proj.weight.to(devices.cpu, copy=True))

--- a/extensions-builtin/SwinIR/swinir_model_arch.py
+++ b/extensions-builtin/SwinIR/swinir_model_arch.py
@@ -587,7 +587,8 @@ class Upsample(nn.Sequential):
             m.append(nn.Conv2d(num_feat, 9 * num_feat, 3, 1, 1))
             m.append(nn.PixelShuffle(3))
         else:
-            raise ValueError(f'scale {scale} is not supported. ' 'Supported scales: 2^n and 3.')
+            msg = f"scale {scale} is not supported. Supported scales: 2^n and 3."
+            raise ValueError(msg)
         super(Upsample, self).__init__(*m)
 
 

--- a/extensions-builtin/SwinIR/swinir_model_arch_v2.py
+++ b/extensions-builtin/SwinIR/swinir_model_arch_v2.py
@@ -620,7 +620,8 @@ class Upsample(nn.Sequential):
             m.append(nn.Conv2d(num_feat, 9 * num_feat, 3, 1, 1))
             m.append(nn.PixelShuffle(3))
         else:
-            raise ValueError(f'scale {scale} is not supported. ' 'Supported scales: 2^n and 3.')
+            msg = f"scale {scale} is not supported. Supported scales: 2^n and 3."
+            raise ValueError(msg)
         super(Upsample, self).__init__(*m)
 
 class Upsample_hf(nn.Sequential):
@@ -641,7 +642,8 @@ class Upsample_hf(nn.Sequential):
             m.append(nn.Conv2d(num_feat, 9 * num_feat, 3, 1, 1))
             m.append(nn.PixelShuffle(3))
         else:
-            raise ValueError(f'scale {scale} is not supported. ' 'Supported scales: 2^n and 3.')
+            msg = f"scale {scale} is not supported. Supported scales: 2^n and 3."
+            raise ValueError(msg)
         super(Upsample_hf, self).__init__(*m)
 
 

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -566,7 +566,8 @@ class Api:
     def set_config(self, req: Dict[str, Any]):
         checkpoint_name = req.get("sd_model_checkpoint", None)
         if checkpoint_name is not None and checkpoint_name not in checkpoint_aliases:
-            raise RuntimeError(f"model {checkpoint_name!r} not found")
+            msg = f"model {checkpoint_name!r} not found"
+            raise RuntimeError(msg)
 
         for k, v in req.items():
             shared.opts.set(k, v, is_api=True)

--- a/modules/codeformer/codeformer_arch.py
+++ b/modules/codeformer/codeformer_arch.py
@@ -55,7 +55,8 @@ class PositionEmbeddingSine(nn.Module):
         self.temperature = temperature
         self.normalize = normalize
         if scale is not None and normalize is False:
-            raise ValueError("normalize should be True if scale is passed")
+            msg = 'normalize should be True if scale is passed'
+            raise ValueError(msg)
         if scale is None:
             scale = 2 * math.pi
         self.scale = scale
@@ -93,7 +94,8 @@ def _get_activation_fn(activation):
         return F.gelu
     if activation == "glu":
         return F.glu
-    raise RuntimeError(F"activation should be relu/gelu, not {activation}.")
+    msg = f'activation should be relu/gelu, not {activation}.'
+    raise RuntimeError(msg)
 
 
 class TransformerSALayer(nn.Module):

--- a/modules/codeformer/vqgan_arch.py
+++ b/modules/codeformer/vqgan_arch.py
@@ -380,7 +380,8 @@ class VQAutoEncoder(nn.Module):
                 self.load_state_dict(torch.load(model_path, map_location='cpu')['params'])
                 logger.info(f'vqgan is loaded from: {model_path} [params]')
             else:
-                raise ValueError('Wrong params!')
+                msg = "Wrong params!"
+                raise ValueError(msg)
 
 
     def forward(self, x):
@@ -429,7 +430,8 @@ class VQGANDiscriminator(nn.Module):
             elif 'params' in chkpt:
                 self.load_state_dict(torch.load(model_path, map_location='cpu')['params'])
             else:
-                raise ValueError('Wrong params!')
+                msg = "Wrong params!"
+                raise ValueError(msg)
 
     def forward(self, x):
         return self.main(x)

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -179,7 +179,8 @@ class UpscalerESRGAN(Upscaler):
         elif "conv_first.weight" in state_dict:
             state_dict = mod2normal(state_dict)
         elif "model.0.weight" not in state_dict:
-            raise Exception("The file is not a recognized ESRGAN model.")
+            msg = 'The file is not a recognized ESRGAN model.'
+            raise Exception(msg)
 
         in_nc, out_nc, nf, nb, plus, mscale = infer_params(state_dict)
 

--- a/modules/esrgan_model_arch.py
+++ b/modules/esrgan_model_arch.py
@@ -37,7 +37,8 @@ class RRDBNet(nn.Module):
         elif upsample_mode == 'pixelshuffle':
             upsample_block = pixelshuffle_block
         else:
-            raise NotImplementedError(f'upsample mode [{upsample_mode}] is not found')
+            msg = f'upsample mode [{upsample_mode}] is not found'
+            raise NotImplementedError(msg)
         if upscale == 3:
             upsampler = upsample_block(nf, nf, 3, act_type=act_type, convtype=convtype)
         else:
@@ -349,7 +350,8 @@ def act(act_type, inplace=True, neg_slope=0.2, n_prelu=1, beta=1.0):
     elif act_type == 'sigmoid':  # [0, 1] range output
         layer = nn.Sigmoid()
     else:
-        raise NotImplementedError(f'activation layer [{act_type}] is not found')
+        msg = f'activation layer [{act_type}] is not found'
+        raise NotImplementedError(msg)
     return layer
 
 
@@ -371,7 +373,8 @@ def norm(norm_type, nc):
     elif norm_type == 'none':
         def norm_layer(x): return Identity()
     else:
-        raise NotImplementedError(f'normalization layer [{norm_type}] is not found')
+        msg = f'normalization layer [{norm_type}] is not found'
+        raise NotImplementedError(msg)
     return layer
 
 
@@ -387,7 +390,8 @@ def pad(pad_type, padding):
     elif pad_type == 'zero':
         layer = nn.ZeroPad2d(padding)
     else:
-        raise NotImplementedError(f'padding layer [{pad_type}] is not implemented')
+        msg = f'padding layer [{pad_type}] is not implemented'
+        raise NotImplementedError(msg)
     return layer
 
 
@@ -415,7 +419,8 @@ def sequential(*args):
     """ Flatten Sequential. It unwraps nn.Sequential. """
     if len(args) == 1:
         if isinstance(args[0], OrderedDict):
-            raise NotImplementedError('sequential does not support OrderedDict input.')
+            msg = 'sequential does not support OrderedDict input.'
+            raise NotImplementedError(msg)
         return args[0]  # No sequential is needed.
     modules = []
     for module in args:

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -198,9 +198,11 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
             # have another 4 channels for unmasked picture's latent space, plus one channel for mask, for a total of 9
             if a.shape != b.shape and a.shape[0:1] + a.shape[2:] == b.shape[0:1] + b.shape[2:]:
                 if a.shape[1] == 4 and b.shape[1] == 9:
-                    raise RuntimeError("When merging inpainting model with a normal one, A must be the inpainting model.")
+                    msg = 'When merging inpainting model with a normal one, A must be the inpainting model.'
+                    raise RuntimeError(msg)
                 if a.shape[1] == 4 and b.shape[1] == 8:
-                    raise RuntimeError("When merging instruct-pix2pix model with a normal one, A must be the instruct-pix2pix model.")
+                    msg = 'When merging instruct-pix2pix model with a normal one, A must be the instruct-pix2pix model.'
+                    raise RuntimeError(msg)
 
                 if a.shape[1] == 8 and b.shape[1] == 4:#If we have an Instruct-Pix2Pix model...
                     theta_0[key][:, 0:4, :, :] = theta_func2(a[:, 0:4, :, :], b, multiplier)#Merge only the vectors the models have in common.  Otherwise we get an error due to dimension mismatch.

--- a/modules/gitpython_hack.py
+++ b/modules/gitpython_hack.py
@@ -12,7 +12,8 @@ class Git(git.Git):
     """
 
     def _get_persistent_cmd(self, attr_name, cmd_name, *args, **kwargs):
-        raise NotImplementedError(f"Refusing to use persistent process: {attr_name} ({cmd_name} {args} {kwargs})")
+        msg = f"Refusing to use persistent process: {attr_name} ({cmd_name} {args} {kwargs})"
+        raise NotImplementedError(msg)
 
     def get_object_header(self, ref: str | bytes) -> tuple[str, str, int]:
         ret = subprocess.check_output(

--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -56,7 +56,8 @@ class HypernetworkModule(torch.nn.Module):
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(f'hypernetwork uses an unsupported activation function: {activation_func}')
+                msg = f"hypernetwork uses an unsupported activation function: {activation_func}"
+                raise RuntimeError(msg)
 
             # Add layer normalization
             if add_layer_norm:
@@ -94,7 +95,8 @@ class HypernetworkModule(torch.nn.Module):
                         kaiming_normal_(w, nonlinearity='leaky_relu' if 'leakyrelu' == activation_func else 'relu')
                         zeros_(b)
                     else:
-                        raise KeyError(f"Key {weight_init} is not defined as initialization!")
+                        msg = f"Key {weight_init} is not defined as initialization!"
+                        raise KeyError(msg)
         self.to(devices.device)
 
     def fix_old_state_dict(self, state_dict):

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -353,9 +353,9 @@ def prepare_environment():
         startup_timer.record("install torch")
 
     if not args.skip_torch_cuda_test and not check_run_python("import torch; assert torch.cuda.is_available()"):
+        msg = 'Torch is not able to use GPU; add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'
         raise RuntimeError(
-            'Torch is not able to use GPU; '
-            'add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'
+            msg
         )
     startup_timer.record("torch GPU test")
 

--- a/modules/models/diffusion/ddpm_edit.py
+++ b/modules/models/diffusion/ddpm_edit.py
@@ -173,7 +173,8 @@ class DDPM(pl.LightningModule):
         elif self.parameterization == "x0":
             lvlb_weights = 0.5 * np.sqrt(torch.Tensor(alphas_cumprod)) / (2. * 1 - torch.Tensor(alphas_cumprod))
         else:
-            raise NotImplementedError("mu not supported")
+            msg = 'mu not supported'
+            raise NotImplementedError(msg)
         # TODO how to choose this term
         lvlb_weights[0] = lvlb_weights[1]
         self.register_buffer('lvlb_weights', lvlb_weights, persistent=False)
@@ -321,7 +322,8 @@ class DDPM(pl.LightningModule):
             else:
                 loss = torch.nn.functional.mse_loss(target, pred, reduction='none')
         else:
-            raise NotImplementedError("unknown loss type '{loss_type}'")
+            msg = "unknown loss type '{loss_type}'"
+            raise NotImplementedError(msg)
 
         return loss
 
@@ -336,7 +338,8 @@ class DDPM(pl.LightningModule):
         elif self.parameterization == "x0":
             target = x_start
         else:
-            raise NotImplementedError(f"Paramterization {self.parameterization} not yet supported")
+            msg = f'Paramterization {self.parameterization} not yet supported'
+            raise NotImplementedError(msg)
 
         loss = self.get_loss(model_out, target, mean=False).mean(dim=[1, 2, 3])
 
@@ -579,7 +582,8 @@ class LatentDiffusion(DDPM):
         elif isinstance(encoder_posterior, torch.Tensor):
             z = encoder_posterior
         else:
-            raise NotImplementedError(f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented")
+            msg = f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented"
+            raise NotImplementedError(msg)
         return self.scale_factor * z
 
     def get_learned_conditioning(self, c):
@@ -1091,7 +1095,8 @@ class LatentDiffusion(DDPM):
                                        return_x0=return_x0,
                                        score_corrector=score_corrector, corrector_kwargs=corrector_kwargs)
         if return_codebook_ids:
-            raise DeprecationWarning("Support dropped.")
+            msg = 'Support dropped.'
+            raise DeprecationWarning(msg)
             model_mean, _, model_log_variance, logits = outputs
         elif return_x0:
             model_mean, _, model_log_variance, x0 = outputs

--- a/modules/models/diffusion/uni_pc/uni_pc.py
+++ b/modules/models/diffusion/uni_pc/uni_pc.py
@@ -93,7 +93,8 @@ class NoiseScheduleVP:
         """
 
         if schedule not in ['discrete', 'linear', 'cosine']:
-            raise ValueError(f"Unsupported noise schedule {schedule}. The schedule needs to be 'discrete' or 'linear' or 'cosine'")
+            msg = f"Unsupported noise schedule {schedule}. The schedule needs to be 'discrete' or 'linear' or 'cosine'"
+            raise ValueError(msg)
 
         self.schedule = schedule
         if schedule == 'discrete':
@@ -471,7 +472,8 @@ class UniPC:
             t = torch.linspace(t_T**(1. / t_order), t_0**(1. / t_order), N + 1).pow(t_order).to(device)
             return t
         else:
-            raise ValueError(f"Unsupported skip_type {skip_type}, need to be 'logSNR' or 'time_uniform' or 'time_quadratic'")
+            msg = f"Unsupported skip_type {skip_type}, need to be 'logSNR' or 'time_uniform' or 'time_quadratic'"
+            raise ValueError(msg)
 
     def get_orders_and_timesteps_for_singlestep_solver(self, steps, order, skip_type, t_T, t_0, device):
         """
@@ -496,7 +498,8 @@ class UniPC:
             K = steps
             orders = [1,] * steps
         else:
-            raise ValueError("'order' must be '1' or '2' or '3'.")
+            msg = "'order' must be '1' or '2' or '3'."
+            raise ValueError(msg)
         if skip_type == 'logSNR':
             # To reproduce the results in DPM-Solver paper
             timesteps_outer = self.get_time_steps(skip_type, t_T, t_0, K, device)

--- a/modules/options.py
+++ b/modules/options.py
@@ -93,10 +93,12 @@ class Options:
 
                 comp_args = info.component_args if info else None
                 if isinstance(comp_args, dict) and comp_args.get('visible', True) is False:
-                    raise RuntimeError(f"not possible to set {key} because it is restricted")
+                    msg = f"not possible to set {key} because it is restricted"
+                    raise RuntimeError(msg)
 
                 if cmd_opts.hide_ui_dir_config and key in self.restricted_opts:
-                    raise RuntimeError(f"not possible to set {key} because it is restricted")
+                    msg = f"not possible to set {key} because it is restricted"
+                    raise RuntimeError(msg)
 
                 self.data[key] = value
                 return

--- a/modules/patches.py
+++ b/modules/patches.py
@@ -19,7 +19,8 @@ def patch(key, obj, field, replacement):
 
     patch_key = (obj, field)
     if patch_key in originals[key]:
-        raise RuntimeError(f"patch for {field} is already applied")
+        msg = f"patch for {field} is already applied"
+        raise RuntimeError(msg)
 
     original_func = getattr(obj, field)
     originals[key][patch_key] = original_func
@@ -46,7 +47,8 @@ def undo(key, obj, field):
     patch_key = (obj, field)
 
     if patch_key not in originals[key]:
-        raise RuntimeError(f"there is no patch for {field} to undo")
+        msg = f"there is no patch for {field} to undo"
+        raise RuntimeError(msg)
 
     original_func = originals[key].pop(patch_key)
     setattr(obj, field, original_func)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -399,7 +399,8 @@ class StableDiffusionProcessing:
             self.all_negative_prompts = [self.negative_prompt] * len(self.all_prompts)
 
         if len(self.all_prompts) != len(self.all_negative_prompts):
-            raise RuntimeError(f"Received a different number of prompts ({len(self.all_prompts)}) and negative prompts ({len(self.all_negative_prompts)})")
+            msg = f"Received a different number of prompts ({len(self.all_prompts)}) and negative prompts ({len(self.all_negative_prompts)})"
+            raise RuntimeError(msg)
 
         self.all_prompts = [shared.prompt_styles.apply_styles_to_prompt(x, self.styles) for x in self.all_prompts]
         self.all_negative_prompts = [shared.prompt_styles.apply_negative_styles_to_prompt(x, self.styles) for x in self.all_negative_prompts]
@@ -767,7 +768,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     if p.refiner_checkpoint not in (None, "", "None", "none"):
         p.refiner_checkpoint_info = sd_models.get_closet_checkpoint_match(p.refiner_checkpoint)
         if p.refiner_checkpoint_info is None:
-            raise Exception(f'Could not find checkpoint with name {p.refiner_checkpoint}')
+            msg = f"Could not find checkpoint with name {p.refiner_checkpoint}"
+            raise Exception(msg)
 
     p.sd_model_name = shared.sd_model.sd_checkpoint_info.name_for_extra
     p.sd_model_hash = shared.sd_model.sd_model_hash
@@ -1099,7 +1101,8 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 self.hr_checkpoint_info = sd_models.get_closet_checkpoint_match(self.hr_checkpoint_name)
 
                 if self.hr_checkpoint_info is None:
-                    raise Exception(f'Could not find checkpoint with name {self.hr_checkpoint_name}')
+                    msg = f"Could not find checkpoint with name {self.hr_checkpoint_name}"
+                    raise Exception(msg)
 
                 self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
 
@@ -1115,7 +1118,8 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             self.latent_scale_mode = shared.latent_upscale_modes.get(self.hr_upscaler, None) if self.hr_upscaler is not None else shared.latent_upscale_modes.get(shared.latent_upscale_default_mode, "nearest")
             if self.enable_hr and self.latent_scale_mode is None:
                 if not any(x.name == self.hr_upscaler for x in shared.sd_upscalers):
-                    raise Exception(f"could not find upscaler named {self.hr_upscaler}")
+                    msg = f"could not find upscaler named {self.hr_upscaler}"
+                    raise Exception(msg)
 
             self.calculate_target_resolution()
 
@@ -1491,7 +1495,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             self.batch_size = len(imgs)
             batch_images = np.array(imgs)
         else:
-            raise RuntimeError(f"bad number of images passed: {len(imgs)}; expecting {self.batch_size} or less")
+            msg = f"bad number of images passed: {len(imgs)}; expecting {self.batch_size} or less"
+            raise RuntimeError(msg)
 
         image = torch.from_numpy(batch_images)
         image = image.to(shared.device, dtype=devices.dtype_vae)

--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -72,9 +72,11 @@ class UpscalerRealESRGAN(Upscaler):
                         model_dir=self.model_download_path,
                     )
                 if not os.path.exists(scaler.local_data_path):
-                    raise FileNotFoundError(f"RealESRGAN data missing: {scaler.local_data_path}")
+                    msg = f"RealESRGAN data missing: {scaler.local_data_path}"
+                    raise FileNotFoundError(msg)
                 return scaler
-        raise ValueError(f"Unable to find model info: {path}")
+        msg = f"Unable to find model info: {path}"
+        raise ValueError(msg)
 
     def load_models(self, _):
         return get_realesrgan_models(self)

--- a/modules/safe.py
+++ b/modules/safe.py
@@ -61,7 +61,8 @@ class RestrictedUnpickler(pickle.Unpickler):
             return set
 
         # Forbid everything else.
-        raise Exception(f"global '{module}/{name}' is forbidden")
+        msg = f"global '{module}/{name}' is forbidden"
+        raise Exception(msg)
 
 
 # Regular expression that accepts 'dirname/version', 'dirname/data.pkl', and 'dirname/data/<number>'
@@ -73,7 +74,8 @@ def check_zip_filenames(filename, names):
         if allowed_zip_names_re.match(name):
             continue
 
-        raise Exception(f"bad file inside {filename}: {name}")
+        msg = f'bad file inside {filename}: {name}'
+        raise Exception(msg)
 
 
 def check_pt(filename, extra_handler):
@@ -86,9 +88,11 @@ def check_pt(filename, extra_handler):
             # find filename of data.pkl in zip file: '<directory name>/data.pkl'
             data_pkl_filenames = [f for f in z.namelist() if data_pkl_re.match(f)]
             if len(data_pkl_filenames) == 0:
-                raise Exception(f"data.pkl not found in {filename}")
+                msg = f'data.pkl not found in {filename}'
+                raise Exception(msg)
             if len(data_pkl_filenames) > 1:
-                raise Exception(f"Multiple data.pkl found in {filename}")
+                msg = f'Multiple data.pkl found in {filename}'
+                raise Exception(msg)
             with z.open(data_pkl_filenames[0]) as file:
                 unpickler = RestrictedUnpickler(file)
                 unpickler.extra_handler = extra_handler

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -257,8 +257,8 @@ def split_cross_attention_forward(self, x, context=None, mask=None, **kwargs):
 
         if steps > 64:
             max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                               f'Need: {mem_required / 64 / gb:0.1f}GB free, Have:{mem_free_total / gb:0.1f}GB free')
+            msg = f"Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). Need: {mem_required / 64 / gb:0.1f}GB free, Have:{mem_free_total / gb:0.1f}GB free"
+            raise RuntimeError(msg)
 
         slice_size = q.shape[1] // steps
         for i in range(0, q.shape[1], slice_size):

--- a/modules/sd_hijack_unet.py
+++ b/modules/sd_hijack_unet.py
@@ -18,7 +18,8 @@ class TorchHijackForUnet:
         if hasattr(torch, item):
             return getattr(torch, item)
 
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
+        msg = f"'{type(self).__name__}' object has no attribute '{item}'"
+        raise AttributeError(msg)
 
     def cat(self, tensors, *args, **kwargs):
         if len(tensors) == 2:

--- a/modules/sd_models_xl.py
+++ b/modules/sd_models_xl.py
@@ -60,7 +60,8 @@ def tokenize(self: sgm.modules.GeneralConditioner, texts):
     for embedder in [embedder for embedder in self.embedders if hasattr(embedder, 'tokenize')]:
         return embedder.tokenize(texts)
 
-    raise AssertionError('no tokenizer available')
+    msg = 'no tokenizer available'
+    raise AssertionError(msg)
 
 
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -30,7 +30,8 @@ def create_sampler(name, model):
     assert config is not None, f'bad sampler name: {name}'
 
     if model.is_sdxl and config.options.get("no_sdxl", False):
-        raise Exception(f"Sampler {config.name} is not supported for SDXL")
+        msg = f'Sampler {config.name} is not supported for SDXL'
+        raise Exception(msg)
 
     sampler = config.constructor(model)
     sampler.config = config

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -198,7 +198,8 @@ class TorchHijack:
         if hasattr(torch, item):
             return getattr(torch, item)
 
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
+        msg = f"'{type(self).__name__}' object has no attribute '{item}'"
+        raise AttributeError(msg)
 
     def randn_like(self, x):
         return self.rng.next()

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -100,7 +100,8 @@ def decoder_model():
             loaded_model.to(devices.device, devices.dtype)
             sd_vae_taesd_models[model_name] = loaded_model
         else:
-            raise FileNotFoundError('TAESD model not found')
+            msg = "TAESD model not found"
+            raise FileNotFoundError(msg)
 
     return loaded_model.decoder
 
@@ -119,6 +120,7 @@ def encoder_model():
             loaded_model.to(devices.device, devices.dtype)
             sd_vae_taesd_models[model_name] = loaded_model
         else:
-            raise FileNotFoundError('TAESD model not found')
+            msg = "TAESD model not found"
+            raise FileNotFoundError(msg)
 
     return loaded_model.encoder

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -59,7 +59,8 @@ class PersonalizedBase(Dataset):
         for path in tqdm.tqdm(self.image_paths):
             alpha_channel = None
             if shared.state.interrupted:
-                raise Exception("interrupted")
+                msg = "interrupted"
+                raise Exception(msg)
             try:
                 image = Image.open(path)
                 #Currently does not work for single color transparency

--- a/modules/textual_inversion/learn_schedule.py
+++ b/modules/textual_inversion/learn_schedule.py
@@ -33,7 +33,8 @@ class LearnScheduleIterator:
                     return
             assert self.rates
         except (ValueError, AssertionError) as e:
-            raise Exception('Invalid learning rate schedule. It should be a number or, for example, like "0.001:100, 0.00001:1000, 1e-5:10000" to have lr of 0.001 until step 100, 0.00001 until 1000, and 1e-5 until 10000.') from e
+            msg = 'Invalid learning rate schedule. It should be a number or, for example, like "0.001:100, 0.00001:1000, 1e-5:10000" to have lr of 0.001 until step 100, 0.00001 until 1000, and 1e-5 until 10000.'
+            raise Exception(msg) from e
 
 
     def __iter__(self):

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -205,7 +205,8 @@ class EmbeddingDatabase:
             shape = vec.shape[-1]
             vectors = vec.shape[0]
         else:
-            raise Exception(f"Couldn't identify {filename} as neither textual inversion embedding nor diffuser concept.")
+            msg = f"Couldn't identify {filename} as neither textual inversion embedding nor diffuser concept."
+            raise Exception(msg)
 
         embedding = Embedding(vec, name)
         embedding.step = data.get('step', None)

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -356,7 +356,8 @@ def install_extension_from_url(dirname, url, branch_name=None):
 
     normalized_url = normalize_git_url(url)
     if any(x for x in extensions.extensions if normalize_git_url(x.remote) == normalized_url):
-        raise Exception(f'Extension with this URL is already installed: {url}')
+        msg = f"Extension with this URL is already installed: {url}"
+        raise Exception(msg)
 
     tmpdir = os.path.join(paths.data_path, "tmp", dirname)
 

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -31,11 +31,13 @@ def fetch_file(filename: str = ""):
         raise HTTPException(status_code=404, detail="File not found")
 
     if not any(Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs):
-        raise ValueError(f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages.")
+        msg = f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages."
+        raise ValueError(msg)
 
     ext = os.path.splitext(filename)[1].lower()
     if ext not in (".png", ".jpg", ".jpeg", ".webp", ".gif"):
-        raise ValueError(f"File cannot be fetched: {filename}. Only png, jpg, webp, and gif.")
+        msg = f"File cannot be fetched: {filename}. Only png, jpg, webp, and gif."
+        raise ValueError(msg)
 
     # would profit from returning 304
     return FileResponse(filename, headers={"Accept-Ranges": "bytes"})

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -35,7 +35,8 @@ def create_setting_component(key, is_quicksettings=False):
     elif t == bool:
         comp = gr.Checkbox
     else:
-        raise Exception(f'bad options item type: {t} for key {key}')
+        msg = f'bad options item type: {t} for key {key}'
+        raise Exception(msg)
 
     elem_id = f"setting_{key}"
 

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -59,10 +59,12 @@ class Script(scripts.Script):
         modules.processing.fix_seed(p)
         # Raise error if promp type is not positive or negative
         if prompt_type not in ["positive", "negative"]:
-            raise ValueError(f"Unknown prompt type {prompt_type}")
+            msg = f"Unknown prompt type {prompt_type}"
+            raise ValueError(msg)
         # Raise error if variations delimiter is not comma or space
         if variations_delimiter not in ["comma", "space"]:
-            raise ValueError(f"Unknown variations delimiter {variations_delimiter}")
+            msg = f"Unknown variations delimiter {variations_delimiter}"
+            raise ValueError(msg)
 
         prompt = p.prompt if prompt_type == "positive" else p.negative_prompt
         original_prompt = prompt[0] if type(prompt) == list else prompt

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -36,7 +36,8 @@ def apply_field(field):
 
 def apply_prompt(p, x, xs):
     if xs[0] not in p.prompt and xs[0] not in p.negative_prompt:
-        raise RuntimeError(f"Prompt S/R did not find {xs[0]} in prompt or negative prompt.")
+        msg = f"Prompt S/R did not find {xs[0]} in prompt or negative prompt."
+        raise RuntimeError(msg)
 
     p.prompt = p.prompt.replace(xs[0], x)
     p.negative_prompt = p.negative_prompt.replace(xs[0], x)
@@ -70,20 +71,23 @@ def apply_order(p, x, xs):
 def confirm_samplers(p, xs):
     for x in xs:
         if x.lower() not in sd_samplers.samplers_map:
-            raise RuntimeError(f"Unknown sampler: {x}")
+            msg = f"Unknown sampler: {x}"
+            raise RuntimeError(msg)
 
 
 def apply_checkpoint(p, x, xs):
     info = modules.sd_models.get_closet_checkpoint_match(x)
     if info is None:
-        raise RuntimeError(f"Unknown checkpoint: {x}")
+        msg = f"Unknown checkpoint: {x}"
+        raise RuntimeError(msg)
     p.override_settings['sd_model_checkpoint'] = info.name
 
 
 def confirm_checkpoints(p, xs):
     for x in xs:
         if modules.sd_models.get_closet_checkpoint_match(x) is None:
-            raise RuntimeError(f"Unknown checkpoint: {x}")
+            msg = f"Unknown checkpoint: {x}"
+            raise RuntimeError(msg)
 
 
 def confirm_checkpoints_or_none(p, xs):
@@ -92,7 +96,8 @@ def confirm_checkpoints_or_none(p, xs):
             continue
 
         if modules.sd_models.get_closet_checkpoint_match(x) is None:
-            raise RuntimeError(f"Unknown checkpoint: {x}")
+            msg = f"Unknown checkpoint: {x}"
+            raise RuntimeError(msg)
 
 
 def apply_clip_skip(p, x, xs):


### PR DESCRIPTION
## Description

Just a minor code fix to make python tracebacks more readable.

from 
```shell
Traceback (most recent call last):
  ...
      raise RuntimeError("mu not supported")
RuntimeError: mu not supported
```
to
```shell
Traceback (most recent call last):
  ...
      raise RuntimeError(msg)
RuntimeError: mu not supported
```

## Screenshots/videos:
None needed.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
