### PR TITLE
Only use SGM noise multiplier in img2img when denoising strength = 1

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -144,7 +144,7 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         sigmas = self.get_sigmas(p, steps)
         sigma_sched = sigmas[steps - t_enc - 1:]
 
-        if opts.sgm_noise_multiplier:
+        if opts.sgm_noise_multiplier and p.denoising_strength == 1:
             p.extra_generation_params["SGM noise multiplier"] = True
             noise_multiplier = torch.sqrt(1.0 + sigma_sched[0] ** 2.0)
         else:


### PR DESCRIPTION
## Description

Small correction to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12818. This is only ever supposed to apply at full denoise. It's pretty obvious this does not work correctly without this change when using hires fix.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
