### PR TITLE
Do not change quicksettings dropdown option when value returned is `None`

### DIFF
--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -87,7 +87,7 @@ class UiSettings:
         if not opts.same_type(value, opts.data_labels[key].default):
             return gr.update(visible=True), opts.dumpjson()
 
-        if not opts.set(key, value):
+        if value is None or not opts.set(key, value):
             return gr.update(value=getattr(opts, key)), opts.dumpjson()
 
         opts.save(shared.config_filename)


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12705

As the issue describes: when a user types into a quicksettings dropdown option, such as the SD checkpoint, and ultimately does not make a selection, the value returned on the backend is `None`, which will cause different behavior depending on the quicksetting. This PR fixes that behavior, so a value of `None` will leave the quicksetting alone.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
