### PR TITLE
patch Extension time format in systme time zone

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -177,7 +177,7 @@ def extension_table():
                 <td>{remote}</td>
                 <td>{ext.branch}</td>
                 <td>{version_link}</td>
-                <td>{time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(ext.commit_date))}</td>
+                <td>{datetime.fromtimestamp(ext.commit_date) if ext.commit_date else ""}</td>
                 <td{' class="extension_status"' if ext.remote is not None else ''}>{ext_status}</td>
             </tr>
     """

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -6,7 +6,6 @@ import os.path
 import gradio as gr
 
 from modules import generation_parameters_copypaste, images, sysinfo, errors, ui_extra_networks
-from modules.paths_internal import models_path
 
 
 class UserMetadataEditor:


### PR DESCRIPTION
## Description
Extension time format in systme time zone
matches the time display on GitHub web page
patch https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12851
demo
```py
import git
import time
from datetime import datetime
commit_date = git.Repo('../').head.commit.committed_date
print(commit_date)
# 1693374871
print(time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(commit_date)))
# 2023-08-30 05:54:31
print(datetime.fromtimestamp(commit_date))
# 2023-08-30 14:54:31  accounts for system time zone
```

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
