### PR TITLE
Fix generation params regex

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -9,7 +9,7 @@ from modules.paths import data_path
 from modules import shared, ui_tempdir, script_callbacks, processing
 from PIL import Image
 
-re_param_code = r'\s*([\w ]+):\s*("(?:\\"[^,]|\\"|\\|[^\"])+"|[^,]*)(?:,|$)'
+re_param_code = r'\s*([\w ]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'
 re_param = re.compile(re_param_code)
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")


### PR DESCRIPTION
## Description

In certain scenarios, it seems that the regex for generation params end early. In particular, if a parameter has the string `\"\",` in it, then it will end before the actual end of the data.

I discovered the issue here: https://github.com/ModelSurge/sd-webui-comfyui/pull/147#issuecomment-1683367396

Example of input that the current regex does not match correctly (scroll to the bottom of the text window): https://regex101.com/r/ghxKfI/1

You can see that the new regex matches properly: https://regex101.com/r/ghxKfI/2


## Screenshots/videos:

<details>

<summary>old regex (click to see screenshot)</summary>

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/32277961/313a8217-fd9d-4ee3-ab2c-e45e190741dd)

</details>

<details>

<summary>new regex (click to see screenshot)</summary>

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/32277961/1949458c-5742-4382-822b-e7a18157ee3f)

</details>


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
