### PR TITLE
account for customizable extra network separators in remove code

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -140,7 +140,7 @@ function setupExtraNetworks() {
 
 onUiLoaded(setupExtraNetworks);
 
-var re_extranet =   /<([^:^>]+:[^:]+):[\d.]+>(.*)/;
+var re_extranet = /<([^:^>]+:[^:]+):[\d.]+>(.*)/;
 var re_extranet_g = /<([^:^>]+:[^:]+):[\d.]+>/g;
 
 function tryToRemoveExtraNetworkFromPrompt(textarea, text) {

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -154,7 +154,7 @@ function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
         var extraTextAfterNet = m[2];
         var partToSearch = m[1];
         var foundAtPosition = -1;
-        var escapedSeparator = reEscape(opts.extra_networks_add_text_separator);
+        var escapedSeparator = `(?:${reEscape(opts.extra_networks_add_text_separator)})?`;
         var re = new RegExp(escapedSeparator + re_extranet_str, 'g');
         newTextareaText = textarea.value.replaceAll(re, function(found, net, pos) {
             m = found.match(re_extranet);

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -141,9 +141,12 @@ function setupExtraNetworks() {
 onUiLoaded(setupExtraNetworks);
 
 var re_extranet = /<([^:]+:[^:]+):[\d.]+>(.*)/;
-var re_extranet_g = /\s+<([^:]+:[^:]+):[\d.]+>/g;
+var re_extranet_str = '<([^:]+:[^:]+):[\\d.]+>';
 
 function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
+    function reEscape(s) {
+        return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
     var m = text.match(re_extranet);
     var replaced = false;
     var newTextareaText;
@@ -151,7 +154,9 @@ function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
         var extraTextAfterNet = m[2];
         var partToSearch = m[1];
         var foundAtPosition = -1;
-        newTextareaText = textarea.value.replaceAll(re_extranet_g, function(found, net, pos) {
+        var escapedSeparator = reEscape(opts.extra_networks_add_text_separator);
+        var re = new RegExp(escapedSeparator + re_extranet_str, 'g');
+        newTextareaText = textarea.value.replaceAll(re, function(found, net, pos) {
             m = found.match(re_extranet);
             if (m[1] == partToSearch) {
                 replaced = true;

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -140,23 +140,19 @@ function setupExtraNetworks() {
 
 onUiLoaded(setupExtraNetworks);
 
-var re_extranet = /<([^:]+:[^:]+):[\d.]+>(.*)/;
-var re_extranet_str = '<([^:]+:[^:]+):[\\d.]+>';
+var re_extranet =   /<([^:^>]+:[^:]+):[\d.]+>(.*)/;
+var re_extranet_g = /<([^:^>]+:[^:]+):[\d.]+>/g;
 
 function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
-    function reEscape(s) {
-        return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    }
     var m = text.match(re_extranet);
     var replaced = false;
     var newTextareaText;
     if (m) {
+        var extraTextBeforeNet = opts.extra_networks_add_text_separator;
         var extraTextAfterNet = m[2];
         var partToSearch = m[1];
         var foundAtPosition = -1;
-        var escapedSeparator = `(?:${reEscape(opts.extra_networks_add_text_separator)})?`;
-        var re = new RegExp(escapedSeparator + re_extranet_str, 'g');
-        newTextareaText = textarea.value.replaceAll(re, function(found, net, pos) {
+        newTextareaText = textarea.value.replaceAll(re_extranet_g, function(found, net, pos) {
             m = found.match(re_extranet);
             if (m[1] == partToSearch) {
                 replaced = true;
@@ -166,8 +162,13 @@ function tryToRemoveExtraNetworkFromPrompt(textarea, text) {
             return found;
         });
 
-        if (foundAtPosition >= 0 && newTextareaText.substr(foundAtPosition, extraTextAfterNet.length) == extraTextAfterNet) {
-            newTextareaText = newTextareaText.substr(0, foundAtPosition) + newTextareaText.substr(foundAtPosition + extraTextAfterNet.length);
+        if (foundAtPosition >= 0) {
+            if (newTextareaText.substr(foundAtPosition, extraTextAfterNet.length) == extraTextAfterNet) {
+                newTextareaText = newTextareaText.substr(0, foundAtPosition) + newTextareaText.substr(foundAtPosition + extraTextAfterNet.length);
+            }
+            if (newTextareaText.substr(foundAtPosition - extraTextBeforeNet.length, extraTextBeforeNet.length) == extraTextBeforeNet) {
+                newTextareaText = newTextareaText.substr(0, foundAtPosition - extraTextBeforeNet.length) + newTextareaText.substr(foundAtPosition);
+            }
         }
     } else {
         newTextareaText = textarea.value.replaceAll(new RegExp(text, "g"), function(found) {


### PR DESCRIPTION
## Description

This pull request addresses removing lora from the prompt when clicking a lora card in the extra networks UI to toggle add/remove when the extra network separator has been customized by the user. This changes the current regular expression replace function, which currently only looks for leading spaces, and instead looks for whatever the user has customized their separator to be. Because this input is customizable, it also escapes symbols in the extra network separator.

This only changes the `tryToRemoveExtraNetworkFromPrompt` javascript function and related variables.

Current known limitations: `<>` as custom separators do not work.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
