### PR TITLE
Use default dropdown padding on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -83,8 +83,10 @@ div.compact{
     white-space: nowrap;
 }
 
-.gradio-dropdown ul.options li.item {
-    padding: 0.05em 0;
+@media (pointer:fine) {
+    .gradio-dropdown ul.options li.item {
+        padding: 0.05em 0;
+    }
 }
 
 .gradio-dropdown ul.options li.item.selected {


### PR DESCRIPTION
## Description
Applies the padding from #8943 on desktop only (or with a mouse), to make it easier to select items on touchscreens.

## Screenshots/videos:
![IMG_0002](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4073789/67b070cb-5ed0-4f57-aca8-1b127a7a9627)

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
