### PR TITLE
Add 'None' to dropdown for refiner checkpoints

### DIFF
--- a/modules/processing_scripts/refiner.py
+++ b/modules/processing_scripts/refiner.py
@@ -21,7 +21,7 @@ class ScriptRefiner(scripts.ScriptBuiltinUI):
     def ui(self, is_img2img):
         with InputAccordion(False, label="Refiner", elem_id=self.elem_id("enable")) as enable_refiner:
             with gr.Row():
-                refiner_checkpoint = gr.Dropdown(label='Checkpoint', elem_id=self.elem_id("checkpoint"), choices=sd_models.checkpoint_tiles(), value='', tooltip="switch to another model in the middle of generation")
+                refiner_checkpoint = gr.Dropdown(label='Checkpoint', elem_id=self.elem_id("checkpoint"), choices=["None"] + sd_models.checkpoint_tiles(), value='None', tooltip="switch to another model in the middle of generation")
                 create_refresh_button(refiner_checkpoint, sd_models.list_models, lambda: {"choices": sd_models.checkpoint_tiles()}, self.elem_id("checkpoint_refresh"))
 
                 refiner_switch_at = gr.Slider(value=0.8, label="Switch at", minimum=0.01, maximum=1.0, step=0.01, elem_id=self.elem_id("switch_at"), tooltip="fraction of sampling steps when the switch to refiner model should happen; 1=never, 0.5=switch in the middle of generation")


### PR DESCRIPTION
## Description
There is no 'None' option in the drop-down for the refiner checkpoints, so once set, they cannot be removed.
Add a 'None' option to the dropdown so that it can be deselected.

stable diffusion checkpoint dropdown is unchanged

## Screenshots/videos:
![スクリーンショット 2023-08-31 214431](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6410332/a20d09a9-3e4b-42dd-a10b-26daa29935ba)

![スクリーンショット 2023-08-31 214403](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6410332/15e5cda5-e8fd-4930-a65f-c6042813b54f)


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
