### PR TITLE
fix batch img2img output dir with script

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -661,7 +661,15 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
         save_image_with_geninfo(image_to_save, info, temp_file_path, extension, existing_pnginfo=params.pnginfo, pnginfo_section_name=pnginfo_section_name)
 
-        os.replace(temp_file_path, filename_without_extension + extension)
+        full_file_name = filename_without_extension + extension
+        if shared.opts.save_images_add_number_suffix and os.path.exists(full_file_name):
+            count = 1
+            while True:
+                full_file_name = f"{filename_without_extension}_{count}{extension}"
+                if not os.path.exists(full_file_name):
+                    break
+                count += 1
+        os.replace(temp_file_path, full_file_name)
 
     fullfn_without_extension, extension = os.path.splitext(params.filename)
     if hasattr(os, 'statvfs'):

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -117,15 +117,14 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
         if output_dir:
             p.outpath_samples = output_dir
             p.override_settings['save_to_dirs'] = False
+            if p.n_iter > 1 or p.batch_size > 1:
+                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
+            else:
+                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
 
         if proc is None:
-            if output_dir:
-                if p.n_iter > 1 or p.batch_size > 1:
-                    p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
-                else:
-                    p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
             process_images(p)
 
 

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -114,11 +114,14 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
             else:
                 p.override_settings.pop("sd_model_checkpoint", None)
 
+        if output_dir:
+            p.outpath_samples = output_dir
+            p.override_settings['save_to_dirs'] = False
+
         proc = modules.scripts.scripts_img2img.run(p, *args)
+
         if proc is None:
             if output_dir:
-                p.outpath_samples = output_dir
-                p.override_settings['save_to_dirs'] = False
                 if p.n_iter > 1 or p.batch_size > 1:
                     p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
                 else:

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -26,7 +26,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "samples_format": OptionInfo('png', 'File format for images'),
     "samples_filename_pattern": OptionInfo("", "Images filename pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),
     "save_images_add_number": OptionInfo(True, "Add number to filename when saving", component_args=hide_dirs),
-
+    "save_images_add_number_suffix": OptionInfo(True, "Add number suffix when necessary", component_args=hide_dirs).info("prevent existing image from being override"),
     "grid_save": OptionInfo(True, "Always save all generated image grids"),
     "grid_format": OptionInfo('png', 'File format for grids'),
     "grid_extended_filename": OptionInfo(False, "Add extended info (seed, prompt) to filename when saving grid"),


### PR DESCRIPTION
## Description

Add opt `save_images_add_number_suffix`
similar concept to add numbering prefix for image, but only when thre existing a file with the same name
this prevents files from being overwritten

currently for batch img2img the output dir will be ignored when a script such as XYZ is enabled
the image will be I'll put it to the default output
although this is undesirable but it is not catastrophic

using `save_images_add_number_suffix` this allows the use of original file name when script is used

~~this fix makes it so that the output directory will be set the they specified directory in batch img2img regardless if a script is enabled or not
if a script is active it will use the default user defined file name pattern for saving images
only when no script is active will the original file name be used as the output file name~~

~~the reason why this is done is because if we use the original file names scripts such as Xyz would generate multiple images of the same name and thus overriding previous generated files~~

not sure but this might be a possible fix for [[Bug]: Batch img2img with multiple X/Y/Z denoising values is only saving one image (WebUI 1.6.0)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12913) 
I do have my doubts because what he is experiencing seems to be different issue
as `Sysinfo` is not uploaded I wasn't able to conduct further diagnosis

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
