### PR TITLE
fix: update shared.opts.data when add_option

### DIFF
--- a/modules/options.py
+++ b/modules/options.py
@@ -210,6 +210,7 @@ class Options:
 
     def add_option(self, key, info):
         self.data_labels[key] = info
+        self.data[key] = info.default
 
     def reorder(self):
         """reorder settings so that all items related to section always go together"""


### PR DESCRIPTION
## Description


If we add a new option but don't save it in config.json, we won't be able to set it in 

```
stored_opts = {k: opts.data[k] for k in p.override_settings.keys()}
```
This will result in a KeyError being raised for  `opts.data[k]`

for example, we will override `control_net_no_detectmap` parameters, if we have no save it in config.json, we cannot to set it in API.


## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
