### PR TITLE
Hotfix to put style apply button in tools row

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -201,6 +201,13 @@ function restoreProgressImg2img() {
 onUiLoaded(function() {
     showRestoreProgressButton('txt2img', localGet("txt2img_task_id"));
     showRestoreProgressButton('img2img', localGet("img2img_task_id"));
+
+    /* temporary fix to put style apply button in tools row */
+    for (const mode of ['txt2img', 'img2img']) {
+        const apply_style_btn = gradioApp().getElementById(`${mode}_style_apply`);
+        const tools = gradioApp().querySelector(`#${mode}_tools .form`);
+        tools.append(apply_style_btn);
+    }
 });
 
 


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13076, addresses a ton more comments.

The technical reason this was done is because the styles UI is now a separate component, so while on the Gradio backend the component is a lot more clean, it prevents making this simple change reflected in the frontend. But, we can easily make this workaround happen via only the frontend for now.

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/0597a856-2be5-4ce9-ba6c-a2a007648947)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
