### PR TITLE
Sysinfo filename 

### DIFF
--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -50,10 +50,10 @@ def get():
 
     text = json.dumps(res, ensure_ascii=False, indent=4)
 
-    h = hashlib.sha256(text.encode("utf8"))
-    text = text.replace(checksum_token, h.hexdigest())
+    checksum_hex = hashlib.sha256(text.encode("utf8")).hexdigest()
+    text = text.replace(checksum_token, checksum_hex)
 
-    return text
+    return text, checksum_hex[:4]
 
 
 re_checksum = re.compile(r'"Checksum": "([0-9a-fA-F]{64})"')

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1356,8 +1356,8 @@ def setup_ui_api(app):
     def download_sysinfo(attachment=False):
         from fastapi.responses import PlainTextResponse
 
-        text = sysinfo.get()
-        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.txt"
+        text, check_sum_4 = sysinfo.get()
+        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}_{check_sum_4}.json"
 
         return PlainTextResponse(text, headers={'Content-Disposition': f'{"attachment" if attachment else "inline"}; filename="{filename}"'})
 


### PR DESCRIPTION
## Description
some QoL improvements

1. save sysinfo as `.json`
so when opening them in a text editor it knows how to highlight the text and I don't have to set it manually

2. append the first 4 digits of the checksum to the end of the filename
this can be used to quickly compare if two sysinfo are the same

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
