### PR TITLE
thread safe extra network list_items

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -66,7 +66,8 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         return item
 
     def list_items(self):
-        for index, name in enumerate(networks.available_networks):
+        names = list(networks.available_networks)
+        for index, name in enumerate(names):
             item = self.create_item(name, index)
 
             if item is not None:

--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -68,6 +68,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         return item
 
     def list_items(self):
+        # instantiate a list to protect against concurrent modification
         names = list(networks.available_networks)
         for index, name in enumerate(names):
             item = self.create_item(name, index)

--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -17,6 +17,8 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
 
     def create_item(self, name, index=None, enable_filter=True):
         lora_on_disk = networks.available_networks.get(name)
+        if lora_on_disk is None:
+            return
 
         path, ext = os.path.splitext(lora_on_disk.filename)
 
@@ -69,7 +71,6 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         names = list(networks.available_networks)
         for index, name in enumerate(names):
             item = self.create_item(name, index)
-
             if item is not None:
                 yield item
 

--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -66,11 +66,11 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         return item
 
     def list_items(self):
-        with self.thread_lock:
-            for index, name in enumerate(networks.available_networks):
-                item = self.create_item(name, index)
-                if item is not None:
-                    yield item
+        for index, name in enumerate(networks.available_networks):
+            item = self.create_item(name, index)
+
+            if item is not None:
+                yield item
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.lora_dir, shared.cmd_opts.lyco_dir_backcompat]

--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -66,11 +66,11 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         return item
 
     def list_items(self):
-        for index, name in enumerate(networks.available_networks):
-            item = self.create_item(name, index)
-
-            if item is not None:
-                yield item
+        with self.thread_lock:
+            for index, name in enumerate(networks.available_networks):
+                item = self.create_item(name, index)
+                if item is not None:
+                    yield item
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.lora_dir, shared.cmd_opts.lyco_dir_backcompat]

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -1,7 +1,6 @@
 import os.path
 import urllib.parse
 from pathlib import Path
-from threading import Lock
 
 from modules import shared, ui_extra_networks_user_metadata, errors, extra_networks
 from modules.images import read_info_from_image, save_image_with_geninfo
@@ -95,7 +94,6 @@ class ExtraNetworksPage:
         self.allow_negative_prompt = False
         self.metadata = {}
         self.items = {}
-        self.thread_lock = Lock()
 
     def refresh(self):
         pass

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -1,6 +1,7 @@
 import os.path
 import urllib.parse
 from pathlib import Path
+from threading import Lock
 
 from modules import shared, ui_extra_networks_user_metadata, errors, extra_networks
 from modules.images import read_info_from_image, save_image_with_geninfo
@@ -94,6 +95,7 @@ class ExtraNetworksPage:
         self.allow_negative_prompt = False
         self.metadata = {}
         self.items = {}
+        self.thread_lock = Lock()
 
     def refresh(self):
         pass

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -33,6 +33,7 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
+        # instantiate a list to protect against concurrent modification
         names = list(sd_models.checkpoints_list)
         for index, name in enumerate(names):
             item = self.create_item(name, index)

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -30,9 +30,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        names = list(sd_models.checkpoints_list)
-        for index, name in enumerate(names):
-            yield self.create_item(name, index)
+        with self.thread_lock:
+            for index, name in enumerate(sd_models.checkpoints_list):
+                yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -30,9 +30,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        with self.thread_lock:
-            for index, name in enumerate(sd_models.checkpoints_list):
-                yield self.create_item(name, index)
+        names = list(sd_models.checkpoints_list)
+        for index, name in enumerate(names):
+            yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -15,6 +15,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
 
     def create_item(self, name, index=None, enable_filter=True):
         checkpoint: sd_models.CheckpointInfo = sd_models.checkpoint_aliases.get(name)
+        if checkpoint is None:
+            return
+
         path, ext = os.path.splitext(checkpoint.filename)
         return {
             "name": checkpoint.name_for_extra,
@@ -32,7 +35,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         names = list(sd_models.checkpoints_list)
         for index, name in enumerate(names):
-            yield self.create_item(name, index)
+            item = self.create_item(name, index)
+            if item is not None:
+                yield item
 
     def allowed_directories_for_previews(self):
         return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -31,8 +31,9 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        for index, name in enumerate(shared.hypernetworks):
-            yield self.create_item(name, index)
+        with self.thread_lock:
+            for index, name in enumerate(shared.hypernetworks):
+                yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.hypernetwork_dir]

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -31,7 +31,8 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        for index, name in enumerate(shared.hypernetworks):
+        names = list(shared.hypernetworks)
+        for index, name in enumerate(names):
             yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -13,7 +13,10 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         shared.reload_hypernetworks()
 
     def create_item(self, name, index=None, enable_filter=True):
-        full_path = shared.hypernetworks[name]
+        full_path = shared.hypernetworks.get(name)
+        if full_path is None:
+            return
+
         path, ext = os.path.splitext(full_path)
         sha256 = sha256_from_cache(full_path, f'hypernet/{name}')
         shorthash = sha256[0:10] if sha256 else None
@@ -33,7 +36,9 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         names = list(shared.hypernetworks)
         for index, name in enumerate(names):
-            yield self.create_item(name, index)
+            item = self.create_item(name, index)
+            if item is not None:
+                yield item
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.hypernetwork_dir]

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -31,9 +31,8 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        with self.thread_lock:
-            for index, name in enumerate(shared.hypernetworks):
-                yield self.create_item(name, index)
+        for index, name in enumerate(shared.hypernetworks):
+            yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.hypernetwork_dir]

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -34,6 +34,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
+        # instantiate a list to protect against concurrent modification
         names = list(shared.hypernetworks)
         for index, name in enumerate(names):
             item = self.create_item(name, index)

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -29,7 +29,8 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        for index, name in enumerate(sd_hijack.model_hijack.embedding_db.word_embeddings):
+        names = list(sd_hijack.model_hijack.embedding_db.word_embeddings)
+        for index, name in enumerate(names):
             yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -29,8 +29,9 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        for index, name in enumerate(sd_hijack.model_hijack.embedding_db.word_embeddings):
-            yield self.create_item(name, index)
+        with self.thread_lock:
+            for index, name in enumerate(sd_hijack.model_hijack.embedding_db.word_embeddings):
+                yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return list(sd_hijack.model_hijack.embedding_db.embedding_dirs)

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -14,6 +14,8 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
 
     def create_item(self, name, index=None, enable_filter=True):
         embedding = sd_hijack.model_hijack.embedding_db.word_embeddings.get(name)
+        if embedding is None:
+            return
 
         path, ext = os.path.splitext(embedding.filename)
         return {
@@ -31,7 +33,9 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
     def list_items(self):
         names = list(sd_hijack.model_hijack.embedding_db.word_embeddings)
         for index, name in enumerate(names):
-            yield self.create_item(name, index)
+            item = self.create_item(name, index)
+            if item is not None:
+                yield item
 
     def allowed_directories_for_previews(self):
         return list(sd_hijack.model_hijack.embedding_db.embedding_dirs)

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -31,6 +31,7 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
+        # instantiate a list to protect against concurrent modification
         names = list(sd_hijack.model_hijack.embedding_db.word_embeddings)
         for index, name in enumerate(names):
             item = self.create_item(name, index)

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -29,9 +29,8 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
         }
 
     def list_items(self):
-        with self.thread_lock:
-            for index, name in enumerate(sd_hijack.model_hijack.embedding_db.word_embeddings):
-                yield self.create_item(name, index)
+        for index, name in enumerate(sd_hijack.model_hijack.embedding_db.word_embeddings):
+            yield self.create_item(name, index)
 
     def allowed_directories_for_previews(self):
         return list(sd_hijack.model_hijack.embedding_db.embedding_dirs)


### PR DESCRIPTION
## Description
should prevent this from happening https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13011 https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13896
I was able to reproduce the issue using strategically placed breakpoints manually steping

since refreshing of extra networks can  be called concurrently 
the dictionary might be modified during looping list_items
we should use locking to protect it against accidental unexpected changes

even though the error described in the issue post is only for lora
as other extra networks tab share the same logic I applyed the same treatment to all of them

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
