### PR TITLE
Add Fallback at images.read_info_from_image if exif data was invalid

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -718,7 +718,12 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
     geninfo = items.pop('parameters', None)
 
     if "exif" in items:
-        exif = piexif.load(items["exif"])
+        exif_data = items["exif"]
+        try:
+            exif = piexif.load(exif_data)
+        except OSError:
+            # memory / exif was not valid so piexif tried to read from a file
+            exif = None
         exif_comment = (exif or {}).get("Exif", {}).get(piexif.ExifIFD.UserComment, b'')
         try:
             exif_comment = piexif.helper.UserComment.load(exif_comment)


### PR DESCRIPTION
## Description
Here is[ PNG image](https://drive.google.com/file/d/1xftQ4Ei5YSHmGrDSx4kl-iQ4DA7DtB3z/view?usp=drive_link) with corrupted Exif (or, invalid EXIF which is double quoted bytes string).

When processing pipeline tries to load those kind of images, it will throw OSError and stop, instead of fallback with empty exif data.



## Screenshots/videos:
Before patch
```
*** Error completing request
*** Arguments: (2, None, None, 'path-to-images', '', True, 0, 4, 512, 512, True, 'ESRGAN_4x', 'None', 0, 0, 0, 0) {}
    Traceback (most recent call last):
      File "F:\stable-diffusion-webui\modules\call_queue.py", line 57, in f
        res = list(func(*args, **kwargs))
      File "F:\stable-diffusion-webui\modules\call_queue.py", line 36, in f
        res = func(*args, **kwargs)
      File "F:\stable-diffusion-webui\modules\postprocessing.py", line 53, in run_postprocessing
        parameters, existing_pnginfo = images.read_info_from_image(image_data)
      File "F:\stable-diffusion-webui\modules\images.py", line 725, in read_info_from_image
        exif = piexif.load(exif_data)
      File "F:\stable-diffusion-webui\venv\lib\site-packages\piexif\_load.py", line 28, in load
        exifReader = _ExifReader(input_data)
      File "F:\stable-diffusion-webui\venv\lib\site-packages\piexif\_load.py", line 85, in __init__
        with open(data, 'rb') as f:
    OSError: [Errno 22] Invalid argument: "b'Exif\\x00\\x00MM\\x00*\\x00\\x00\\x00\\x08\\x00\\x04\\x01;\\x00\\x02\\x00\\x00\\x00\\n\\x00\\x00\\x08J\\x87i\\x00\\x04\\x00\\x00\\x00\\x01\\x00\\x00\\x08T\\x9c\\x9d\\x00\\x01\\x00\\x00\\x00\\x08\\x00\\x00\\x10\\xcc\\xea\\x1c\\x00\\x07\\x00\\x00\\x08\\x0c\\x00\\x00\\x00>\\x00\\x00\\x00\\x00\\x1c\\xea\\x00\\x00\\x00\\x08\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\ ...
```

After patch:

No error happened.



### Notes:
Same error can happen in Pillow, but it does not fail or crash - it fallbacks to empty exif correctly.

```
WARNING:gradio.processing_utils:Failed to transpose image <PIL.PngImagePlugin.PngImageFile image mode=RGB size=2614x1464 at 0x27435E21E70> based on EXIF data.
Traceback (most recent call last):
  File "F:\stable-diffusion-webui\venv\lib\site-packages\gradio\processing_utils.py", line 62, in decode_base64_to_image
    img = ImageOps.exif_transpose(img)
  File "F:\stable-diffusion-webui\venv\lib\site-packages\PIL\ImageOps.py", line 590, in exif_transpose
    exif = image.getexif()
  File "F:\stable-diffusion-webui\venv\lib\site-packages\PIL\PngImagePlugin.py", line 1028, in getexif
    return super().getexif()
  File "F:\stable-diffusion-webui\venv\lib\site-packages\PIL\Image.py", line 1455, in getexif
    self._exif.load(exif_info)
  File "F:\stable-diffusion-webui\venv\lib\site-packages\PIL\Image.py", line 3719, in load
    self._info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
  File "F:\stable-diffusion-webui\venv\lib\site-packages\PIL\TiffImagePlugin.py", line 507, in __init__
    raise SyntaxError(msg)
SyntaxError: not a TIFF file (header b"b'Exif\\x" not valid)
```




## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
