### PR TITLE
Fix script-info API being broken

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -504,7 +504,7 @@ class ScriptRunner:
                                     v = [item[0] for item in v]
                                 else:
                                     print(f"Invalid type for {field} in {script.filename}, value {v} is not {types}, casting")
-                                    v = [types[0](x) for x in v] # 
+                                    v = [types[0](x) for x in v]
                         elif not isinstance(v, types):
                             print(f"Invalid type for {field} in {script.filename}, value {v} is not {types}")
                     setattr(arg_info, field, v)


### PR DESCRIPTION
Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13127

## Description

Fix the broken /sdapi/v1/script-info API.
This is pure stable diffusion right after installation, with --api --port 9053 argument.

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/35677394/3fe2727a-beca-4f44-b621-e7bac8086358)


This happened because now choices can have [('key', 'value'),...] type, but API model strictly finds List[str] type.

This is fixed with the type checks and cast / parsing.

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/35677394/c0cc96d6-7d4f-4eb0-847b-8e098d7cb8b8)



## Screenshots/videos:

After the fix, choices appear like this:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/35677394/9e0a1bf2-12b7-4615-895d-70090557afde)



Either API response models, or the casting code, or maybe `wrap_call` method can be fixed.
But for sanity, I just fixed and leaved optional str cast as default, which should not fail at least...


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
