### PR TITLE
Fix float64 dtype error on MPS when loading some models

### DIFF
--- a/modules/sd_disable_initialization.py
+++ b/modules/sd_disable_initialization.py
@@ -188,6 +188,8 @@ class LoadStateDictOnMeta(ReplaceHelper):
 
                 if param.is_meta:
                     dtype = sd_param.dtype if sd_param is not None else param.dtype
+                    if dtype == torch.float64 and device.type == 'mps':
+                        dtype = torch.float32
                     module._parameters[name] = torch.nn.parameter.Parameter(torch.zeros_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
 
             for name in module._buffers:


### PR DESCRIPTION
## Description

Users have reported an error when loading some SD 1.5 models on MPS (#12907). I have been unable to reproduce it, however based on feedback I've gotten from brkirch/stable-diffusion-webui#36, this fix should work.

Fixes #12907.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
