### PR TITLE
Don't use multicond parser for negative prompt counter

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import mimetypes
 import os
 import sys
@@ -151,11 +152,14 @@ def connect_clear_prompt(button):
     )
 
 
-def update_token_counter(text, steps):
+def update_token_counter(text, steps, is_positive=True):
     try:
         text, _ = extra_networks.parse_prompt(text)
 
-        _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([text])
+        if is_positive:
+            _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([text])
+        else:
+            prompt_flat_list = [text]
         prompt_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, steps)
 
     except Exception:
@@ -533,7 +537,7 @@ def create_ui():
             ]
 
             toprow.token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[toprow.prompt, steps], outputs=[toprow.token_counter])
-            toprow.negative_token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[toprow.negative_prompt, steps], outputs=[toprow.negative_token_counter])
+            toprow.negative_token_button.click(fn=wrap_queued_call(functools.partial(update_token_counter, is_positive=False)), inputs=[toprow.negative_prompt, steps], outputs=[toprow.negative_token_counter])
 
         extra_networks_ui = ui_extra_networks.create_ui(txt2img_interface, [txt2img_generation_tab], 'txt2img')
         ui_extra_networks.setup_ui(extra_networks_ui, txt2img_gallery)


### PR DESCRIPTION
## Description

The negative prompt token counter uses the multicond prompt parser, which is currently only effectively used by the positive prompt when generating.

When using conds caching, if the user only changes the negative prompt, then `prompt_parser.get_multicond_prompt_list` is called only to update the negative counter, but is not called during generation. This creates issues for prompt extensions that patch `get_multicond_prompt_list` to update the counter correctly. See for example https://github.com/ljleb/sd-webui-neutral-prompt/issues/44

## Screenshots/videos:

Before (negative counter = 2/75, positive counter = 2/75):

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/32277961/c24875c0-b3c3-4a5e-b4e1-3ef6864905f7)

After (negative counter = 4/75, positive counter = 2/75):

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/32277961/565eb1ba-eedd-41d6-8be9-0a91361b7ae4)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
