### PR TITLE
Re fix batch img2img output dir with script

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -117,6 +117,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
         if output_dir:
             p.outpath_samples = output_dir
             p.override_settings['save_to_dirs'] = False
+            p.override_settings['save_images_replace_action'] = "Add number suffix"
             if p.n_iter > 1 or p.batch_size > 1:
                 p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
             else:
@@ -125,6 +126,7 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
         proc = modules.scripts.scripts_img2img.run(p, *args)
 
         if proc is None:
+            p.override_settings.pop('save_images_replace_action', None)
             process_images(p)
 
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -711,7 +711,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     if p.scripts is not None:
         p.scripts.before_process(p)
 
-    stored_opts = {k: opts.data[k] for k in p.override_settings.keys()}
+    stored_opts = {k: opts.data[k] for k in p.override_settings.keys() if k in opts.data}
 
     try:
         # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint


### PR DESCRIPTION
## Description

Ensure not override images with script enabled
refix #12926 fix batch img2img output dir with script whitch was broken by https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/3ca4655a18eb80cca5f806412f2cb2d56cc536e5
by forcing the `save_images_replace_action` to `Add number suffix` when a script is enabled
for situations batch img2img mixed XYZ, as there's no way to know how many images will they script produce this uses  `save_images_replace_action`to add the suffix
due to how scripts run `[generation_number]` is not useful

fix a bug
if a setting is not yet saved to settings
if one tries to override it `stored_opts = {k: opts.data[k] for k in p.override_settings.keys()}` will error
adding `if k in opts.data` at the end will check if the key exists in `opt.data` before trying to access it

previously before [Rework img2img batch image save](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12164) strip generating multiple images with the same name isn't a problem because the saving is handled by batch img2img itself
but the issue with letting img2img handle saving images will not have the right metadata
there was a fix for this on metadata in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11747
but the issue with this is that some extensions in this case `controlnet` more than one image per input, which causes an issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12286

the method used here isn't perfectly ideal but it at least would guarantee no error what happened
downsides are
when a script is also enabled in batch `img2img save_images_replace_action` to `Add number suffix`
meaning that if you do multiple runs at the same output dir it cannot be replaced
> this does not apply when you were apply directory is blank
> and when script is not enabled

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
