### PR TITLE
fix: Processing negative embeddings wrong

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -730,6 +730,7 @@ def reload_model_weights(sd_model=None, info=None):
             return sd_model
 
     sd_model = reuse_model_from_already_loaded(sd_model, checkpoint_info, timer)
+    sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)
     if sd_model is not None and sd_model.sd_checkpoint_info.filename == checkpoint_info.filename:
         return sd_model
 


### PR DESCRIPTION
## Description
- When checkpoint switches from SDXL to other versions such as SD1.5, what is stored in `embedding_db` is the textual inversion of SDXL. If the model is loaded from `already_loaded`, the SD1.5 generation tasks will not be able to load the correct embeddings, and vice versa.
- It is necessary to reload the textual inversion.
- This could be the cause of this [issue](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13150).

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
