### PR TITLE
fix issues when webui_dir is not work_dir

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -64,7 +64,7 @@ Use --skip-python-version-check to suppress this warning.
 @lru_cache()
 def commit_hash():
     try:
-        return subprocess.check_output([git, "rev-parse", "HEAD"], shell=False, encoding='utf8').strip()
+        return subprocess.check_output([git, "-C", script_path, "rev-parse", "HEAD"], shell=False, encoding='utf8').strip()
     except Exception:
         return "<none>"
 
@@ -72,7 +72,7 @@ def commit_hash():
 @lru_cache()
 def git_tag():
     try:
-        return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
+        return subprocess.check_output([git, "-C", script_path, "describe", "--tags"], shell=False, encoding='utf8').strip()
     except Exception:
         try:
 

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir  # noqa: F401
+from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir, cwd  # noqa: F401
 
 import modules.safe  # noqa: F401
 

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -8,6 +8,7 @@ import shlex
 commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
 sys.argv += shlex.split(commandline_args)
 
+cwd = os.getcwd()
 modules_path = os.path.dirname(os.path.realpath(__file__))
 script_path = os.path.dirname(modules_path)
 

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -2,12 +2,12 @@ import os
 import gradio as gr
 
 from modules import localization, shared, scripts
-from modules.paths import script_path, data_path
+from modules.paths import script_path, data_path, cwd
 
 
 def webpath(fn):
-    if fn.startswith(script_path):
-        web_path = os.path.relpath(fn, script_path).replace('\\', '/')
+    if fn.startswith(cwd):
+        web_path = os.path.relpath(fn, cwd)
     else:
         web_path = os.path.abspath(fn)
 


### PR DESCRIPTION
## Description

when webui dir is not work dir, the path created by `modules/ui_gradio_extensions.webpath(fn)` will be wrong
causeing issues like 
style.css return 404
![2023-09-12 17_01_36_572 chrome](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/59ecf1db-259a-470b-a418-49e53538f010)

minor fix 
if user launches webui from a different work directory
fetching the tag and commit will fail

### after further consideration I suggest we change the work directory to be the webui dir
reason being there are things that can break when CWD is not webui dir
so effectively we don't really support executing from external directory (this PR is a fix for this, but I'm not sure if I covered all issues that can occurred due to this)

secondly executing from an upper directory would cause a security issue in that
anything under the work directory can be served by gradio
this may be considered a security issue

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
