### PR TITLE
Fix major issue add_option overriding config with default

### DIFF
--- a/modules/options.py
+++ b/modules/options.py
@@ -210,7 +210,8 @@ class Options:
 
     def add_option(self, key, info):
         self.data_labels[key] = info
-        self.data[key] = info.default
+        if key not in self.data:
+            self.data[key] = info.default
 
     def reorder(self):
         """reorder settings so that all items related to section always go together"""


### PR DESCRIPTION
## Description
fix major issue caused by
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12957
any options added by `add_option` will be reverted to default in the settings page next time the settings is saved

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
