### PR TITLE
initialize state.time_start befroe state.job_count

### DIFF
--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -103,6 +103,7 @@ class State:
 
     def begin(self, job: str = "(unknown)"):
         self.sampling_step = 0
+        self.time_start = time.time()
         self.job_count = -1
         self.processing_has_refined_job_count = False
         self.job_no = 0
@@ -114,7 +115,6 @@ class State:
         self.skipped = False
         self.interrupted = False
         self.textinfo = None
-        self.time_start = time.time()
         self.job = job
         devices.torch_gc()
         log.info("Starting job %s", job)


### PR DESCRIPTION
## Description
this should prevent an edge case described in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13225 where
a call `/sdapi/v1/progress` happens after `state.job` has been set but befor initialization `state.time` causeing
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/102b6617dacffdcc89c56badcaae6c5e83c3ff21/modules/api/api.py#L504
to error out as `state.time` is `None`

this prevent this from ever happening by initialize state.time_start befroe state.job_count

there are other ways of solving this
like not initializing `state.time` as `None`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/102b6617dacffdcc89c56badcaae6c5e83c3ff21/modules/shared_state.py#L27

or adding logic to prevent it from subtracting `None`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/102b6617dacffdcc89c56badcaae6c5e83c3ff21/modules/api/api.py#L504
## Checklist:

in the https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13225 even though he describes this cause web UI to crash, but I think he might not be using the word crash correctly

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
