### PR TITLE
Better Support for Portable Git

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -1,6 +1,7 @@
 @echo off
 
 if not defined PYTHON (set PYTHON=python)
+if defined GIT (set "GIT_PYTHON_GIT_EXECUTABLE=%GIT%")
 if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
 
 set SD_WEBUI_RESTART=tmp/restart

--- a/webui.sh
+++ b/webui.sh
@@ -51,6 +51,8 @@ fi
 if [[ -z "${GIT}" ]]
 then
     export GIT="git"
+else
+    export GIT_PYTHON_GIT_EXECUTABLE="${GIT}"
 fi
 
 # python3 venv without trailing slash (defaults to ${install_dir}/${clone_dir}/venv)


### PR DESCRIPTION
## Description

The `%GIT%` configuration in `webui-user.bat` is not fully functioning. It only works if the git executable can also be found under `%PATH%`. Otherwise, the following error shows up:

```console
Traceback (most recent call last):
  File "C:\PortablePython\App\Python\lib\site-packages\git\__init__.py", line 89, in <module>
    refresh()
  File "C:\PortablePython\App\Python\lib\site-packages\git\__init__.py", line 76, in refresh
    if not Git.refresh(path=path):
  File "C:\PortablePython\App\Python\lib\site-packages\git\cmd.py", line 392, in refresh
    raise ImportError(err)
ImportError: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.
```

(a sample run on top of [PortablePython](https://sourceforge.net/projects/portable-python/files/Portable%20Python%203.10/) and [PortableGit](https://git-scm.com/download/win))

```diff
  @echo off

- set PYTHON=
- set GIT=
- set VENV_DIR=
+ set PYTHON=C:\PortablePython\App\Python\python.exe
+ set GIT=C:\PortableGit\bin\git.exe
+ set VENV_DIR=-
  set COMMANDLINE_ARGS=

  call webui.bat
```


## Root Cause

According to [GitPython#requirements](https://github.com/gitpython-developers/GitPython#requirements), environment variable `%GIT_PYTHON_GIT_EXECUTABLE%` should be properly setup for such cases.


## Proposed Solution

Automatically map `%GIT_PYTHON_GIT_EXECUTABLE%` to the value saved in `%GIT%` , if needed.


## Screenshots/videos:

N/A


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
