### PR TITLE
Escape HTML in user metadata description before appending to card

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -244,7 +244,7 @@ class ExtraNetworksPage:
             "tabname": quote_js(tabname),
             "local_preview": quote_js(item["local_preview"]),
             "name": html.escape(item["name"]),
-            "description": (item.get("description") or "" if shared.opts.extra_networks_card_show_desc else ""),
+            "description": html.escape(item.get("description") or "" if shared.opts.extra_networks_card_show_desc else ""),
             "card_clicked": onclick,
             "save_card_preview": '"' + html.escape(f"""return saveCardPreview(event, {quote_js(tabname)}, {quote_js(item["local_preview"])})""") + '"',
             "search_term": item.get("search_term", ""),


### PR DESCRIPTION
## Description

Currently the model description is appended to a card on the document as-is. This allows for the user to inadvertently add HTML to the model description shown on-card and have it be appended onto the DOM if `show descriptions on card` is enabled. On a single-user system this presents a minimal security hazard, but on a shared system, any user could insert malicious code into the card metadata via the metadata editor.

This also can cause issues where HTML in the description results in unexpected behavior, like the model card or other cards ceasing to display. For instance, replacing the model description with `<div>` causes the model to vanish on refresh, while setting it to `<div><div>` causes other models to cease appearing. In a real-world case, https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/issues/10 is caused by the text `<title>_<trigger word>` appearing in the model description. While I can easily fix this on my end by removing the offending text, it will result in an unexpected state for the user where important informal text is removed, like information about other models used (IE, "used detailer model with `<lora:detailer:0.6>`)"

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
