### PR TITLE
add --skip-load-model-at-start

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -117,3 +117,4 @@ parser.add_argument('--api-server-stop', action='store_true', help='enable serve
 parser.add_argument('--timeout-keep-alive', type=int, default=30, help='set timeout_keep_alive for uvicorn')
 parser.add_argument("--disable-all-extensions", action='store_true', help="prevent all extensions from running regardless of any other settings", default=False)
 parser.add_argument("--disable-extra-extensions", action='store_true', help="prevent all extensions except built-in from running regardless of any other settings", default=False)
+parser.add_argument("--skip-load-model-at-start", action='store_true', help="if load a model at web start, only take effect when --nowebui", )

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -151,8 +151,8 @@ def initialize_rest(*, reload_script_modules=False):
 
         from modules import devices
         devices.first_time_calculation()
-
-    Thread(target=load_model).start()
+    if not shared.cmd_opts.skip_load_model_at_start:
+        Thread(target=load_model).start()
 
     from modules import shared_items
     shared_items.reload_hypernetworks()


### PR DESCRIPTION
## Description

When a user starts with --nowebui mode, it is often accessed through an API, and multiple models may need to be loaded. But currently, after startup, one model will be automatically loaded, which may be unnecessary, or the unwanted model, especially when the loaded model is very large.

So I added a parameter that allows webui to skip this automatic loading process
## Screenshots/videos:
* Before
<img width="1255" alt="image" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7628879/5f257928-a8ea-44a7-ad2e-cabd8bcc17bf">
   
  
* After  

<img width="652" alt="image" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7628879/8e18998a-2396-4823-a15a-ee46df8e9b9a">


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
