### PR TITLE
 fix: lora_in_memory_limit: none >int

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -202,9 +202,10 @@ def load_network(name, network_on_disk):
 
 
 def purge_networks_from_memory():
-    while len(networks_in_memory) > shared.opts.lora_in_memory_limit and len(networks_in_memory) > 0:
-        name = next(iter(networks_in_memory))
-        networks_in_memory.pop(name, None)
+    if (shared.opts.lora_in_memory_limit):
+        while len(networks_in_memory) > shared.opts.lora_in_memory_limit and len(networks_in_memory) > 0:
+            name = next(iter(networks_in_memory))
+            networks_in_memory.pop(name, None)
 
     devices.torch_gc()
 


### PR DESCRIPTION
## Description

* Every time I started sdwebui, lora was not running at all because there was no variable named shared.opts.lora_in_memory_limit.
* Before the while I put an if statement that checks the variable shared.opts.lora_in_memory_limit
* Previously lora was not working. It works now.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
