### PR TITLE
xyz_grid: add prepare

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -205,13 +205,14 @@ def csv_string_to_list_strip(data_str):
 
 
 class AxisOption:
-    def __init__(self, label, type, apply, format_value=format_value_add_label, confirm=None, cost=0.0, choices=None):
+    def __init__(self, label, type, apply, format_value=format_value_add_label, confirm=None, cost=0.0, choices=None, prepare=None):
         self.label = label
         self.type = type
         self.apply = apply
         self.format_value = format_value
         self.confirm = confirm
         self.cost = cost
+        self.prepare = prepare
         self.choices = choices
 
 
@@ -536,6 +537,8 @@ class Script(scripts.Script):
 
             if opt.choices is not None and not csv_mode:
                 valslist = vals_dropdown
+            elif opt.prepare is not None:
+                valslist = opt.prepare(vals)
             else:
                 valslist = csv_string_to_list_strip(vals)
 


### PR DESCRIPTION
## Description

* add `prepare` option to support a raw input
* with this change, one can add entries line by line with or without commas or quotes.

* without this fix, a line with commas could be used with `"blahblah,blahblah"`

See also #13268 

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/232347/f34ac473-84f5-4cb0-805a-62e1309990bb)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/232347/c9c947fe-8c62-4a81-ab5d-052abd7c27b4)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
