### PR TITLE
xyz_grid: add raw_mode

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -440,6 +440,7 @@ class Script(scripts.Script):
             with gr.Column():
                 include_lone_images = gr.Checkbox(label='Include Sub Images', value=False, elem_id=self.elem_id("include_lone_images"))
                 include_sub_grids = gr.Checkbox(label='Include Sub Grids', value=False, elem_id=self.elem_id("include_sub_grids"))
+                raw_mode = gr.Checkbox(label='Use raw text lines', value=False, elem_id=self.elem_id("raw_mode"))
             with gr.Column():
                 margin_size = gr.Slider(label="Grid margins (px)", minimum=0, maximum=500, value=0, step=2, elem_id=self.elem_id("margin_size"))
             with gr.Column():
@@ -522,9 +523,9 @@ class Script(scripts.Script):
             (z_values_dropdown, lambda params: get_dropdown_update_from_params("Z", params)),
         )
 
-        return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode]
+        return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode, raw_mode]
 
-    def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode):
+    def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode, raw_mode):
         if not no_fixed_seeds:
             modules.processing.fix_seed(p)
 
@@ -539,6 +540,8 @@ class Script(scripts.Script):
                 valslist = vals_dropdown
             elif opt.prepare is not None:
                 valslist = opt.prepare(vals)
+            elif raw_mode and vals.strip().find("\n") != -1:
+                valslist = vals.strip().split("\n")
             else:
                 valslist = csv_string_to_list_strip(vals)
 


### PR DESCRIPTION
## Description

* This is another attempt to input raw text lines
* for some inputs with `"\n"` included, (`x.strip().find("\n") != -1` case)
* it does not affect any functionality, except one accidentally inputs `\n` chars in the X/Y/Z values

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/232347/b1d21721-63b5-4d6f-915a-e89da85abb49)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
