### PR TITLE
XYZ if not include sub grids do not save sub grid

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -773,6 +773,8 @@ class Script(scripts.Script):
                 # TODO: See previous comment about intentional data misalignment.
                 adj_g = g-1 if g > 0 else g
                 images.save_image(processed.images[g], p.outpath_grids, "xyz_grid", info=processed.infotexts[g], extension=opts.grid_format, prompt=processed.all_prompts[adj_g], seed=processed.all_seeds[adj_g], grid=True, p=processed)
+                if not include_sub_grids:  # if not include_sub_grids then skip saving after the first grid
+                    break
 
         if not include_sub_grids:
             # Done with sub-grids, drop all related information:


### PR DESCRIPTION
## Description
feature request [How to stop XYZ plot from saving sub portions of a grid](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13157)

if XYZ opt `Include Sub Grids` is not check also don't save sub grid to file

this method reuses the same checkbox, which meant that this does change the current behavior
so some users might not be happy
it might make sense to make it a separate option

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
