### PR TITLE
[POC] Script organiser.

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -411,6 +411,7 @@ class ScriptRunner:
         self.scripts = []
         self.selectable_scripts = []
         self.alwayson_scripts = []
+        self.script_organiser = dict()
         self.titles = []
         self.title_map = {}
         self.infotext_fields = []
@@ -429,6 +430,7 @@ class ScriptRunner:
         self.scripts.clear()
         self.alwayson_scripts.clear()
         self.selectable_scripts.clear()
+        self.script_organiser.clear()
 
         auto_processing_scripts = scripts_auto_postprocessing.create_auto_preprocessing_script_data()
 
@@ -444,6 +446,10 @@ class ScriptRunner:
             if visibility == AlwaysVisible:
                 self.scripts.append(script)
                 self.alwayson_scripts.append(script)
+                try:
+                    self.script_organiser[script] = script.CALLBACK_ORDER
+                except AttributeError:
+                    self.script_organiser[script] = dict()
                 script.alwayson = True
 
             elif visibility:
@@ -617,7 +623,7 @@ class ScriptRunner:
                 errors.report(f"Error running before_process: {script.filename}", exc_info=True)
 
     def process(self, p):
-        for script in self.alwayson_scripts:
+        for script in sorted(self.alwayson_scripts, key = lambda x: self.script_organiser.get(x, 50).get("process", 50)):
             try:
                 script_args = p.script_args[script.args_from:script.args_to]
                 script.process(p, *script_args)


### PR DESCRIPTION
## Description

Adds a simple independent `script_organiser` attribute to the `ScriptRunner` class, which reads the attribute (dict) `CALLBACK_ORDER` from scripts should it exist, and organises script running order by priority value assigned to each callback, instead of the longstanding name of extension's folder. Priority is optional and currently defaults to 50 as a placeholder, and I've only applied it to `process` callback's alwayson scripts, but it seems to work correctly.
This allows fine grained control for extensions to choose when to run each callback relative to other extensions, which is crucial for several extensions' correct operation (controlnet, animatediff, regional prompter, adetailer, ultimate upscale, wildcards, segment anything to name a few). Currently this order is global and indirectly user controlled (naming scheme), which is really bad for devs.

(Sorry, I'm not sure why it's saying the PR targets the master branch, doesn't seem so on my end.)

@vladmandic What are your thoughts on this?

Edit: [Moved.](https://github.com/vladmandic/automatic/pull/2224)

## Screenshots/videos:


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
