### PR TITLE
Fix: --sd_model in "Prompts from file or textbox" script is not working

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -5,9 +5,15 @@ import shlex
 import modules.scripts as scripts
 import gradio as gr
 
-from modules import sd_samplers, errors
+from modules import sd_samplers, errors, sd_models
 from modules.processing import Processed, process_images
 from modules.shared import state
+
+
+def process_model_tag(tag):
+    info = sd_models.get_closet_checkpoint_match(tag)
+    assert info is not None, f'Unknown checkpoint: {tag}'
+    return info.name
 
 
 def process_string_tag(tag):
@@ -27,7 +33,7 @@ def process_boolean_tag(tag):
 
 
 prompt_tags = {
-    "sd_model": None,
+    "sd_model": process_model_tag,
     "outpath_samples": process_string_tag,
     "outpath_grids": process_string_tag,
     "prompt_for_display": process_string_tag,
@@ -156,7 +162,10 @@ class Script(scripts.Script):
 
             copy_p = copy.copy(p)
             for k, v in args.items():
-                setattr(copy_p, k, v)
+                if k == "sd_model":
+                    copy_p.override_settings['sd_model_checkpoint'] = v
+                else:
+                    setattr(copy_p, k, v)
 
             proc = process_images(copy_p)
             images += proc.images


### PR DESCRIPTION
## Description
Fixes bug #8079 
The Features page lists "sd_model" as a valid parameter for the "Prompts from file or textbox" script, but the implementation was never finished.
This patch enables the use of the "sd_model" parameter as originally intended.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] All tests passed, but my code was not included in the [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
- [x] The code has been manually tested, both for valid and invalid input. No issues were observed.