### PR TITLE
use orderdict as lru cache:opt/bug

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -309,6 +309,7 @@ def get_checkpoint_state_dict(checkpoint_info: CheckpointInfo, timer):
     if checkpoint_info in checkpoints_loaded:
         # use checkpoint cache
         print(f"Loading weights [{sd_model_hash}] from cache")
+        checkpoints_loaded.move_to_end(checkpoint_info)
         return checkpoints_loaded[checkpoint_info]
 
     print(f"Loading weights [{sd_model_hash}] from {checkpoint_info.filename}")

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -309,6 +309,7 @@ def get_checkpoint_state_dict(checkpoint_info: CheckpointInfo, timer):
     if checkpoint_info in checkpoints_loaded:
         # use checkpoint cache
         print(f"Loading weights [{sd_model_hash}] from cache")
+        # move to end as latest
         checkpoints_loaded.move_to_end(checkpoint_info)
         return checkpoints_loaded[checkpoint_info]
 


### PR DESCRIPTION
…to end

## Description

* use dict[key]=model; did not update orderdict order
* choice 1: use move-to-end

## Screenshots/videos:
```
checkpoints_loaded cache keys [<modules.sd_models.CheckpointInfo object at 0x7f7fe1f36fe0>, <modules.sd_models.CheckpointInfo object at 0x7f7fb83bc610>]
search checkpoints <modules.sd_models.CheckpointInfo object at 0x7f7fe1f36fe0>
Loading weights [None] from cache
shared.opts.sd_checkpoint_cache 2
Loading VAE weights specified in settings: cached vae-ft-mse-840000-ema-pruned.ckpt
Applying attention optimization: xformers... done.
Weights loaded in 11.9s (send model to cpu: 0.8s, apply weights to model: 8.6s, apply channels_last: 0.1s, load VAE: 1.2s, move model to device: 1.1s).
100%|██████████| 20/20 [00:01<00:00, 12.07it/s]
Total progress: 100%|██████████| 20/20 [00:01<00:00, 10.30it/s]
Reusing loaded model chilloutmix_NiPrunedFp32Fix.safetensors to load aZovyaPhotoreal_v2.safetensors
checkpoints_loaded cache keys [<modules.sd_models.CheckpointInfo object at 0x7f7fe1f36fe0>, <modules.sd_models.CheckpointInfo object at 0x7f7fb83bc610>]
```

### fix
```
Reusing loaded model chilloutmix_NiPrunedFp32Fix.safetensors to load aZovyaPhotoreal_v2.safetensors
checkpoints_loaded cache keys [<modules.sd_models.CheckpointInfo object at 0x7fb795a5eda0>, <modules.sd_models.CheckpointInfo object at 0x7fb795a8db70>]
search checkpoints <modules.sd_models.CheckpointInfo object at 0x7fb795a5eda0>
Loading weights [None] from cache
shared.opts.sd_checkpoint_cache 2
Loading VAE weights specified in settings: cached vae-ft-mse-840000-ema-pruned.ckpt
Applying attention optimization: xformers... done.
Weights loaded in 9.2s (send model to cpu: 1.1s, apply weights to model: 6.1s, apply channels_last: 0.1s, load VAE: 1.3s, hijack: 0.1s, move model to device: 0.5s).
100%|██████████| 20/20 [00:01<00:00, 14.49it/s]
Total progress: 100%|██████████| 20/20 [00:01<00:00, 12.22it/s]
Reusing loaded model aZovyaPhotoreal_v2.safetensors to load chilloutmix_NiPrunedFp32Fix.safetensors
checkpoints_loaded cache keys [<modules.sd_models.CheckpointInfo object at 0x7fb795a8db70>, <modules.sd_models.CheckpointInfo object at 0x7fb795a5eda0>]
```

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
