### PR TITLE
Fix ScriptInfo for web API was not working

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -303,7 +303,7 @@ class ScriptArg(BaseModel):
     minimum: Optional[Any] = Field(default=None, title="Minimum", description="Minimum allowed value for the argumentin UI")
     maximum: Optional[Any] = Field(default=None, title="Minimum", description="Maximum allowed value for the argumentin UI")
     step: Optional[Any] = Field(default=None, title="Minimum", description="Step for changing value of the argumentin UI")
-    choices: Optional[List[str]] = Field(default=None, title="Choices", description="Possible values for the argument")
+    choices: Optional[List[int]] = Field(default=None, title="Choices", description="Possible values for the argument")
 
 
 class ScriptInfo(BaseModel):


### PR DESCRIPTION
## Description
Fix ScriptInfo for web API as it was not working

Corrected 'choices' field data type in ScriptInfo.
- Fixed a validation error in the 'ScriptInfo' model where the 'choices' field was expected to be of type 'str' but was provided as 'int'.

Trace:
      File "E:\git\stable-diffusion-webui\venv\Lib\site-packages\fastapi\routing.py", line 141, in serialize_response
        raise ValidationError(errors, field.type_)
    pydantic.error_wrappers.ValidationError: 31 validation errors for ScriptInfo
    response -> 0 -> args -> 2 -> choices -> 0
      str type expected (type=type_error.str)