### PR TITLE
Update dragdrop.js

### DIFF
--- a/javascript/dragdrop.js
+++ b/javascript/dragdrop.js
@@ -119,7 +119,7 @@ window.addEventListener('paste', e => {
     }
 
     const firstFreeImageField = visibleImageFields
-        .filter(el => el.querySelector('input[type=file]'))?.[0];
+        .filter(el => !el.querySelector('img'))?.[0];
 
     dropReplaceImage(
         firstFreeImageField ?


### PR DESCRIPTION
## Description

Find out that i cant put two images in different places for images.
For example in "Inpaint upload" there is two places with images: Image and it's mask. So when i press Ctrl+V it puts image in first box, but when i try to put to second one, it puts again at first one.
I just fixed it to work for every box.
My fix work like that:
Press Ctrl+V -> puts to first available box, where tag <image> does not present. If you fill all possible image boxes it will put at last one(by logic of AUTOMATIC1111, not mine)
When you delete first one image, it will put at first box.
## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [+] I have performed a self-review of my own code
- [+] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [?] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
