### PR TITLE
Fix data-sort-name containing spaces

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -235,7 +235,7 @@ class ExtraNetworksPage:
         if search_only and shared.opts.extra_networks_hidden_models == "Never":
             return ""
 
-        sort_keys = " ".join([html.escape(f'data-sort-{k}={v}') for k, v in item.get("sort_keys", {}).items()]).strip()
+        sort_keys = " ".join([f'data-sort-{k}="{html.escape(str(v))}"' for k, v in item.get("sort_keys", {}).items()]).strip()
 
         args = {
             "background_image": background_image,


### PR DESCRIPTION
Spaces in extra network filenames cause the card's `data-sort-name` attribute to be truncated to the first word, with the rest added as empty attributes.

Before:
```html
<div class="card" ... data-sort-name="3d" rendering="" v12.safetensors="">
```

After:
```html
<div class="card" ... data-sort-name="3d rendering style v12.safetensors">
```

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
