### PR TITLE
added task_id to txt2img and progress API calls, 

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -109,6 +109,7 @@ StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
         {"key": "send_images", "type": bool, "default": True},
         {"key": "save_images", "type": bool, "default": False},
         {"key": "alwayson_scripts", "type": dict, "default": {}},
+        {"key": "task_id", "type": str, "default": None},
     ]
 ).generate_model()
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -157,6 +157,7 @@ class StableDiffusionProcessing:
     token_merging_ratio = 0
     token_merging_ratio_hr = 0
     disable_extra_networks: bool = False
+    task_id: str = None
 
     scripts_value: scripts.ScriptRunner = field(default=None, init=False)
     script_args_value: list = field(default=None, init=False)
@@ -201,6 +202,8 @@ class StableDiffusionProcessing:
     sd_vae_hash: str = field(default=None, init=False)
 
     is_api: bool = field(default=False, init=False)
+    
+    task_id: str = field(default=None, init=False)
 
     def __post_init__(self):
         if self.sampler_index is not None:
@@ -481,9 +484,10 @@ class StableDiffusionProcessing:
 
 
 class Processed:
-    def __init__(self, p: StableDiffusionProcessing, images_list, seed=-1, info="", subseed=None, all_prompts=None, all_negative_prompts=None, all_seeds=None, all_subseeds=None, index_of_first_image=0, infotexts=None, comments=""):
+    def __init__(self, p: StableDiffusionProcessing, images_list, seed=-1, info="", subseed=None, all_prompts=None, all_negative_prompts=None, all_seeds=None, all_subseeds=None, index_of_first_image=0, infotexts=None, comments="", task_id=None,):
         self.images = images_list
         self.prompt = p.prompt
+        self.task_id  = p.task_id
         self.negative_prompt = p.negative_prompt
         self.seed = seed
         self.subseed = subseed


### PR DESCRIPTION

## Description

This allows a new field to be submitted in the txt2image API call, "task_id" 
This field accepts strings, and is pushed through the progress stack, so you can  get the images  progress with the /internal/progress API call



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
