### PR TITLE
fix FileNotFoundError error on restart on macOS (webui.sh)

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -233,6 +233,8 @@ prepare_tcmalloc() {
 
 KEEP_GOING=1
 export SD_WEBUI_RESTART=tmp/restart
+mkdir tmp 2>/dev/null
+
 while [[ "$KEEP_GOING" -eq "1" ]]; do
     if [[ ! -z "${ACCELERATE}" ]] && [ ${ACCELERATE}="True" ] && [ -x "$(command -v accelerate)" ]; then
         printf "\n%s\n" "${delimiter}"


### PR DESCRIPTION
## Description
Hello!

In a macOS environment, when toggling the enable/disable state of extensions in the Extension tab and pressing the `Apply and restart UI` button, the following error log appears in the console.  
Additionally, in order for changes to extensions to take effect, I need to terminate the process and then restart the functionality.

```sh
Traceback (most recent call last):
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/gradio/routes.py", line 488, in run_predict
    output = await app.get_blocks().process_api(
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/gradio/blocks.py", line 1431, in process_api
    result = await self.call_function(
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/gradio/blocks.py", line 1103, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/Users/username/stable-diffusion-webui/venv/lib/python3.9/site-packages/gradio/utils.py", line 707, in wrapper
    response = f(*args, **kwargs)
  File "/Users/username/stable-diffusion-webui/modules/ui_extensions.py", line 54, in apply_and_restart
    restart.restart_program()
  File "/Users/username/stable-diffusion-webui/modules/restart.py", line 17, in restart_program
    (Path(script_path) / "tmp" / "restart").touch()
  File "/Users/username/.rye/py/cpython@3.9.18/install/lib/python3.9/pathlib.py", line 1315, in touch
    fd = self._raw_open(flags, mode)
  File "/Users/username/.rye/py/cpython@3.9.18/install/lib/python3.9/pathlib.py", line 1127, in _raw_open
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/username/stable-diffusion-webui/tmp/restart'
```

This error occurs due to the absence of the `tmp/restart` file. Upon reviewing the `webui.sh` script, I noticed it lacks a process to create the `tmp` directory.  
This process is present in the `webui.bat` file, so I believe it's necessary to add it to `webui.sh` as well.

I've only tested this on a local Apple Silicon macOS environment.  
I assume the `webui.sh` script is also used on Linux systems. If the changes are unnecessary on a Linux environment, could you let me know.  
(I've only been able to test on macOS).

Best regards!

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
I have read the following documentation but could not perform the test...
Am I correct in understanding that this is to start a Web UI instance with a specific command and then run tests on it?
https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests