### PR TITLE
I found a code snippet in webui.sh that disables python venv and moved it to the appropriate location

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -4,12 +4,6 @@
 # change the variables in webui-user.sh instead #
 #################################################
 
-
-use_venv=1
-if [[ $venv_dir == "-" ]]; then
-  use_venv=0
-fi
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 
@@ -26,6 +20,12 @@ fi
 if [[ -f "$SCRIPT_DIR"/webui-user.sh ]]
 then
     source "$SCRIPT_DIR"/webui-user.sh
+fi
+
+# If $venv_dir is "-", then disable venv support
+use_venv=1
+if [[ $venv_dir == "-" ]]; then
+  use_venv=0
 fi
 
 # Set defaults


### PR DESCRIPTION
There seems to be a code snippet in webui.sh that disables the python venv, but there is no relevant variable. So I moved it to after loading webui-user.sh and now it works.