### PR TITLE
Fix accidentally closing popup dialogs

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -226,7 +226,7 @@ function popup(contents) {
     if (!globalPopup) {
         globalPopup = document.createElement('div');
         globalPopup.classList.add('global-popup');
-        
+
         var close = document.createElement('div');
         close.classList.add('global-popup-close');
         close.addEventListener("click", closePopup);

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -216,27 +216,24 @@ function extraNetworksSearchButton(tabs_id, event) {
 
 var globalPopup = null;
 var globalPopupInner = null;
+
 function closePopup() {
     if (!globalPopup) return;
-
     globalPopup.style.display = "none";
 }
+
 function popup(contents) {
     if (!globalPopup) {
         globalPopup = document.createElement('div');
-        globalPopup.onclick = closePopup;
         globalPopup.classList.add('global-popup');
-
+        
         var close = document.createElement('div');
         close.classList.add('global-popup-close');
-        close.onclick = closePopup;
+        close.addEventListener("click", closePopup);
         close.title = "Close";
         globalPopup.appendChild(close);
 
         globalPopupInner = document.createElement('div');
-        globalPopupInner.onclick = function(event) {
-            event.stopPropagation(); return false;
-        };
         globalPopupInner.classList.add('global-popup-inner');
         globalPopup.appendChild(globalPopupInner);
 

--- a/style.css
+++ b/style.css
@@ -581,7 +581,6 @@ table.popup-table .link{
     width: 100%;
     height: 100%;
     overflow: auto;
-    background-color: rgba(20, 20, 20, 0.95);
 }
 
 .global-popup *{
@@ -590,9 +589,6 @@ table.popup-table .link{
 
 .global-popup-close:before {
     content: "×";
-}
-
-.global-popup-close{
     position: fixed;
     right: 0.25em;
     top: 0;
@@ -601,10 +597,20 @@ table.popup-table .link{
     font-size: 32pt;
 }
 
+.global-popup-close{
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(20, 20, 20, 0.95);
+}
+
 .global-popup-inner{
     display: inline-block;
     margin: auto;
     padding: 2em;
+    z-index: 1001;
 }
 
 /* fullpage image viewer */


### PR DESCRIPTION
Fixes a really annoying behavior where any click or mouseup outside the border of a popup dialog would close it.

Dragging past the edge when selecting text would close it, as would clicking the end of the styles dropdown.
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/4073789/f7c80f5a-2524-44be-ac10-d3e02066f611)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
