### PR TITLE
Don't change number input on scroll

### DIFF
--- a/javascript/imageviewerGamepad.js
+++ b/javascript/imageviewerGamepad.js
@@ -35,8 +35,19 @@ Primarily for vr controller type pointer devices.
 I use the wheel event because there's currently no way to do it properly with web xr.
  */
 let isScrolling = false;
-window.addEventListener('wheel', (e) => {
-    if (!opts.js_modal_lightbox_gamepad || isScrolling) return;
+
+onOptionsChanged(function() {
+    if (opts.js_modal_lightbox_gamepad) {
+        window.addEventListener('wheel', modalScroll);
+    } else {
+        window.removeEventListener('wheel', modalScroll);
+    }
+});
+
+function modalScroll(e) {
+    if (document.activeElement.type === "number") document.activeElement.blur();
+
+    if (isScrolling) return;
     isScrolling = true;
 
     if (e.deltaX <= -0.6) {
@@ -48,7 +59,7 @@ window.addEventListener('wheel', (e) => {
     setTimeout(() => {
         isScrolling = false;
     }, opts.js_modal_lightbox_gamepad_repeat);
-});
+}
 
 function sleepUntil(f, timeout) {
     return new Promise((resolve) => {


### PR DESCRIPTION
The wheel listener in `imageviewerGamepad.js` (or _any_ wheel listener, apparently) causes number inputs to increment/decrement when focused.

I've also changed it to only add the listener if `Navigate image viewer with gamepad` is enabled, so the function isn't running on every scroll.

Fixes #13442

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
