### PR TITLE
Edit-attention fixes

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -26,7 +26,7 @@ function keyupEditAttention(event) {
 
         // Set the selection to the text between the parenthesis
         const parenContent = text.substring(beforeParen + 1, selectionStart + afterParen);
-        if (!/.*:[\d.]+/.test(parenContent)) return false;
+        if (!/.*:[\d.]+/s.test(parenContent)) return false;
         const lastColon = parenContent.lastIndexOf(":");
         selectionStart = beforeParen + 1;
         selectionEnd = selectionStart + lastColon;
@@ -67,10 +67,10 @@ function keyupEditAttention(event) {
     var closeCharacter = ')';
     var delta = opts.keyedit_precision_attention;
 
-    if (selectionStart > 0 && /<.*:[\d.]+>/.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(">") + 1))) {
+    if (selectionStart > 0 && /<.*:[\d.]+>/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(">") + 1))) {
         closeCharacter = '>';
         delta = opts.keyedit_precision_extra;
-    } else if (selectionStart > 0 && /\(.*\)|\[.*\]/.test(text.slice(selectionStart - 1, selectionEnd + 1))) {
+    } else if (selectionStart > 0 && /\(.*\)|\[.*\]/s.test(text.slice(selectionStart - 1, selectionEnd + 1))) {
         closeCharacter = null;
         if (isPlus) {
             text = text.slice(0, selectionStart) + text[selectionStart - 1] + text.slice(selectionStart, selectionEnd) + text[selectionEnd] + text.slice(selectionEnd);
@@ -81,7 +81,7 @@ function keyupEditAttention(event) {
             selectionStart--;
             selectionEnd--;
         }
-    } else if (selectionStart == 0 || !/\(.*:[\d.]+\)/.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(")") + 1))) {
+    } else if (selectionStart == 0 || !/\(.*:[\d.]+\)/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(")") + 1))) {
         // do not include spaces at the end
         while (selectionEnd > selectionStart && text[selectionEnd - 1] == ' ') {
             selectionEnd--;

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -26,7 +26,7 @@ function keyupEditAttention(event) {
 
         // Set the selection to the text between the parenthesis
         const parenContent = text.substring(beforeParen + 1, selectionStart + afterParen);
-        if (!/.*:[\d.]+/s.test(parenContent)) return false;
+        if (!/.*:-?[\d.]+/s.test(parenContent)) return false;
         const lastColon = parenContent.lastIndexOf(":");
         selectionStart = beforeParen + 1;
         selectionEnd = selectionStart + lastColon;
@@ -67,7 +67,7 @@ function keyupEditAttention(event) {
     var closeCharacter = ')';
     var delta = opts.keyedit_precision_attention;
 
-    if (selectionStart > 0 && /<.*:[\d.]+>/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(">") + 1))) {
+    if (selectionStart > 0 && /<.*:-?[\d.]+>/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(">") + 1))) {
         closeCharacter = '>';
         delta = opts.keyedit_precision_extra;
     } else if (selectionStart > 0 && /\(.*\)|\[.*\]/s.test(text.slice(selectionStart - 1, selectionEnd + 1))) {
@@ -81,7 +81,7 @@ function keyupEditAttention(event) {
             selectionStart--;
             selectionEnd--;
         }
-    } else if (selectionStart == 0 || !/\(.*:[\d.]+\)/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(")") + 1))) {
+    } else if (selectionStart == 0 || !/\(.*:-?[\d.]+\)/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(")") + 1))) {
         // do not include spaces at the end
         while (selectionEnd > selectionStart && text[selectionEnd - 1] == ' ') {
             selectionEnd--;

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -71,16 +71,23 @@ function keyupEditAttention(event) {
         closeCharacter = '>';
         delta = opts.keyedit_precision_extra;
     } else if (selectionStart > 0 && /\(.*\)|\[.*\]/s.test(text.slice(selectionStart - 1, selectionEnd + 1))) {
-        closeCharacter = null;
-        if (isPlus) {
-            text = text.slice(0, selectionStart) + text[selectionStart - 1] + text.slice(selectionStart, selectionEnd) + text[selectionEnd] + text.slice(selectionEnd);
-            selectionStart++;
-            selectionEnd++;
-        } else {
-            text = text.slice(0, selectionStart - 1) + text.slice(selectionStart, selectionEnd) + text.slice(selectionEnd + 1);
-            selectionStart--;
-            selectionEnd--;
+        let start = text[selectionStart - 1];
+        let end = text[selectionEnd];
+        let numParen = 0;
+
+        while (text[selectionStart - numParen - 1] == start && text[selectionEnd + numParen] == end) {
+            numParen++;
         }
+
+        if (start == "(") {
+            weight = 1.1 ** numParen;
+        } else {
+            weight = 0.9 ** numParen;
+        }
+
+        text = text.slice(0, selectionStart - numParen) + "(" + text.slice(selectionStart, selectionEnd) + ":" + weight + ")" + text.slice(selectionEnd + numParen);
+        selectionStart -= numParen - 1;
+        selectionEnd -= numParen - 1;
     } else if (selectionStart == 0 || !/\(.*:-?[\d.]+\)/s.test(text.slice(selectionStart - 1, selectionEnd + text.slice(selectionEnd).indexOf(")") + 1))) {
         // do not include spaces at the end
         while (selectionEnd > selectionStart && text[selectionEnd - 1] == ' ') {
@@ -97,23 +104,21 @@ function keyupEditAttention(event) {
         selectionEnd++;
     }
 
-    if (closeCharacter) {
-        var end = text.slice(selectionEnd + 1).indexOf(closeCharacter) + 1;
-        var weight = parseFloat(text.slice(selectionEnd + 1, selectionEnd + end));
-        if (isNaN(weight)) return;
+    var end = text.slice(selectionEnd + 1).indexOf(closeCharacter) + 1;
+    var weight = parseFloat(text.slice(selectionEnd + 1, selectionEnd + end));
+    if (isNaN(weight)) return;
 
-        weight += isPlus ? delta : -delta;
-        weight = parseFloat(weight.toPrecision(12));
-        if (String(weight).length == 1) weight += ".0";
+    weight += isPlus ? delta : -delta;
+    weight = parseFloat(weight.toPrecision(12));
+    if (Number.isInteger(weight)) weight += ".0";
 
-        if (closeCharacter == ')' && weight == 1) {
-            var endParenPos = text.substring(selectionEnd).indexOf(')');
-            text = text.slice(0, selectionStart - 1) + text.slice(selectionStart, selectionEnd) + text.slice(selectionEnd + endParenPos + 1);
-            selectionStart--;
-            selectionEnd--;
-        } else {
-            text = text.slice(0, selectionEnd + 1) + weight + text.slice(selectionEnd + end);
-        }
+    if (closeCharacter == ')' && weight == 1) {
+        var endParenPos = text.substring(selectionEnd).indexOf(')');
+        text = text.slice(0, selectionStart - 1) + text.slice(selectionStart, selectionEnd) + text.slice(selectionEnd + endParenPos + 1);
+        selectionStart--;
+        selectionEnd--;
+    } else {
+        text = text.slice(0, selectionEnd + 1) + weight + text.slice(selectionEnd + end);
     }
 
     target.focus();

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -256,7 +256,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row").needs_reload_ui(),
     "keyedit_precision_attention": OptionInfo(0.1, "Ctrl+up/down precision when editing (attention:1.1)", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
-    "keyedit_delimiters": OptionInfo(r".,\/!?%^*;:{}=`~() ", "Ctrl+up/down word delimiters"),
+    "keyedit_delimiters": OptionInfo(r".,\/!?%^*;:{}=`~()[]<>| ", "Ctrl+up/down word delimiters"),
     "keyedit_delimiters_whitespace": OptionInfo(["Tab", "Carriage Return", "Line Feed"], "Ctrl+up/down whitespace delimiters", gr.CheckboxGroup, lambda: {"choices": ["Tab", "Carriage Return", "Line Feed"]}),
     "keyedit_move": OptionInfo(True, "Alt+left/right moves prompt elements"),
     "quicksettings_list": OptionInfo(["sd_model_checkpoint"], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(shared.opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear at the top of page rather than in settings tab").needs_reload_ui(),

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -258,6 +258,7 @@ options_templates.update(options_section(('ui', "User interface"), {
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "keyedit_delimiters": OptionInfo(r".,\/!?%^*;:{}=`~()[]<>| ", "Ctrl+up/down word delimiters"),
     "keyedit_delimiters_whitespace": OptionInfo(["Tab", "Carriage Return", "Line Feed"], "Ctrl+up/down whitespace delimiters", gr.CheckboxGroup, lambda: {"choices": ["Tab", "Carriage Return", "Line Feed"]}),
+    "keyedit_convert": OptionInfo(True, "Convert (attention) to (attention:1.1)"),
     "keyedit_move": OptionInfo(True, "Alt+left/right moves prompt elements"),
     "quicksettings_list": OptionInfo(["sd_model_checkpoint"], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(shared.opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear at the top of page rather than in settings tab").needs_reload_ui(),
     "ui_tab_order": OptionInfo([], "UI tab order", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
@@ -332,4 +333,3 @@ options_templates.update(options_section((None, "Hidden options"), {
     "restore_config_state_file": OptionInfo("", "Config state file to restore from, under 'config-states/' folder"),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
 }))
-


### PR DESCRIPTION
Currently, if the cursor is inside parentheses or angle brackets that aren't an (emphasis:1.0) block, Ctrl+Up/Down does nothing.

Fixes it by using regular expressions to more accurately check if selected text is inside an emphasis block.

If selected text is inside (parentheses) or [square brackets], as with old-style emphasis blocks, they'll be ((added)) or removed accordingly, or optionally converted to (numeric:1.1).

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
