### PR TITLE
fix: checkpoints_loaded:{checkpoint:state_dict}, model.load_state_dict issue in dict value empty

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -310,6 +310,8 @@ def get_checkpoint_state_dict(checkpoint_info: CheckpointInfo, timer):
     if checkpoint_info in checkpoints_loaded:
         # use checkpoint cache
         print(f"Loading weights [{sd_model_hash}] from cache")
+        # move to end as latest
+        checkpoints_loaded.move_to_end(checkpoint_info)
         return checkpoints_loaded[checkpoint_info]
 
     print(f"Loading weights [{sd_model_hash}] from {checkpoint_info.filename}")


### PR DESCRIPTION
## Description

* in my mind: checkpoints_loaded: use to cache state_dict
* bug: model.load_state_dict(state_dict, strict=False) change state_dict to {}
* reason: use with sd_disable_initialization.LoadStateDictOnMeta, will clean state_dict
* fix: took the easier way, move cache code in front of model.load_state_dict(state_dict, strict=False),by the way, use deepcopy

---
---
---

## Screenshots/videos:


### the original error
```
autodl-fs/sd-data/extensions/sd-webui-controlnet/scripts/hook.py", line 850, in forward_webui
        return forward(*args, **kwargs)
      File "/root/autodl-fs/sd-data/extensions/sd-webui-controlnet/scripts/hook.py", line 591, in forward
        control = param.control_model(x=x_in, hint=hint, timesteps=timesteps, context=context, y=y)
      File "/root/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "/root/autodl-fs/sd-data/extensions/sd-webui-controlnet/scripts/cldm.py", line 31, in forward
        return self.control_model(*args, **kwargs)
      File "/root/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "/root/autodl-fs/sd-data/extensions/sd-webui-controlnet/scripts/cldm.py", line 304, in forward
        assert y.shape[0] == x.shape[0]
    AttributeError: 'NoneType' object has no attribute 'shape'
```
**Explain**
```
 set checkpoint cache size:6
 use sdxl and sdxl controlnet, normal
 change, use sd1.5 normal
 change, use sdxl and sdxl controlnet, checkpoints cache in ram, raise error
   -  code:load from cache, get state_dict is {}
   -  code:adjust model type, sdxl key not in state_dict, set model.is_sdxl = False, real model is previous model sd1.5
   -  code:but, controlnet use sdxl canny, y value must be not none, then, raise error
```
---
---
---

**print str(state_dict)[:100] for monitor**

### use master branch code:ERROR
```

    with sd_disable_initialization.LoadStateDictOnMeta(state_dict, device=model_target_device(sd_model), weight_dtype_conversion=weight_dtype_conversion):
        load_model_weights(sd_model, checkpoint_info, state_dict, timer)
```
**pay attention to:after map(in sd_disable_initialization.py), the state_dict has been change**
```
clip_is_included_into_sd:True, shared.cmd_opts.do_not_download_clip:False
self.filename:/root/autodl-fs/sd-data/models/Stable-diffusion/7EhrMEzi5YX.safetensors, checkpoint/7EhrMEzi5YX.safetensors
load_model_weights <modules.sd_models.CheckpointInfo object at 0x7f5e086257e0> model.is_sdxl False
before load model load_state_dict {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor([[ 0.0016,
model.load_state_dict /root/autodl-fs/qwcache/stable-diffusion-webui/modules/sd_disable_initialization.py
before map {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor(..., device=
load_state_dict torch before load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch after load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch del load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch after strict OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch _IncompatibleKeys OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
after map {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor(..., device=
after load model load_state_dict state_dict {}
after load model load_state_dict state_dict {}
```

### without  sd_disable_initialization.LoadStateDictOnMeta:NORMAL

```
    load_model_weights(sd_model, checkpoint_info, state_dict, timer)
```
```
clip_is_included_into_sd:True, shared.cmd_opts.do_not_download_clip:False
self.filename:/root/autodl-fs/sd-data/models/Stable-diffusion/epicrealism_pureEvolutionV5.safetensors, checkpoint/epicrealism_pureEvolutionV5.safetensors
load_model_weights <modules.sd_models.CheckpointInfo object at 0x7f9f34629ae0> model.is_sdxl False
before load model load_state_dict {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor([[ 0.0016,
model.load_state_dict /root/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py
load_state_dict torch before load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch after load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch del load OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch after strict OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
load_state_dict torch _IncompatibleKeys OrderedDict([('cond_stage_model.transformer.text_model.embeddings.position_embedding.weight', tensor
after load model load_state_dict state_dict {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor([[ 0.0016,
after load model load_state_dict state_dict {'cond_stage_model.transformer.text_model.embeddings.position_embedding.weight': tensor([[ 0.0016,
shared.opts.sd_checkpoint_cache 6
```

### MR && with sd_disable_initialization.LoadStateDictOnMeta:NORMAL
**(load_state_dict still change state_dict to {}, but did not effect the follow code)**
**load from cache correctly**
```
Applying attention optimization: xformers... done.
Model loaded in 14.0s (create model: 0.5s, apply weights to model: 13.2s).
Reusing loaded model 7EhrMEzi5YX.safetensors [732d0dd2cf] to load sd_xl_base_1.0.safetensors [31e35c80fc]
Loading weights [31e35c80fc] from cache
Creating model from config: /root/autodl-fs/sd-data/models/Stable-diffusion/sd_xl_base_1.0.yaml
...
instantiate_from_config done
load_state_dict torch before load OrderedDict([('conditioner.embedders.0.transformer.text_model.embeddings.position_embedding.weight',
load_state_dict torch after load OrderedDict([('conditioner.embedders.0.transformer.text_model.embeddings.position_embedding.weight',
load_state_dict torch del load OrderedDict([('conditioner.embedders.0.transformer.text_model.embeddings.position_embedding.weight',
load_state_dict torch after strict OrderedDict([('conditioner.embedders.0.transformer.text_model.embeddings.position_embedding.weight',
load_state_dict torch _IncompatibleKeys OrderedDict([('conditioner.embedders.0.transformer.text_model.embeddings.position_embedding.weight',
after load model load_state_dict state_dict  {}
Loading VAE weights found near the checkpoint: cached sd_xl_base_1.0.vae.safetensors
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)



## anyone can explain this? module_load_state_dict did not declare, how did it run?
```
in modules/sd_disable_initialization.py
        module_load_state_dict = self.replace(torch.nn.Module, 'load_state_dict', lambda *args, **kwargs: load_state_dict(module_load_state_dict, *args, **kwargs))
```
