### PR TITLE
keep infotext_params to shared

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -364,10 +364,7 @@ def create_override_settings_dict(text_pairs):
 def connect_paste(button, paste_fields, input_comp, override_settings_component, tabname):
     def paste_func(prompt):
         if not prompt and not shared.cmd_opts.hide_ui_dir_config:
-            filename = os.path.join(data_path, "params.txt")
-            if os.path.exists(filename):
-                with open(filename, "r", encoding="utf8") as file:
-                    prompt = file.read()
+            prompt = shared.infotext_params
 
         params = parse_generation_parameters(prompt)
         script_callbacks.infotext_pasted_callback(prompt, params)

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -113,7 +113,12 @@ def process_batch(p, input_dir, output_dir, inpaint_mask_dir, args, to_scale=Fal
                     p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
                 else:
                     p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
-            process_images(p)
+            try:
+                process_images(p)
+            except Exception as e:
+                if p.scripts is not None:
+                    p.scripts.postprocess(p, Processed(p, [], comments=e))
+                raise e
 
 
 def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, steps: int, sampler_name: str, mask_blur: int, mask_alpha: float, inpainting_fill: int, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, selected_scale_tab: int, height: int, width: int, scale_by: float, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, img2img_batch_use_png_info: bool, img2img_batch_png_info_props: list, img2img_batch_png_info_dir: str, request: gr.Request, *args):
@@ -205,7 +210,12 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
         else:
             processed = modules.scripts.scripts_img2img.run(p, *args)
             if processed is None:
-                processed = process_images(p)
+                try:
+                    processed = process_images(p)
+                except Exception as e:
+                    if p.scripts is not None:
+                        p.scripts.postprocess(p, Processed(p, [], comments=e))
+                    raise e
 
     shared.total_tqdm.clear()
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -849,9 +849,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             # Example: a wildcard processed by process_batch sets an extra model
             # strength, which is saved as "Model Strength: 1.0" in the infotext
             if n == 0:
-                with open(os.path.join(paths.data_path, "params.txt"), "w", encoding="utf8") as file:
-                    processed = Processed(p, [])
-                    file.write(processed.infotext(p, 0))
+                processed = Processed(p, [], p.seed, "")
+                shared.infotext_params = processed.infotext(p, 0)
 
             p.setup_conds()
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -85,3 +85,5 @@ list_checkpoint_tiles = shared_items.list_checkpoint_tiles
 refresh_checkpoints = shared_items.refresh_checkpoints
 list_samplers = shared_items.list_samplers
 reload_hypernetworks = shared_items.reload_hypernetworks
+
+infotext_params = ''

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -52,7 +52,12 @@ def txt2img(id_task: str, prompt: str, negative_prompt: str, prompt_styles, step
         processed = modules.scripts.scripts_txt2img.run(p, *args)
 
         if processed is None:
-            processed = processing.process_images(p)
+            try:
+                processed = processing.process_images(p)
+            except Exception as e:
+                if p.scripts is not None:
+                    p.scripts.postprocess(p, Processed(p, [], comments=e))
+                raise e
 
     shared.total_tqdm.clear()
 


### PR DESCRIPTION
## Description

keep infotext_params to shared instead of writing to params.txt to lower the interaction with disks

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
