### PR TITLE
Avoid stack dumps on <Ctrl+C>

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -1,4 +1,5 @@
 from modules import launch_utils
+import signal
 
 args = launch_utils.args
 python = launch_utils.python
@@ -23,6 +24,9 @@ prepare_environment = launch_utils.prepare_environment
 configure_for_tests = launch_utils.configure_for_tests
 start = launch_utils.start
 
+def ctrl_c_handler(signum, frame):
+    print("Interrupted with <Ctrl+C>, exiting...")
+    exit(0)
 
 def main():
     if args.dump_sysinfo:
@@ -32,6 +36,7 @@ def main():
 
         exit(0)
 
+    signal.signal(signal.SIGINT, ctrl_c_handler)
     launch_utils.startup_timer.record("initial startup")
 
     with launch_utils.startup_timer.subcategory("prepare environment"):

--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -151,9 +151,13 @@ def dumpstacks():
 def configure_sigint_handler():
     # make the program just exit at ctrl+c without waiting for anything
     def sigint_handler(sig, frame):
-        print(f'Interrupted with signal {sig} in {frame}')
+        # avoid dumping stack on ctrl+c
+        if sig == signal.SIGINT:
+            print("Interrupted with <Ctrl+C>, exiting...")
+        else:
+            print(f'Interrupted with signal {sig} in {frame}')
 
-        dumpstacks()
+            dumpstacks()
 
         os._exit(0)
 


### PR DESCRIPTION
This change implements #13564.

## Description

This change:
 - modifies original `sigint_handler` in `initialize_util.py` to check for `signal.SIGINT` and exit without dumping stack
 - adds new `ctrl_c_handler` in `launch.py` to handle `signal.SIGINT` until the `sigint_handler` is installed

## Screenshots/videos:

N/A

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
