### PR TITLE
fix the key error exception when processing override_settings keys

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -711,7 +711,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     if p.scripts is not None:
         p.scripts.before_process(p)
 
-    stored_opts = {k: opts.data[k] for k in p.override_settings.keys() if k in opts.data}
+    stored_opts = {k: opts.data[k] if k in opts.data else opts.get_default(k) for k in p.override_settings.keys() if k in opts.data}
 
     try:
         # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint


### PR DESCRIPTION


## Description

There is an option named `control_net_detectedmap_dir` in the controlnet extension.
 If the sd-webui is starting using --nowebui, there maybe no `config.json` file or no `control_net_detectedmap_dir` in the config.json.
And when sending a API with `control_net_detectedmap_dir` key in `override_settings`, the exception will occur, because the `control_net_detectedmap_dir` is not in `opts.data`.
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7628879/f200986f-d6f0-4b7a-b35a-79cb4663abb5)


The root cause is that the extension registers the options using `shared.opts.add_option`, in this method, it only updates the attribute `data_labels` and doesn't update the attribute data.
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7628879/3556bfee-6a85-4ced-8f81-378b4905ee20)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7628879/59703f24-6816-40e5-ab5c-ad4610a8560f)

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
