### PR TITLE
fix unload reload issue.

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -713,6 +713,9 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
             shared.opts.data["sd_checkpoint_hash"] = already_loaded.sd_checkpoint_info.sha256
 
         print(f"Using already loaded model {already_loaded.sd_checkpoint_info.title}: done in {timer.summary()}")
+        sd_hijack.model_hijack.hijack(already_loaded)
+        sd_unet.apply_unet()
+
         sd_vae.reload_vae_weights(already_loaded)
         return model_data.sd_model
     elif shared.opts.sd_checkpoints_limit > 1 and len(model_data.loaded_sd_models) < shared.opts.sd_checkpoints_limit:

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -695,12 +695,13 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         if len(model_data.loaded_sd_models) > shared.opts.sd_checkpoints_limit > 0:
             print(f"Unloading model {len(model_data.loaded_sd_models)} over the limit of {shared.opts.sd_checkpoints_limit}: {loaded_model.sd_checkpoint_info.title}")
             model_data.loaded_sd_models.pop()
-            send_model_to_trash(loaded_model)
-            timer.record("send model to trash")
+            if sd_model is None or sd_model and loaded_model.sd_checkpoint_info.title != sd_model.sd_checkpoint_info.title:
+                send_model_to_trash(loaded_model)
+                timer.record("send model to trash")
 
-        if shared.opts.sd_checkpoints_keep_in_cpu:
-            send_model_to_cpu(sd_model)
-            timer.record("send model to cpu")
+    if sd_model and shared.opts.sd_checkpoints_keep_in_cpu:
+        send_model_to_cpu(sd_model)
+        timer.record("send model to cpu")
 
     if already_loaded is not None:
         send_model_to_device(already_loaded)


### PR DESCRIPTION
## Description

* [x] check valid sd_model before call `send_model_to_cpu` when reload after unload.
* [x] fix realod after unload issue. (raise ``AttributeError: 'NoneType' object has no attribute 'lowvram'`` error)
  * call `sd_hijack.model_hijack.hijack(already_loaded)`, `sd_unet.apply_unet()` are needed to use a reusing model. 

##  Steps to reproduce the problem

### `sd_checkpoints_limit == 1` case:
1. go to `Settings tab` -> `Actions`, click `Unload SD checkpoint to free VRAM` then `Reload SD checkpoint back into VRAM`
2. generate an image -> you will get the follow `TypeError`
   <details> 
   <summary>TypeError: 'NoneType' object is not callable</summary>
   <div>
   <pre>
   Unloaded weights 0.0s. ## <--- unload button clicked
   Using already loaded model ACertainModel-half.ckpt [57ca9c4028]: done in 1.1s (send model to device: 1.1s) ## <-- reload button clicked.
   ### generate button clicked then,
   *** Error completing request
   *** Arguments: ('task(y9ni6a78lfre3r4)', 'girl,.... (snip)
   </pre>
   <pre>
    Traceback (most recent call last):
      File "F:\webui\webui\stable-diffusion-webui\modules\call_queue.py", line 57, in f
        res = list(func(*args, **kwargs))
      File "F:\webui\webui\stable-diffusion-webui\modules\call_queue.py", line 36, in f
        res = func(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\txt2img.py", line 55, in txt2img
        processed = processing.process_images(p)
      File "F:\webui\webui\stable-diffusion-webui\modules\processing.py", line 734, in process_images
        res = process_images_inner(p)
      File "F:\webui\webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\batch_hijack.py", line 42, in processing_process_images_hijack
        return getattr(processing, '__controlnet_original_process_images_inner')(p, *args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\processing.py", line 869, in process_images_inner
        samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
      File "F:\webui\webui\stable-diffusion-webui\modules\processing.py", line 1145, in sample
        samples = self.sampler.sample(self, x, conditioning, unconditional_conditioning, image_conditioning=self.txt2img_image_conditioning(x))
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_samplers_kdiffusion.py", line 235, in sample
        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_samplers_common.py", line 261, in launch_sampling
        return func()
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_samplers_kdiffusion.py", line 235, in <lambda>
        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\torch\utils\_contextlib.py", line 115, in decorate_context
        return func(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\sampling.py", line 594, in sample_dpmpp_2m
        denoised = model(x, sigmas[i] * s_in, **extra_args)
      File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1503, in _call_impl
        return forward_call(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_samplers_cfg_denoiser.py", line 169, in forward
        x_out = self.inner_model(x_in, sigma_in, cond=make_condition_dict(cond_in, image_cond_in))
      File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1503, in _call_impl
        return forward_call(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\external.py", line 112, in forward
        eps = self.get_eps(input * c_in, self.sigma_to_t(sigma), **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\repositories\k-diffusion\k_diffusion\external.py", line 138, in get_eps
        return self.inner_model.apply_model(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_hijack_utils.py", line 17, in <lambda>
        setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: self(*args, **kwargs))
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_hijack_utils.py", line 28, in __call__
        return self.__orig_func(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\repositories\stable-diffusion-stability-ai\ldm\models\diffusion\ddpm.py", line 858, in apply_model
        x_recon = self.model(x_noisy, t, **cond)
      File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1503, in _call_impl
        return forward_call(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\repositories\stable-diffusion-stability-ai\ldm\models\diffusion\ddpm.py", line 1335, in forward
        out = self.diffusion_model(x, t, context=cc)
      File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1503, in _call_impl
        return forward_call(*args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\sd_unet.py", line 91, in UNetModel_forward
        return original_forward(self, x, timesteps, context, *args, **kwargs)
    TypeError: 'NoneType' object is not callable
   </pre>
   </div>
   </details>
3. in this case, `sd_hijack.model_hijack.hijack(already_loaded)`, `sd_unet.apply_unet()` calls are needed to use a reusing model. 

###  `sd_checkpoints_limit > 1` case:
1. load `A checkpoint`
2. load `B checkpoint`
3. load `A checkpoint` again and generate image -> no ploblem
4. go to `Settings tab` -> `Actions`, click `Unload SD checkpoint to free VRAM` then `Reload SD checkpoint back into VRAM`
   <details>
   <summary>AttributeError: 'NoneType' object has no attribute 'lowvram'</summary>
   <pre>
   >### choose A, B checkpoints several times.
   Reusing loaded model Basil_mix_fixed.safetensors [0ff127093f] to load Brav6.safetensors [c6318fa24a]
   Loading weights [c6318fa24a] from F:\webui\webui\stable-diffusion-webui\models\Stable-diffusion\Brav6.safetensors
   Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\vae-ft-mse-840000-ema-pruned.safetensors
   Applying attention optimization: sdp-no-mem... done.
   Weights loaded in 7.3s (send model to cpu: 1.6s, load weights from disk: 0.5s, apply weights to model: 3.8s, load VAE: 0.4s, move model to device: 1.0s).
   Reusing loaded model blessing-henmixfit.safetensors [3cc7ad686a] to load braBeautifulRealistic_brav5.safetensors [ac68270450]
   Loading weights [ac68270450] from F:\webui\webui\stable-diffusion-webui\models\Stable-diffusion\braBeautifulRealistic_brav5.safetensors
   Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\vae-ft-mse-840000-ema-pruned.safetensors
   Applying attention optimization: sdp-no-mem... done.
   Weights loaded in 8.1s (send model to cpu: 1.6s, load weights from disk: 1.3s, apply weights to model: 3.8s, load VAE: 0.4s, move model to device: 1.0s).
   Using already loaded model Brav6.safetensors [c6318fa24a]: done in 2.4s (send model to cpu: 1.3s, send model to device: 1.1s)
   </pre>
   <pre>
   Unloaded weights 0.0s. ### <--- unload clicked.
   Traceback (most recent call last): ## <--- reload clicked
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\gradio\routes.py", line 488, in run_predict
    output = await app.get_blocks().process_api(
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1431, in process_api
    result = await self.call_function(
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1103, in call_function
    prediction = await anyio.to_thread.run_sync(
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\anyio\to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 807, in run
    result = context.run(func, *args)
   File "F:\webui\webui\stable-diffusion-webui\venv\lib\site-packages\gradio\utils.py", line 707, in wrapper
    response = f(*args, **kwargs)
   File "F:\webui\webui\stable-diffusion-webui\modules\sd_models.py", line 753, in reload_model_weights
    if sd_model.sd_model_checkpoint == checkpoint_info.filename:
   File "F:\webui\webui\stable-diffusion-webui\modules\sd_models.py", line 702, in reuse_model_from_already_loaded
    send_model_to_cpu(sd_model)
   File "F:\webui\webui\stable-diffusion-webui\modules\sd_models.py", line 562, in send_model_to_cpu
    if m.lowvram:
   AttributeError: 'NoneType' object has no attribute 'lowvram'
   </pre>
   </details>
 5. after this error, you can't select any other checkpoint at all, (goto tab `Extensions`-> `Apply and Restart UI` button click needed)
 6. in this case, unload button calls `sd_hijack.model_hijack.undo_hijack(model_data.sd_model)`, then `model_data.sd_model=None` (sd_model is nullified.
 7. but `reuse_model_from_already_loaded()` tries to call `send_model_to_cpu(sd_model)` -> `NoneType` error rises.
 8. so we need to check the validity of `sd_model`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
