### PR TITLE
Support inference with LyCORIS GLora networks

### DIFF
--- a/extensions-builtin/Lora/network_glora.py
+++ b/extensions-builtin/Lora/network_glora.py
@@ -1,0 +1,33 @@
+
+import network
+
+class ModuleTypeGLora(network.ModuleType):
+    def create_module(self, net: network.Network, weights: network.NetworkWeights):
+        if all(x in weights.w for x in ["a1.weight", "a2.weight", "alpha", "b1.weight", "b2.weight"]):
+            return NetworkModuleGLora(net, weights)
+
+        return None
+
+# adapted from https://github.com/KohakuBlueleaf/LyCORIS
+class NetworkModuleGLora(network.NetworkModule):
+    def __init__(self,  net: network.Network, weights: network.NetworkWeights):
+        super().__init__(net, weights)
+
+        if hasattr(self.sd_module, 'weight'):
+            self.shape = self.sd_module.weight.shape
+
+        self.w1a = weights.w["a1.weight"]
+        self.w1b = weights.w["b1.weight"]
+        self.w2a = weights.w["a2.weight"]
+        self.w2b = weights.w["b2.weight"]
+
+    def calc_updown(self, orig_weight):
+        w1a = self.w1a.to(orig_weight.device, dtype=orig_weight.dtype)
+        w1b = self.w1b.to(orig_weight.device, dtype=orig_weight.dtype)
+        w2a = self.w2a.to(orig_weight.device, dtype=orig_weight.dtype)
+        w2b = self.w2b.to(orig_weight.device, dtype=orig_weight.dtype)
+
+        output_shape = [w1a.size(0), w1b.size(1)]
+        updown = ((w2b @ w1b) + ((orig_weight @ w2a) @ w1a))
+
+        return self.finalize_updown(updown, orig_weight, output_shape)

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -5,6 +5,7 @@ import re
 import lora_patches
 import network
 import network_lora
+import network_glora
 import network_hada
 import network_ia3
 import network_lokr
@@ -23,6 +24,7 @@ module_types = [
     network_lokr.ModuleTypeLokr(),
     network_full.ModuleTypeFull(),
     network_norm.ModuleTypeNorm(),
+    network_glora.ModuleTypeGLora(),
 ]
 
 


### PR DESCRIPTION
## Description

This PR adds support for inference of networks that are trained with LyCORIS GLora. The implementation is based on the excellent implementation by @KohakuBlueleaf here: https://github.com/KohakuBlueleaf/LyCORIS/blob/main/lycoris/modules/glora.py

Changes:
* Added a new Python file `network_glora.py` in extensions-builtin/Lora.
* Modified extensions-builtin/Lora/networks.py to use the new module type.

Other notes:
* The network tested was trained with [kohya_ss](https://github.com/bmaltais/kohya_ss) with arguments `--network_module=lycoris.kohya --network_args "conv_dim=4" "conv_alpha=4" "algo=glora"`
* Link to the GLora paper: https://arxiv.org/abs/2306.07967


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
