### PR TITLE
fix IndexError

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -820,6 +820,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 state.skipped = False
 
             if state.interrupted:
+                infotexts.append(Processed(p, []).infotext(p, 0))
                 break
 
             sd_models.reload_model_weights()  # model can be changed for example by refiner


### PR DESCRIPTION
## Description

~~~
      File "F:\webui\webui\stable-diffusion-webui\modules\processing.py", line 734, in process_images
        res = process_images_inner(p)
      File "F:\webui\webui\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\batch_hijack.py", line 42, in processing_process_images_hijack
        return getattr(processing, '__controlnet_original_process_images_inner')(p, *args, **kwargs)
      File "F:\webui\webui\stable-diffusion-webui\modules\processing.py", line 989, in process_images_inner
        info=infotexts[0],
    IndexError: list index out of range
...
~~~
* fix IndexError: list index out of range error when interrupted while postprocessing
* This fix simply adds a default infotext

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
