### PR TITLE
added option to play notification sound or not

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -22,6 +22,7 @@ restricted_opts = {
 }
 
 options_templates.update(options_section(('saving-images', "Saving images/grids"), {
+    "notification_audio": OptionInfo(True, "Play notification sound after image generation", comment_after="(notification.mp3 should be present in the root directory)").needs_reload_ui(),
     "samples_save": OptionInfo(True, "Always save all generated images"),
     "samples_format": OptionInfo('png', 'File format for images'),
     "samples_filename_pattern": OptionInfo("", "Images filename pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1286,7 +1286,7 @@ def create_ui():
 
             loadsave.setup_ui()
 
-        if os.path.exists(os.path.join(script_path, "notification.mp3")):
+        if os.path.exists(os.path.join(script_path, "notification.mp3")) and shared.opts.notification_audio:
             gr.Audio(interactive=False, value=os.path.join(script_path, "notification.mp3"), elem_id="audio_notification", visible=False)
 
         footer = shared.html("footer.html")


### PR DESCRIPTION
## Description

**Issue**: Sometimes you need to turn notification sound off and then back on depending on the environment you are working in. It is inconvenient to rename notification.mp3 file each time just to manage the notification sound.

The PR adds a checkbox to settings named "Play notification sound" which allows to turn sound on and off.

## Checklist:

- [v] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [v] I have performed a self-review of my own code
- [v] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [v] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
