### PR TITLE
Start / Restart Generation by Ctrl (Alt) + Enter

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,23 +121,25 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 /**
- * Add a ctrl+enter as a shortcut to start a generation
+ * Add a Ctrl (Alt) + Enter as a shortcut to start / restart a generation
  */
-document.addEventListener('keydown', function(e) {
-    var handled = false;
-    if (e.key !== undefined) {
-        if ((e.key == "Enter" && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
-    } else if (e.keyCode !== undefined) {
-        if ((e.keyCode == 13 && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
-    }
-    if (handled) {
-        var button = get_uiCurrentTabContent().querySelector('button[id$=_generate]');
-        if (button) {
-            button.click();
+document.addEventListener('keydown', (e) => {
+    const isEnter = e.key === 'Enter' || e.keyCode === 13
+    const isModifierKey = e.metaKey || e.ctrlKey || e.altKey
+
+    const interruptButton = get_uiCurrentTabContent().querySelector('button[id$=_interrupt]')
+    const generateButton = get_uiCurrentTabContent().querySelector('button[id$=_generate]')
+
+    if (isEnter && isModifierKey) {
+        if (interruptButton.style.display === 'block') {
+            interruptButton.click()
+            setTimeout(() => generateButton.click(), 500)
+        } else {
+            generateButton.click()
         }
-        e.preventDefault();
+        e.preventDefault()
     }
-});
+})
 
 /**
  * checks that a UI element is not in another hidden element or tab content


### PR DESCRIPTION
Add ability to interrupt current generation and start generation again by Ctrl (Alt) + Enter

## Description

Now, when you experiment with prompting (using hotkeys as usual), you don't have to reach for your mouse to interrupt the current generation, but simply press Ctrl + Enter or Alt + Enter to interrupt current generation and start next.

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1196046/fa7a472a-197f-46ae-a7d9-3ccc80081b83

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
