### PR TITLE
Fix ugly error at startup due to clip model loading.

### DIFF
--- a/modules/sd_disable_initialization.py
+++ b/modules/sd_disable_initialization.py
@@ -65,7 +65,7 @@ class DisableInitialization(ReplaceHelper):
             return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
 
         def CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs):
-            res = self.CLIPTextModel_from_pretrained(None, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
+            res = self.CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
             res.name_or_path = pretrained_model_name_or_path
             return res
 


### PR DESCRIPTION
## Description

I have a problem with both dev and master where the clip model loading errors out here and proceeds to download the pickle anyway. 

Once you have d/l the model it never stops making this error because this doesn't really disable anything, it just makes it load the "slow" way.

see:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13245

It may not save you from downloading the 2 clip models for both SD and SDXL but at least it stops the command line from spamming every time I run SD.

If anyone has a better fix to prevent CLIP model loading entirely...

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
