### PR TITLE
Support inference with OFT networks

### DIFF
--- a/extensions-builtin/Lora/lyco_helpers.py
+++ b/extensions-builtin/Lora/lyco_helpers.py
@@ -19,3 +19,50 @@ def rebuild_cp_decomposition(up, down, mid):
     up = up.reshape(up.size(0), -1)
     down = down.reshape(down.size(0), -1)
     return torch.einsum('n m k l, i n, m j -> i j k l', mid, up, down)
+
+
+# copied from https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/lokr.py
+def factorization(dimension: int, factor:int=-1) -> tuple[int, int]:
+    '''
+    return a tuple of two value of input dimension decomposed by the number closest to factor
+    second value is higher or equal than first value.
+
+    In LoRA with Kroneckor Product, first value is a value for weight scale.
+    secon value is a value for weight.
+
+    Becuase of non-commutative property, A⊗B ≠ B⊗A. Meaning of two matrices is slightly different.
+
+    examples)
+    factor
+        -1               2                4               8               16               ...
+    127 -> 1, 127   127 -> 1, 127    127 -> 1, 127   127 -> 1, 127   127 -> 1, 127
+    128 -> 8, 16    128 -> 2, 64     128 -> 4, 32    128 -> 8, 16    128 -> 8, 16
+    250 -> 10, 25   250 -> 2, 125    250 -> 2, 125   250 -> 5, 50    250 -> 10, 25
+    360 -> 8, 45    360 -> 2, 180    360 -> 4, 90    360 -> 8, 45    360 -> 12, 30
+    512 -> 16, 32   512 -> 2, 256    512 -> 4, 128   512 -> 8, 64    512 -> 16, 32
+    1024 -> 32, 32  1024 -> 2, 512   1024 -> 4, 256  1024 -> 8, 128  1024 -> 16, 64
+    '''
+
+    if factor > 0 and (dimension % factor) == 0:
+        m = factor
+        n = dimension // factor
+        if m > n:
+            n, m = m, n
+        return m, n
+    if factor < 0:
+        factor = dimension
+    m, n = 1, dimension
+    length = m + n
+    while m<n:
+        new_m = m + 1
+        while dimension%new_m != 0:
+            new_m += 1
+        new_n = dimension // new_m
+        if new_m + new_n > length or new_m>factor:
+            break
+        else:
+            m, n = new_m, new_n
+    if m > n:
+        n, m = m, n
+    return m, n
+

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -1,11 +1,12 @@
 import torch
 import network
 from einops import rearrange
+from modules import devices
 
 
 class ModuleTypeOFT(network.ModuleType):
     def create_module(self, net: network.Network, weights: network.NetworkWeights):
-        if all(x in weights.w for x in ["oft_blocks"]):
+        if all(x in weights.w for x in ["oft_blocks"]) or all(x in weights.w for x in ["oft_diag"]):
             return NetworkModuleOFT(net, weights)
 
         return None
@@ -16,66 +17,117 @@ class NetworkModuleOFT(network.NetworkModule):
 
         super().__init__(net, weights)
 
-        self.oft_blocks = weights.w["oft_blocks"]
-        self.alpha = weights.w["alpha"]
-        self.dim = self.oft_blocks.shape[0]
-        self.num_blocks = self.dim
+        self.lin_module = None
+        # kohya-ss
+        if "oft_blocks" in weights.w.keys():
+            self.is_kohya = True
+            self.oft_blocks = weights.w["oft_blocks"]
+            self.alpha = weights.w["alpha"]
+            self.dim = self.oft_blocks.shape[0]
+        elif "oft_diag" in weights.w.keys():
+            self.is_kohya = False
+            self.oft_blocks = weights.w["oft_diag"]
+            # alpha is rank if alpha is 0 or None
+            if self.alpha is None:
+                pass
+            self.dim = self.oft_blocks.shape[0] # FIXME: almost certainly incorrect, assumes tensor is shape [*, m, n]
+        else:
+            raise ValueError("oft_blocks or oft_diag must be in weights dict")
 
-        if "Linear" in self.sd_module.__class__.__name__:
+        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
+        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
+        is_other_linear = type(self.sd_module) in [ torch.nn.MultiheadAttention]
+        #if "Linear" in self.sd_module.__class__.__name__ or is_linear:
+        if is_linear:
             self.out_dim = self.sd_module.out_features
-        elif "Conv" in self.sd_module.__class__.__name__:
+            #elif hasattr(self.sd_module, "embed_dim"):
+            #    self.out_dim = self.sd_module.embed_dim
+            #else:
+            #    raise ValueError("Linear sd_module must have out_features or embed_dim")
+        elif is_other_linear:
+            self.out_dim = self.sd_module.embed_dim
+        elif is_conv:
             self.out_dim = self.sd_module.out_channels
+        else:
+            raise ValueError("sd_module must be Linear or Conv")
 
-        self.constraint = self.alpha * self.out_dim
-        self.block_size = self.out_dim // self.num_blocks
+
+        if self.is_kohya:
+            self.num_blocks = self.dim
+            self.block_size = self.out_dim // self.num_blocks
+            self.constraint = self.alpha * self.out_dim
+        #elif is_linear or is_conv:
+        else:
+            self.num_blocks, self.block_size = factorization(self.out_dim, self.dim)
+            self.constraint = None
 
         self.org_module: list[torch.Module] = [self.sd_module]
 
-    # def merge_weight(self, R_weight, org_weight):
-    #     R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)
-    #     if org_weight.dim() == 4:
-    #         weight = torch.einsum("oihw, op -> pihw", org_weight, R_weight)
-    #     else:
-    #         weight = torch.einsum("oi, op -> pi", org_weight, R_weight)
-    #     weight = torch.einsum(
-    #         "k n m, k n ... -> k m ...", 
-    #         self.oft_diag * scale + torch.eye(self.block_size, device=device), 
-    #         org_weight
-    #     )
-    #     return weight
+        # if is_other_linear:
+        #     weight = self.oft_blocks.reshape(self.oft_blocks.shape[0], -1)
+        #     module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False)
+        #     with torch.no_grad():
+        #         if weight.shape != module.weight.shape:
+        #             weight = weight.reshape(module.weight.shape)
+        #         module.weight.copy_(weight)
+        #     module.to(device=devices.cpu, dtype=devices.dtype)
+        #     module.weight.requires_grad_(False)
+        #     self.lin_module = module
+            #return module
+
+    def merge_weight(self, R_weight, org_weight):
+        R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)
+        if org_weight.dim() == 4:
+            weight = torch.einsum("oihw, op -> pihw", org_weight, R_weight)
+        else:
+            weight = torch.einsum("oi, op -> pi", org_weight, R_weight)
+        #weight = torch.einsum(
+        #    "k n m, k n ... -> k m ...", 
+        #    self.oft_diag * scale + torch.eye(self.block_size, device=device), 
+        #    org_weight
+        #)
+        return weight
 
     def get_weight(self, oft_blocks, multiplier=None):
-        # constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
+        if self.constraint is not None:
+            constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
 
-        # block_Q = oft_blocks - oft_blocks.transpose(1, 2)
-        # norm_Q = torch.norm(block_Q.flatten())
-        # new_norm_Q = torch.clamp(norm_Q, max=constraint)
-        # block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        # m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
-        # block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
+        block_Q = oft_blocks - oft_blocks.transpose(1, 2)
+        norm_Q = torch.norm(block_Q.flatten())
+        if self.constraint is not None:
+            new_norm_Q = torch.clamp(norm_Q, max=constraint)
+        else:
+            new_norm_Q = norm_Q
+        block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
+        m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
 
-        # block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
-        # R = torch.block_diag(*block_R_weighted)
-        #return R
-        return self.oft_blocks
+        block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
+        R = torch.block_diag(*block_R_weighted)
+        return R
+        #return self.oft_blocks
 
 
     def calc_updown(self, orig_weight):
         multiplier = self.multiplier() * self.calc_scale()
-        #R = self.get_weight(self.oft_blocks, multiplier)
-        R = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-        #merged_weight = self.merge_weight(R, orig_weight)
+        R = self.get_weight(self.oft_blocks, multiplier)
+        #R = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        merged_weight = self.merge_weight(R, orig_weight)
 
-        orig_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
-        weight = torch.einsum(
-            'k n m, k n ... -> k m ...',
-            R * multiplier + torch.eye(self.block_size, device=orig_weight.device),
-            orig_weight
-        )
-        weight = rearrange(weight, 'k m ... -> (k m) ...')
+        #if self.lin_module is not None:
+        #    R = self.lin_module.weight.to(orig_weight.device, dtype=orig_weight.dtype)
+        #    weight = torch.mul(torch.mul(R, multiplier), orig_weight)
+        #else:
+        #    orig_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
+        #    weight = torch.einsum(
+        #        'k n m, k n ... -> k m ...',
+        #        R * multiplier + torch.eye(self.block_size, device=orig_weight.device),
+        #        orig_weight
+        #    )
+        #    weight = rearrange(weight, 'k m ... -> (k m) ...')
 
-        #updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
-        updown = weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
+        updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
+        #updown = weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
         output_shape = orig_weight.shape
         orig_weight = orig_weight
 
@@ -100,3 +152,49 @@ class NetworkModuleOFT(network.NetworkModule):
             ex_bias = ex_bias * self.multiplier()
 
         return updown, ex_bias
+    
+# copied from https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/lokr.py
+def factorization(dimension: int, factor:int=-1) -> tuple[int, int]:
+    '''
+    return a tuple of two value of input dimension decomposed by the number closest to factor
+    second value is higher or equal than first value.
+    
+    In LoRA with Kroneckor Product, first value is a value for weight scale.
+    secon value is a value for weight.
+    
+    Becuase of non-commutative property, A⊗B ≠ B⊗A. Meaning of two matrices is slightly different.
+    
+    examples)
+    factor
+        -1               2                4               8               16               ...
+    127 -> 1, 127   127 -> 1, 127    127 -> 1, 127   127 -> 1, 127   127 -> 1, 127
+    128 -> 8, 16    128 -> 2, 64     128 -> 4, 32    128 -> 8, 16    128 -> 8, 16
+    250 -> 10, 25   250 -> 2, 125    250 -> 2, 125   250 -> 5, 50    250 -> 10, 25
+    360 -> 8, 45    360 -> 2, 180    360 -> 4, 90    360 -> 8, 45    360 -> 12, 30
+    512 -> 16, 32   512 -> 2, 256    512 -> 4, 128   512 -> 8, 64    512 -> 16, 32
+    1024 -> 32, 32  1024 -> 2, 512   1024 -> 4, 256  1024 -> 8, 128  1024 -> 16, 64
+    '''
+    
+    if factor > 0 and (dimension % factor) == 0:
+        m = factor
+        n = dimension // factor
+        if m > n:
+            n, m = m, n
+        return m, n
+    if factor < 0:
+        factor = dimension
+    m, n = 1, dimension
+    length = m + n
+    while m<n:
+        new_m = m + 1
+        while dimension%new_m != 0:
+            new_m += 1
+        new_n = dimension // new_m
+        if new_m + new_n > length or new_m>factor:
+            break
+        else:
+            m, n = new_m, new_n
+    if m > n:
+        n, m = m, n
+    return m, n
+

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -1,5 +1,6 @@
 import torch
 import network
+from modules import devices
 
 
 class ModuleTypeOFT(network.ModuleType):
@@ -29,23 +30,56 @@ class NetworkModuleOFT(network.NetworkModule):
         self.block_size = self.out_dim // self.num_blocks
 
         self.org_module: list[torch.Module] = [self.sd_module]
+        self.org_weight = self.org_module[0].weight.to(self.org_module[0].weight.device, copy=True)
+        #self.org_weight = self.org_module[0].weight.to(devices.cpu, copy=True)
         self.R = self.get_weight(self.oft_blocks)
+
+        self.merged_weight = self.merge_weight()
         self.apply_to()
+        self.merged = False
+
+
+    def merge_weight(self):
+        org_sd = self.org_module[0].state_dict()
+        R = self.R.to(self.org_weight.device, dtype=self.org_weight.dtype)
+        if self.org_weight.dim() == 4:
+            weight = torch.einsum("oihw, op -> pihw", self.org_weight, R)
+        else:
+            weight = torch.einsum("oi, op -> pi", self.org_weight, R)
+        org_sd['weight'] = weight
+        # replace weight
+        #self.org_module[0].load_state_dict(org_sd)
+        return weight
+        pass
+    
+    def replace_weight(self, new_weight):
+        org_sd = self.org_module[0].state_dict()
+        org_sd['weight'] = new_weight
+        self.org_module[0].load_state_dict(org_sd)
+        self.merged = True
+
+    def restore_weight(self):
+        org_sd = self.org_module[0].state_dict()
+        org_sd['weight'] = self.org_weight
+        self.org_module[0].load_state_dict(org_sd)
+        self.merged = False
+
 
     # replace forward method of original linear rather than replacing the module
     # how do we revert this to unload the weights?
     def apply_to(self):
         self.org_forward = self.org_module[0].forward
         #self.org_module[0].forward = self.forward
+        self.org_module[0].register_forward_pre_hook(self.pre_forward_hook)
         self.org_module[0].register_forward_hook(self.forward_hook)
 
     def get_weight(self, oft_blocks, multiplier=None):
-        self.constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
+        constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
         block_Q = oft_blocks - oft_blocks.transpose(1, 2)
         norm_Q = torch.norm(block_Q.flatten())
-        new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
+        new_norm_Q = torch.clamp(norm_Q, max=constraint)
         block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        m_I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
         block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
         #block_R_weighted = multiplier * block_R + (1 - multiplier) * I
         #R = torch.block_diag(*block_R_weighted)
@@ -54,33 +88,47 @@ class NetworkModuleOFT(network.NetworkModule):
         return R
 
     def calc_updown(self, orig_weight):
-        oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        #oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
 
-        R = self.get_weight(oft_blocks)
-        self.R = R
+        #R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
+        ##self.R = R
 
-        # if orig_weight.dim() == 4:
-        #     weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
-        # else:
-        #     weight = torch.einsum("oi, op -> pi", orig_weight, R)
+        #if orig_weight.dim() == 4:
+        #    weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
+        #else:
+        #    weight = torch.einsum("oi, op -> pi", orig_weight, R)
 
-        updown = orig_weight @ R
-        output_shape = self.oft_blocks.shape
+        #updown = orig_weight @ R
+        #updown = weight
+        updown = torch.zeros_like(orig_weight, device=orig_weight.device, dtype=orig_weight.dtype)
+        #updown = orig_weight
+        output_shape = orig_weight.shape
+        #orig_weight = self.merged_weight.to(orig_weight.device, dtype=orig_weight.dtype)
+        #output_shape = self.oft_blocks.shape
 
         return self.finalize_updown(updown, orig_weight, output_shape)
     
-    def forward_hook(self, module, args, output):
-        #print(f'Forward hook in {self.network_key} called')
-        x = output
-        R = self.R.to(x.device, dtype=x.dtype)
+    def pre_forward_hook(self, module, input):
+        if not self.merged:
+            self.replace_weight(self.merged_weight)
 
-        if x.dim() == 4:
-            x = x.permute(0, 2, 3, 1)
-            x = torch.matmul(x, R)
-            x = x.permute(0, 3, 1, 2)
-        else:
-            x = torch.matmul(x, R)
-        return x
+    
+    def forward_hook(self, module, args, output):
+        if self.merged:
+            pass
+            #self.restore_weight()
+        #print(f'Forward hook in {self.network_key} called')
+
+        #x = output
+        #R = self.R.to(x.device, dtype=x.dtype)
+
+        #if x.dim() == 4:
+        #    x = x.permute(0, 2, 3, 1)
+        #    x = torch.matmul(x, R)
+        #    x = x.permute(0, 3, 1, 2)
+        #else:
+        #    x = torch.matmul(x, R)
+        #return x
 
     # def forward(self, x, y=None):
     #     x = self.org_forward(x)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -32,21 +32,27 @@ class NetworkModuleOFT(network.NetworkModule):
         self.org_module: list[torch.Module] = [self.sd_module]
         self.org_weight = self.org_module[0].weight.to(self.org_module[0].weight.device, copy=True)
         #self.org_weight = self.org_module[0].weight.to(devices.cpu, copy=True)
-        self.R = self.get_weight(self.oft_blocks)
+        init_multiplier = self.multiplier() * self.calc_scale()
+        self.last_multiplier = init_multiplier
+        self.R = self.get_weight(self.oft_blocks, init_multiplier)
 
         self.merged_weight = self.merge_weight()
         self.apply_to()
         self.merged = False
 
+        # weights_backup = getattr(self.org_module[0], 'network_weights_backup', None)
+        # if weights_backup is None:
+        #     self.org_module[0].network_weights_backup = self.org_weight
+
 
     def merge_weight(self):
-        org_sd = self.org_module[0].state_dict()
+        #org_sd = self.org_module[0].state_dict()
         R = self.R.to(self.org_weight.device, dtype=self.org_weight.dtype)
         if self.org_weight.dim() == 4:
             weight = torch.einsum("oihw, op -> pihw", self.org_weight, R)
         else:
             weight = torch.einsum("oi, op -> pi", self.org_weight, R)
-        org_sd['weight'] = weight
+        #org_sd['weight'] = weight
         # replace weight
         #self.org_module[0].load_state_dict(org_sd)
         return weight
@@ -74,6 +80,7 @@ class NetworkModuleOFT(network.NetworkModule):
         self.org_module[0].register_forward_hook(self.forward_hook)
 
     def get_weight(self, oft_blocks, multiplier=None):
+        multiplier = multiplier.to(oft_blocks.device, dtype=oft_blocks.dtype)
         constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
         block_Q = oft_blocks - oft_blocks.transpose(1, 2)
         norm_Q = torch.norm(block_Q.flatten())
@@ -81,9 +88,9 @@ class NetworkModuleOFT(network.NetworkModule):
         block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
         m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
         block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
-        #block_R_weighted = multiplier * block_R + (1 - multiplier) * I
-        #R = torch.block_diag(*block_R_weighted)
-        R = torch.block_diag(*block_R)
+        block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
+        R = torch.block_diag(*block_R_weighted)
+        #R = torch.block_diag(*block_R)
 
         return R
 
@@ -93,6 +100,8 @@ class NetworkModuleOFT(network.NetworkModule):
         #R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
         ##self.R = R
 
+        #R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
+        ##self.R = R
         #if orig_weight.dim() == 4:
         #    weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
         #else:
@@ -103,19 +112,33 @@ class NetworkModuleOFT(network.NetworkModule):
         updown = torch.zeros_like(orig_weight, device=orig_weight.device, dtype=orig_weight.dtype)
         #updown = orig_weight
         output_shape = orig_weight.shape
-        #orig_weight = self.merged_weight.to(orig_weight.device, dtype=orig_weight.dtype)
+        orig_weight = self.merged_weight.to(orig_weight.device, dtype=orig_weight.dtype)
         #output_shape = self.oft_blocks.shape
 
         return self.finalize_updown(updown, orig_weight, output_shape)
     
     def pre_forward_hook(self, module, input):
-        if not self.merged:
+        multiplier = self.multiplier() * self.calc_scale()
+        if not multiplier==self.last_multiplier or not self.merged:
+
+        #if multiplier != self.last_multiplier or not self.merged:
+            self.R = self.get_weight(self.oft_blocks, multiplier)
+            self.last_multiplier = multiplier
+            self.merged_weight = self.merge_weight()
             self.replace_weight(self.merged_weight)
+        #elif not self.merged:
+        #    self.replace_weight(self.merged_weight)
 
     
     def forward_hook(self, module, args, output):
-        if self.merged:
-            pass
+        pass
+        #output = output * self.multiplier() * self.calc_scale()
+        #if len(args) > 0:
+        #    y = args[0]
+        #    output = output + y
+        #return output
+        #if self.merged:
+        #    pass
             #self.restore_weight()
         #print(f'Forward hook in {self.network_key} called')
 

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -11,8 +11,8 @@ class ModuleTypeOFT(network.ModuleType):
 
         return None
 
-# adapted from kohya-ss' implementation https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
-# and KohakuBlueleaf's implementation https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/diag_oft.py
+# Supports both kohya-ss' implementation of COFT  https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
+# and KohakuBlueleaf's implementation of OFT/COFT https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/diag_oft.py
 class NetworkModuleOFT(network.NetworkModule):
     def __init__(self,  net: network.Network, weights: network.NetworkWeights):
 
@@ -25,117 +25,61 @@ class NetworkModuleOFT(network.NetworkModule):
         if "oft_blocks" in weights.w.keys():
             self.is_kohya = True
             self.oft_blocks = weights.w["oft_blocks"] # (num_blocks, block_size, block_size)
-            self.alpha = weights.w["alpha"]
+            self.alpha = weights.w["alpha"] # alpha is constraint
             self.dim = self.oft_blocks.shape[0] # lora dim
-            #self.oft_blocks = rearrange(self.oft_blocks, 'k m ... -> (k m) ...')
+        # LyCORIS
         elif "oft_diag" in weights.w.keys():
             self.is_kohya = False
-            self.oft_blocks = weights.w["oft_diag"] # (num_blocks, block_size, block_size)
-
-            # alpha is rank if alpha is 0 or None
-            if self.alpha is None:
-                pass
-            self.dim = self.oft_blocks.shape[1] # FIXME: almost certainly incorrect, assumes tensor is shape [*, m, n]
-        else:
-            raise ValueError("oft_blocks or oft_diag must be in weights dict")
+            self.oft_blocks = weights.w["oft_diag"]
+            # self.alpha is unused
+            self.dim = self.oft_blocks.shape[1] # (num_blocks, block_size, block_size)
 
         is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
         is_conv = type(self.sd_module) in [torch.nn.Conv2d]
-        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention]
+        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention] # unsupported
 
         if is_linear:
             self.out_dim = self.sd_module.out_features
-        elif is_other_linear:
-            self.out_dim = self.sd_module.embed_dim
         elif is_conv:
             self.out_dim = self.sd_module.out_channels
-        else:
-            raise ValueError("sd_module must be Linear or Conv")
+        elif is_other_linear:
+            self.out_dim = self.sd_module.embed_dim
 
         if self.is_kohya:
             self.constraint = self.alpha * self.out_dim
-            self.num_blocks, self.block_size = factorization(self.out_dim, self.dim)
+            self.num_blocks = self.dim
+            self.block_size = self.out_dim // self.dim
         else:
             self.constraint = None
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
 
-    def merge_weight(self, R_weight, org_weight):
-        R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)
-        if org_weight.dim() == 4:
-            weight = torch.einsum("oihw, op -> pihw", org_weight, R_weight)
-        else:
-            weight = torch.einsum("oi, op -> pi", org_weight, R_weight)
-        return weight
+    def calc_updown_kb(self, orig_weight, multiplier):
+        oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        oft_blocks = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix
 
-    def get_weight(self, oft_blocks, multiplier=None):
-        if self.constraint is not None:
-            constraint = self.constraint.to(oft_blocks.device, dtype=oft_blocks.dtype)
+        R = oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        R = R * multiplier + torch.eye(self.block_size, device=orig_weight.device)
 
-        block_Q = oft_blocks - oft_blocks.transpose(1, 2)
-        norm_Q = torch.norm(block_Q.flatten())
-        if self.constraint is not None:
-            new_norm_Q = torch.clamp(norm_Q, max=constraint)
-        else:
-            new_norm_Q = norm_Q
-        block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        m_I = torch.eye(self.num_blocks, device=oft_blocks.device).unsqueeze(0).repeat(self.block_size, 1, 1)
-        #m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
-        block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
-
-        block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
-        R = torch.block_diag(*block_R_weighted)
-        return R
-
-    def calc_updown_kohya(self, orig_weight, multiplier):
-        R = self.get_weight(self.oft_blocks, multiplier)
-        merged_weight = self.merge_weight(R, orig_weight)
+        # This errors out for MultiheadAttention, might need to be handled up-stream
+        merged_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
+        merged_weight = torch.einsum(
+            'k n m, k n ... -> k m ...',
+            R,
+            merged_weight
+        )
+        merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
 
         updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
         output_shape = orig_weight.shape
-        orig_weight = orig_weight
-        return self.finalize_updown(updown, orig_weight, output_shape)
-
-    def calc_updown_kb(self, orig_weight, multiplier):
-        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention]
-
-        if not is_other_linear:
-            oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-
-            # ensure skew-symmetric matrix
-            oft_blocks = oft_blocks - oft_blocks.transpose(1, 2)
-
-            R = oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-            R = R * multiplier + torch.eye(self.block_size, device=orig_weight.device)
-
-            merged_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
-            merged_weight = torch.einsum(
-                'k n m, k n ... -> k m ...',
-                R,
-                merged_weight
-            )
-            merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
-
-            updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
-            output_shape = orig_weight.shape
-        else:
-            # FIXME: skip MultiheadAttention for now
-            #up = self.lin_module.weight.to(orig_weight.device, dtype=orig_weight.dtype)
-            updown = torch.zeros([orig_weight.shape[1], orig_weight.shape[1]], device=orig_weight.device, dtype=orig_weight.dtype)
-            output_shape = (orig_weight.shape[1], orig_weight.shape[1])
-
         return self.finalize_updown(updown, orig_weight, output_shape)
 
     def calc_updown(self, orig_weight):
-        # if alpha is a very small number as in coft, calc_scale will return a almost zero number so we ignore it
-        #multiplier = self.multiplier() * self.calc_scale()
+        # if alpha is a very small number as in coft, calc_scale() will return a almost zero number so we ignore it
         multiplier = self.multiplier()
-
         return self.calc_updown_kb(orig_weight, multiplier)
 
     # override to remove the multiplier/scale factor; it's already multiplied in get_weight
     def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
-        #return super().finalize_updown(updown, orig_weight, output_shape, ex_bias)
-
         if self.bias is not None:
             updown = updown.reshape(self.bias.shape)
             updown += self.bias.to(orig_weight.device, dtype=orig_weight.dtype)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -58,17 +58,18 @@ class NetworkModuleOFT(network.NetworkModule):
 
     def calc_updown(self, orig_weight):
         # this works
-        R = self.R
+        # R = self.R
+        self.R = self.get_weight(self.multiplier())
 
-        # this causes major deepfrying i.e. just doesn't work
+        # sending R to device causes major deepfrying i.e. just doesn't work
         # R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
 
-        if orig_weight.dim() == 4:
-            weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
-        else:
-            weight = torch.einsum("oi, op -> pi", orig_weight, R)
+        # if orig_weight.dim() == 4:
+        #     weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
+        # else:
+        #     weight = torch.einsum("oi, op -> pi", orig_weight, R)
 
-        updown = orig_weight @ R
+        updown = orig_weight @ self.R
         output_shape = self.oft_blocks.shape
 
         ## this works

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -9,7 +9,7 @@ class ModuleTypeOFT(network.ModuleType):
 
         return None
 
-# adapted from https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
+# adapted from kohya's implementation https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
 class NetworkModuleOFT(network.NetworkModule):
     def __init__(self,  net: network.Network, weights: network.NetworkWeights):
 
@@ -17,7 +17,6 @@ class NetworkModuleOFT(network.NetworkModule):
 
         self.oft_blocks = weights.w["oft_blocks"]
         self.alpha = weights.w["alpha"]
-
         self.dim = self.oft_blocks.shape[0]
         self.num_blocks = self.dim
 
@@ -26,55 +25,45 @@ class NetworkModuleOFT(network.NetworkModule):
         elif "Conv" in self.sd_module.__class__.__name__:
             self.out_dim = self.sd_module.out_channels
 
-        self.constraint = self.alpha
-        #self.constraint = self.alpha * self.out_dim
+        self.constraint = self.alpha * self.out_dim
         self.block_size = self.out_dim // self.num_blocks
 
         self.org_module: list[torch.Module] = [self.sd_module]
-
-        self.R = self.get_weight()
-
+        self.R = self.get_weight(self.oft_blocks)
         self.apply_to()
 
     # replace forward method of original linear rather than replacing the module
+    # how do we revert this to unload the weights?
     def apply_to(self):
         self.org_forward = self.org_module[0].forward
         self.org_module[0].forward = self.forward
     
-    def get_weight(self, multiplier=None):
-        if not multiplier:
-            multiplier = self.multiplier()
-        block_Q = self.oft_blocks - self.oft_blocks.transpose(1, 2)
+    def get_weight(self, oft_blocks, multiplier=None):
+        block_Q = oft_blocks - oft_blocks.transpose(1, 2)
         norm_Q = torch.norm(block_Q.flatten())
         new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
         block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
         I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
         block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
-
-        block_R_weighted = multiplier * block_R + (1 - multiplier) * I
-        R = torch.block_diag(*block_R_weighted)
+        #block_R_weighted = multiplier * block_R + (1 - multiplier) * I
+        #R = torch.block_diag(*block_R_weighted)
+        R = torch.block_diag(*block_R)
 
         return R
 
     def calc_updown(self, orig_weight):
-        # this works
-        # R = self.R
-        self.R = self.get_weight(self.multiplier())
+        oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
 
-        # sending R to device causes major deepfrying i.e. just doesn't work
-        # R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
+        R = self.get_weight(oft_blocks)
+        self.R = R
 
         # if orig_weight.dim() == 4:
         #     weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
         # else:
         #     weight = torch.einsum("oi, op -> pi", orig_weight, R)
 
-        updown = orig_weight @ self.R
+        updown = orig_weight @ R
         output_shape = self.oft_blocks.shape
-
-        ## this works
-        # updown = orig_weight @ R
-        # output_shape = [orig_weight.size(0), R.size(1)]
 
         return self.finalize_updown(updown, orig_weight, output_shape)
     
@@ -82,8 +71,11 @@ class NetworkModuleOFT(network.NetworkModule):
         x = self.org_forward(x)
         if self.multiplier() == 0.0:
             return x
+
+        # calculating R here is excruciatingly slow
         #R = self.get_weight().to(x.device, dtype=x.dtype)
         R = self.R.to(x.device, dtype=x.dtype)
+
         if x.dim() == 4:
             x = x.permute(0, 2, 3, 1)
             x = torch.matmul(x, R)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -63,7 +63,7 @@ class NetworkModuleOFT(network.NetworkModule):
         orig_weight = orig_weight
 
         return self.finalize_updown(updown, orig_weight, output_shape)
-    
+
     # override to remove the multiplier/scale factor; it's already multiplied in get_weight
     def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
         #return super().finalize_updown(updown, orig_weight, output_shape, ex_bias)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -1,0 +1,82 @@
+import torch
+import network
+
+
+class ModuleTypeOFT(network.ModuleType):
+    def create_module(self, net: network.Network, weights: network.NetworkWeights):
+        if all(x in weights.w for x in ["oft_blocks"]):
+            return NetworkModuleOFT(net, weights)
+
+        return None
+
+# adapted from https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
+class NetworkModuleOFT(network.NetworkModule):
+    def __init__(self,  net: network.Network, weights: network.NetworkWeights):
+        super().__init__(net, weights)
+
+        self.oft_blocks = weights.w["oft_blocks"]
+        self.alpha = weights.w["alpha"]
+
+        self.dim = self.oft_blocks.shape[0]
+        self.num_blocks = self.dim
+
+        #if type(self.alpha) == torch.Tensor:
+        #    self.alpha = self.alpha.detach().numpy()
+
+        if "Linear" in self.sd_module.__class__.__name__:
+            self.out_dim = self.sd_module.out_features
+        elif "Conv" in self.sd_module.__class__.__name__:
+            self.out_dim = self.sd_module.out_channels
+
+        self.constraint = self.alpha * self.out_dim
+        self.block_size = self.out_dim // self.num_blocks
+
+        self.oft_multiplier = self.multiplier()
+
+        # replace forward method of original linear rather than replacing the module
+        # self.org_forward = self.sd_module.forward
+        # self.sd_module.forward = self.forward
+    
+    def get_weight(self):
+        block_Q = self.oft_blocks - self.oft_blocks.transpose(1, 2)
+        norm_Q = torch.norm(block_Q.flatten())
+        new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
+        block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
+        I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
+
+        block_R_weighted = self.oft_multiplier * block_R + (1 - self.oft_multiplier) * I
+        R = torch.block_diag(*block_R_weighted)
+
+        return R
+
+    def calc_updown(self, orig_weight):
+        oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        block_Q = oft_blocks - oft_blocks.transpose(1, 2)
+        norm_Q = torch.norm(block_Q.flatten())
+        new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
+        block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
+        I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
+
+        block_R_weighted = self.oft_multiplier * block_R + (1 - self.oft_multiplier) * I
+        R = torch.block_diag(*block_R_weighted)
+        #R = self.get_weight().to(orig_weight.device, dtype=orig_weight.dtype)
+        # W = R*W_0
+        updown = orig_weight + R
+        output_shape = [R.size(0), orig_weight.size(1)]
+        return self.finalize_updown(updown, orig_weight, output_shape)
+    
+    # def forward(self, x, y=None):
+    #     x = self.org_forward(x)
+    #     if self.oft_multiplier == 0.0:
+    #         return x
+
+    #     R = self.get_weight().to(x.device, dtype=x.dtype)
+    #     if x.dim() == 4:
+    #         x = x.permute(0, 2, 3, 1)
+    #         x = torch.matmul(x, R)
+    #         x = x.permute(0, 3, 1, 2)
+    #     else:
+    #         x = torch.matmul(x, R)
+    #     return x

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -12,6 +12,7 @@ class ModuleTypeOFT(network.ModuleType):
 # adapted from https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
 class NetworkModuleOFT(network.NetworkModule):
     def __init__(self,  net: network.Network, weights: network.NetworkWeights):
+
         super().__init__(net, weights)
 
         self.oft_blocks = weights.w["oft_blocks"]
@@ -20,24 +21,29 @@ class NetworkModuleOFT(network.NetworkModule):
         self.dim = self.oft_blocks.shape[0]
         self.num_blocks = self.dim
 
-        #if type(self.alpha) == torch.Tensor:
-        #    self.alpha = self.alpha.detach().numpy()
-
         if "Linear" in self.sd_module.__class__.__name__:
             self.out_dim = self.sd_module.out_features
         elif "Conv" in self.sd_module.__class__.__name__:
             self.out_dim = self.sd_module.out_channels
 
-        self.constraint = self.alpha * self.out_dim
+        self.constraint = self.alpha
+        #self.constraint = self.alpha * self.out_dim
         self.block_size = self.out_dim // self.num_blocks
 
-        self.oft_multiplier = self.multiplier()
+        self.org_module: list[torch.Module] = [self.sd_module]
 
-        # replace forward method of original linear rather than replacing the module
-        # self.org_forward = self.sd_module.forward
-        # self.sd_module.forward = self.forward
+        self.R = self.get_weight()
+
+        self.apply_to()
+
+    # replace forward method of original linear rather than replacing the module
+    def apply_to(self):
+        self.org_forward = self.org_module[0].forward
+        self.org_module[0].forward = self.forward
     
-    def get_weight(self):
+    def get_weight(self, multiplier=None):
+        if not multiplier:
+            multiplier = self.multiplier()
         block_Q = self.oft_blocks - self.oft_blocks.transpose(1, 2)
         norm_Q = torch.norm(block_Q.flatten())
         new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
@@ -45,38 +51,31 @@ class NetworkModuleOFT(network.NetworkModule):
         I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
         block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
 
-        block_R_weighted = self.oft_multiplier * block_R + (1 - self.oft_multiplier) * I
+        block_R_weighted = multiplier * block_R + (1 - multiplier) * I
         R = torch.block_diag(*block_R_weighted)
 
         return R
 
     def calc_updown(self, orig_weight):
-        oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-        block_Q = oft_blocks - oft_blocks.transpose(1, 2)
-        norm_Q = torch.norm(block_Q.flatten())
-        new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
-        block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
-        block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
-
-        block_R_weighted = self.oft_multiplier * block_R + (1 - self.oft_multiplier) * I
-        R = torch.block_diag(*block_R_weighted)
-        #R = self.get_weight().to(orig_weight.device, dtype=orig_weight.dtype)
-        # W = R*W_0
-        updown = orig_weight + R
-        output_shape = [R.size(0), orig_weight.size(1)]
+        R = self.R
+        if orig_weight.dim() == 4:
+            weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
+        else:
+            weight = torch.einsum("oi, op -> pi", orig_weight, R)
+        updown = orig_weight @ R
+        output_shape = [orig_weight.size(0), R.size(1)]
+        #output_shape = [R.size(0), orig_weight.size(1)]
         return self.finalize_updown(updown, orig_weight, output_shape)
     
-    # def forward(self, x, y=None):
-    #     x = self.org_forward(x)
-    #     if self.oft_multiplier == 0.0:
-    #         return x
-
-    #     R = self.get_weight().to(x.device, dtype=x.dtype)
-    #     if x.dim() == 4:
-    #         x = x.permute(0, 2, 3, 1)
-    #         x = torch.matmul(x, R)
-    #         x = x.permute(0, 3, 1, 2)
-    #     else:
-    #         x = torch.matmul(x, R)
-    #     return x
+    def forward(self, x, y=None):
+        x = self.org_forward(x)
+        if self.multiplier() == 0.0:
+            return x
+        R = self.get_weight().to(x.device, dtype=x.dtype)
+        if x.dim() == 4:
+            x = x.permute(0, 2, 3, 1)
+            x = torch.matmul(x, R)
+            x = x.permute(0, 3, 1, 2)
+        else:
+            x = torch.matmul(x, R)
+        return x

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -2,6 +2,7 @@ import torch
 import network
 from lyco_helpers import factorization
 from einops import rearrange
+from modules import devices
 
 
 class ModuleTypeOFT(network.ModuleType):
@@ -24,12 +25,14 @@ class NetworkModuleOFT(network.NetworkModule):
         # kohya-ss
         if "oft_blocks" in weights.w.keys():
             self.is_kohya = True
-            self.oft_blocks = weights.w["oft_blocks"]
+            self.oft_blocks = weights.w["oft_blocks"] # (num_blocks, block_size, block_size)
             self.alpha = weights.w["alpha"]
-            self.dim = self.oft_blocks.shape[0]
+            self.dim = self.oft_blocks.shape[0] # lora dim
+            #self.oft_blocks = rearrange(self.oft_blocks, 'k m ... -> (k m) ...')
         elif "oft_diag" in weights.w.keys():
             self.is_kohya = False
-            self.oft_blocks = weights.w["oft_diag"]
+            self.oft_blocks = weights.w["oft_diag"] # (num_blocks, block_size, block_size)
+
             # alpha is rank if alpha is 0 or None
             if self.alpha is None:
                 pass
@@ -51,12 +54,57 @@ class NetworkModuleOFT(network.NetworkModule):
             raise ValueError("sd_module must be Linear or Conv")
 
         if self.is_kohya:
-            self.num_blocks = self.dim
-            self.block_size = self.out_dim // self.num_blocks
+            #self.num_blocks = self.dim
+            #self.block_size = self.out_dim // self.num_blocks
+            #self.block_size = self.dim
+            #self.num_blocks = self.out_dim // self.block_size
             self.constraint = self.alpha * self.out_dim
+            self.num_blocks, self.block_size = factorization(self.out_dim, self.dim)
         else:
-            self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
             self.constraint = None
+            self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
+
+        if is_other_linear:
+            self.lin_module = self.create_module(weights.w, "oft_diag", none_ok=True)
+
+
+    def create_module(self, weights, key, none_ok=False):
+        weight = weights.get(key)
+
+        if weight is None and none_ok:
+            return None
+
+        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear, torch.nn.MultiheadAttention]
+        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
+
+        if is_linear:
+            weight = weight.reshape(weight.shape[0], -1)
+            module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False)
+        elif is_conv and key == "lora_down.weight" or key == "dyn_up":
+            if len(weight.shape) == 2:
+                weight = weight.reshape(weight.shape[0], -1, 1, 1)
+
+            if weight.shape[2] != 1 or weight.shape[3] != 1:
+                module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], self.sd_module.kernel_size, self.sd_module.stride, self.sd_module.padding, bias=False)
+            else:
+                module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], (1, 1), bias=False)
+        elif is_conv and key == "lora_mid.weight":
+            module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], self.sd_module.kernel_size, self.sd_module.stride, self.sd_module.padding, bias=False)
+        elif is_conv and key == "lora_up.weight" or key == "dyn_down":
+            module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], (1, 1), bias=False)
+        else:
+            raise AssertionError(f'Lora layer {self.network_key} matched a layer with unsupported type: {type(self.sd_module).__name__}')
+
+        with torch.no_grad():
+            if weight.shape != module.weight.shape:
+                weight = weight.reshape(module.weight.shape)
+            module.weight.copy_(weight)
+
+        module.to(device=devices.cpu, dtype=devices.dtype)
+        module.weight.requires_grad_(False)
+
+        return module
+
 
     def merge_weight(self, R_weight, org_weight):
         R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)
@@ -77,7 +125,8 @@ class NetworkModuleOFT(network.NetworkModule):
         else:
             new_norm_Q = norm_Q
         block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        m_I = torch.eye(self.num_blocks, device=oft_blocks.device).unsqueeze(0).repeat(self.block_size, 1, 1)
+        #m_I = torch.eye(self.block_size, device=oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
         block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
 
         block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
@@ -97,25 +146,33 @@ class NetworkModuleOFT(network.NetworkModule):
         is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention]
 
         if not is_other_linear:
-            if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
-                orig_weight=orig_weight.permute(1, 0)
+            #if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
+            #    orig_weight=orig_weight.permute(1, 0)
 
-            R = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+            oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+
+            # without this line the results are significantly worse / less accurate
+            oft_blocks = oft_blocks - oft_blocks.transpose(1, 2)
+
+            R = oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+            R = R * multiplier + torch.eye(self.block_size, device=orig_weight.device)
+
             merged_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
             merged_weight = torch.einsum(
                 'k n m, k n ... -> k m ...',
-                R * multiplier + torch.eye(self.block_size, device=orig_weight.device),
+                R,
                 merged_weight
             )
             merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
 
-            if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
-                orig_weight=orig_weight.permute(1, 0)
+            #if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
+            #    orig_weight=orig_weight.permute(1, 0)
 
             updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
             output_shape = orig_weight.shape
         else:
             # FIXME: skip MultiheadAttention for now
+            #up = self.lin_module.weight.to(orig_weight.device, dtype=orig_weight.dtype)
             updown = torch.zeros([orig_weight.shape[1], orig_weight.shape[1]], device=orig_weight.device, dtype=orig_weight.dtype)
             output_shape = (orig_weight.shape[1], orig_weight.shape[1])
 
@@ -123,10 +180,10 @@ class NetworkModuleOFT(network.NetworkModule):
 
     def calc_updown(self, orig_weight):
         multiplier = self.multiplier() * self.calc_scale()
-        if self.is_kohya:
-            return self.calc_updown_kohya(orig_weight, multiplier)
-        else:
-            return self.calc_updown_kb(orig_weight, multiplier)
+        #if self.is_kohya:
+        #    return self.calc_updown_kohya(orig_weight, multiplier)
+        #else:
+        return self.calc_updown_kb(orig_weight, multiplier)
 
     # override to remove the multiplier/scale factor; it's already multiplied in get_weight
     def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -2,7 +2,6 @@ import torch
 import network
 from lyco_helpers import factorization
 from einops import rearrange
-from modules import devices
 
 
 class ModuleTypeOFT(network.ModuleType):
@@ -54,57 +53,11 @@ class NetworkModuleOFT(network.NetworkModule):
             raise ValueError("sd_module must be Linear or Conv")
 
         if self.is_kohya:
-            #self.num_blocks = self.dim
-            #self.block_size = self.out_dim // self.num_blocks
-            #self.block_size = self.dim
-            #self.num_blocks = self.out_dim // self.block_size
             self.constraint = self.alpha * self.out_dim
             self.num_blocks, self.block_size = factorization(self.out_dim, self.dim)
         else:
             self.constraint = None
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
-
-        if is_other_linear:
-            self.lin_module = self.create_module(weights.w, "oft_diag", none_ok=True)
-
-
-    def create_module(self, weights, key, none_ok=False):
-        weight = weights.get(key)
-
-        if weight is None and none_ok:
-            return None
-
-        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear, torch.nn.MultiheadAttention]
-        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
-
-        if is_linear:
-            weight = weight.reshape(weight.shape[0], -1)
-            module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False)
-        elif is_conv and key == "lora_down.weight" or key == "dyn_up":
-            if len(weight.shape) == 2:
-                weight = weight.reshape(weight.shape[0], -1, 1, 1)
-
-            if weight.shape[2] != 1 or weight.shape[3] != 1:
-                module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], self.sd_module.kernel_size, self.sd_module.stride, self.sd_module.padding, bias=False)
-            else:
-                module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], (1, 1), bias=False)
-        elif is_conv and key == "lora_mid.weight":
-            module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], self.sd_module.kernel_size, self.sd_module.stride, self.sd_module.padding, bias=False)
-        elif is_conv and key == "lora_up.weight" or key == "dyn_down":
-            module = torch.nn.Conv2d(weight.shape[1], weight.shape[0], (1, 1), bias=False)
-        else:
-            raise AssertionError(f'Lora layer {self.network_key} matched a layer with unsupported type: {type(self.sd_module).__name__}')
-
-        with torch.no_grad():
-            if weight.shape != module.weight.shape:
-                weight = weight.reshape(module.weight.shape)
-            module.weight.copy_(weight)
-
-        module.to(device=devices.cpu, dtype=devices.dtype)
-        module.weight.requires_grad_(False)
-
-        return module
-
 
     def merge_weight(self, R_weight, org_weight):
         R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -37,7 +37,7 @@ class NetworkModuleOFT(network.NetworkModule):
     def apply_to(self):
         self.org_forward = self.org_module[0].forward
         self.org_module[0].forward = self.forward
-    
+
     def get_weight(self, oft_blocks, multiplier=None):
         block_Q = oft_blocks - oft_blocks.transpose(1, 2)
         norm_Q = torch.norm(block_Q.flatten())
@@ -66,7 +66,7 @@ class NetworkModuleOFT(network.NetworkModule):
         output_shape = self.oft_blocks.shape
 
         return self.finalize_updown(updown, orig_weight, output_shape)
-    
+
     def forward(self, x, y=None):
         x = self.org_forward(x)
         if self.multiplier() == 0.0:

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -57,21 +57,32 @@ class NetworkModuleOFT(network.NetworkModule):
         return R
 
     def calc_updown(self, orig_weight):
+        # this works
         R = self.R
+
+        # this causes major deepfrying i.e. just doesn't work
+        # R = self.R.to(orig_weight.device, dtype=orig_weight.dtype)
+
         if orig_weight.dim() == 4:
             weight = torch.einsum("oihw, op -> pihw", orig_weight, R)
         else:
             weight = torch.einsum("oi, op -> pi", orig_weight, R)
+
         updown = orig_weight @ R
-        output_shape = [orig_weight.size(0), R.size(1)]
-        #output_shape = [R.size(0), orig_weight.size(1)]
+        output_shape = self.oft_blocks.shape
+
+        ## this works
+        # updown = orig_weight @ R
+        # output_shape = [orig_weight.size(0), R.size(1)]
+
         return self.finalize_updown(updown, orig_weight, output_shape)
     
     def forward(self, x, y=None):
         x = self.org_forward(x)
         if self.multiplier() == 0.0:
             return x
-        R = self.get_weight().to(x.device, dtype=x.dtype)
+        #R = self.get_weight().to(x.device, dtype=x.dtype)
+        R = self.R.to(x.device, dtype=x.dtype)
         if x.dim() == 4:
             x = x.permute(0, 2, 3, 1)
             x = torch.matmul(x, R)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -1,7 +1,7 @@
 import torch
 import network
+from lyco_helpers import factorization
 from einops import rearrange
-from modules import devices
 
 
 class ModuleTypeOFT(network.ModuleType):
@@ -11,7 +11,8 @@ class ModuleTypeOFT(network.ModuleType):
 
         return None
 
-# adapted from kohya's implementation https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
+# adapted from kohya-ss' implementation https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py
+# and KohakuBlueleaf's implementation https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/diag_oft.py
 class NetworkModuleOFT(network.NetworkModule):
     def __init__(self,  net: network.Network, weights: network.NetworkWeights):
 
@@ -19,6 +20,7 @@ class NetworkModuleOFT(network.NetworkModule):
 
         self.lin_module = None
         self.org_module: list[torch.Module] = [self.sd_module]
+
         # kohya-ss
         if "oft_blocks" in weights.w.keys():
             self.is_kohya = True
@@ -37,49 +39,24 @@ class NetworkModuleOFT(network.NetworkModule):
 
         is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
         is_conv = type(self.sd_module) in [torch.nn.Conv2d]
-        is_other_linear = type(self.sd_module) in [ torch.nn.MultiheadAttention]
-        #if "Linear" in self.sd_module.__class__.__name__ or is_linear:
+        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention]
+
         if is_linear:
             self.out_dim = self.sd_module.out_features
-            #elif hasattr(self.sd_module, "embed_dim"):
-            #    self.out_dim = self.sd_module.embed_dim
-            #else:
-            #    raise ValueError("Linear sd_module must have out_features or embed_dim")
         elif is_other_linear:
             self.out_dim = self.sd_module.embed_dim
-            #self.org_weight = self.org_module[0].weight
-#            if hasattr(self.sd_module, "in_proj_weight"):
-#                self.in_proj_dim = self.sd_module.in_proj_weight.shape[1]
-#            if hasattr(self.sd_module, "out_proj_weight"):
-#                self.out_proj_dim = self.sd_module.out_proj_weight.shape[0]
-#            self.in_proj_dim = self.sd_module.in_proj_weight.shape[1]
         elif is_conv:
             self.out_dim = self.sd_module.out_channels
         else:
             raise ValueError("sd_module must be Linear or Conv")
 
-
         if self.is_kohya:
             self.num_blocks = self.dim
             self.block_size = self.out_dim // self.num_blocks
             self.constraint = self.alpha * self.out_dim
-        #elif is_linear or is_conv:
         else:
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
             self.constraint = None
-
-
-        # if is_other_linear:
-        #     weight = self.oft_blocks.reshape(self.oft_blocks.shape[0], -1)
-        #     module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False)
-        #     with torch.no_grad():
-        #         if weight.shape != module.weight.shape:
-        #             weight = weight.reshape(module.weight.shape)
-        #         module.weight.copy_(weight)
-        #     module.to(device=devices.cpu, dtype=devices.dtype)
-        #     module.weight.requires_grad_(False)
-        #     self.lin_module = module
-            #return module
 
     def merge_weight(self, R_weight, org_weight):
         R_weight = R_weight.to(org_weight.device, dtype=org_weight.dtype)
@@ -87,11 +64,6 @@ class NetworkModuleOFT(network.NetworkModule):
             weight = torch.einsum("oihw, op -> pihw", org_weight, R_weight)
         else:
             weight = torch.einsum("oi, op -> pi", org_weight, R_weight)
-        #weight = torch.einsum(
-        #    "k n m, k n ... -> k m ...", 
-        #    self.oft_diag * scale + torch.eye(self.block_size, device=device), 
-        #    org_weight
-        #)
         return weight
 
     def get_weight(self, oft_blocks, multiplier=None):
@@ -111,47 +83,50 @@ class NetworkModuleOFT(network.NetworkModule):
         block_R_weighted = multiplier * block_R + (1 - multiplier) * m_I
         R = torch.block_diag(*block_R_weighted)
         return R
-        #return self.oft_blocks
 
+    def calc_updown_kohya(self, orig_weight, multiplier):
+        R = self.get_weight(self.oft_blocks, multiplier)
+        merged_weight = self.merge_weight(R, orig_weight)
 
-    def calc_updown(self, orig_weight):
-        multiplier = self.multiplier() * self.calc_scale()
-        is_other_linear = type(self.sd_module) in [ torch.nn.MultiheadAttention]
-        if self.is_kohya and not is_other_linear:
-            R = self.get_weight(self.oft_blocks, multiplier)
-            #R = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-            merged_weight = self.merge_weight(R, orig_weight)
-        elif not self.is_kohya and not is_other_linear:
+        updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
+        output_shape = orig_weight.shape
+        orig_weight = orig_weight
+        return self.finalize_updown(updown, orig_weight, output_shape)
+
+    def calc_updown_kb(self, orig_weight, multiplier):
+        is_other_linear = type(self.sd_module) in [torch.nn.MultiheadAttention]
+
+        if not is_other_linear:
             if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
                 orig_weight=orig_weight.permute(1, 0)
+
             R = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
             merged_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
-            #orig_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.block_size, n=self.num_blocks)
             merged_weight = torch.einsum(
                 'k n m, k n ... -> k m ...',
                 R * multiplier + torch.eye(self.block_size, device=orig_weight.device),
-                merged_weight 
+                merged_weight
             )
             merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
+
             if is_other_linear and orig_weight.shape[0] != orig_weight.shape[1]:
                 orig_weight=orig_weight.permute(1, 0)
-                #merged_weight=merged_weight.permute(1, 0)
+
             updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
-            #updown = weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
             output_shape = orig_weight.shape
         else:
-            # skip for now
+            # FIXME: skip MultiheadAttention for now
             updown = torch.zeros([orig_weight.shape[1], orig_weight.shape[1]], device=orig_weight.device, dtype=orig_weight.dtype)
             output_shape = (orig_weight.shape[1], orig_weight.shape[1])
 
-        #if self.lin_module is not None:
-        #    R = self.lin_module.weight.to(orig_weight.device, dtype=orig_weight.dtype)
-        #    weight = torch.mul(torch.mul(R, multiplier), orig_weight)
-        #else:
-
-        orig_weight = orig_weight
-
         return self.finalize_updown(updown, orig_weight, output_shape)
+
+    def calc_updown(self, orig_weight):
+        multiplier = self.multiplier() * self.calc_scale()
+        if self.is_kohya:
+            return self.calc_updown_kohya(orig_weight, multiplier)
+        else:
+            return self.calc_updown_kb(orig_weight, multiplier)
 
     # override to remove the multiplier/scale factor; it's already multiplied in get_weight
     def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
@@ -172,49 +147,3 @@ class NetworkModuleOFT(network.NetworkModule):
             ex_bias = ex_bias * self.multiplier()
 
         return updown, ex_bias
-    
-# copied from https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/lokr.py
-def factorization(dimension: int, factor:int=-1) -> tuple[int, int]:
-    '''
-    return a tuple of two value of input dimension decomposed by the number closest to factor
-    second value is higher or equal than first value.
-    
-    In LoRA with Kroneckor Product, first value is a value for weight scale.
-    secon value is a value for weight.
-    
-    Becuase of non-commutative property, A⊗B ≠ B⊗A. Meaning of two matrices is slightly different.
-    
-    examples)
-    factor
-        -1               2                4               8               16               ...
-    127 -> 1, 127   127 -> 1, 127    127 -> 1, 127   127 -> 1, 127   127 -> 1, 127
-    128 -> 8, 16    128 -> 2, 64     128 -> 4, 32    128 -> 8, 16    128 -> 8, 16
-    250 -> 10, 25   250 -> 2, 125    250 -> 2, 125   250 -> 5, 50    250 -> 10, 25
-    360 -> 8, 45    360 -> 2, 180    360 -> 4, 90    360 -> 8, 45    360 -> 12, 30
-    512 -> 16, 32   512 -> 2, 256    512 -> 4, 128   512 -> 8, 64    512 -> 16, 32
-    1024 -> 32, 32  1024 -> 2, 512   1024 -> 4, 256  1024 -> 8, 128  1024 -> 16, 64
-    '''
-    
-    if factor > 0 and (dimension % factor) == 0:
-        m = factor
-        n = dimension // factor
-        if m > n:
-            n, m = m, n
-        return m, n
-    if factor < 0:
-        factor = dimension
-    m, n = 1, dimension
-    length = m + n
-    while m<n:
-        new_m = m + 1
-        while dimension%new_m != 0:
-            new_m += 1
-        new_n = dimension // new_m
-        if new_m + new_n > length or new_m>factor:
-            break
-        else:
-            m, n = new_m, new_n
-    if m > n:
-        n, m = m, n
-    return m, n
-

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -43,8 +43,8 @@ class NetworkModuleOFT(network.NetworkModule):
         norm_Q = torch.norm(block_Q.flatten())
         new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
         block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-        I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
-        block_R = torch.matmul(I + block_Q, (I - block_Q).inverse())
+        m_I = torch.eye(self.block_size, device=self.oft_blocks.device).unsqueeze(0).repeat(self.num_blocks, 1, 1)
+        block_R = torch.matmul(m_I + block_Q, (m_I - block_Q).inverse())
         #block_R_weighted = multiplier * block_R + (1 - multiplier) * I
         #R = torch.block_diag(*block_R_weighted)
         R = torch.block_diag(*block_R)

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -11,6 +11,7 @@ import network_ia3
 import network_lokr
 import network_full
 import network_norm
+import network_oft
 
 import torch
 from typing import Union
@@ -28,6 +29,7 @@ module_types = [
     network_full.ModuleTypeFull(),
     network_norm.ModuleTypeNorm(),
     network_glora.ModuleTypeGLora(),
+    network_oft.ModuleTypeOFT(),
 ]
 
 
@@ -182,6 +184,9 @@ def load_network(name, network_on_disk):
             sd_module = shared.sd_model.network_layer_mapping.get(key, None)
         elif sd_module is None and "lora_te1_text_model" in key_network_without_network_parts:
             key = key_network_without_network_parts.replace("lora_te1_text_model", "0_transformer_text_model")
+            sd_module = shared.sd_model.network_layer_mapping.get(key, None)
+        elif sd_module is None and "oft_unet" in key_network_without_network_parts:
+            key = key_network_without_network_parts.replace("oft_unet", "diffusion_model")
             sd_module = shared.sd_model.network_layer_mapping.get(key, None)
 
             # some SD1 Loras also have correct compvis keys

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -191,8 +191,15 @@ def load_network(name, network_on_disk):
                 key = key_network_without_network_parts.replace("lora_te1_text_model", "transformer_text_model")
                 sd_module = shared.sd_model.network_layer_mapping.get(key, None)
 
+        # kohya_ss OFT module
         elif sd_module is None and "oft_unet" in key_network_without_network_parts:
             key = key_network_without_network_parts.replace("oft_unet", "diffusion_model")
+            sd_module = shared.sd_model.network_layer_mapping.get(key, None)
+
+        # KohakuBlueLeaf OFT module
+        if sd_module is None and "oft_diag" in key:
+            key = key_network_without_network_parts.replace("lora_unet", "diffusion_model")
+            key = key_network_without_network_parts.replace("lora_te1_text_model", "0_transformer_text_model")
             sd_module = shared.sd_model.network_layer_mapping.get(key, None)
 
         if sd_module is None:

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -169,10 +169,6 @@ def load_network(name, network_on_disk):
             else:
                 emb_dict[vec_name] = weight
             bundle_embeddings[emb_name] = emb_dict
-        
-        #if key_network_without_network_parts == "oft_unet":
-        #    print(key_network_without_network_parts)
-        #    pass
 
         key = convert_diffusers_name_to_compvis(key_network_without_network_parts, is_sd2)
         sd_module = shared.sd_model.network_layer_mapping.get(key, None)
@@ -196,31 +192,8 @@ def load_network(name, network_on_disk):
                 sd_module = shared.sd_model.network_layer_mapping.get(key, None)
 
         elif sd_module is None and "oft_unet" in key_network_without_network_parts:
-        #    UNET_TARGET_REPLACE_MODULE_ALL_LINEAR = ["Transformer2DModel"]
-        #    UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
-            UNET_TARGET_REPLACE_MODULE_ATTN_ONLY = ["CrossAttention"]
-            # TODO: Change matchedm odules based on whether all linear, conv, etc
-
             key = key_network_without_network_parts.replace("oft_unet", "diffusion_model")
             sd_module = shared.sd_model.network_layer_mapping.get(key, None)
-            #key_no_suffix = key.rsplit("_to_", 1)[0]
-            ## Match all modules of class CrossAttention
-            #replace_module_list = []
-            #for module_type in UNET_TARGET_REPLACE_MODULE_ATTN_ONLY:
-            #    replace_module_list += [module for k, module in shared.sd_model.network_layer_mapping.items() if module_type in module.__class__.__name__]
-
-            #matched_module = replace_module_list.get(key_no_suffix, None)
-            #if key.endswith('to_q'):
-            #    sd_module = matched_module.to_q or None
-            #if key.endswith('to_k'):
-            #    sd_module = matched_module.to_k or None
-            #if key.endswith('to_v'):
-            #    sd_module = matched_module.to_v or None
-            #if key.endswith('to_out_0'):
-            #    sd_module = matched_module.to_out[0] or None
-            #if key.endswith('to_out_1'):
-            #    sd_module = matched_module.to_out[1] or None
-
 
         if sd_module is None:
             keys_failed_to_match[key_network] = key
@@ -242,14 +215,6 @@ def load_network(name, network_on_disk):
             raise AssertionError(f"Could not find a module type (out of {', '.join([x.__class__.__name__ for x in module_types])}) that would accept those keys: {', '.join(weights.w)}")
 
         net.modules[key] = net_module
-    
-    # replaces forward method of original Linear
-    # applied_to_count = 0
-    #for key, created_module in net.modules.items():
-    #    if isinstance(created_module, network_oft.NetworkModuleOFT):
-    #        net_module.apply_to()
-            #applied_to_count += 1
-    # print(f'Applied OFT modules: {applied_to_count}')
 
     embeddings = {}
     for emb_name, data in bundle_embeddings.items():


### PR DESCRIPTION
## Description

This PR adds support for inference of OFT networks trained with kohya-ss [sd-scripts](https://github.com/kohya-ss/sd-scripts). The implementation is based on kohya's implementation here: https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py

~~This is a draft PR because of these major issues:~~
* ~~The network remains affects all generations after loading even when supposed to be unloaded~~
* ~~It noticeably slows down inference~~

~~The current implementation replaces sd_module's forward method with a custom forward method, which I believe is the cause of the network continuing to affect future generations and the speed of inference.~~

### ~~Any suggestions on how to fix these issues is greatly appreciated!~~

Related links:
OFT project page: https://oft.wyliu.com
OFT official repository: https://github.com/Zeju1997/oft

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
