### PR TITLE
fix bug when using --gfpgan-models-path

### DIFF
--- a/modules/gfpgan_model.py
+++ b/modules/gfpgan_model.py
@@ -9,6 +9,7 @@ from modules import paths, shared, devices, modelloader, errors
 model_dir = "GFPGAN"
 user_path = None
 model_path = os.path.join(paths.models_path, model_dir)
+model_file_path = None
 model_url = "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth"
 have_gfpgan = False
 loaded_gfpgan_model = None
@@ -17,24 +18,32 @@ loaded_gfpgan_model = None
 def gfpgann():
     global loaded_gfpgan_model
     global model_path
+    global model_file_path
     if loaded_gfpgan_model is not None:
         loaded_gfpgan_model.gfpgan.to(devices.device_gfpgan)
         return loaded_gfpgan_model
 
     if gfpgan_constructor is None:
         return None
+  
+    models = modelloader.load_models(model_path, model_url, user_path, ext_filter=['.pth'])
 
-    models = modelloader.load_models(model_path, model_url, user_path, ext_filter="GFPGAN")
     if len(models) == 1 and models[0].startswith("http"):
         model_file = models[0]
     elif len(models) != 0:
-        latest_file = max(models, key=os.path.getctime)
+        gfp_models = []
+        for item in models:
+            if 'GFPGAN' in os.path.basename(item):
+                gfp_models.append(item)
+        latest_file = max(gfp_models, key=os.path.getctime)
         model_file = latest_file
     else:
         print("Unable to load gfpgan model!")
         return None
+
     if hasattr(facexlib.detection.retinaface, 'device'):
         facexlib.detection.retinaface.device = devices.device_gfpgan
+    model_file_path = model_file
     model = gfpgan_constructor(model_path=model_file, upscale=1, arch='clean', channel_multiplier=2, bg_upsampler=None, device=devices.device_gfpgan)
     loaded_gfpgan_model = model
 
@@ -77,19 +86,25 @@ def setup_model(dirname):
         global user_path
         global have_gfpgan
         global gfpgan_constructor
+        global model_file_path
+
+        facexlib_path = model_path
+
+        if dirname is not None:
+            facexlib_path = dirname
 
         load_file_from_url_orig = gfpgan.utils.load_file_from_url
         facex_load_file_from_url_orig = facexlib.detection.load_file_from_url
         facex_load_file_from_url_orig2 = facexlib.parsing.load_file_from_url
 
         def my_load_file_from_url(**kwargs):
-            return load_file_from_url_orig(**dict(kwargs, model_dir=model_path))
+            return load_file_from_url_orig(**dict(kwargs, model_dir=model_file_path))
 
         def facex_load_file_from_url(**kwargs):
-            return facex_load_file_from_url_orig(**dict(kwargs, save_dir=model_path, model_dir=None))
+            return facex_load_file_from_url_orig(**dict(kwargs, save_dir=facexlib_path, model_dir=None))
 
         def facex_load_file_from_url2(**kwargs):
-            return facex_load_file_from_url_orig2(**dict(kwargs, save_dir=model_path, model_dir=None))
+            return facex_load_file_from_url_orig2(**dict(kwargs, save_dir=facexlib_path, model_dir=None))
 
         gfpgan.utils.load_file_from_url = my_load_file_from_url
         facexlib.detection.load_file_from_url = facex_load_file_from_url

--- a/modules/gfpgan_model.py
+++ b/modules/gfpgan_model.py
@@ -25,7 +25,7 @@ def gfpgann():
 
     if gfpgan_constructor is None:
         return None
-  
+
     models = modelloader.load_models(model_path, model_url, user_path, ext_filter=['.pth'])
 
     if len(models) == 1 and models[0].startswith("http"):


### PR DESCRIPTION
## Description

* **a simple description of what you're trying to accomplish**
  * First, when using `--gfpgan-models-path`, for example, `--gfpgan-models-path D:/custom/webui_models/GFPGAN`, and selecting **GFPGan** as the **Face restoration model** in **Restore faces**, the `detection_Resnet50_Final.pth` file is still being downloaded to the original `models\GFPGAN` directory. This is because the `save_dir` parameter in `facexlib.detection.load_file_from_url` and `facexlib.parsing.load_file_from_url` is assigned as `model_path` instead of using the cmd parameter, which is `user_path`.

  * Second, in `modelloader.load_models()`, the `ext_filter` parameter is assigned as `ext_filter="GFPGAN"` (it should be `ext_filter=['.pth']`), which also causes the validation fail, resulting in a remote download every time.

  * Third, after fixing the above two issues, if I initially place the `GFPGANv1.4.pth`, `detection_Resnet50_Final.pth`, and `parsing_parsenet.pth` files in the `--gfpgan-models-path`, it will cause a new problem with gfpgan: 

    > File "C:\Users\Contra\anaconda3\envs\sd-pytorch2\lib\site-packages\gfpgan-1.3.8-py3.10.egg\gfpgan\utils.py", line 97, in init self.gfpgan.load_state_dict(loadnet[keyname], strict=True) 
    > KeyError: 'params' 

    This is because `detection_Resnet50_Final.pth` or` parsing_parsenet.pth` is being mistakenly loaded as `GFPGANv1.4.pth`.

* **a summary of changes in code**
  * Add `model_file_path`. Because actually the parameter accepted by `gfpgan.utils.load_file_from_url` is the full path of the model file, not just its directory path.
  * Change `ext_filter="GFPGAN"` to `ext_filter=['.pth']`.
  * Add `facexlib_path` for `save_dir`  of `facexlib.detection.load_file_from_url` and `facexlib.parsing.load_file_from_url`. The value depends on whether `--gfpgan-models-path` exists.
  * Add `if 'GFPGAN' in os.path.basename(item)` to take the `GFPGANv1.4.pth` to `model_file`.
  
* **which issues it fixes, if any**

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
