### PR TITLE
Update prompts_from_file script to allow concatenating entries with the general prompt.

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -108,6 +108,7 @@ class Script(scripts.Script):
     def ui(self, is_img2img):
         checkbox_iterate = gr.Checkbox(label="Iterate seed every line", value=False, elem_id=self.elem_id("checkbox_iterate"))
         checkbox_iterate_batch = gr.Checkbox(label="Use same random seed for all lines", value=False, elem_id=self.elem_id("checkbox_iterate_batch"))
+        prompt_position = gr.Radio(["start", "end"], label="Insert prompts at the", elem_id=self.elem_id("prompt_position"), value="start")
 
         prompt_txt = gr.Textbox(label="List of prompt inputs", lines=1, elem_id=self.elem_id("prompt_txt"))
         file = gr.File(label="Upload prompt inputs", type='binary', elem_id=self.elem_id("file"))
@@ -118,9 +119,9 @@ class Script(scripts.Script):
         # We don't shrink back to 1, because that causes the control to ignore [enter], and it may
         # be unclear to the user that shift-enter is needed.
         prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt], show_progress=False)
-        return [checkbox_iterate, checkbox_iterate_batch, prompt_txt]
+        return [checkbox_iterate, checkbox_iterate_batch, prompt_position, prompt_txt]
 
-    def run(self, p, checkbox_iterate, checkbox_iterate_batch, prompt_txt: str):
+    def run(self, p, checkbox_iterate, checkbox_iterate_batch, prompt_position, prompt_txt: str):
         lines = [x for x in (x.strip() for x in prompt_txt.splitlines()) if x]
 
         p.do_not_save_grid = True
@@ -157,6 +158,18 @@ class Script(scripts.Script):
             copy_p = copy.copy(p)
             for k, v in args.items():
                 setattr(copy_p, k, v)
+
+            if args.get("prompt") and p.prompt:
+                if prompt_position == "start":
+                    copy_p.prompt = args.get("prompt") + " " + p.prompt
+                else:
+                    copy_p.prompt = p.prompt + " " + args.get("prompt")
+           
+            if args.get("negative_prompt") and p.negative_prompt:
+                if prompt_position == "start":
+                    copy_p.negative_prompt = args.get("negative_prompt") + " " + p.negative_prompt
+                else:
+                    copy_p.negative_prompt = p.negative_prompt + " " + args.get("negative_prompt")
 
             proc = process_images(copy_p)
             images += proc.images

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -164,7 +164,7 @@ class Script(scripts.Script):
                     copy_p.prompt = args.get("prompt") + " " + p.prompt
                 else:
                     copy_p.prompt = p.prompt + " " + args.get("prompt")
-           
+
             if args.get("negative_prompt") and p.negative_prompt:
                 if prompt_position == "start":
                     copy_p.negative_prompt = args.get("negative_prompt") + " " + p.negative_prompt


### PR DESCRIPTION
## Description

To allow for more flexibility, I'd like the prompts_from_file script to allow integrating the general prompts (like the other matrix scripts do).

It's a pretty minor change, I've added a toggle to position the iterated prompts before or after the general ones, and support also doing the same for the negative prompt if the user is using the arguments format.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
