### PR TITLE
Empty dirs

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -153,7 +153,14 @@ class ExtraNetworksPage:
                     while subdir.startswith("/"):
                         subdir = subdir[1:]
 
-                    is_empty = len(os.listdir(x)) == 0
+                    files = os.listdir(x)
+                    is_empty = True
+                    if len(files) > 0:
+                        if any(file for file in files for ext in [".pth", ".pt", ".ckpt", ".safetensors"] if file.endswith(ext)):
+                            is_empty = False
+                    if is_empty:
+                        continue
+
                     if not is_empty and not subdir.endswith("/"):
                         subdir = subdir + "/"
 


### PR DESCRIPTION
## Description

* [x] do not show empty dirs without models
* ~~[x] do not show empty dirs without `scripts` extensions~~ (currently, empty extensions are possible. only `javascript/*.js` or even only `style.css` extensions are possible.)

currently only `.pt`, `.ckpt`, and `.safetensors` are listed.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/extensions-builtin/Lora/networks.py#L495-L505

## Show case (I guess, rare use case)
without this fix, all sub dirs will be shown.
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/232347/5dfac1c3-6397-402b-91bb-3ee3908469f8)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
