### PR TITLE
call state.jobnext() before postproces*()

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -886,6 +886,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             devices.torch_gc()
 
+            state.nextjob()
+
             if p.scripts is not None:
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
 
@@ -957,8 +959,6 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             del x_samples_ddim
 
             devices.torch_gc()
-
-            state.nextjob()
 
         if not infotexts:
             infotexts.append(Processed(p, []).infotext(p, 0))


### PR DESCRIPTION
## Description

* call `state.jobnext()` before `postprocess*()` to support `job_count`, `job_no` controls in postprocessing easily.

with this small fix, `state.job_count` and `state.job_no` could be easily controlled without hacky ways.

* without this fix, one can control `job_count` and `job_no` in `postprocess*()` by the following hacky way:
  - increase `job_no` in the `postprocess*()` - HACK
  - increase `job_count` in the `postprocess*` (slight jumping back progress bar)
  - decrease `job_no` before return. (possible live progress bar **jumping back** too much will occur) - HACK

## Show case (with or without this fix. above hacky workaround applied)
- webui + a face detailer extension with progress support (postprocess extension, use `postprocess_image()` internally)

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/232347/011a416a-1951-49de-b9c4-708cdef0c71c

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)



