### PR TITLE
simple ldap auth

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -118,3 +118,7 @@ parser.add_argument('--timeout-keep-alive', type=int, default=30, help='set time
 parser.add_argument("--disable-all-extensions", action='store_true', help="prevent all extensions from running regardless of any other settings", default=False)
 parser.add_argument("--disable-extra-extensions", action='store_true', help="prevent all extensions except built-in from running regardless of any other settings", default=False)
 parser.add_argument("--skip-load-model-at-start", action='store_true', help="if load a model at web start, only take effect when --nowebui", )
+parser.add_argument("--ldap-uri", type=str, help='ldap url e.g. ldap://localhost:389', default=None)
+parser.add_argument("--ldap-bind-dn", type=str, help='ldap bind dn e.g. cn={username},ou=users,dc=example,dc=com', default=None)
+parser.add_argument("--outdir-samples", type=str, help='samples output directory', default="")
+

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -95,7 +95,7 @@ def check_versions():
 
     expected_torch_version = "2.0.0"
     expected_xformers_version = "0.0.20"
-    expected_gradio_version = "3.41.2"
+    expected_gradio_version = "3.43.2"
 
     if version.parse(torch.__version__) < version.parse(expected_torch_version):
         print_error_explanation(f"""

--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -104,6 +104,18 @@ def validate_tls_options():
     startup_timer.record("TLS")
 
 
+def webui_auth_ldap(username, password):
+    from modules.shared_cmd_options import cmd_opts
+    import ldap
+    conn = ldap.initialize(cmd_opts.ldap_uri)
+    try:
+        conn.simple_bind_s(cmd_opts.ldap_bind_dn.replace('{username}', username), password)
+        return True
+    except Exception:
+        conn.unbind()
+        return False
+
+
 def get_gradio_auth_creds():
     """
     Convert the gradio_auth and gradio_auth_path commandline arguments into

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -67,7 +67,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
 }))
 
 options_templates.update(options_section(('saving-paths', "Paths for saving"), {
-    "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to three directories below", component_args=hide_dirs),
+    "outdir_samples": OptionInfo(cmd_opts.outdir_samples, "Output directory for images; if empty, defaults to three directories below", component_args=hide_dirs),
     "outdir_txt2img_samples": OptionInfo("outputs/txt2img-images", 'Output directory for txt2img images', component_args=hide_dirs),
     "outdir_img2img_samples": OptionInfo("outputs/img2img-images", 'Output directory for img2img images', component_args=hide_dirs),
     "outdir_extras_samples": OptionInfo("outputs/extras-images", 'Output directory for images from extras tab', component_args=hide_dirs),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ clean-fid
 einops
 fastapi>=0.90.1
 gfpgan
-gradio==3.41.2
+gradio==3.43.2
 inflection
 jsonmerge
 kornia
@@ -32,3 +32,4 @@ torch
 torchdiffeq
 torchsde
 transformers==4.30.2
+python-ldap==3.2.0

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -7,7 +7,7 @@ clean-fid==0.1.35
 einops==0.4.1
 fastapi==0.94.0
 gfpgan==1.3.8
-gradio==3.41.2
+gradio==3.43.2
 httpcore==0.15
 inflection==0.5.1
 jsonmerge==1.8.0

--- a/webui.py
+++ b/webui.py
@@ -45,6 +45,14 @@ def api_only():
     )
 
 
+def webui_auth():
+    from modules.shared_cmd_options import cmd_opts
+    if cmd_opts.ldap_uri:
+        return initialize_util.webui_auth_ldap
+    else:
+        return list(initialize_util.get_gradio_auth_creds()) or None
+
+
 def webui():
     from modules.shared_cmd_options import cmd_opts
 
@@ -67,8 +75,6 @@ def webui():
         if not cmd_opts.no_gradio_queue:
             shared.demo.queue(64)
 
-        gradio_auth_creds = list(initialize_util.get_gradio_auth_creds()) or None
-
         auto_launch_browser = False
         if os.getenv('SD_WEBUI_RESTARTING') != '1':
             if shared.opts.auto_launch_browser == "Remote" or cmd_opts.autolaunch:
@@ -84,7 +90,7 @@ def webui():
             ssl_certfile=cmd_opts.tls_certfile,
             ssl_verify=cmd_opts.disable_tls_verify,
             debug=cmd_opts.gradio_debug,
-            auth=gradio_auth_creds,
+            auth=webui_auth(),
             inbrowser=auto_launch_browser,
             prevent_thread_lock=True,
             allowed_paths=cmd_opts.gradio_allowed_path,


### PR DESCRIPTION
Simple ldap auth support:
```
--ldap-uri=ldap://localhost:389
--ldap-bind-dn="cn={username},ou=users,dc=example,dc=com"
```
Where {username} will be replaced with username from the auth web form.

Also support for outdir override as when using in a read-only binary more relative dir is not writable
```
--outdir-samples=/path/to/dir
```

This was created and tested for Syncloud self-hosted platform (https://github.com/syncloud/platform) - https://github.com/syncloud/stable-diffusion
