### PR TITLE
return-gif

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -103,8 +103,9 @@ def decode_base64_to_image(encoding):
 
 def encode_pil_to_base64(image):
     with io.BytesIO() as output_bytes:
-
-        if opts.samples_format.lower() == 'png':
+        if image.format is not None and image.format.lower() in ('gif', 'webp'):
+            image.save(output_bytes, format=image.format, save_all=True)
+        elif opts.samples_format.lower() == 'png':
             use_metadata = False
             metadata = PngImagePlugin.PngInfo()
             for key, value in image.info.items():


### PR DESCRIPTION
Enable the returned images to support animated formats, such as GIF and WebP.