### PR TITLE
requirements_versions httpx==0.24.1

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -29,3 +29,4 @@ torch
 torchdiffeq==0.2.3
 torchsde==0.2.6
 transformers==4.30.2
+httpx==0.24.1


### PR DESCRIPTION
## Description

@AUTOMATIC1111 urgent fix need I believe this needs to be pushed to `master` ASAP
I think they started about 2 hours ago
currently any new install will not be able to Launch
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13836
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13840
`Httpx==0.24.1`
https://pypi.org/project/httpx/#history
I did a quick test with Httpx 0.25.0 and 0.25.1 both are not able to run
even though 0.25.0 is from 20230911 until yesterday webui only installs 0.24.1
I just happened to a pip freeze yesterday
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/206#issuecomment-1789282528

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
