### PR TITLE
Fix issue 13236

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,3 +1,4 @@
+httpx==0.24.1
 GitPython==3.1.32
 Pillow==9.5.0
 accelerate==0.21.0


### PR DESCRIPTION
[issue](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13236)

incorrect version of httpx-0.25.1 installs automatically, enforce httpx-0.24.1 not 