### PR TITLE
Add option to set notification sound volume

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -26,7 +26,11 @@ onAfterUiUpdate(function() {
     lastHeadImg = headImg;
 
     // play notification sound if available
-    gradioApp().querySelector('#audio_notification audio')?.play();
+    const notificationAudio = gradioApp().querySelector('#audio_notification audio');
+    if (notificationAudio) {
+        notificationAudio.volume = opts.notification_volume / 100.0 || 1.0;
+        notificationAudio.play();
+    }
 
     if (document.hasFocus()) return;
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -64,6 +64,7 @@ options_templates.update(options_section(('saving-images', "Saving images/grids"
     "save_incomplete_images": OptionInfo(False, "Save incomplete images").info("save images that has been interrupted in mid-generation; even if not saved, they will still show up in webui output."),
 
     "notification_audio": OptionInfo(True, "Play notification sound after image generation").info("notification.mp3 should be present in the root directory").needs_reload_ui(),
+    "notification_volume": OptionInfo(100, "Notification sound volume", gr.Slider, {"minimum": 0, "maximum": 100, "step": 1}).info("in %"),
 }))
 
 options_templates.update(options_section(('saving-paths', "Paths for saving"), {


### PR DESCRIPTION
## Description

* a simple description of what you're trying to accomplish
  * This PR adds the option to the settings for changing the volume of the optional notification sound that can be played after image generation. This can be useful if the volume of the used notification sound should be lowered without the need to modify the sound file self.

* a summary of changes in code
  * The option for changing the volume value was added to the shared options in percent
  * Before playing the notification sound, the volume will be adjusted based on the set value in the options

## Screenshots/videos:
![grafik](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/118578287/82b79dbd-e131-4b44-9c0a-ead230c3e7d0)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
