### PR TITLE
Add consistency Decoder to VAE options.

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -55,7 +55,7 @@ def samples_to_images_tensor(sample, approximation=None, model=None):
         with devices.autocast(), torch.no_grad():
             x_sample = sd_vae_consistency.decoder_model()(
                 sample.to(devices.device, devices.dtype)/0.18215,
-                schedule=[1.0]
+                schedule=[1.0],
             )
         sd_vae_consistency.unload()
     else:

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -54,8 +54,8 @@ def samples_to_images_tensor(sample, approximation=None, model=None):
     elif approximation == 4:
         with devices.autocast(), torch.no_grad():
             x_sample = sd_vae_consistency.decoder_model()(
-                sample.to(devices.device, devices.dtype)/0.18215,
-                schedule=[1.0],
+                sample.detach().to(devices.device, devices.dtype)/0.18215,
+                schedule=[float(i.strip()) for i in shared.opts.sd_vae_consistency_schedule.split(',')],
             )
         sd_vae_consistency.unload()
     else:

--- a/modules/sd_vae_consistency.py
+++ b/modules/sd_vae_consistency.py
@@ -30,4 +30,5 @@ def decoder_model():
 def unload():
     global sd_vae_consistency_models
     if sd_vae_consistency_models is not None:
+        devices.torch_gc()
         sd_vae_consistency_models.ckpt.to('cpu')

--- a/modules/sd_vae_consistency.py
+++ b/modules/sd_vae_consistency.py
@@ -1,0 +1,35 @@
+"""
+Consistency Decoder
+Improved decoding for stable diffusion vaes.
+
+https://github.com/openai/consistencydecoder
+"""
+import os
+import torch
+import torch.nn as nn
+
+from modules import devices, paths_internal, shared
+from consistencydecoder import ConsistencyDecoder
+
+
+sd_vae_consistency_models = None
+model_path = os.path.join(paths_internal.models_path, 'consistencydecoder')
+
+
+def decoder_model():
+    global sd_vae_consistency_models
+    if getattr(shared.sd_model, 'is_sdxl', False):
+        raise NotImplementedError("SDXL is not supported for consistency decoder")
+    if sd_vae_consistency_models is not None:
+        sd_vae_consistency_models.ckpt.to(devices.device)
+        return sd_vae_consistency_models
+
+    loaded_model = ConsistencyDecoder(devices.device, model_path)
+    sd_vae_consistency_models = loaded_model
+    return loaded_model
+
+
+def unload():
+    global sd_vae_consistency_models
+    if sd_vae_consistency_models is not None:
+        sd_vae_consistency_models.ckpt.to('cpu')

--- a/modules/sd_vae_consistency.py
+++ b/modules/sd_vae_consistency.py
@@ -5,8 +5,6 @@ Improved decoding for stable diffusion vaes.
 https://github.com/openai/consistencydecoder
 """
 import os
-import torch
-import torch.nn as nn
 
 from modules import devices, paths_internal, shared
 from consistencydecoder import ConsistencyDecoder

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -173,6 +173,7 @@ For img2img, VAE is used to process user's input image before the sampling, and 
     "auto_vae_precision": OptionInfo(True, "Automatically revert VAE to 32-bit floats").info("triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image"),
     "sd_vae_encode_method": OptionInfo("Full", "VAE type for encode", gr.Radio, {"choices": ["Full", "TAESD"]}, infotext='VAE Encoder').info("method to encode image to latent (use in img2img, hires-fix or inpaint mask)"),
     "sd_vae_decode_method": OptionInfo("Full", "VAE type for decode", gr.Radio, {"choices": ["Full", "TAESD", "Consistency Decoder"]}, infotext='VAE Decoder').info("method to decode latent to image"),
+    "sd_vae_consistency_schedule": OptionInfo("1.0, 0.5", "consistency schedule").info("sampling schedule for consistency decoder."),
 }))
 
 options_templates.update(options_section(('img2img', "img2img"), {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -172,7 +172,7 @@ For img2img, VAE is used to process user's input image before the sampling, and 
     "sd_vae_overrides_per_model_preferences": OptionInfo(True, "Selected VAE overrides per-model preferences").info("you can set per-model VAE either by editing user metadata for checkpoints, or by making the VAE have same name as checkpoint"),
     "auto_vae_precision": OptionInfo(True, "Automatically revert VAE to 32-bit floats").info("triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image"),
     "sd_vae_encode_method": OptionInfo("Full", "VAE type for encode", gr.Radio, {"choices": ["Full", "TAESD"]}, infotext='VAE Encoder').info("method to encode image to latent (use in img2img, hires-fix or inpaint mask)"),
-    "sd_vae_decode_method": OptionInfo("Full", "VAE type for decode", gr.Radio, {"choices": ["Full", "TAESD"]}, infotext='VAE Decoder').info("method to decode latent to image"),
+    "sd_vae_decode_method": OptionInfo("Full", "VAE type for decode", gr.Radio, {"choices": ["Full", "TAESD", "Consistency Decoder"]}, infotext='VAE Decoder').info("method to decode latent to image"),
 }))
 
 options_templates.update(options_section(('img2img', "img2img"), {

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,5 @@ torch
 torchdiffeq
 torchsde
 transformers==4.30.2
+
+git+https://github.com/openai/consistencydecoder.git

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -30,3 +30,4 @@ torchdiffeq==0.2.3
 torchsde==0.2.6
 transformers==4.30.2
 httpx==0.24.1
+git+https://github.com/openai/consistencydecoder.git


### PR DESCRIPTION
## Description
Consistency Decoder: https://github.com/openai/consistencydecoder
I added it Just like TAESD.

It require lot of resource to "decode" the image (it is actually a latent guided consistency model on pixel space directly).
So we may want to implement some tile method for it.
But directly tile may not be a good idea. And mathmetically identical tile algorithm require pytorch implementation(I'm testing it but it is not successful)

may require more dev on this, but since it is wokring as it should be for now. I PR it.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
