### PR TITLE
Extension / Script load and execution order system

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -89,14 +89,16 @@ class Extension:
 
         self.have_info_from_repo = True
 
-    def list_files(self, subdir, extension):
+    def list_files(self, subdir, extension, load_order=None):
+        if load_order is None:
+            load_order = {}
         dirpath = os.path.join(self.path, subdir)
         if not os.path.isdir(dirpath):
             return []
 
         res = []
         for filename in sorted(os.listdir(dirpath)):
-            res.append(scripts.ScriptFile(self.path, filename, os.path.join(dirpath, filename)))
+            res.append(scripts.ScriptFile(self.path, filename, os.path.join(dirpath, filename), load_order.get(filename)))
 
         res = [x for x in res if os.path.splitext(x.path)[1].lower() == extension and os.path.isfile(x.path)]
 

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -1,4 +1,5 @@
 import os
+import json
 import threading
 
 from modules import shared, errors, cache, scripts
@@ -89,12 +90,19 @@ class Extension:
 
         self.have_info_from_repo = True
 
-    def list_files(self, subdir, extension, load_order=None):
-        if load_order is None:
-            load_order = {}
+    def list_files(self, subdir, extension):
         dirpath = os.path.join(self.path, subdir)
         if not os.path.isdir(dirpath):
             return []
+
+        load_order = {}
+        try:
+            with open(os.path.join(self.path, 'webui-extension-properties.json'), 'r', encoding='utf-8') as file:
+                load_order = json.load(file).get('load_order')
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            print(e)
 
         res = []
         for filename in sorted(os.listdir(dirpath)):

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -244,8 +244,8 @@ class Script:
 
         May be called in show() or ui() - but it may be too late in the latter as some components may already be created.
 
-        This function is an alternative to before_component in that it also called to run before a component is created, but
-        it doesn't require to be called for every created component - just for the one you need.
+        This function is an alternative to before_component in that it is also called before a component is created, but
+        it doesn't require being called for every created component - just for the one you need.
         """
         if self.on_before_component_elem_id is None:
             self.on_before_component_elem_id = []
@@ -399,7 +399,7 @@ def load_scripts():
         load_order = shared.opts.script_order_override.get(short_path) or script_file.load_order
         if load_order is not None:
             return [load_order, short_path]
-        # Auto assign load order base on script type
+        # assign load order base on script type
         for key in script_default_order:
             if path.is_relative_to(key):
                 return [script_default_order[key], short_path]
@@ -458,14 +458,12 @@ def get_function_order(script_path, script_class, function_name):
     # scripts callback order override or specified by function attribute
     order = shared.opts.script_order_override.get(fn_path) or getattr(getattr(script_class, function_name), 'order', None)
     if order is not None:
-        print(order, fn_path)
         return [order, fn_path]
-    # Auto assign load order base on script type
+    # assign load order base on script type
     for key in script_default_order:
         if path.is_relative_to(key):
-            print(script_default_order[key], fn_path)
             return [script_default_order[key], fn_path]
-    return [order, 10000]
+    return [10000, fn_path]
 
 
 class ScriptRunner:

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -356,7 +356,12 @@ def get_short_path(path: Path):
             return path
 
 
-script_default_order = {paths.extensions_dir: 700, paths.extensions_builtin_dir: 500, os.path.join(paths.script_path, 'scripts'): 300, paths.script_path: 100}
+script_default_order = {
+    paths.extensions_dir: 70000,
+    paths.extensions_builtin_dir: 50000,
+    os.path.join(paths.script_path, 'scripts'): 30000,
+    paths.script_path: 1000000
+}
 
 
 def assign_script_default_order(file_path):
@@ -364,16 +369,16 @@ def assign_script_default_order(file_path):
     Args:
         file_path: path to script file
     Returns: order number
-        internal webui scripts: 100
-        built-in scripts: 300
-        built-in extensions: 500
-        extension: 700
-        other: 10000 (should never reach)
+        internal webui scripts: 10000
+        built-in scripts: 30000
+        built-in extensions: 50000
+        extension: 70000
+        other: 1000000 (should never reach)
     """
     for key in script_default_order:
         if file_path.is_relative_to(key):
             return script_default_order[key]
-    return 10000
+    return 1000000
 
 
 def load_scripts():
@@ -403,7 +408,7 @@ def load_scripts():
             order: number
         2. Default load order specified by extension properties
         3. Assign order using assign_script_default_order()
-        
+
         if multiple scripts file have the same load order then the object_id will be used for comparison
         """
         path = Path(script_file.path)

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import json
 import inspect
 from pathlib import Path
 from collections import namedtuple
@@ -313,7 +312,7 @@ postprocessing_scripts_data = []
 ScriptClassData = namedtuple("ScriptClassData", ["script_class", "path", "basedir", "module"])
 
 
-def list_scripts(scriptdirname, extension, *, include_extensions=True, read_property=False):
+def list_scripts(scriptdirname, extension, *, include_extensions=True):
     scripts_list = []
 
     basedir = os.path.join(paths.script_path, scriptdirname)
@@ -323,17 +322,7 @@ def list_scripts(scriptdirname, extension, *, include_extensions=True, read_prop
 
     if include_extensions:
         for ext in extensions.active():
-            property_path = os.path.join(ext.path, 'webui-extension-property.json')
-            scripts_load_order = None
-            if read_property:
-                try:
-                    with open(property_path, 'r', encoding='utf-8') as file:
-                        scripts_load_order = json.load(file).get('load_order')
-                except FileNotFoundError:
-                    pass
-                except Exception as e:
-                    print(e)
-            scripts_list += ext.list_files(scriptdirname, extension, scripts_load_order)
+            scripts_list += ext.list_files(scriptdirname, extension)
 
     scripts_list = [x for x in scripts_list if os.path.splitext(x.path)[1].lower() == extension and os.path.isfile(x.path)]
 
@@ -376,7 +365,7 @@ def load_scripts():
     postprocessing_scripts_data.clear()
     script_callbacks.clear_callbacks()
 
-    scripts_list = list_scripts("scripts", ".py", read_property=True) + list_scripts("modules/processing_scripts", ".py", include_extensions=False)
+    scripts_list = list_scripts("scripts", ".py") + list_scripts("modules/processing_scripts", ".py", include_extensions=False)
 
     syspath = sys.path
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -338,4 +338,5 @@ options_templates.update(options_section((None, "Hidden options"), {
     "disable_all_extensions": OptionInfo("none", "Disable all extensions (preserves the list of disabled extensions)", gr.Radio, {"choices": ["none", "extra", "all"]}),
     "restore_config_state_file": OptionInfo("", "Config state file to restore from, under 'config-states/' folder"),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
+    "script_load_order_override": OptionInfo({}, "Override default load order of scripts/extensions"),
 }))

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -338,5 +338,5 @@ options_templates.update(options_section((None, "Hidden options"), {
     "disable_all_extensions": OptionInfo("none", "Disable all extensions (preserves the list of disabled extensions)", gr.Radio, {"choices": ["none", "extra", "all"]}),
     "restore_config_state_file": OptionInfo("", "Config state file to restore from, under 'config-states/' folder"),
     "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
-    "script_load_order_override": OptionInfo({}, "Override default load order of scripts/extensions"),
+    "script_order_override": OptionInfo({}, "Override default load and callback order of scripts/extensions"),
 }))


### PR DESCRIPTION
please help and test if there's any flaws to the system

---

## Description
Currently webui loads extensions based on its installation path
initially this is fine but as the amount of extension and the complexity grows this becomes increasingly troublesome

Here I implemented a system that allows a extension developer to specify
1. the `load order` each `entry_script.py`
2. the `Script class initialization order` of each `scripts.Script` class
3. the `function execution order` of almost every function in each `scripts.Script` class

this should solve the issue of an extension depending on another extensions being loaded first
> example: some extensions been required control net to be loaded first

and opens up the possibility of executing `callback functions` in special sequence
> example: `a1>b1>c1>c2>b2>a2`

## Usage explanation
### scrip_file.py Load order
in the route to directory of an extension create a `webui-extension-properties.json` with the following structure
```json
{
    "load_order": {
        "script_file.py": 55555,
        "script_file.py": 66666,
        "script_file.py": 77777
    }
}
```
`script_file_name.py` corresponds to each entry script `script_file.py` under the `scripts` directory the requires a custom load order

###  Function execution order and Script class initialization order
> both of these can be configured using the same method
in a custom scripts.Script class after defining a `callback function` add a `order` attribute the function method
```py
from modules import scripts
class ExampleScript(scripts.Script):
    def title(self):
        return "tExampleScript"
    title.order = 87654
    def ui(self, is_img2img):
        pass
    ui.order = 76543
    def show(self, is_img2img):
        return scripts.AlwaysVisible
    show.order = 65432
    def before_process(self, p, *args):
        pass
    before_process.order = 54321
    def postprocess_batch(self, p, *args, **kwargs):
        pass
    postprocess_batch.order = 43210
```
`Function execution order`
`callback function` from all `Scripts` will be sorted based on their `order` attribute

details
`show.order` also acts as the `Script class initialization order` 
`ui.order` has ability to rearrange the order of `gr.Accordion` of a `always on script`
`title.order` serves as the order of how a script is stored order in webui but in most cases the store order shouldn't matter should be irrelevant, but it can be used to control the order of how `selectable strips` are listed
other orders like the callbacks of `alwayson_scripts` such as `before_process.order` `postprocess_batch` are normal and no special purpose other than defining the

<details><summary>these are all the current function that have `order attribute`</summary>
<p>

```py
[
    'ui',
    'setup',
    'before_process',
    'process',
    'before_process_batch',
    'after_extra_networks_activate',
    'process_batch',
    'before_hr',
    'postprocess',
    'postprocess_batch',
    'postprocess_batch_list',
    'postprocess_image',
    'before_component',
    'after_component',
]
```

</p>
</details> 

there are certain functions that I did not add the attribute
either because I believe they do not need it or I'm not sure the function of
the `run` function used by selectable Scripts does not need to be ordered
I'm not familiar with `on_before_component` and `on_after_component` and as it seem to serve different purpose I did not add `order` to it

---

### all orders can override be user in `config.json`
currently the setting is only accessible by directly editing the config file file
and adding the dict key `script_order_override`
restructure of the values is as follows
```json
"script_order_override": {
    "scripts\\xyz_grid.py": 12345,
    "extensions\\example_extension\\scripts\\script_0.py": 23456
    "scripts\\xyz_grid.py>Script>ui": 34567
    "extensions\\example_extension\\scripts\\script_2.py>ScriptClassName>before_process_batch": 45678
}
```

instructor is simple `identifying string` as key `order number` as value
the first two entries in this example are `Scriptfile.py Load order` entries
the last two are entries for Script function `>` character is used as a separator
for exact detail reference the `object_id` in `scripts.get_function_execution_order` and `scripts.get_script_load_order` 
> note the `\\` is due to json encoding, the real string is `\`

- the user is able to override any configuration by the script itself the user defined configuration has the top priority and will override any predefined order by an extension

**currently there is no user interface to configure order override**
this can be implemented at the later date if this system is accepted
> not sure if I would be the one to implemented as I'm not good with UI

### defalt order when order is not specified
> applies to current extensions
a default value will be assigned automatically by web UI if order is not specified
the order is given based on the type source of the extension / script
```
internal webui scripts: 10000
built-in scripts: 30000
built-in extensions: 50000
extension: 70000
if for some reason it did not match any of the four categorie a order of 1000000 is assigned
```

### included bug fix
there's some strange behavior on of the original (current) script loading order
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/5e80d9ee99c5899e5e2b130408ffb65a0585a62a/modules/scripts.py#L368-L374 
base on comment message
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/64b7e8382377bb578d9740c061979776b214cfd9
to described behavior is `1st webui, 2nd extensions-builtin, 3rd extensions`
but in reality this code produces 
`1st built-in-scripts + webui, 2nd extensions, 3rd extensions-builtin`
in this PR it is corrected too the order described above in `defalt order when order is not specified`
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
