### PR TITLE
Fixes generation restart not working for some users when 'Ctrl+Enter' is pressed

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,9 +133,18 @@ document.addEventListener('keydown', function(e) {
     if (isEnter && isModifierKey) {
         if (interruptButton.style.display === 'block') {
             interruptButton.click();
-            setTimeout(function() {
-                generateButton.click();
-            }, 500);
+            const callback = (mutationList) => {
+                for (const mutation of mutationList) {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                        if (interruptButton.style.display === 'none') {
+                            generateButton.click();
+                            observer.disconnect();
+                        }
+                    }
+                }
+            };
+            const observer = new MutationObserver(callback);
+            observer.observe(interruptButton, {attributes: true});
         } else {
             generateButton.click();
         }


### PR DESCRIPTION
## Description

[As you expected](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13644#issuecomment-1763358262), a delay of 500 ms may not be enough. In my case it is.

I suggest using `MutationObserver` instead of `setTimeout` to observe the 'Interrupt' button state.

The required delay time may be different for some users, but pressing the 'Generate' button depending on the 'Interrupt' state triggers accurately.

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/44464226/c6cc3ce8-9ec3-4844-ba93-e5f49d5d7432

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
