### PR TITLE
Adds 'Path' sorting for Extra network cards

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -235,7 +235,7 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
     "extra_networks_card_height": OptionInfo(0, "Card height for Extra Networks").info("in pixels"),
     "extra_networks_card_text_scale": OptionInfo(1.0, "Card text scale", gr.Slider, {"minimum": 0.0, "maximum": 2.0, "step": 0.01}).info("1 = original size"),
     "extra_networks_card_show_desc": OptionInfo(True, "Show description on card"),
-    "extra_networks_card_order_field": OptionInfo("Name", "Default order field for Extra Networks cards", gr.Dropdown, {"choices": ['Name', 'Date Created', 'Date Modified']}).needs_reload_ui(),
+    "extra_networks_card_order_field": OptionInfo("Path", "Default order field for Extra Networks cards", gr.Dropdown, {"choices": ['Path', 'Name', 'Date Created', 'Date Modified']}).needs_reload_ui(),
     "extra_networks_card_order": OptionInfo("Ascending", "Default order for Extra Networks cards", gr.Dropdown, {"choices": ['Ascending', 'Descending']}).needs_reload_ui(),
     "extra_networks_add_text_separator": OptionInfo(" ", "Extra networks separator").info("extra text to add before <...> when adding extra network to prompt"),
     "ui_extra_networks_tab_reorder": OptionInfo("", "Extra networks tab order").needs_reload_ui(),

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -279,6 +279,7 @@ class ExtraNetworksPage:
             "date_created": int(stat.st_ctime or 0),
             "date_modified": int(stat.st_mtime or 0),
             "name": pth.name.lower(),
+            "path": str(pth.parent).lower(),
         }
 
     def find_preview(self, path):
@@ -382,7 +383,7 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
             related_tabs.append(tab)
 
     edit_search = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", elem_classes="search", placeholder="Search...", visible=False, interactive=True)
-    dropdown_sort = gr.Dropdown(choices=['Name', 'Date Created', 'Date Modified', ], value=shared.opts.extra_networks_card_order_field, elem_id=tabname+"_extra_sort", elem_classes="sort", multiselect=False, visible=False, show_label=False, interactive=True, label=tabname+"_extra_sort_order")
+    dropdown_sort = gr.Dropdown(choices=['Path', 'Name', 'Date Created', 'Date Modified', ], value=shared.opts.extra_networks_card_order_field, elem_id=tabname+"_extra_sort", elem_classes="sort", multiselect=False, visible=False, show_label=False, interactive=True, label=tabname+"_extra_sort_order")
     button_sortorder = ToolButton(switch_values_symbol, elem_id=tabname+"_extra_sortorder", elem_classes=["sortorder"] + ([] if shared.opts.extra_networks_card_order == "Ascending" else ["sortReverse"]), visible=False, tooltip="Invert sort order")
     button_refresh = gr.Button('Refresh', elem_id=tabname+"_extra_refresh", visible=False)
     checkbox_show_dirs = gr.Checkbox(True, label='Show dirs', elem_id=tabname+"_extra_show_dirs", elem_classes="show-dirs", visible=False)


### PR DESCRIPTION
## Description

_Sorry for re-creating the PR, but I messed up with commits in my fork and created a new one from scratch :)_

Related commit: [`d9499f4`](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/d9499f4301018ebd2977685d098381aa4111d2ae)

Sorting by "Name" does not take into account nested directories if loras are placed in them. When there are a lot of loras, the "Path" sorting makes it convenient to control their display order in the "all" subdir tab using directory naming.

For example, after the loras in the root directory, I need the "all" tab to display the loras from the "Tweaks" subdir first, then "Style", and finally "Character". I name these subdirs appropriately and get the result I want. Sorting by "Name" sends character loras to the top of the list for obvious reasons. Organizing directories loses its meaning.

Using subdir tabs is not always handy, because when you change tab, for example, from "Lora" to "Checkpoints" you have to click them every time to change the "Search" value. It is easier to organize the cards displaying order using directory names once, and use the subdir tabs as needed.

Also, sorting by "Path" now works correctly for "Textual Inversions" too. Before that, the "Default Sort" worked there in a similar way with "Name".

## Screenshots/videos:

![Files structure](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/44464226/e5464e4f-d8c1-4e7b-a28a-d26a5a87c9aa)
![Sort by Path](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/44464226/c5b99cdd-34af-4c91-94f6-fdb5dc433382)
![Sort by Name](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/44464226/35cb213d-397b-4867-bece-6e21c41ad8be)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)