### PR TITLE
Hotfix: call shared.state.end() after postprocessing done

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -78,7 +78,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         image_data.close()
 
     devices.torch_gc()
-
+    shared.state.end()
     return outputs, ui_common.plaintext_to_html(infotext), ''
 
 


### PR DESCRIPTION
## Description

The shared.state.end() was missing in `modules/postprocessing.py`.

This will result the invalid API response as result after the job is done:
```
{'progress': 0.01,
 'eta_relative': 8755.73311328888,
 'state': {'skipped': False,
  'interrupted': False,
  'job': 'CodeFormer',
  'job_count': -1,
  'job_timestamp': '20231115141010',
  'job_no': 0,
  'sampling_step': 0,
  'sampling_steps': 20},
 'current_image': None,
 'textinfo': None}
```


The related test should be added to check API status.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
