### PR TITLE
feat: fix randn found element of type float at pos 2

### DIFF
--- a/modules/rng.py
+++ b/modules/rng.py
@@ -110,7 +110,7 @@ class ImageRNG:
         self.is_first = True
 
     def first(self):
-        noise_shape = self.shape if self.seed_resize_from_h <= 0 or self.seed_resize_from_w <= 0 else (self.shape[0], self.seed_resize_from_h // 8, self.seed_resize_from_w // 8)
+        noise_shape = self.shape if self.seed_resize_from_h <= 0 or self.seed_resize_from_w <= 0 else (self.shape[0], int(self.seed_resize_from_h) // 8, int(self.seed_resize_from_w // 8))
 
         xs = []
 


### PR DESCRIPTION
## Description

The values passed from gradio's components here are always of the float type, which results in the outcomes of `self.seed_resize_from_h // 8` and `self.seed_resize_from_w // 8` being float values that merely appear to be integers. This can cause issues at the following location:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/rng.py#L61

`TypeError: randn(): argument 'size' must be tuple of ints, but found element of type float at pos 2`

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/rng.py#L142

`TypeError: slice indices must be integers or None or have an __index__ method`


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
