### PR TITLE
Option to show batch img2img results in UI

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -189,6 +189,7 @@ options_templates.update(options_section(('img2img', "img2img"), {
     "img2img_inpaint_sketch_default_brush_color": OptionInfo("#ffffff", "Inpaint sketch initial brush color", ui_components.FormColorPicker, {}).info("default brush color of img2img inpaint sketch").needs_reload_ui(),
     "return_mask": OptionInfo(False, "For inpainting, include the greyscale mask in results for web"),
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
+    "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations"), {


### PR DESCRIPTION
## Description
add settings `Settings > img2img > Show the first N batch img2img results in UI`
this option allows the user to control the amount of images to return to the UI when performing batch img2img
images up to is it amount will be shown when performing batch img2img, this prevents webui from trying to display too many images and having to keep them all in memory

this is similar to how extras tab have an option to show resulting image
I've only noticed that there's no option to do this because there was an extension submission
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/231

from my testing gen info should be correct
and should works with script, tested with XYZ grid

### default set to 32 images
set 0 to disable, -1 for unlimited

## Screenshots/videos
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f6cc2bd5-92d0-4b09-bc9a-d92154f4c665)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c81c0f2a-714b-453e-a2b9-7dcc0283d60e)

<details><summary>outdated</summary>
<p>

add option to show batch img2img results in UI, default disabled
> user can be set to default  enabled `ui-config / Default system`

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/caf1da36-975b-4277-ac31-1d416f149c77)

</p>
</details> 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
