### PR TITLE
save sysinfo as .json

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -441,7 +441,7 @@ def dump_sysinfo():
     import datetime
 
     text = sysinfo.get()
-    filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.txt"
+    filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
 
     with open(filename, "w", encoding="utf8") as file:
         file.write(text)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1308,7 +1308,7 @@ def setup_ui_api(app):
         from fastapi.responses import PlainTextResponse
 
         text = sysinfo.get()
-        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.txt"
+        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
 
         return PlainTextResponse(text, headers={'Content-Disposition': f'{"attachment" if attachment else "inline"}; filename="{filename}"'})
 


### PR DESCRIPTION
## Description
Change the fire extension of sysinfo to `.json`

GitHub now allows uploading of .json files in issues
[sysinfo-yyyy-mm-dd-hh-mm.json](https://github.com/AUTOMATIC1111/stable-diffusion-webui/files/13403858/sysinfo-yyyy-mm-dd-hh-mm.json)

> my previous PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12980

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
