### PR TITLE
Add FP32 fallback support on sd_vae_approx

### DIFF
--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from typing import Optional, List
 from torch import Tensor
 import platform
 from modules.sd_hijack_utils import CondFunc

--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -1,6 +1,8 @@
 import logging
 
 import torch
+from typing import Optional, List
+from torch import Tensor
 import platform
 from modules.sd_hijack_utils import CondFunc
 from packaging import version
@@ -51,6 +53,17 @@ def cumsum_fix(input, cumsum_func, *args, **kwargs):
     return cumsum_func(input, *args, **kwargs)
 
 
+# MPS workaround for https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14046
+def interpolate_with_fp32_fallback(orig_func, *args, **kwargs) -> Tensor:
+    try:
+        return orig_func(*args, **kwargs)
+    except RuntimeError as e:
+        if "not implemented for" in str(e) and "Half" in str(e):
+            input_tensor = args[0]
+            return orig_func(input_tensor.to(torch.float32), *args[1:], **kwargs).to(input_tensor.dtype)
+        else:
+            print(f"An unexpected RuntimeError occurred: {str(e)}")
+
 if has_mps:
     if platform.mac_ver()[0].startswith("13.2."):
         # MPS workaround for https://github.com/pytorch/pytorch/issues/95188, thanks to danieldk (https://github.com/explosion/curated-transformers/pull/124)
@@ -76,6 +89,9 @@ if has_mps:
 
         # MPS workaround for https://github.com/pytorch/pytorch/issues/96113
         CondFunc('torch.nn.functional.layer_norm', lambda orig_func, x, normalized_shape, weight, bias, eps, **kwargs: orig_func(x.float(), normalized_shape, weight.float() if weight is not None else None, bias.float() if bias is not None else bias, eps).to(x.dtype), lambda _, input, *args, **kwargs: len(args) == 4 and input.device.type == 'mps')
+
+        # MPS workaround for https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14046
+        CondFunc('torch.nn.functional.interpolate', interpolate_with_fp32_fallback, None)
 
         # MPS workaround for https://github.com/pytorch/pytorch/issues/92311
         if platform.processor() == 'i386':

--- a/modules/sd_vae_approx.py
+++ b/modules/sd_vae_approx.py
@@ -21,7 +21,13 @@ class VAEApprox(nn.Module):
 
     def forward(self, x):
         extra = 11
-        x = nn.functional.interpolate(x, (x.shape[2] * 2, x.shape[3] * 2))
+        try:
+            x = nn.functional.interpolate(x, (x.shape[2] * 2, x.shape[3] * 2))
+        except RuntimeError as e:
+            if "not implemented for" in str(e) and "Half" in str(e):
+                x = nn.functional.interpolate(x.to(torch.float32), (x.shape[2] * 2, x.shape[3] * 2)).to(x.dtype)
+            else:
+                print(f"An unexpected RuntimeError occurred: {str(e)}")
         x = nn.functional.pad(x, (extra, extra, extra, extra))
 
         for layer in [self.conv1, self.conv2, self.conv3, self.conv4, self.conv5, self.conv6, self.conv7, self.conv8, ]:

--- a/modules/sd_vae_approx.py
+++ b/modules/sd_vae_approx.py
@@ -21,13 +21,7 @@ class VAEApprox(nn.Module):
 
     def forward(self, x):
         extra = 11
-        try:
-            x = nn.functional.interpolate(x, (x.shape[2] * 2, x.shape[3] * 2))
-        except RuntimeError as e:
-            if "not implemented for" in str(e) and "Half" in str(e):
-                x = nn.functional.interpolate(x.to(torch.float32), (x.shape[2] * 2, x.shape[3] * 2)).to(x.dtype)
-            else:
-                print(f"An unexpected RuntimeError occurred: {str(e)}")
+        x = nn.functional.interpolate(x, (x.shape[2] * 2, x.shape[3] * 2))
         x = nn.functional.pad(x, (extra, extra, extra, extra))
 
         for layer in [self.conv1, self.conv2, self.conv3, self.conv4, self.conv5, self.conv6, self.conv7, self.conv8, ]:


### PR DESCRIPTION
## Description

Add FP32 fallback support on sd_vae_approx

This tries to execute interpolate with FP32 if it failed.

Background is that
on some environment such as Mx chip MacOS devices, we get error as follows:

```
"torch/nn/functional.py", line 3931, in interpolate
        return torch._C._nn.upsample_nearest2d(input, output_size, scale_factors)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    RuntimeError: "upsample_nearest2d_channels_last" not implemented for 'Half'
```

In this case, ```--no-half``` doesn't help to solve. Therefore this commits add the FP32 fallback execution to solve it.

Note that the submodule may require additional modifications. The following is the example modification on the other submodule.

```repositories/stable-diffusion-stability-ai/ldm/modules/diffusionmodules/openaimodel.py

class Upsample(nn.Module):
..snip..
    def forward(self, x):
        assert x.shape[1] == self.channels
        if self.dims == 3:
            x = F.interpolate(
                x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode="nearest"
            )
        else:
            try:
                x = F.interpolate(x, scale_factor=2, mode="nearest")
            except:
                x = F.interpolate(x.to(th.float32), scale_factor=2, mode="nearest").to(x.dtype)
        if self.use_conv:
            x = self.conv(x)
        return x
..snip..
```

You can see the FP32 fallback execution as same as sd_vae_approx.py.

## Confirmed environment

* ```uname -a``` : ```Darwin m2mba.local 21.6.0 Darwin Kernel Version 21.6.0: Wed Oct  4 23:56:03 PDT 2023; root:xnu-8020.240.18.704.15~1/RELEASE_ARM64_T8110 arm64```
* ```python3 --version``` : ```Python 3.11.4```
* ```print(torch.__version__)``` : ```2.0.1```
* ```print(torch.backends.mps.is_available() )``` : ```True```


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
       * this is targetted to dev branch
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
        * No lint error on my modified part
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
        * No new error on my modified part
