### PR TITLE
use extension name for determining an extension is installed in the index

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -452,6 +452,7 @@ def get_date(info: dict, key):
 def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text=""):
     extlist = available_extensions["extensions"]
     installed_extensions = {extension.name for extension in extensions.extensions}
+    installed_extension_urls = {normalize_git_url(extension.remote) for extension in extensions.extensions if extension.remote is not None}
 
     tags = available_extensions.get("tags", {})
     tags_to_hide = set(hide_tags)
@@ -484,7 +485,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         if url is None:
             continue
 
-        existing = get_extension_dirname_from_url(url) in installed_extensions
+        existing = get_extension_dirname_from_url(url) in installed_extensions or normalize_git_url(url) in installed_extension_urls
         extension_tags = extension_tags + ["installed"] if existing else extension_tags
 
         if any(x for x in extension_tags if x in tags_to_hide):

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -335,6 +335,11 @@ def normalize_git_url(url):
     return url
 
 
+def get_extension_dirname_from_url(url):
+    *parts, last_part = url.split('/')
+    return normalize_git_url(last_part)
+
+
 def install_extension_from_url(dirname, url, branch_name=None):
     check_access()
 
@@ -346,10 +351,7 @@ def install_extension_from_url(dirname, url, branch_name=None):
     assert url, 'No URL specified'
 
     if dirname is None or dirname == "":
-        *parts, last_part = url.split('/')
-        last_part = normalize_git_url(last_part)
-
-        dirname = last_part
+        dirname = get_extension_dirname_from_url(url)
 
     target_dir = os.path.join(extensions.extensions_dir, dirname)
     assert not os.path.exists(target_dir), f'Extension directory already exists: {target_dir}'
@@ -449,7 +451,7 @@ def get_date(info: dict, key):
 
 def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text=""):
     extlist = available_extensions["extensions"]
-    installed_extension_urls = {normalize_git_url(extension.remote): extension.name for extension in extensions.extensions}
+    installed_extensions = {extension.name for extension in extensions.extensions}
 
     tags = available_extensions.get("tags", {})
     tags_to_hide = set(hide_tags)
@@ -482,7 +484,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
         if url is None:
             continue
 
-        existing = installed_extension_urls.get(normalize_git_url(url), None)
+        existing = get_extension_dirname_from_url(url) in installed_extensions
         extension_tags = extension_tags + ["installed"] if existing else extension_tags
 
         if any(x for x in extension_tags if x in tags_to_hide):


### PR DESCRIPTION
## Rationale behind this change

* If users are using `insteadOf` git config directive, the entire `installed` tag will bork as no remote url will match that in the index.
* Even though with the situation where the remote url may be different for an already installed extension (forks), users are expected to fail later for `AssertionError: Extension directory already exists`
* The original implementation, however, does cover the case where an extension is installed with a non-default folder name. But most of these cases are unlikely to have git enabled (say "Download ZIP") so there will be no `remote` field anyway.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
