### PR TITLE
Move exception_records related methods to errors.py

### DIFF
--- a/modules/errors.py
+++ b/modules/errors.py
@@ -6,6 +6,21 @@ import traceback
 exception_records = []
 
 
+def format_traceback(tb):
+    return [[f"{x.filename}, line {x.lineno}, {x.name}", x.line] for x in traceback.extract_tb(tb)]
+
+
+def format_exception(e, tb):
+    return {"exception": str(e), "traceback": format_traceback(tb)}
+
+
+def get_exceptions():
+    try:
+        return list(reversed(exception_records))
+    except Exception as e:
+        return str(e)
+
+
 def record_exception():
     _, e, tb = sys.exc_info()
     if e is None:
@@ -14,8 +29,7 @@ def record_exception():
     if exception_records and exception_records[-1] == e:
         return
 
-    from modules import sysinfo
-    exception_records.append(sysinfo.format_exception(e, tb))
+    exception_records.append(format_exception(e, tb))
 
     if len(exception_records) > 5:
         exception_records.pop(0)

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -85,7 +85,7 @@ def get_dict():
         "Checksum": checksum_token,
         "Commandline": sys.argv,
         "Torch env info": get_torch_sysinfo(),
-        "Exceptions": get_exceptions(),
+        "Exceptions": errors.get_exceptions(),
         "CPU": {
             "model": platform.processor(),
             "count logical": psutil.cpu_count(logical=True),
@@ -103,21 +103,6 @@ def get_dict():
     }
 
     return res
-
-
-def format_traceback(tb):
-    return [[f"{x.filename}, line {x.lineno}, {x.name}", x.line] for x in traceback.extract_tb(tb)]
-
-
-def format_exception(e, tb):
-    return {"exception": str(e), "traceback": format_traceback(tb)}
-
-
-def get_exceptions():
-    try:
-        return list(reversed(errors.exception_records))
-    except Exception as e:
-        return str(e)
 
 
 def get_environment():

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-import traceback
 
 import platform
 import hashlib


### PR DESCRIPTION
## Description

* Move exception_records related methods to errors.py
* Putting all getters and setters of a file into another file makes no sense and would cause problems
* Fixes circular dependency problem when errors happen in shared.py

## Screenshots/videos:
![639df9b4f3f2af2cd2db1cfe28356f91](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/2220320/7c8df78f-635c-4c3e-8221-833f7ffd31cf)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
