### PR TITLE
json.dump(ensure_ascii=False)

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -32,7 +32,7 @@ def dump_cache():
         with cache_lock:
             cache_filename_tmp = cache_filename + "-"
             with open(cache_filename_tmp, "w", encoding="utf8") as file:
-                json.dump(cache_data, file, indent=4)
+                json.dump(cache_data, file, indent=4, ensure_ascii=False)
 
             os.replace(cache_filename_tmp, cache_filename)
 

--- a/modules/options.py
+++ b/modules/options.py
@@ -158,7 +158,7 @@ class Options:
         assert not cmd_opts.freeze_settings, "saving settings is disabled"
 
         with open(filename, "w", encoding="utf8") as file:
-            json.dump(self.data, file, indent=4)
+            json.dump(self.data, file, indent=4, ensure_ascii=False)
 
     def same_type(self, x, y):
         if x is None or y is None:

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -65,7 +65,7 @@ def save_config_state(name):
     filename = os.path.join(config_states_dir, f"{timestamp}_{name}.json")
     print(f"Saving backup of webui/extension state to {filename}.")
     with open(filename, "w", encoding="utf-8") as f:
-        json.dump(current_config_state, f, indent=4)
+        json.dump(current_config_state, f, indent=4, ensure_ascii=False)
     config_states.list_config_states()
     new_value = next(iter(config_states.all_config_states.keys()), "Current")
     new_choices = ["Current"] + list(config_states.all_config_states.keys())

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -134,7 +134,7 @@ class UserMetadataEditor:
         basename, ext = os.path.splitext(filename)
 
         with open(basename + '.json', "w", encoding="utf8") as file:
-            json.dump(metadata, file, indent=4)
+            json.dump(metadata, file, indent=4, ensure_ascii=False)
 
     def save_user_metadata(self, name, desc, notes):
         user_metadata = self.get_user_metadata(name)

--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -141,7 +141,7 @@ class UiLoadsave:
 
     def write_to_file(self, current_ui_settings):
         with open(self.filename, "w", encoding="utf8") as file:
-            json.dump(current_ui_settings, file, indent=4)
+            json.dump(current_ui_settings, file, indent=4, ensure_ascii=False)
 
     def dump_defaults(self):
         """saves default values to a file unless tjhe file is present and there was an error loading default values at start"""


### PR DESCRIPTION
## Description
`json.dump(ensure_ascii=False)` for `lora metadata` `config` `cache.json` `ui-config`  `config_states`
improve readability especially useful for non English users

example lora metadata
from this
```json
{
    "description": "",
    "sd version": "SD1",
    "activation text": "",
    "preferred weight": 0.5,
    "notes": "\u9019\u662f\u500b\u6e2c\u8a66"
}
```
to this
```json
{
    "description": "",
    "sd version": "SD1",
    "activation text": "",
    "preferred weight": 0.5,
    "notes": "這是個測試"
}
```
## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
