### PR TITLE
add Block component creation callback

### DIFF
--- a/modules/gradio_extensons.py
+++ b/modules/gradio_extensons.py
@@ -47,9 +47,19 @@ def Block_get_config(self):
 
 
 def BlockContext_init(self, *args, **kwargs):
+    if scripts.scripts_current is not None:
+        scripts.scripts_current.before_component(self, **kwargs)
+
+    scripts.script_callbacks.before_component_callback(self, **kwargs)
+
     res = original_BlockContext_init(self, *args, **kwargs)
 
     add_classes_to_gradio_component(self)
+
+    scripts.script_callbacks.after_component_callback(self, **kwargs)
+
+    if scripts.scripts_current is not None:
+        scripts.scripts_current.after_component(self, **kwargs)
 
     return res
 


### PR DESCRIPTION
## Description

allow insert components using `on_before/after_component_elem_id` or `before/after_component` from extensions to before / after a `Block`
this is not previously possible because the callback is not called for Blocks
this PR allows this

<details><summary>Example</summary>
<p>

insert befor and after `txt2img_hires_fix_row4`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/f0f100e67b78f686dc73cf3c8cad422e45cc9b8a/modules/ui.py#L333


insert hear
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/50e5580a-2090-48d4-8551-d9d31e9edec1)

like so

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/e87c7267-141f-4c9a-b9dd-0406c0e5188b)

<details><summary>Demo extention script
</summary>
<p>

```py
from modules import scripts
import gradio as gr


class Script(scripts.Script):
    before_cb = None
    after_cb = None
    
    def title(self):
        return "block insert component demo"

    def show(self, is_img2img):
        if not is_img2img:
            self.on_before_component_elem_id = [
                ('txt2img_hires_fix_row4', self.before_hires_fix_extended_ui),
            ]
            self.on_after_component_elem_id = [
                ('txt2img_hires_fix_row4', self.after_hires_fix_extended_ui),
            ]
            return scripts.AlwaysVisible

    def ui(self, is_img2img):
        if self.before_cb and self.after_cb:
            return [self.before_cb, self.after_cb]

    def before_process(self, p, *args):
        print(*args)

    def before_hires_fix_extended_ui(self, *args, **kwargs):
        with gr.Accordion(label='Before'):
            self.before_cb = gr.Checkbox(label='Before Checkbox')

    def after_hires_fix_extended_ui(self, *args, **kwargs):
        with gr.Accordion(label='After'):
            self.after_cb = gr.Checkbox(label='After Checkbox')

```

</p>
</details> 

</p>
</details> 




## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
