### PR TITLE
catch uncaught exception with ui creation scripts

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -570,40 +570,44 @@ class ScriptRunner:
         if controls is None:
             return
 
-        script.name = wrap_call(script.title, script.filename, "title", default=script.filename).lower()
-        api_args = []
+        try:
+            script.name = wrap_call(script.title, script.filename, "title", default=script.filename).lower()
+            api_args = []
 
-        for control in controls:
-            control.custom_script_source = os.path.basename(script.filename)
+            for control in controls:
+                control.custom_script_source = os.path.basename(script.filename)
 
-            arg_info = api_models.ScriptArg(label=control.label or "")
+                arg_info = api_models.ScriptArg(label=control.label or "")
 
-            for field in ("value", "minimum", "maximum", "step"):
-                v = getattr(control, field, None)
-                if v is not None:
-                    setattr(arg_info, field, v)
+                for field in ("value", "minimum", "maximum", "step"):
+                    v = getattr(control, field, None)
+                    if v is not None:
+                        setattr(arg_info, field, v)
 
-            choices = getattr(control, 'choices', None)  # as of gradio 3.41, some items in choices are strings, and some are tuples where the first elem is the string
-            if choices is not None:
-                arg_info.choices = [x[0] if isinstance(x, tuple) else x for x in choices]
+                choices = getattr(control, 'choices', None)  # as of gradio 3.41, some items in choices are strings, and some are tuples where the first elem is the string
+                if choices is not None:
+                    arg_info.choices = [x[0] if isinstance(x, tuple) else x for x in choices]
 
-            api_args.append(arg_info)
+                api_args.append(arg_info)
 
-        script.api_info = api_models.ScriptInfo(
-            name=script.name,
-            is_img2img=script.is_img2img,
-            is_alwayson=script.alwayson,
-            args=api_args,
-        )
+            script.api_info = api_models.ScriptInfo(
+                name=script.name,
+                is_img2img=script.is_img2img,
+                is_alwayson=script.alwayson,
+                args=api_args,
+            )
 
-        if script.infotext_fields is not None:
-            self.infotext_fields += script.infotext_fields
+            if script.infotext_fields is not None:
+                self.infotext_fields += script.infotext_fields
 
-        if script.paste_field_names is not None:
-            self.paste_field_names += script.paste_field_names
+            if script.paste_field_names is not None:
+                self.paste_field_names += script.paste_field_names
 
-        self.inputs += controls
-        script.args_to = len(self.inputs)
+            self.inputs += controls
+            script.args_to = len(self.inputs)
+
+        except Exception:
+            errors.report(f"Error creating UI for {script.name}: ", exc_info=True)
 
     def setup_ui_for_section(self, section, scriptlist=None):
         if scriptlist is None:


### PR DESCRIPTION
prevent total webui crash

```py
from modules import scripts


class Script(scripts.Script):
    def title(self):
        return None  # if someone really messed up

    def show(self, is_img2img):
        return scripts.AlwaysVisible

    def ui(self, is_img2img):
        # for whatever reason a None object is return inplace of a UI element
        return [None]

```
a situation like this can happen due to a messed up extension update
as webui crashed on startup the average user may not be able to disable the offending extension

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
