### PR TITLE
Update devices.py - Make 'use-cpu all' actually apply to 'all'

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -38,7 +38,7 @@ def get_optimal_device():
 
 
 def get_device_for(task):
-    if task in shared.cmd_opts.use_cpu:
+    if task in shared.cmd_opts.use_cpu or "all" in shared.cmd_opts.use_cpu:
         return cpu
 
     return get_optimal_device()


### PR DESCRIPTION

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

fixes issue where "--use-cpu all" properly makes SD run on CPU but leaves ControlNet (and other extensions, I presume) pointed at GPU, causing a crash in ControlNet caused by a mismatch between devices between SD and CN. This change would make all calls to get_device_for(task) return cpu when using "--use-cpu all" as an argument. This is on the assumption that "all" is meant to point everything to the CPU but I might have misunderstood the intent of the argument.

Should fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14097 and https://github.com/Mikubill/sd-webui-controlnet/issues/2247

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

```
test/test_extras.py::test_simple_upscaling_performed PASSED                                                                                                                                                                    [  3%]
test/test_extras.py::test_png_info_performed PASSED                                                                                                                                                                            [  6%]
test/test_extras.py::test_interrogate_performed PASSED                                                                                                                                                                         [ 10%]
test/test_img2img.py::test_img2img_simple_performed PASSED                                                                                                                                                                     [ 13%]
test/test_img2img.py::test_inpainting_masked_performed PASSED                                                                                                                                                                  [ 17%]
test/test_img2img.py::test_inpainting_with_inverted_masked_performed PASSED                                                                                                                                                    [ 20%]
test/test_img2img.py::test_img2img_sd_upscale_performed PASSED                                                                                                                                                                 [ 24%]
test/test_txt2img.py::test_txt2img_simple_performed PASSED                                                                                                                                                                     [ 27%]
test/test_txt2img.py::test_txt2img_with_negative_prompt_performed PASSED                                                                                                                                                       [ 31%]
test/test_txt2img.py::test_txt2img_with_complex_prompt_performed PASSED                                                                                                                                                        [ 34%]
test/test_txt2img.py::test_txt2img_not_square_image_performed PASSED                                                                                                                                                           [ 37%]
test/test_txt2img.py::test_txt2img_with_hrfix_performed PASSED                                                                                                                                                                 [ 41%]
test/test_txt2img.py::test_txt2img_with_tiling_performed PASSED                                                                                                                                                                [ 44%]
test/test_txt2img.py::test_txt2img_with_restore_faces_performed PASSED                                                                                                                                                         [ 48%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[PLMS] PASSED                                                                                                                                                 [ 51%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[DDIM] PASSED                                                                                                                                                 [ 55%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[UniPC] PASSED                                                                                                                                                [ 58%]
test/test_txt2img.py::test_txt2img_multiple_batches_performed PASSED                                                                                                                                                           [ 62%]
test/test_txt2img.py::test_txt2img_batch_performed PASSED                                                                                                                                                                      [ 65%]
test/test_utils.py::test_options_write PASSED                                                                                                                                                                                  [ 68%]
test/test_utils.py::test_get_api_url[sdapi/v1/cmd-flags] PASSED                                                                                                                                                                [ 72%]
test/test_utils.py::test_get_api_url[sdapi/v1/samplers] PASSED                                                                                                                                                                 [ 75%]
test/test_utils.py::test_get_api_url[sdapi/v1/upscalers] PASSED                                                                                                                                                                [ 79%]
test/test_utils.py::test_get_api_url[sdapi/v1/sd-models] PASSED                                                                                                                                                                [ 82%]
test/test_utils.py::test_get_api_url[sdapi/v1/hypernetworks] PASSED                                                                                                                                                            [ 86%]
test/test_utils.py::test_get_api_url[sdapi/v1/face-restorers] PASSED                                                                                                                                                           [ 89%]
test/test_utils.py::test_get_api_url[sdapi/v1/realesrgan-models] PASSED                                                                                                                                                        [ 93%]
test/test_utils.py::test_get_api_url[sdapi/v1/prompt-styles] PASSED                                                                                                                                                            [ 96%]
test/test_utils.py::test_get_api_url[sdapi/v1/embeddings] PASSED                                                                                                                                                               [100%]

================================================================================================== 29 passed in 120.32s (0:02:00) ===================================================================================================
```
