### PR TITLE
fix not able to exit metadata popup when pop up is too big

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -392,3 +392,9 @@ function extraNetworksRefreshSingleCard(page, tabname, name) {
         }
     });
 }
+
+window.addEventListener("keydown", function(event) {
+    if (event.key == "Escape") {
+        closePopup();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -646,6 +646,8 @@ table.popup-table .link{
     margin: auto;
     padding: 2em;
     z-index: 1001;
+    max-height: 90%;
+    max-width: 90%;
 }
 
 /* fullpage image viewer */


### PR DESCRIPTION
## Description

sometime the extra network cards metadata pop up can be too big as to take up the entire screen
when this happened it is not possible to exit the metadata pop up

solution
add `max-height: 90%;`  and `max-width: 90%;` `.global-popup-inner` 
this prevents the pop-up from being too big as to making exiting the pop-up impossible

> this is what I came up with using my limited web development knowledge

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/96a6f11b-b449-4f90-93bf-68d1be50ba65

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
