### PR TITLE
Update launch_utils.py - fixes repetead package reinstalls

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -120,12 +120,12 @@ def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_
 
 def is_installed(package):
     try:
-    	dist = importlib.metadata.distribution(package)
+        dist = importlib.metadata.distribution(package)
     except importlib.metadata.PackageNotFoundError:
-        try: 
+        try:
             spec = importlib.util.find_spec(package)
         except ModuleNotFoundError:
-    	    return False
+            return False
 
         return spec is not None
 

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 import importlib.util
+import importlib.metadata
 import platform
 import json
 from functools import lru_cache
@@ -119,11 +120,16 @@ def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_
 
 def is_installed(package):
     try:
-        spec = importlib.util.find_spec(package)
-    except ModuleNotFoundError:
-        return False
+    	dist = importlib.metadata.distribution(package)
+    except importlib.metadata.PackageNotFoundError:
+        try: 
+            spec = importlib.util.find_spec(package)
+        except ModuleNotFoundError:
+    	    return False
 
-    return spec is not None
+        return spec is not None
+
+    return dist is not None
 
 
 def repo_dir(name):


### PR DESCRIPTION
## Description

Fixes failing dependency checks for extensions having a different package name and import name (for example **ffmpeg-python** / **ffmpeg**), which currently is causing the unneeded reinstall of packages at runtime.

In fact with the current code, the same string is used when installing a package and when checking for its presence, as you can see in the following example:

```python 
launch_utils.run_pip("install ffmpeg-python", "required package");
```
> [ Installing required package: "ffmpeg-python" ... ] [ Installed ]

```python 
launch_utils.is_installed("ffmpeg-python");
```
> False

...which would actually return true with:

```python
launch_utils.is_installed("ffmpeg");
```
> True

This PR modifies **is_installed()** from `launch_utils.py` so that it correctly confirms that a package is installed by returning a valid metadata object when passed the import name of an installed module, like this:

```python
pkg_metadata = importlib.metadata.distribution(mod_name);
```
> <importlib.metadata.PathDistribution object at 0x7fe14698a290>

I've been using this for a couple of months now, without noticing any issues at all (as documented by https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13487)

In case the above method fails, the code tries validating for package existence using the previous method... which if IIRC was still useful in some specific conditions...

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)