### PR TITLE
#13354 - Fix Lora loading

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -151,7 +151,11 @@ def load_network(name, network_on_disk):
     matched_networks = {}
 
     for key_network, weight in sd.items():
-        key_network_without_network_parts, network_part = key_network.split(".", 1)
+        if "." in key_network:
+            key_network_without_network_parts, network_part = key_network.split(".", 1)
+        else:
+            key_network_without_network_parts = key_network
+            network_part = None
 
         key = convert_diffusers_name_to_compvis(key_network_without_network_parts, is_sd2)
         sd_module = shared.sd_model.network_layer_mapping.get(key, None)


### PR DESCRIPTION
## Description

* Properly loading a LORA

* The variable key_network gets values like below. There are some values have no dot ., because those values are top level properties. if key_network gets top level properties, it substitute into the variable key_network_without_network_parts .

*  #13354

## Screenshots/videos:


## Checklist:

- [x ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
