### PR TITLE
remove clean_text()

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -2,7 +2,6 @@ import csv
 import fnmatch
 import os
 import os.path
-import re
 import typing
 import shutil
 
@@ -12,22 +11,6 @@ class PromptStyle(typing.NamedTuple):
     prompt: str
     negative_prompt: str
     path: str = None
-
-
-def clean_text(text: str) -> str:
-    """
-    Iterating through a list of regular expressions and replacement strings, we
-    clean up the prompt and style text to make it easier to match against each
-    other.
-    """
-    re_list = [
-        ("multiple commas", re.compile("(,+\s+)+,?"), ", "),
-        ("multiple spaces", re.compile("\s{2,}"), " "),
-    ]
-    for _, regex, replace in re_list:
-        text = regex.sub(replace, text)
-
-    return text.strip(", ")
 
 
 def merge_prompts(style_prompt: str, prompt: str) -> str:
@@ -44,7 +27,7 @@ def apply_styles_to_prompt(prompt, styles):
     for style in styles:
         prompt = merge_prompts(style, prompt)
 
-    return clean_text(prompt)
+    return prompt
 
 
 def unwrap_style_text_from_prompt(style_text, prompt):
@@ -56,8 +39,8 @@ def unwrap_style_text_from_prompt(style_text, prompt):
     Note that the "cleaned" version of the style text is only used for matching
     purposes here. It isn't returned; the original style text is not modified.
     """
-    stripped_prompt = clean_text(prompt)
-    stripped_style_text = clean_text(style_text)
+    stripped_prompt = prompt
+    stripped_style_text = style_text
     if "{prompt}" in stripped_style_text:
         # Work out whether the prompt is wrapped in the style text. If so, we
         # return True and the "inner" prompt text that isn't part of the style.


### PR DESCRIPTION
## Description

@cjj1977

remove `clean_text()` introduce by https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14125 Allow use of mutiple styles csv files

### Reasons:
- this changes users from so that when they loads then later on it's different from what they initially typed

if a user's have a very complex prompt they may wish to separate it into different segments by using new line
`clean_text()` remove the possibility keepint the formatted prompt in geninfo

- may cause issues with extensions

it is possible some syntax or some future syntax may wish to use new line as determine, so this could have a potential of breaking currency syntax or limiting future syntax

> I remember someone mentioning the idea of commenting a entire line of prompt syntex , Auto rejected to the idea, because he didn't want to add too many syntax to the prompt, and I believe they're also extensions that achieve such a thing

- can't be seeds breaking in some cases

edge case  example
if prompt or negative prompt only consistent of spaces they will be removed and can cause issues

we should not do pump formatting they're already extensions that does as for those who wish
formatting should not be forced onto the user

### Request to be pushed to 1.7.0-RC

note I have not extensively test if removeing `clean_text()` would break `mutiple styles csv files`, but as far as I understand  `clean_text()` just makes it easier to match, which is more of a luxury and and not as important as the above reasons

and if this does break `mutiple styles csv files` then I suggest reverting `mutiple styles csv files` for the time being

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
