### PR TITLE
change state dict comparison to ref compare

### DIFF
--- a/modules/sd_disable_initialization.py
+++ b/modules/sd_disable_initialization.py
@@ -215,7 +215,7 @@ class LoadStateDictOnMeta(ReplaceHelper):
             would be on the meta device.
             """
 
-            if state_dict == sd:
+            if state_dict is sd:
                 state_dict = {k: v.to(device="meta", dtype=v.dtype) for k, v in state_dict.items()}
 
             original(module, state_dict, strict=strict)


### PR DESCRIPTION
## Description

This hopefully will fix this: 

```
  File "modules\sd_models.py", line 499, in get_sd_model
    load_model()
  File "modules\sd_models.py", line 626, in load_model
    load_model_weights(sd_model, checkpoint_info, state_dict, timer)
  File "modules\sd_models.py", line 409, in load_model_weights
    sd_vae.load_vae(model, vae_file, vae_source)
  File "modules\sd_vae.py", line 212, in load_vae
    _load_vae_dict(model, vae_dict_1)
  File "modules\sd_vae.py", line 239, in _load_vae_dict
    model.first_stage_model.load_state_dict(vae_dict_1)
  File "modules\sd_disable_initialization.py", line 223, in <lambda>
    module_load_state_dict = self.replace(torch.nn.Module, 'load_state_dict', lambda *args, **kwargs: load_state_dict(module_load_state_dict, *args, **kwargs))
  File "modules\sd_disable_initialization.py", line 218, in load_state_dict
    if state_dict == sd:
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

I have seen this constantly popping up on my radar while I have absolutely no idea why this happens and there is no issue nor discussion about this error here.

I haven't really check if this actually works / not breaking something else.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
