### PR TITLE
add option: Live preview in full page image viewer

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -34,7 +34,7 @@ function updateOnBackgroundChange() {
     if (modalImage && modalImage.offsetParent) {
         let currentButton = selected_gallery_button();
         let preview = gradioApp().querySelectorAll('.livePreview > img');
-        if (preview.length > 0) {
+        if (opts.js_live_preview_in_modal_lightbox && preview.length > 0) {
             // show preview image if available
             modalImage.src = preview[preview.length - 1].src;
         } else if (currentButton?.children?.length > 0 && modalImage.src != currentButton.children[0].src) {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -330,6 +330,7 @@ options_templates.update(options_section(('ui', "Live previews", "ui"), {
     "live_preview_content": OptionInfo("Prompt", "Live preview subject", gr.Radio, {"choices": ["Combined", "Prompt", "Negative prompt"]}),
     "live_preview_refresh_period": OptionInfo(1000, "Progressbar and preview update period").info("in milliseconds"),
     "live_preview_fast_interrupt": OptionInfo(False, "Return image with chosen live preview method on interrupt").info("makes interrupts faster"),
+    "js_live_preview_in_modal_lightbox": OptionInfo(True, "Show Live preview in full page image viewer"),
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters", "sd"), {


### PR DESCRIPTION
- feature request: https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/14213 Option for Full Page Viewer ("ModalView"): LastGeneratedImage or CurrentPreviewImage 

- add option to make  #13459 "show the preview image in the modal view if available" optional

not sure if I should place this option under live preview or under gallery
I put it under live preview because I guess it's the first place that people look when for stuff for live preview

---
someone is requesting this to get pushed to 1.7.0-RC
https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/14213#discussioncomment-7848590
> I hope the PR gets added because the new 1.7 functionality prevents me from using one of my custom extensions effectively.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
