### PR TITLE
Add keyboard shortcuts for generate/skip/interrupt

### DIFF
--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -79,11 +79,11 @@ class Toprow:
     def create_prompts(self):
         with gr.Column(elem_id=f"{self.id_part}_prompt_container", elem_classes=["prompt-container-compact"] if self.is_compact else [], scale=6):
             with gr.Row(elem_id=f"{self.id_part}_prompt_row", elem_classes=["prompt-row"]):
-                self.prompt = gr.Textbox(label="Prompt", elem_id=f"{self.id_part}_prompt", show_label=False, lines=3, placeholder="Prompt (press Ctrl+Enter or Alt+Enter to generate)", elem_classes=["prompt"])
+                self.prompt = gr.Textbox(label="Prompt", elem_id=f"{self.id_part}_prompt", show_label=False, lines=3, placeholder="Prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Ctrl+Alt+Enter to interrupt)", elem_classes=["prompt"])
                 self.prompt_img = gr.File(label="", elem_id=f"{self.id_part}_prompt_image", file_count="single", type="binary", visible=False)
 
             with gr.Row(elem_id=f"{self.id_part}_neg_prompt_row", elem_classes=["prompt-row"]):
-                self.negative_prompt = gr.Textbox(label="Negative prompt", elem_id=f"{self.id_part}_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt (press Ctrl+Enter or Alt+Enter to generate)", elem_classes=["prompt"])
+                self.negative_prompt = gr.Textbox(label="Negative prompt", elem_id=f"{self.id_part}_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Ctrl+Alt+Enter to interrupt)", elem_classes=["prompt"])
 
         self.prompt_img.change(
             fn=modules.images.image_data,

--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -79,11 +79,11 @@ class Toprow:
     def create_prompts(self):
         with gr.Column(elem_id=f"{self.id_part}_prompt_container", elem_classes=["prompt-container-compact"] if self.is_compact else [], scale=6):
             with gr.Row(elem_id=f"{self.id_part}_prompt_row", elem_classes=["prompt-row"]):
-                self.prompt = gr.Textbox(label="Prompt", elem_id=f"{self.id_part}_prompt", show_label=False, lines=3, placeholder="Prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Ctrl+Alt+Enter to interrupt)", elem_classes=["prompt"])
+                self.prompt = gr.Textbox(label="Prompt", elem_id=f"{self.id_part}_prompt", show_label=False, lines=3, placeholder="Prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)", elem_classes=["prompt"])
                 self.prompt_img = gr.File(label="", elem_id=f"{self.id_part}_prompt_image", file_count="single", type="binary", visible=False)
 
             with gr.Row(elem_id=f"{self.id_part}_neg_prompt_row", elem_classes=["prompt-row"]):
-                self.negative_prompt = gr.Textbox(label="Negative prompt", elem_id=f"{self.id_part}_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Ctrl+Alt+Enter to interrupt)", elem_classes=["prompt"])
+                self.negative_prompt = gr.Textbox(label="Negative prompt", elem_id=f"{self.id_part}_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)", elem_classes=["prompt"])
 
         self.prompt_img.change(
             fn=modules.images.image_data,

--- a/script.js
+++ b/script.js
@@ -164,12 +164,11 @@ document.addEventListener('keydown', function(e) {
 
     if (isEsc) {
         const globalPopup = document.querySelector('.global-popup');
-        if (!globalPopup || globalPopup.style.display === "none") {
+        const lightboxModal = document.querySelector('#lightboxModal');
+        if (!globalPopup || globalPopup.style.display === 'none') {
+            if (document.activeElement === lightboxModal) return;
             interruptButton.click();
             e.preventDefault();
-        } else {
-            if (!globalPopup) return;
-            globalPopup.style.display = "none";
         }
     }
 });

--- a/script.js
+++ b/script.js
@@ -124,18 +124,19 @@ document.addEventListener("DOMContentLoaded", function() {
  * Add keyboard shortcuts:
  * Ctrl+Enter to start/restart a generation
  * Alt/Option+Enter to skip a generation
- * Alt/Option+Ctrl+Enter to interrupt a generation
+ * Esc to interrupt a generation
  */
 document.addEventListener('keydown', function(e) {
     const isEnter = e.key === 'Enter' || e.keyCode === 13;
     const isCtrlKey = e.metaKey || e.ctrlKey;
     const isAltKey = e.altKey;
+    const isEsc = e.key === 'Escape';
 
     const generateButton = get_uiCurrentTabContent().querySelector('button[id$=_generate]');
     const interruptButton = get_uiCurrentTabContent().querySelector('button[id$=_interrupt]');
     const skipButton = get_uiCurrentTabContent().querySelector('button[id$=_skip]');
 
-    if (isCtrlKey && isEnter && !isAltKey) {
+    if (isCtrlKey && isEnter) {
         if (interruptButton.style.display === 'block') {
             interruptButton.click();
             const callback = (mutationList) => {
@@ -156,14 +157,18 @@ document.addEventListener('keydown', function(e) {
         e.preventDefault();
     }
 
-    if (isAltKey && isEnter && !isCtrlKey) {
+    if (isAltKey && isEnter) {
         skipButton.click();
         e.preventDefault();
     }
 
-    if (isAltKey && isCtrlKey && isEnter) {
-        interruptButton.click();
-        e.preventDefault();
+    if (isEsc) {
+        if (!globalPopup || globalPopup.style.display === "none") {
+            interruptButton.click();
+            e.preventDefault();
+        } else {
+            closePopup();
+        }
     }
 });
 

--- a/script.js
+++ b/script.js
@@ -163,11 +163,13 @@ document.addEventListener('keydown', function(e) {
     }
 
     if (isEsc) {
+        const globalPopup = document.querySelector('.global-popup');
         if (!globalPopup || globalPopup.style.display === "none") {
             interruptButton.click();
             e.preventDefault();
         } else {
-            closePopup();
+            if (!globalPopup) return;
+            globalPopup.style.display = "none";
         }
     }
 });

--- a/script.js
+++ b/script.js
@@ -121,16 +121,21 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 /**
- * Add a ctrl+enter as a shortcut to start a generation
+ * Add keyboard shortcuts:
+ * Ctrl+Enter to start/restart a generation
+ * Alt/Option+Enter to skip a generation
+ * Alt/Option+Ctrl+Enter to interrupt a generation
  */
 document.addEventListener('keydown', function(e) {
     const isEnter = e.key === 'Enter' || e.keyCode === 13;
-    const isModifierKey = e.metaKey || e.ctrlKey || e.altKey;
+    const isCtrlKey = e.metaKey || e.ctrlKey;
+    const isAltKey = e.altKey;
 
-    const interruptButton = get_uiCurrentTabContent().querySelector('button[id$=_interrupt]');
     const generateButton = get_uiCurrentTabContent().querySelector('button[id$=_generate]');
+    const interruptButton = get_uiCurrentTabContent().querySelector('button[id$=_interrupt]');
+    const skipButton = get_uiCurrentTabContent().querySelector('button[id$=_skip]');
 
-    if (isEnter && isModifierKey) {
+    if (isCtrlKey && isEnter && !isAltKey) {
         if (interruptButton.style.display === 'block') {
             interruptButton.click();
             const callback = (mutationList) => {
@@ -148,6 +153,16 @@ document.addEventListener('keydown', function(e) {
         } else {
             generateButton.click();
         }
+        e.preventDefault();
+    }
+
+    if (isAltKey && isEnter && !isCtrlKey) {
+        skipButton.click();
+        e.preventDefault();
+    }
+
+    if (isAltKey && isCtrlKey && isEnter) {
+        interruptButton.click();
         e.preventDefault();
     }
 });


### PR DESCRIPTION
## Description

A small addition to #13644

Ctrl+Enter to start/restart a generation
**add:** Alt+Enter to skip
**add:** Esc to interrupt (if there is a popup or lightbox, closes it first)

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/44464226/81debbdd-d634-43dc-8eac-74b41c9e458a

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
