### PR TITLE
Fix styles

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -155,10 +155,8 @@ class StyleDatabase:
                     row["name"], prompt, negative_prompt, path
                 )
 
-    def get_style_paths(self) -> list():
-        """
-        Returns a list of all distinct paths, including the default path, of
-        files that styles are loaded from."""
+    def get_style_paths(self) -> set:
+        """Returns a set of all distinct paths of files that styles are loaded from."""
         # Update any styles without a path to the default path
         for style in list(self.styles.values()):
             if not style.path:
@@ -172,9 +170,9 @@ class StyleDatabase:
                 style_paths.add(style.path)
 
         # Remove any paths for styles that are just list dividers
-        style_paths.remove("do_not_save")
+        style_paths.discard("do_not_save")
 
-        return list(style_paths)
+        return style_paths
 
     def get_style_prompts(self, styles):
         return [self.styles.get(x, self.no_style).prompt for x in styles]
@@ -196,20 +194,7 @@ class StyleDatabase:
         # The path argument is deprecated, but kept for backwards compatibility
         _ = path
 
-        # Update any styles without a path to the default path
-        for style in list(self.styles.values()):
-            if not style.path:
-                self.styles[style.name] = style._replace(path=self.default_path)
-
-        # Create a list of all distinct paths, including the default path
-        style_paths = set()
-        style_paths.add(self.default_path)
-        for _, style in self.styles.items():
-            if style.path:
-                style_paths.add(style.path)
-
-        # Remove any paths for styles that are just list dividers
-        style_paths.remove("do_not_save")
+        style_paths = self.get_style_paths()
 
         csv_names = [os.path.split(path)[1].lower() for path in style_paths]
 

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -98,10 +98,8 @@ class StyleDatabase:
         self.path = path
 
         folder, file = os.path.split(self.path)
-        self.default_file = file.split("*")[0] + ".csv"
-        if self.default_file == ".csv":
-            self.default_file = "styles.csv"
-        self.default_path = os.path.join(folder, self.default_file)
+        filename, _, ext = file.partition('*')
+        self.default_path = os.path.join(folder, filename + ext)
 
         self.prompt_fields = [field for field in PromptStyle._fields if field != "path"]
 


### PR DESCRIPTION
## Description

fix #14263 [Bug]: KeyError: "do_not_save" when trying to save a prompt 
cause again by https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14125 Allow use of mutiple styles csv files

this trigger while saveing styles with single files (no * multi csv)

and when in single file mode the `.csv` is incorrectly appended to the styles file path
causing it to constantly generate more and more `style.csv` then `style.csv.csv` then `style.csv.csv.csv` .....

### Push to 1.7.0 RC

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
