### PR TITLE
Fix wrong implementation in network_oft

### DIFF
--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -56,14 +56,15 @@ class NetworkModuleOFT(network.NetworkModule):
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
 
     def calc_updown(self, orig_weight):
-        I = torch.eye(self.block_size, device=self.oft_blocks.device)
         oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
+        eye = torch.eye(self.block_size, device=self.oft_blocks.device)
+
         if self.is_kohya:
             block_Q = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix
             norm_Q = torch.norm(block_Q.flatten())
             new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
             block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
-            oft_blocks = torch.matmul(I + block_Q, (I - block_Q).float().inverse())
+            oft_blocks = torch.matmul(eye + block_Q, (eye - block_Q).float().inverse())
 
         R = oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
 

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -53,12 +53,17 @@ class NetworkModuleOFT(network.NetworkModule):
             self.constraint = None
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)
 
-    def calc_updown_kb(self, orig_weight, multiplier):
+    def calc_updown(self, orig_weight):
+        I = torch.eye(self.block_size, device=self.oft_blocks.device)
         oft_blocks = self.oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-        oft_blocks = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix
+        if self.is_kohya:
+            block_Q = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix
+            norm_Q = torch.norm(block_Q.flatten())
+            new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
+            block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
+            oft_blocks = torch.matmul(I + block_Q, (I - block_Q).float().inverse())
 
         R = oft_blocks.to(orig_weight.device, dtype=orig_weight.dtype)
-        R = R * multiplier + torch.eye(self.block_size, device=orig_weight.device)
 
         # This errors out for MultiheadAttention, might need to be handled up-stream
         merged_weight = rearrange(orig_weight, '(k n) ... -> k n ...', k=self.num_blocks, n=self.block_size)
@@ -70,15 +75,10 @@ class NetworkModuleOFT(network.NetworkModule):
         merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
 
         updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
+        print(torch.norm(updown))
         output_shape = orig_weight.shape
         return self.finalize_updown(updown, orig_weight, output_shape)
 
-    def calc_updown(self, orig_weight):
-        # if alpha is a very small number as in coft, calc_scale() will return a almost zero number so we ignore it
-        multiplier = self.multiplier()
-        return self.calc_updown_kb(orig_weight, multiplier)
-
-    # override to remove the multiplier/scale factor; it's already multiplied in get_weight
     def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
         if self.bias is not None:
             updown = updown.reshape(self.bias.shape)
@@ -94,4 +94,5 @@ class NetworkModuleOFT(network.NetworkModule):
         if ex_bias is not None:
             ex_bias = ex_bias * self.multiplier()
 
-        return updown, ex_bias
+        # Ignore calc_scale, which is not used in OFT.
+        return updown * self.multiplier(), ex_bias

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -77,6 +77,5 @@ class NetworkModuleOFT(network.NetworkModule):
         merged_weight = rearrange(merged_weight, 'k m ... -> (k m) ...')
 
         updown = merged_weight.to(orig_weight.device, dtype=orig_weight.dtype) - orig_weight
-        print(torch.norm(updown))
         output_shape = orig_weight.shape
         return self.finalize_updown(updown, orig_weight, output_shape)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -21,6 +21,8 @@ class NetworkModuleOFT(network.NetworkModule):
         self.lin_module = None
         self.org_module: list[torch.Module] = [self.sd_module]
 
+        self.scale = 1.0
+
         # kohya-ss
         if "oft_blocks" in weights.w.keys():
             self.is_kohya = True
@@ -78,21 +80,3 @@ class NetworkModuleOFT(network.NetworkModule):
         print(torch.norm(updown))
         output_shape = orig_weight.shape
         return self.finalize_updown(updown, orig_weight, output_shape)
-
-    def finalize_updown(self, updown, orig_weight, output_shape, ex_bias=None):
-        if self.bias is not None:
-            updown = updown.reshape(self.bias.shape)
-            updown += self.bias.to(orig_weight.device, dtype=orig_weight.dtype)
-            updown = updown.reshape(output_shape)
-
-        if len(output_shape) == 4:
-            updown = updown.reshape(output_shape)
-
-        if orig_weight.size().numel() == updown.size().numel():
-            updown = updown.reshape(orig_weight.shape)
-
-        if ex_bias is not None:
-            ex_bias = ex_bias * self.multiplier()
-
-        # Ignore calc_scale, which is not used in OFT.
-        return updown * self.multiplier(), ex_bias


### PR DESCRIPTION
## Description
As title, the previous implementation:#13692 from @v0xie have something wrong.
I just change things in it to ensure we have correct math form for it. (For both kohya and LyCORIS)

The incorrect part of original implementation:
* Kohya
  * Only rebuild the Q, but never rebuild the R
  * Ignore the constraint, Which cannot be ignored. (In training, the constraint will not "update" the weight directly, we cannot ignore it)
* LyCORIS
  * Take R(oft_diag) as oft_blocks and "rebuild again"
* both
  * Take R with multiplier as `R*mul + I`, which should be `R*mul + I*(1-mul)`
  * I put the multiplier back to finalize_updown so this is removed.

Some other improvement:
* use "mul=1" to rebuild R, and put multiplier back to finalize. (Since we will calc diff weight)
* use `self.scale` to ensure `calc_scale` will return 1.0, instead of custom finalize function.

## Demos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/59680068/d56deda9-049a-4374-9cd3-dcb39969bf2f)



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
