### PR TITLE
default False js_live_preview_in_modal_lightbox

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -331,7 +331,7 @@ options_templates.update(options_section(('ui', "Live previews", "ui"), {
     "live_preview_content": OptionInfo("Prompt", "Live preview subject", gr.Radio, {"choices": ["Combined", "Prompt", "Negative prompt"]}),
     "live_preview_refresh_period": OptionInfo(1000, "Progressbar and preview update period").info("in milliseconds"),
     "live_preview_fast_interrupt": OptionInfo(False, "Return image with chosen live preview method on interrupt").info("makes interrupts faster"),
-    "js_live_preview_in_modal_lightbox": OptionInfo(True, "Show Live preview in full page image viewer"),
+    "js_live_preview_in_modal_lightbox": OptionInfo(False, "Show Live preview in full page image viewer"),
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters", "sd"), {


### PR DESCRIPTION
## Description
set `js_live_preview_in_modal_lightbox` to False by default
reason being I don't think people will want to spend too much time staring at constantly changing live preview in full screen
I think it's more useful to have at the static completed image
I didn't set it to False because I assume that your intention was for that to be the default behavior
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14230#issuecomment-1855255250
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14230#issuecomment-1855598616

related PR
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13459
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14230

if you want to change this to false by default then I suggest pushing this to1.7.0-RC because otherwise the `True` value will be saved to the users configs

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
