### PR TITLE
only rewrite ui-config when there is change

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1086,6 +1086,7 @@ def create_ui():
         )
 
     loadsave = ui_loadsave.UiLoadsave(cmd_opts.ui_config_file)
+    ui_settings_from_file = loadsave.ui_settings.copy()
 
     settings = ui_settings.UiSettings()
     settings.create_ui(loadsave, dummy_component)
@@ -1146,7 +1147,8 @@ def create_ui():
 
         modelmerger_ui.setup_ui(dummy_component=dummy_component, sd_model_checkpoint_component=settings.component_dict['sd_model_checkpoint'])
 
-    loadsave.dump_defaults()
+    if ui_settings_from_file != loadsave.ui_settings:
+        loadsave.dump_defaults()
     demo.ui_loadsave = loadsave
 
     return demo

--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -144,7 +144,7 @@ class UiLoadsave:
             json.dump(current_ui_settings, file, indent=4, ensure_ascii=False)
 
     def dump_defaults(self):
-        """saves default values to a file unless tjhe file is present and there was an error loading default values at start"""
+        """saves default values to a file unless the file is present and there was an error loading default values at start"""
 
         if self.error_loading and os.path.exists(self.filename):
             return


### PR DESCRIPTION
- only rewrite ui-config on load when there is change

`ui-config.json` is is always rewritten on webui load, even when there's no change
there's no point and can cause file corruption if webui is killed at a inappropriate time during load
> and yes I was unlucky enough that this actually happened to me

Changes
- create a copy of the dictionary read from file and compare before writing if there is no change then don't write the file
- a minor typo fix

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
