### PR TITLE
Update Added (Fixed) IPV6 Functionality When there is No Webui Argument Passed webui.py

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -39,7 +39,7 @@ def api_only():
 
     print(f"Startup time: {startup_timer.summary()}.")
     api.launch(
-        server_name = cmd_opts.server_name if cmd_opts.server_name else ("0.0.0.0" if cmd_opts.listen else "127.0.0.1"),
+        server_name=cmd_opts.server_name or ("0.0.0.0" if cmd_opts.listen else "127.0.0.1"),
         port=cmd_opts.port if cmd_opts.port else 7861,
         root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else ""
     )

--- a/webui.py
+++ b/webui.py
@@ -39,7 +39,7 @@ def api_only():
 
     print(f"Startup time: {startup_timer.summary()}.")
     api.launch(
-        server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1",
+        server_name = cmd_opts.server_name if cmd_opts.server_name else ("0.0.0.0" if cmd_opts.listen else "127.0.0.1"),
         port=cmd_opts.port if cmd_opts.port else 7861,
         root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else ""
     )


### PR DESCRIPTION
Added (Fixed) IPV6 Functionality When there is No Webui Argument Passed

## Description

There was a issue in the Script webui.py
when anyone want to run the **api only** with **no webui arguments** it was only loading it to the **local server only** if no listen is passed and either **server-name** is passed it was being ignored i have fixed It Further Proof of Concept and Screenshot's are attached 

**testing COMMANDLINE_ARGS**
--disable-safe-unpickle --server-name [::] --xformers --opt-sdp-attention --enable-insecure-extension-access --api --opt-channelslast --nowebui --no-gradio-queue --port 7860 --ui-settings-file 'config.json' --ui-config-file 'ui-config.json' --no-download-sd-model
## Screenshots/videos:
**BEFORE FIX**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19831661/139bc880-06f4-4d40-8637-d5c5d4bcfbc7)
**AFTER FIX**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/19831661/e7db2b33-1d06-4a80-b2fd-396fae867df1)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
