### PR TITLE
reorder training preprocessing modules in extras tab

### DIFF
--- a/scripts/postprocessing_caption.py
+++ b/scripts/postprocessing_caption.py
@@ -4,7 +4,7 @@ import gradio as gr
 
 class ScriptPostprocessingCeption(scripts_postprocessing.ScriptPostprocessing):
     name = "Caption"
-    order = 4000
+    order = 4040
 
     def ui(self):
         with ui_components.InputAccordion(False, label="Caption") as enable:

--- a/scripts/postprocessing_create_flipped_copies.py
+++ b/scripts/postprocessing_create_flipped_copies.py
@@ -6,7 +6,7 @@ import gradio as gr
 
 class ScriptPostprocessingCreateFlippedCopies(scripts_postprocessing.ScriptPostprocessing):
     name = "Create flipped copies"
-    order = 4000
+    order = 4030
 
     def ui(self):
         with ui_components.InputAccordion(False, label="Create flipped copies") as enable:

--- a/scripts/postprocessing_focal_crop.py
+++ b/scripts/postprocessing_focal_crop.py
@@ -7,7 +7,7 @@ from modules.textual_inversion import autocrop
 
 class ScriptPostprocessingFocalCrop(scripts_postprocessing.ScriptPostprocessing):
     name = "Auto focal point crop"
-    order = 4000
+    order = 4010
 
     def ui(self):
         with ui_components.InputAccordion(False, label="Auto focal point crop") as enable:

--- a/scripts/processing_autosized_crop.py
+++ b/scripts/processing_autosized_crop.py
@@ -28,7 +28,7 @@ def multicrop_pic(image: Image, mindim, maxdim, minarea, maxarea, objective, thr
 
 class ScriptPostprocessingAutosizedCrop(scripts_postprocessing.ScriptPostprocessing):
     name = "Auto-sized crop"
-    order = 4000
+    order = 4020
 
     def ui(self):
         with ui_components.InputAccordion(False, label="Auto-sized crop") as enable:


### PR DESCRIPTION
fix issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14360 Captions not being generated for flipped copies
since captioning is applied before flipping the image the flip the version of the image don't have captions

I reordered the five image training preprocessing modules using the order from before the rework 11d23e8ca55c097ecfa255a05b63f194e25f08be `remove Train/Preprocessing tab and put all its functionality into extras batch images mode`
(hopefully I didn't mess up the order)

| current order | new default |
|--------|--------|
| ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/7d1fc8fe-a38f-43da-9bc6-5298795dd609) | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c36ba72b-1873-4c6c-9833-2e1bef1ecee3) |
---

personally I do not like 11d23e8ca55c097ecfa255a05b63f194e25f08be `remove Train/Preprocessing tab and put all its functionality into extras batch images mode`
I think the use case of `preprocessing images for training` and `applying additional effects such as upscaling among other things that extensions do such as color enhancement` are very different and should be separated
lots of people are not interested in training (or use other tools for training) would probably never uses preprocessing, for them this will be just cluttering the UI
the modules also cannot be disabled / hidden easily

personally I like the version before the rework, but I will have less of an issue if all these is grouped under a "big accordion"

---

there's also another issue caused by the rework
- captioning is now extremely slow compared to what it was before
irrc before captioning was done in a single large batch as opposed to being processed separately
which means that you can just load and unload the model once reducing overhead

assuming that this is the only cause of the slowdown, then adding a function `before_batch_processing` and `after_batch_processing` can solve this issue, they can be used to load it unload the model

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
