### PR TITLE
xyz grid handle axis_type is None

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -476,6 +476,8 @@ class Script(scripts.Script):
         fill_z_button.click(fn=fill, inputs=[z_type, csv_mode], outputs=[z_values, z_values_dropdown])
 
         def select_axis(axis_type, axis_values, axis_values_dropdown, csv_mode):
+            axis_type = axis_type or 0  # if axle type is None set to 0
+
             choices = self.current_axis_options[axis_type].choices
             has_choices = choices is not None
 
@@ -526,6 +528,8 @@ class Script(scripts.Script):
         return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode]
 
     def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, margin_size, csv_mode):
+        x_type, y_type, z_type = x_type or 0, y_type or 0, z_type or 0  # if axle type is None set to 0
+
         if not no_fixed_seeds:
             modules.processing.fix_seed(p)
 


### PR DESCRIPTION
## Description
xyz grid
if the selected axle from dropdown is not found the `axis_type` index will be `None`
triggering and error
```shell
  File "B:\GitHub\stable-diffusion-webui\scripts\xyz_grid.py", line 479, in select_axis
    choices = self.current_axis_options[axis_type].choices
TypeError: list indices must be integers or slices, not NoneType
```

simple fix
if `axis_type` is None then set to index `0` (`Nothing`)

same logic also applies to `run()`

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/8e487158-06a9-4325-bf1e-608b983bc644

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
