### PR TITLE
#14395 Issue: Incompatibility with Quotes in Git Clone Command

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -189,7 +189,7 @@ def git_clone(url, dir, name, commithash=None):
         return
 
     try:
-        run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+        run(f'{git} clone {url} {dir}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise


### PR DESCRIPTION
## Description

* I made a modification in the Python code to address a potential issue related to the usage of double quotes in the Git clone command. The original line employed double quotes around the entire command, which could lead to unexpected behavior, especially in certain environments.
* The change removes the double quotes around the Git command arguments, aiming to enhance compatibility across different systems and environments.
* This modification should ensure consistent behavior and avoid potential issues related to quoting.

## Screenshots/videos:
Error: 
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/113166269/45ee044a-eeff-4030-865c-acf2743355f5)
Solved:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/113166269/544424a9-71f5-40d9-9a19-2600259c3866)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
