### PR TITLE
prevent crash due to Script __init__ exception

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -566,7 +566,12 @@ class ScriptRunner:
         auto_processing_scripts = scripts_auto_postprocessing.create_auto_preprocessing_script_data()
 
         for script_data in auto_processing_scripts + scripts_data:
-            script = script_data.script_class()
+            try:
+                script = script_data.script_class()
+            except Exception:
+                errors.report(f"Error # failed to initialize Script {script_data.module}: ", exc_info=True)
+                continue
+
             script.filename = script_data.path
             script.is_txt2img = not is_img2img
             script.is_img2img = is_img2img


### PR DESCRIPTION
## Description
a Script that for some reason fails to initialize can cause a webui to crash

for example a Script like this
```py
from modules import scripts
class Script(scripts.Script):
    def __init__(self):
        assert False, 'This will crash webui'
```

this issue was brought to my attention by https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14404
for whatever reason the [this line](https://github.com/wcde/sd-webui-kohya-hiresfix/blob/f92a2dd6b09d9d05f6816defd7575a4933ae8371/scripts/khrfix.py#L29) in of code the extension triggers an uncaught exception and crashes web UI

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
