### PR TITLE
fix API thread safe issues of txt2img and img2img

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -418,7 +418,6 @@ class Api:
         task_id = txt2imgreq.force_task_id or create_task_id("txt2img")
 
         script_runner = scripts.scripts_txt2img
-
         with self.txt2img_script_arg_init_lock:
             if not script_runner.scripts:
                 script_runner.initialize_scripts(False)
@@ -489,14 +488,13 @@ class Api:
             mask = decode_base64_to_image(mask)
 
         script_runner = scripts.scripts_img2img
-
         with self.img2img_script_arg_init_lock:
             if not script_runner.scripts:
                 script_runner.initialize_scripts(True)
                 ui.create_ui()
 
-          infotext_script_args = {}
-          self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
+            infotext_script_args = {}
+            self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
 
             if not self.default_script_arg_img2img:
                 self.default_script_arg_img2img = self.init_default_script_args(script_runner)

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -251,8 +251,21 @@ class Api:
         self.default_script_arg_txt2img = []
         self.default_script_arg_img2img = []
 
-        self.txt2img_script_arg_init_lock = Lock()
-        self.img2img_script_arg_init_lock = Lock()
+        txt2img_script_runner = scripts.scripts_txt2img
+        img2img_script_runner = scripts.scripts_img2img
+
+        if not txt2img_script_runner.scripts or not img2img_script_runner.scripts:
+            ui.create_ui()
+
+        if not txt2img_script_runner.scripts:
+            txt2img_script_runner.initialize_scripts(False)
+        if not self.default_script_arg_txt2img:
+            self.default_script_arg_txt2img = self.init_default_script_args(txt2img_script_runner)
+
+        if not img2img_script_runner.scripts:
+            img2img_script_runner.initialize_scripts(True)
+        if not self.default_script_arg_img2img:
+            self.default_script_arg_img2img = self.init_default_script_args(img2img_script_runner)
 
 
 
@@ -418,16 +431,10 @@ class Api:
         task_id = txt2imgreq.force_task_id or create_task_id("txt2img")
 
         script_runner = scripts.scripts_txt2img
-        with self.txt2img_script_arg_init_lock:
-            if not script_runner.scripts:
-                script_runner.initialize_scripts(False)
-                ui.create_ui()
 
-            infotext_script_args = {}
-            self.apply_infotext(txt2imgreq, "txt2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
+        infotext_script_args = {}
+        self.apply_infotext(txt2imgreq, "txt2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
 
-            if not self.default_script_arg_txt2img:
-                self.default_script_arg_txt2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
 
         populate = txt2imgreq.copy(update={  # Override __init__ params
@@ -488,16 +495,10 @@ class Api:
             mask = decode_base64_to_image(mask)
 
         script_runner = scripts.scripts_img2img
-        with self.img2img_script_arg_init_lock:
-            if not script_runner.scripts:
-                script_runner.initialize_scripts(True)
-                ui.create_ui()
 
-            infotext_script_args = {}
-            self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
+        infotext_script_args = {}
+        self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
 
-            if not self.default_script_arg_img2img:
-                self.default_script_arg_img2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
 
         populate = img2imgreq.copy(update={  # Override __init__ params

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -251,6 +251,15 @@ class Api:
         self.default_script_arg_txt2img = []
         self.default_script_arg_img2img = []
 
+        script_runner = scripts.scripts_img2img
+        if not script_runner.scripts:
+            script_runner.initialize_scripts(True)
+            ui.create_ui()
+        if not self.default_script_arg_txt2img:
+            self.default_script_arg_txt2img = self.init_default_script_args(script_runner)
+        if not self.default_script_arg_img2img:
+            self.default_script_arg_img2img = self.init_default_script_args(script_runner)
+
     def add_api_route(self, path: str, endpoint, **kwargs):
         if shared.cmd_opts.api_auth:
             return self.app.add_api_route(path, endpoint, dependencies=[Depends(self.auth)], **kwargs)
@@ -339,11 +348,6 @@ class Api:
         task_id = txt2imgreq.force_task_id or create_task_id("txt2img")
 
         script_runner = scripts.scripts_txt2img
-        if not script_runner.scripts:
-            script_runner.initialize_scripts(False)
-            ui.create_ui()
-        if not self.default_script_arg_txt2img:
-            self.default_script_arg_txt2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
 
         populate = txt2imgreq.copy(update={  # Override __init__ params
@@ -403,11 +407,6 @@ class Api:
             mask = decode_base64_to_image(mask)
 
         script_runner = scripts.scripts_img2img
-        if not script_runner.scripts:
-            script_runner.initialize_scripts(True)
-            ui.create_ui()
-        if not self.default_script_arg_img2img:
-            self.default_script_arg_img2img = self.init_default_script_args(script_runner)
         selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
 
         populate = img2imgreq.copy(update={  # Override __init__ params


### PR DESCRIPTION
## Description

### TL;DR: 

Function `ui.create_ui` and `self.init_default_script_args` are not thread-safe.
It causes thread-safety issues of API `txt2img` and `img2img`.
To ensure the API is thread-safe, I move the code to __init__

### Steps to reproduce the thread-safety issues

#### 1. Run webui with the following command

```cmd
.\webui.bat --api --disable-all-extensions --nowebui
```

#### 2. Run the following python script

```python
import aiohttp
import asyncio


async def main():
    async with aiohttp.ClientSession() as session:
        task1 = session.request('POST', url='http://127.0.0.1:7861/sdapi/v1/txt2img', json={})
        task2 = session.request('POST', url='http://127.0.0.1:7861/sdapi/v1/txt2img', json={})
        task3 = session.request('POST', url='http://127.0.0.1:7861/sdapi/v1/txt2img', json={})
        await asyncio.gather(task1, task2, task3, return_exceptions=True)


asyncio.run(main())
```

In most cases you will see the error on the `terminal` which running webui.
If not encounter the error, `ctrl+c` cancel the webui then repeat the above steps again until the error appears



### Fix issue #10884

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)