### PR TITLE
save info of init image

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1482,7 +1482,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             # Save init image
             if opts.save_init_img:
                 self.init_img_hash = hashlib.md5(img.tobytes()).hexdigest()
-                images.save_image(img, path=opts.outdir_init_images, basename=None, forced_filename=self.init_img_hash, save_to_dirs=False)
+                images.save_image(img, path=opts.outdir_init_images, basename=None, forced_filename=self.init_img_hash, save_to_dirs=False, existing_info=img.info)
 
             image = images.flatten(img, opts.img2img_background_color)
 


### PR DESCRIPTION
## Description
save info of init image
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14450 [Bug]: Init images missing PNG Info

---

Update https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14450#issuecomment-1872212622
I did some testing with gradio 4
and found that `ImageEditor` removes the info 

in other words once we switch to gradio 4 this PR won't work anymore 
I don't think it's a good idea merge PR unless we want to support this behavior, and we will need to find a workaround for gradio 4

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
