### PR TITLE
More lora not found warning

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -1,3 +1,4 @@
+import gradio as gr
 import logging
 import os
 import re
@@ -314,7 +315,12 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
                 emb_db.skipped_embeddings[name] = embedding
 
     if failed_to_load_networks:
-        sd_hijack.model_hijack.comments.append("Networks not found: " + ", ".join(failed_to_load_networks))
+        lora_not_found_message = f'Lora not found: {", ".join(failed_to_load_networks)}'
+        sd_hijack.model_hijack.comments.append(lora_not_found_message)
+        if shared.opts.lora_not_found_warning_console:
+            print(f'\n{lora_not_found_message}\n')
+        if shared.opts.lora_not_found_gradio_warning:
+            gr.Warning(lora_not_found_message)
 
     purge_networks_from_memory()
 

--- a/extensions-builtin/Lora/scripts/lora_script.py
+++ b/extensions-builtin/Lora/scripts/lora_script.py
@@ -39,6 +39,8 @@ shared.options_templates.update(shared.options_section(('extra_networks', "Extra
     "lora_show_all": shared.OptionInfo(False, "Always show all networks on the Lora page").info("otherwise, those detected as for incompatible version of Stable Diffusion will be hidden"),
     "lora_hide_unknown_for_versions": shared.OptionInfo([], "Hide networks of unknown versions for model versions", gr.CheckboxGroup, {"choices": ["SD1", "SD2", "SDXL"]}),
     "lora_in_memory_limit": shared.OptionInfo(0, "Number of Lora networks to keep cached in memory", gr.Number, {"precision": 0}),
+    "lora_not_found_warning_console": shared.OptionInfo(False, "Lora not found warning in console"),
+    "lora_not_found_gradio_warning": shared.OptionInfo(False, "Lora not found warning popup in webui"),
 }))
 
 


### PR DESCRIPTION
## Description
[Feature Request]: Reinstate Lora, etc output warnings in Log window https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14463
related discussion https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/14455#discussioncomment-7971004

- Add more options to show that Lora network is not found
1. in console
2. using gradio Warning

controlled respectively by settings
`Settings > Extra Networks > Lora not found warning in console`
`Settings > Extra Networks > Lora not found popup warning in webui`

- reword the message `Lora` and not and not just generic `Network`

not sure if these option should be enabled or disabled by default
if this is going to be merged please decide what should be the default value before merging

---

an alternative solution to this is to just change the loglevel to `warning`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/de03882d6ca56bc81058f5120f028678a6a54aaa/extensions-builtin/Lora/networks.py#L293


## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/cf4f769c-4722-4764-bfde-d132afedb11c)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/efdddea2-290b-4546-96e2-8496794e53a5)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
