### PR TITLE
Install base requirements before deps to avoid downgrading packages

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -385,6 +385,13 @@ def prepare_environment():
         )
     startup_timer.record("torch GPU test")
 
+    if not os.path.isfile(requirements_file):
+        requirements_file = os.path.join(script_path, requirements_file)
+
+    if not requirements_met(requirements_file):
+        run_pip(f"install -r \"{requirements_file}\"", "requirements")
+        startup_timer.record("install requirements")
+
     if not is_installed("clip"):
         run_pip(f"install {clip_package}", "clip")
         startup_timer.record("install clip")
@@ -409,13 +416,6 @@ def prepare_environment():
     git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
 
     startup_timer.record("clone repositores")
-
-    if not os.path.isfile(requirements_file):
-        requirements_file = os.path.join(script_path, requirements_file)
-
-    if not requirements_met(requirements_file):
-        run_pip(f"install -r \"{requirements_file}\"", "requirements")
-        startup_timer.record("install requirements")
 
     if not args.skip_install:
         run_extensions_installers(settings_file=args.ui_settings_file)


### PR DESCRIPTION
## Description

Closes #14469 (alternate take).

I noticed we end up downgrading some packages during CI, because installing `clip`/`open_clip` etc. will have installed a newer (unconstrained) version.

If we already have those deps satisfied, that shouldn't happen.

## Screenshots/videos:

Nah.

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
