### PR TITLE
Bump numpy to 1.26.2

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -13,7 +13,7 @@ inflection==0.5.1
 jsonmerge==1.8.0
 kornia==0.6.7
 lark==1.1.2
-numpy==1.23.5
+numpy==1.26.2
 omegaconf==2.2.3
 open-clip-torch==2.20.0
 piexif==1.1.3


### PR DESCRIPTION
## Description

This avoids it being downgraded during `launch.py`. Pillow and open-clip-torch also get downgraded, but those would probably entail more code changes.

## Screenshots/videos:

None.

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
