### PR TITLE
Soften Spandrel model-architecture check to just a warning

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -196,7 +196,9 @@ def load_spandrel_model(
     import spandrel
     model = spandrel.ModelLoader(device=device).load_from_file(path)
     if expected_architecture and model.architecture != expected_architecture:
-        raise TypeError(f"Model {path} is not a {expected_architecture} model")
+        logger.warning(
+            f"Model {path!r} is not a {expected_architecture!r} model (got {model.architecture!r})",
+        )
     if half:
         model = model.model.half()
     if dtype:


### PR DESCRIPTION
## Description

As reported by @w-e-w, `RealESRGAN_x4plus.pth` doesn't work post #14425 since it's identified as just `ESRGAN`.

Upscaling inference does work nevertheless though, so this softens the `TypeError` to a log warning (and makes it better).

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
