### PR TITLE
Correct RealESRGAN expected architecture type to ESRGAN

### DIFF
--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -40,7 +40,7 @@ class UpscalerRealESRGAN(Upscaler):
             info.local_data_path,
             device=self.device,
             half=(not cmd_opts.no_half and not cmd_opts.upcast_sampling),
-            expected_architecture="RealESRGAN",
+            expected_architecture="ESRGAN",  # "RealESRGAN" isn't a specific thing for Spandrel
         )
         return upscale_with_model(
             mod,


### PR DESCRIPTION
## Description

Sibling of #14473. Spandrel seems to group all ESRGAN-style models under the ESRGAN architecture category:

> `spandrel\architectures\RealESRGAN` is for anyone using spandrel to init their own models if they want to use the realesrgan version of the arch
> internally they all they converted to original esrgan's key structure when loaded

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
