### PR TITLE
Speed up installation by git clone less

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -189,7 +189,10 @@ def git_clone(url, dir, name, commithash=None):
         return
 
     try:
-        run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+        if commithash is not None:
+            run(f'"{git}" clone -b "{commithash}" "{url}" "{dir}" ', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+        else:
+            run(f'"{git}" clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise


### PR DESCRIPTION

## Description
The main purpose is to speed up installation.

When the commithash is given, we only clone the needed version. When the commithash is not specified, we only clone the latest version. This is to save time and network traffic as well as some disk space, since as time passes by, those repos can be big, and for those who have difficulty using github (like me, and many other developers in China), this can be convenient  to us.

I have run my code in a clean environment and it worked.
## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
