### PR TITLE
Speed up git clone

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -190,15 +190,16 @@ def git_clone(url, dir, name, commithash=None):
 
     try:
         if commithash is not None:
-            os.makedirs(dir)
-            now_dir = os.getcwd()
-            os.chdir(dir)
-            run(f'{git} init')
-            run(f'{git} remote add origin {url}')
-            run(f'{git} pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
+            # os.makedirs(dir)
+            # now_dir = os.getcwd()
+            # os.chdir(dir)
+            # run(f'{git} init')
+            # run(f'{git} remote add origin {url}')
+            run(f'"{git}" -C "{dir}" remote add origin "{url}"')
+            run(f'"{git}" pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
             os.chdir(now_dir)
         else:
-            run(f'{git} clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+            run(f'"{git}" clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -189,7 +189,16 @@ def git_clone(url, dir, name, commithash=None):
         return
 
     try:
-        run(f'"{git}" clone "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+        if commithash is not None:
+            os.makedirs(dir)
+            now_dir = os.getcwd()
+            os.chdir(dir)
+            run(f'{git} init')
+            run(f'{git} remote add origin {url}')
+            run(f'{git} pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
+            os.chdir(now_dir)
+        else:
+            run(f'{git} clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -195,7 +195,7 @@ def git_clone(url, dir, name, commithash=None):
             # # os.chdir(dir)
             # # run(f'{git} init')
             # # run(f'{git} remote add origin {url}')
-            run(f'""{git}" -C "{dir}" remote add origin "{url}"')
+            run(f'"{git}" -C "{dir}" remote add origin "{url}"')
             run(f'"{git}" pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
             # os.chdir(now_dir)
         else:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -190,14 +190,10 @@ def git_clone(url, dir, name, commithash=None):
 
     try:
         if commithash is not None:
-            # # os.makedirs(dir)
-            # # now_dir = os.getcwd()
-            # # os.chdir(dir)
-            # # run(f'{git} init')
-            # # run(f'{git} remote add origin {url}')
-            run(f'{git} -C "{dir}" remote add origin "{url}"')
-            run(f'{git} pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
-            # os.chdir(now_dir)
+            run(f'"{git}" init "{dir}"')
+            run(f'"{git}" -C "{dir}" remote add origin "{url}"')
+            run(f'"{git}" -C "{dir}" fetch origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
+            run(f'"{git}" -C "{dir}" merge {commithash}')
         else:
             run(f'{git} clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -190,13 +190,14 @@ def git_clone(url, dir, name, commithash=None):
 
     try:
         if commithash is not None:
-            os.makedirs(dir)
-            now_dir = os.getcwd()
-            os.chdir(dir)
-            run(f'{git} init')
-            run(f'{git} remote add origin {url}')
-            run(f'{git} pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
-            os.chdir(now_dir)
+            # os.makedirs(dir)
+            # now_dir = os.getcwd()
+            # os.chdir(dir)
+            # run(f'{git} init')
+            # run(f'{git} remote add origin {url}')
+            run(f'"{git}" -C "{dir}" remote add origin "{url}"')
+            run(f'"{git}" pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
+            # os.chdir(now_dir)
         else:
             run(f'{git} clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -195,11 +195,11 @@ def git_clone(url, dir, name, commithash=None):
             # # os.chdir(dir)
             # # run(f'{git} init')
             # # run(f'{git} remote add origin {url}')
-            run(f'"{git}" -C "{dir}" remote add origin "{url}"')
-            run(f'"{git}" pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
+            run(f'{git} -C "{dir}" remote add origin "{url}"')
+            run(f'{git} pull origin {commithash}', f"Cloning {name} into {dir}...", f"Couldn't clone {name}",live=True)
             # os.chdir(now_dir)
         else:
-            run(f'"{git}" clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+            run(f'{git} clone "{url}" "{dir}" --depth 1', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise


### PR DESCRIPTION

## Description
The main purpose is to speed up installation.

When the commithash is given, we only clone the needed version. When the commithash is not specified, we only clone the latest version. This is to save time and network traffic as well as some disk space, since as time passes by, those repos can be big, and for those who have difficulty using github (like me, and many other developers in China), this can be convenient  to us.

I have run my code in a clean environment and it worked.
## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
