### PR TITLE
Fix lint issue from 501993eb

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -151,7 +151,7 @@ function submit() {
 }
 
 function submit_txt2img_upscale() {
-    res = submit.apply(null, arguments);
+    var res = submit(...arguments);
 
     res[2] = selected_gallery_index();
 


### PR DESCRIPTION
## Description

ESlint doesn't like polluting global namespaces like that.

Also, unless you really do need to rebind `this`, `foo(...args)` is the more modern idiom for `foo.apply(null, args)`.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
