### PR TITLE
Add inpaint arguments in .txt file

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -225,6 +225,18 @@ def img2img(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_s
     if mask:
         p.extra_generation_params["Mask blur"] = mask_blur
 
+        if inpainting_mask_invert is not None:
+            p.extra_generation_params["Mask mode"] = inpainting_mask_invert
+
+        if inpainting_fill is not None:
+            p.extra_generation_params["Masked content"] = inpainting_fill
+
+        if inpaint_full_res is not None:
+            p.extra_generation_params["Inpaint area"] = inpaint_full_res
+
+        if inpaint_full_res_padding is not None:
+            p.extra_generation_params["Only masked padding, pixels"] = inpaint_full_res_padding
+
     with closing(p):
         if is_batch:
             assert not shared.cmd_opts.hide_ui_dir_config, "Launched with --hide-ui-dir-config, batch img2img disabled"

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -840,6 +840,10 @@ def create_ui():
                 (toprow.ui_styles.dropdown, lambda d: d["Styles array"] if isinstance(d.get("Styles array"), list) else gr.update()),
                 (denoising_strength, "Denoising strength"),
                 (mask_blur, "Mask blur"),
+                (inpainting_mask_invert, 'Mask mode'),
+                (inpainting_fill, 'Masked content'),
+                (inpaint_full_res, 'Inpaint area'),
+                (inpaint_full_res_padding, 'Only masked padding, pixels'),
                 *scripts.scripts_img2img.infotext_fields
             ]
             parameters_copypaste.add_paste_fields("img2img", init_img, img2img_paste_fields, override_settings)


### PR DESCRIPTION
## Description

### Issue:
While working and reproduce images generated using img2img inpaint tab, there are options that are not exported
After try to generate the same images the options:

inpaint_full_res_padding
inpaint_full_res
inpaint_mask_invert
inpainting_fill

Solution:
Add missing options to inpainting images generated

## Screenshots/videos:

### UI funcionality
![Screenshot 2024-01-01 135004](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/151478027/60b0b686-9a05-4879-b1cb-39815ae9b97f)

### Ruff
![Screenshot 2024-01-01 132933](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/151478027/81228941-e606-4c39-8d32-d4cf9fbc3583)

### Tests
![291703232-1f114d03-5357-4b4c-9cdf-f34411d28770](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/151478027/f62bbabf-6ae2-471d-841e-140628799621)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
