### PR TITLE
Spandrel: "prefer half" instead of "force half"

### DIFF
--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -39,7 +39,7 @@ class UpscalerRealESRGAN(Upscaler):
         model_descriptor = modelloader.load_spandrel_model(
             info.local_data_path,
             device=self.device,
-            half=(not cmd_opts.no_half and not cmd_opts.upcast_sampling),
+            prefer_half=(not cmd_opts.no_half and not cmd_opts.upcast_sampling),
             expected_architecture="ESRGAN",  # "RealESRGAN" isn't a specific thing for Spandrel
         )
         return upscale_with_model(


### PR DESCRIPTION
## Description

As discussed with the Spandrel folks, it's good to heed Spandrel's "supports half precision" flag to avoid e.g. black blotches and what-not.

> This is why spandrel has the `supports_half` tag. Transformer models typically don't work well with fp16

* which issues it fixes, if any
  * None yet, since the current experimental `HAT` code doesn't set `half=True`, but if it did, HAT would have a bad time

## Screenshots/videos:

None.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
