### PR TITLE
reduce unnecessary re-indexing extra networks directory

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -417,21 +417,21 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
 
     dropdown_sort.change(fn=lambda: None, _js="function(){ applyExtraNetworkSort('" + tabname + "'); }")
 
+    def create_html():
+        ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
+
     def pages_html():
         if not ui.pages_contents:
-            return refresh()
-
+            create_html()
         return ui.pages_contents
 
     def refresh():
         for pg in ui.stored_extra_pages:
             pg.refresh()
-
-        ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
-
+        create_html()
         return ui.pages_contents
 
-    interface.load(fn=pages_html, inputs=[], outputs=[*ui.pages])
+    interface.load(fn=pages_html, inputs=[], outputs=ui.pages)
     button_refresh.click(fn=refresh, inputs=[], outputs=ui.pages)
 
     return ui


### PR DESCRIPTION
## Description

webui calles `extra networks refresh()` when the webpages loads
the refresh function includes clearing out the existing extra networks list and crawling through the directories again

this is unnecessary  
particularly in lots of cases on initial launch of the server followed by loading of web page from the browser when the list was just created seconds before

this possibly would help reduce the issue with https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14507
> [Issue]: Long wait times before generation and display of Extra Networks after every launch, due to large amounts of Loras and Checkpoints

assuming that the issue is caused by crawling through the large directory

--- 

more improvements can be done if we cache the extra networks list and HTML
and only updated them when there is change to the directories

it might be possible to improve the performance by making indexing and creating of html multi-threaded (for each network type)

moveing indexing on to a separate thread might also improved performance
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/9c6ea5386b568f72fc8f539c7f3c90053fd64e4a/extensions-builtin/Lora/networks.py#L643

---

## Changes

split the `creating of the HTML` from the `refreshing the list of extra networks`
the refresh button still refreshes the list reindexing the directory
but the creating of the HTML triggered by the loading of web page only creates the HTML and not reloads the list

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
