### PR TITLE
paste infotext cast int as float

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -477,6 +477,8 @@ def connect_paste(button, paste_fields, input_comp, override_settings_component,
 
                     if valtype == bool and v == "False":
                         val = False
+                    elif valtype == int:
+                        val = float(v)
                     else:
                         val = valtype(v)
 


### PR DESCRIPTION
## Description
when casting the infotext string to it's corresponding element type the element type is determined by the default value saved in `ui-config.json`

this causes issues in one particular case

if a slider is implemented with a value range of `[0, 1]` step size of `0.1` default value `1`
if the developer set sleep value to `1` and not `1.0`, a integer one will be saved to `ui-config.json`, 
later when trying to perform paste infotext, becaue the value is a integer the value will be cast to a integer, but in this particular case it should be a float
this will result in an incorrectly value beeing applied to the UI

this is a real issue that I have run into just now
when verifying an extension and decide to take a little bit of time to implement infotext copypast for extension
see https://github.com/scraed/CharacteristicGuidanceWebUI/pull/1 https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/253#issuecomment-1875621234

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
