### PR TITLE
Fix SwinIR issues

### DIFF
--- a/extensions-builtin/SwinIR/scripts/swinir_model.py
+++ b/extensions-builtin/SwinIR/scripts/swinir_model.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+import torch
 from PIL import Image
 
 from modules import devices, modelloader, script_callbacks, shared, upscaler_utils
@@ -69,7 +70,7 @@ class UpscalerSwinIR(Upscaler):
         model_descriptor = modelloader.load_spandrel_model(
             filename,
             device=self._get_device(),
-            dtype=devices.dtype,
+            prefer_half=(devices.dtype == torch.float16),
             expected_architecture="SwinIR",
         )
         if getattr(shared.opts, 'SWIN_torch_compile', False):

--- a/extensions-builtin/SwinIR/scripts/swinir_model.py
+++ b/extensions-builtin/SwinIR/scripts/swinir_model.py
@@ -51,7 +51,7 @@ class UpscalerSwinIR(Upscaler):
             model,
             tile_size=shared.opts.SWIN_tile,
             tile_overlap=shared.opts.SWIN_tile_overlap,
-            scale=4,  # TODO: This was hard-coded before too...
+            scale=model.scale,
             desc="SwinIR",
         )
         devices.torch_gc()


### PR DESCRIPTION
## Description

These should fix the issues @wcde noticed in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14425#issuecomment-1875155134. 

I tested with the default SwinIR 4x model and [2x-LexicaSwinIR](https://openmodeldb.info/models/2x-LexicaSwinIR) and both work on my Macbook.

Since Spandrel declares SwinIR models as `supports_half=False`, SwinIR will henceforth use float32. (With `float16`, all I got was a black image anyway.)

## Screenshots/videos:

Here's a smaller version of the black image I got with `float16`: █

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
