### PR TITLE
handle config.json failed to load

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -249,7 +249,9 @@ def list_extensions(settings_file):
             with open(settings_file, "r", encoding="utf8") as file:
                 settings = json.load(file)
     except Exception:
-        errors.report("Could not load settings", exc_info=True)
+        errors.report(f'\nCould not load settings\nThe config file "{settings_file}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+        os.replace(settings_file, os.path.join(script_path, "tmp", "config.json"))
+        settings = {}
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
     disable_all_extensions = settings.get('disable_all_extensions', 'none')

--- a/modules/options.py
+++ b/modules/options.py
@@ -1,3 +1,4 @@
+import os
 import json
 import sys
 from dataclasses import dataclass
@@ -6,6 +7,7 @@ import gradio as gr
 
 from modules import errors
 from modules.shared_cmd_options import cmd_opts
+from modules.paths_internal import script_path
 
 
 class OptionInfo:
@@ -193,9 +195,13 @@ class Options:
         return type_x == type_y
 
     def load(self, filename):
-        with open(filename, "r", encoding="utf8") as file:
-            self.data = json.load(file)
-
+        try:
+            with open(filename, "r", encoding="utf8") as file:
+                self.data = json.load(file)
+        except Exception:
+            errors.report(f'\nCould not load settings\nThe config file "{filename}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+            os.replace(filename, os.path.join(script_path, "tmp", "config.json"))
+            self.data = {}
         # 1.6.0 VAE defaults
         if self.data.get('sd_vae_as_default') is not None and self.data.get('sd_vae_overrides_per_model_preferences') is None:
             self.data['sd_vae_overrides_per_model_preferences'] = not self.data.get('sd_vae_as_default')


### PR DESCRIPTION
## Description
shows a error like this and rever default if config.json failed to load as opposed to crash
issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14521 
```py
*** Could not load settings
*** The config file "B:\Stable Diffusion\Configs\config.json" is likely corrupted
*** It has been moved to the "tmp/config.json"
*** Reverting config to default
***
    Traceback (most recent call last):
      File "B:\GitHub\stable-diffusion-webui\modules\launch_utils.py", line 250, in list_extensions
        settings = json.load(file)
      File "C:\Programs\Python\3.10.6\lib\json\__init__.py", line 293, in load
        return loads(fp.read(),
      File "C:\Programs\Python\3.10.6\lib\json\__init__.py", line 346, in loads
        return _default_decoder.decode(s)
      File "C:\Programs\Python\3.10.6\lib\json\decoder.py", line 337, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "C:\Programs\Python\3.10.6\lib\json\decoder.py", line 353, in raw_decode
        obj, end = self.scan_once(s, idx)
    json.decoder.JSONDecodeError: Expecting ',' delimiter: line 300 column 32 (char 10686)

---
```

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
