### PR TITLE
Slightly broaden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ __pycache__
 /styles.csv
 /params.txt
 /styles.csv.bak
-/webui-user.bat
-/webui-user.sh
+/webui-user*
 /interrogate
 /user.css
 /.idea
@@ -38,3 +37,5 @@ notification.mp3
 /package-lock.json
 /.coverage*
 /test/test_outputs
+/xxx*
+/attic


### PR DESCRIPTION
## Description

For (my personal) ease of development, this PR proposes to broaden `.gitignore` by:

* `/webui-user-foo-blar.sh` and friends being ignored
* `/xxx-fix-foo.py` and so on being ignored
* [`/attic`](https://www.gnu.org/software/trans-coord/manual/cvs/html_node/Attic.html) for stuff not to be deleted but also not to be committed ever.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
