### PR TITLE
Handle CondFunc exception when resolving attributes

### DIFF
--- a/modules/sd_hijack_utils.py
+++ b/modules/sd_hijack_utils.py
@@ -11,10 +11,14 @@ class CondFunc:
                     break
                 except ImportError:
                     pass
-            for attr_name in func_path[i:-1]:
-                resolved_obj = getattr(resolved_obj, attr_name)
-            orig_func = getattr(resolved_obj, func_path[-1])
-            setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: self(*args, **kwargs))
+            try:
+                for attr_name in func_path[i:-1]:
+                    resolved_obj = getattr(resolved_obj, attr_name)
+                orig_func = getattr(resolved_obj, func_path[-1])
+                setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: self(*args, **kwargs))
+            except AttributeError:
+                print(f"Warning: Failed to resolve {orig_func} for CondFunc hijack")
+                pass
         self.__init__(orig_func, sub_func, cond_func)
         return lambda *args, **kwargs: self(*args, **kwargs)
     def __init__(self, orig_func, sub_func, cond_func):


### PR DESCRIPTION
## Description

* Handle potential `AttributeError` on `getattr`. This happens when `orig_func` string refers to a non-existent object.

For example, I attempted to hijack sd-webui-controlnet `annotator.anime_face_segment.AnimeFaceSegment.__init__` in my extension. However, `annotator.anime_face_segment` is only available starting from ControlNet >= 1.1.420. 

## Screenshots/videos:

```py
# Example usage
CondFunc('annotator.anime_face_segment.AnimeFaceSegment.__init__', ..., ...)
foo()
```

Before this change, an uncaught exception may be thrown at `CondFunc` instantiation, and `foo()` will not be executed unless we wrap every `CondFunc` with a `try-except` block, which is inconvenient.

```txt
      File "D:\stable-diffusion-webui\modules\sd_hijack_utils.py", line 15, in __new__
        resolved_obj = getattr(resolved_obj, attr_name)
    AttributeError: module 'annotator' has no attribute 'anime_face_segment'
```

After this change, a warning will be printed indicating this `CondFunc` didn't take effect:

```
Warning: Failed to resolve annotator.anime_face_segment.AnimeFaceSegment.__init__ for CondFunc hijack
```

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7253534/8843f910-06c4-4708-ae7c-c53b1662c5ec)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
