### PR TITLE
[IPEX] Fix xpu generator

### DIFF
--- a/modules/xpu_specific.py
+++ b/modules/xpu_specific.py
@@ -106,8 +106,8 @@ if has_xpu:
     try:
         # torch.Generator supports "xpu" device since 2.1
         torch.Generator("xpu")
-    except:
-        # W/A for https://github.com/intel/intel-extension-for-pytorch/issues/452: torch.Generator API doesn't support XPU device (for IPEX < 2.1)
+    except RuntimeError:
+        # W/A for https://github.com/intel/intel-extension-for-pytorch/issues/452: torch.Generator API doesn't support XPU device (for torch < 2.1)
         CondFunc('torch.Generator',
             lambda orig_func, device=None: torch.xpu.Generator(device),
             lambda orig_func, device=None: is_xpu_device(device))


### PR DESCRIPTION
## Description

* Checks whether `torch.Generator` supports `xpu` device before hijacking. "xpu" is supported starting from torch 2.1 and at the same time `torch.xpu.Generator` API is removed starting from IPEX 2.1.
* Properly handles the `device` arg when it's a `str`. Fixes issue https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14434

## Screenshots/videos:

Using token merging:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7253534/eb822009-8228-4da3-94f8-80fb57cfc667)

txt2img works as expected:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/7253534/f67eedce-773e-4d14-9b06-7f60cc070469)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
