### PR TITLE
Execute model_loaded_callback after moving to target device

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -842,12 +842,12 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
         sd_hijack.model_hijack.hijack(sd_model)
         timer.record("hijack")
 
-        script_callbacks.model_loaded_callback(sd_model)
-        timer.record("script callbacks")
-
         if not sd_model.lowvram:
             sd_model.to(devices.device)
             timer.record("move model to device")
+
+        script_callbacks.model_loaded_callback(sd_model)
+        timer.record("script callbacks")
 
     print(f"Weights loaded in {timer.summary()}.")
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -273,10 +273,11 @@ def reload_vae_weights(sd_model=None, vae_file=unspecified):
     load_vae(sd_model, vae_file, vae_source)
 
     sd_hijack.model_hijack.hijack(sd_model)
-    script_callbacks.model_loaded_callback(sd_model)
 
     if not sd_model.lowvram:
         sd_model.to(devices.device)
+
+    script_callbacks.model_loaded_callback(sd_model)
 
     print("VAE weights loaded.")
     return sd_model


### PR DESCRIPTION
## Description

This would allow model_loaded callbacks to be applied on the actual target device.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
