### PR TITLE
added Dockerfile for Ubuntu and associated docs

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,7 @@
+FROM python:3.10.6-slim
+WORKDIR /app
+RUN apt update
+RUN apt install -y wget git python3 python3-venv libgl1 libglib2.0-0
+RUN wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh
+COPY ./webui.sh ./webui.sh
+CMD ["bash"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,8 @@
 FROM python:3.10.6-slim
 WORKDIR /app
 RUN apt update
-RUN apt install -y wget git python3 python3-venv libgl1 libglib2.0-0
-RUN wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh
-COPY ./webui.sh ./webui.sh
-CMD ["bash"]
+RUN apt install -y wget git libgl1 libglib2.0-0
+COPY ./ ./
+RUN ./webui.sh -f --skip-torch-cuda-test --exit
+ENV HF_HOME=/root/.cache/huggingface
+CMD ["./webui.sh", "-f", "--listen"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -4,5 +4,4 @@ RUN apt update
 RUN apt install -y wget git libgl1 libglib2.0-0
 COPY ./ ./
 RUN ./webui.sh -f --skip-torch-cuda-test --exit
-ENV HF_HOME=/root/.cache/huggingface
 CMD ["./webui.sh", "-f", "--listen"]

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ Clone this repo, then build the Ubuntu container image:
 sudo docker build -t stable-diffusion-webui -f Dockerfile.ubuntu .
 ```
 
-Run the container image with gpu passthrough, by default it will listen on [http://0.0.0.0:7860](http://0.0.0.0:7860). Be sure to mount your huggingface cache directory to avoid downloading models every time the container starts (`-v ~/.cache/huggingface:/root/.cache/huggingface`).
+Run the container image, by default it will listen on [http://0.0.0.0:7860](http://0.0.0.0:7860). Be sure to mount a cache directory to avoid downloading models every time the container starts (`-v ~/.cache/huggingface:/app/models`). The `--gpus all` option is necessary to use available GPU(s).
 
 ```bash
-sudo docker run -it --rm -p 7860:7860 --gpus all -v ~/.cache/huggingface:/root/.cache/huggingface stable-diffusion-webui
+sudo docker run -it --rm -p 7860:7860 --gpus all -v ~/.cache/huggingface:/app/models stable-diffusion-webui
 ```
 
-The container will start quickly because download & installation was completed in the earlier build steps. If you need to specify additional command line args you can do it like this:
+You can pass command line args like so:
 
 ```bash
 sudo docker run -it --rm -p 7860:7860 --gpus all  stable-diffusion-webui bash -c "./webui.sh -f --listen --medvram --opt-split-attention"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ sudo docker build -t stable-diffusion-webui-build -f Dockerfile.ubuntu .
 sudo docker run -it --rm --name sdwebui -p 7860 --gpus all stable-diffusion-webui-build
 # 3) manually execute webui.sh within the container, -f allows root user to run the script
 ./webui.sh -f
-# 4) *from a separate terminal* commit the image (AFTER webui.sh is done)
+# 4) *from a separate terminal* commit the running container (AFTER webui.sh is done)
 docker commit sdwebui stable-diffusion-webui
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/m
 ```
 3. Run `webui.sh`.
 4. Check `webui-user.sh` for options.
+
+### Automatic Installation on Linux (Ubuntu container w/ GPU)
+
+By default the `webui.sh` script requires GPU access during installation, so building a Ubuntu container takes a few additional steps:
+
+```bash
+# 1) after cloning this repo, build the debian/ubuntu container
+sudo docker build -t stable-diffusion-webui-build -f Dockerfile.ubuntu .
+# 2) start it with --gpus to allow GPU passthrough
+sudo docker run -it --rm --name sdwebui -p 7860 --gpus all stable-diffusion-webui-build
+# 3) manually execute webui.sh within the container, -f allows root user to run the script
+./webui.sh -f
+# 4) *from a separate terminal* commit the image (AFTER webui.sh is done)
+docker commit sdwebui stable-diffusion-webui
+```
+
+Run the container image with gpu passthrough & specify any additional command line args, by default it will listen on [http://0.0.0.0:7860](http://0.0.0.0:7860):
+
+```bash
+ sudo docker run -it --rm -p 7860 --gpus all stable-diffusion-webui bash -c "./webui.sh -f --listen"
+```
+
+The container will start quickly because download & installation was completed in the earlier build steps.
+
 ### Installation on Apple Silicon
 
 Find the instructions [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Installation-on-Apple-Silicon).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ sudo docker run -it --rm -p 7860:7860 --gpus all -v ~/.cache/huggingface:/app/mo
 You can pass command line args like so:
 
 ```bash
-sudo docker run -it --rm -p 7860:7860 --gpus all  stable-diffusion-webui bash -c "./webui.sh -f --listen --medvram --opt-split-attention"
+sudo docker run -it --rm -p 7860:7860 --gpus all -v ~/.cache/huggingface:/app/models stable-diffusion-webui bash -c "./webui.sh -f --listen --medvram --opt-split-attention"
 ```
 
 ### Installation on Apple Silicon

--- a/README.md
+++ b/README.md
@@ -136,26 +136,23 @@ wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/m
 
 ### Automatic Installation on Linux (Ubuntu container w/ GPU)
 
-By default the `webui.sh` script requires GPU access during installation, so building a Ubuntu container takes a few additional steps:
+Clone this repo, then build the Ubuntu container image:
 
 ```bash
-# 1) after cloning this repo, build the debian/ubuntu container
-sudo docker build -t stable-diffusion-webui-build -f Dockerfile.ubuntu .
-# 2) start it with --gpus to allow GPU passthrough
-sudo docker run -it --rm --name sdwebui -p 7860 --gpus all stable-diffusion-webui-build
-# 3) manually execute webui.sh within the container, -f allows root user to run the script
-./webui.sh -f
-# 4) *from a separate terminal* commit the running container (AFTER webui.sh is done)
-docker commit sdwebui stable-diffusion-webui
+sudo docker build -t stable-diffusion-webui -f Dockerfile.ubuntu .
 ```
 
-Run the container image with gpu passthrough & specify any additional command line args, by default it will listen on [http://0.0.0.0:7860](http://0.0.0.0:7860):
+Run the container image with gpu passthrough, by default it will listen on [http://0.0.0.0:7860](http://0.0.0.0:7860). Be sure to mount your huggingface cache directory to avoid downloading models every time the container starts (`-v ~/.cache/huggingface:/root/.cache/huggingface`).
 
 ```bash
- sudo docker run -it --rm -p 7860 --gpus all stable-diffusion-webui bash -c "./webui.sh -f --listen"
+sudo docker run -it --rm -p 7860:7860 --gpus all -v ~/.cache/huggingface:/root/.cache/huggingface stable-diffusion-webui
 ```
 
-The container will start quickly because download & installation was completed in the earlier build steps.
+The container will start quickly because download & installation was completed in the earlier build steps. If you need to specify additional command line args you can do it like this:
+
+```bash
+sudo docker run -it --rm -p 7860:7860 --gpus all  stable-diffusion-webui bash -c "./webui.sh -f --listen --medvram --opt-split-attention"
+```
 
 ### Installation on Apple Silicon
 


### PR DESCRIPTION
## Description

* I added a Dockerfile for Ubuntu and some documentation to build and run a container image.
* I believe many people would find this useful, and there have been some examples cropping up in community but no official instructions here that I could find.
* This could be a first step toward building & publishing images via CI, which could help reduce friction for new users even further.

## Screenshots/videos:

```
~/Desktop/stable-diffusion-webui$  sudo docker run -it --rm -p 7860 --gpus all stable-diffusion-webui bash -c "./webui.sh -f --listen"

################################################################
Install script for stable-diffusion + Web UI
Tested on Debian 11 (Bullseye), Fedora 34+ and openSUSE Leap 15.4 or newer.
################################################################

################################################################
Running on root user
################################################################

################################################################
Create and activate python venv
################################################################

################################################################
Launching launch.py...
################################################################
Cannot locate TCMalloc (improves CPU memory usage)
Python 3.10.6 (main, Aug 23 2022, 08:36:38) [GCC 10.2.1 20210110]
Version: v1.7.0
Commit hash: cf2772fab0af5573da775e7437e6acdca424f26e
Launching Web UI with arguments: -f --listen
no module 'xformers'. Processing without...
no module 'xformers'. Processing without...
No module 'xformers'. Proceeding without it.
Style database not found: /app/stable-diffusion-webui/styles.csv
Loading weights [6ce0161689] from /app/stable-diffusion-webui/models/Stable-diffusion/v1-5-pruned-emaonly.safetensors
Creating model from config: /app/stable-diffusion-webui/configs/v1-inference.yaml
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
Startup time: 3.9s (prepare environment: 0.8s, import torch: 1.2s, import gradio: 0.4s, setup paths: 0.4s, other imports: 0.2s, load scripts: 0.3s, initialize extra networks: 0.1s, create ui: 0.3s, gradio launch: 0.1s).
Applying attention optimization: Doggettx... done.
Model loaded in 1.7s (create model: 0.6s, apply weights to model: 0.9s).
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
