### PR TITLE
Improve the implementation of Manual Cast and IPEX support

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -140,20 +140,20 @@ def manual_cast_forward(target_dtype):
         ):
             args = [arg.to(target_dtype) if isinstance(arg, torch.Tensor) else arg for arg in args]
             kwargs = {k: v.to(target_dtype) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
-        
+
         org_dtype = torch_utils.get_param(self).dtype
         if org_dtype != target_dtype:
             self.to(target_dtype)
         result = self.org_forward(*args, **kwargs)
         if org_dtype != target_dtype:
             self.to(org_dtype)
-        
+
         if target_dtype != dtype_inference:
             if isinstance(result, tuple):
                 result = tuple(
-                    i.to(dtype_inference) 
-                    if isinstance(i, torch.Tensor) 
-                    else i 
+                    i.to(dtype_inference)
+                    if isinstance(i, torch.Tensor)
+                    else i
                     for i in result
                 )
             elif isinstance(result, torch.Tensor):
@@ -185,7 +185,7 @@ def autocast(disable=False):
     if fp8 and device==cpu:
         return torch.autocast("cpu", dtype=torch.bfloat16, enabled=True)
 
-    if dtype == torch.float32 and shared.cmd_opts.precision == "full":
+    if dtype == torch.float32:
         return contextlib.nullcontext()
 
     if has_xpu() or has_mps() or cuda_no_autocast():

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -185,14 +185,14 @@ def autocast(disable=False):
     if fp8 and device==cpu:
         return torch.autocast("cpu", dtype=torch.bfloat16, enabled=True)
 
-    if has_xpu() or has_mps() or cuda_no_autocast():
-        return manual_cast(dtype)
-
     if fp8 and dtype_inference == torch.float32:
         return manual_cast(dtype)
 
     if dtype == torch.float32 or dtype_inference == torch.float32:
         return contextlib.nullcontext()
+
+    if has_xpu() or has_mps() or cuda_no_autocast():
+        return manual_cast(dtype)
 
     return torch.autocast("cuda")
 

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -132,21 +132,6 @@ patch_module_list = [
 ]
 
 
-def cast_output(result):
-    if isinstance(result, tuple):
-        result = tuple(i.to(dtype_inference) if isinstance(i, torch.Tensor) else i for i in result)
-    elif isinstance(result, torch.Tensor):
-        result = result.to(dtype_inference)
-    return result
-
-
-def autocast_with_cast_output(self, *args, **kwargs):
-    result = self.org_forward(*args, **kwargs)
-    if dtype_inference != dtype:
-        result = cast_output(result)
-    return result
-
-
 def manual_cast_forward(target_dtype):
     def forward_wrapper(self, *args, **kwargs):
         if any(
@@ -164,7 +149,15 @@ def manual_cast_forward(target_dtype):
             self.to(org_dtype)
 
         if target_dtype != dtype_inference:
-            result = cast_output(result)
+            if isinstance(result, tuple):
+                result = tuple(
+                    i.to(dtype_inference)
+                    if isinstance(i, torch.Tensor)
+                    else i
+                    for i in result
+                )
+            elif isinstance(result, torch.Tensor):
+                result = result.to(dtype_inference)
         return result
     return forward_wrapper
 
@@ -185,20 +178,6 @@ def manual_cast(target_dtype):
             module_type.forward = module_type.org_forward
 
 
-@contextlib.contextmanager
-def precision_full_with_autocast(autocast_ctx):
-    for module_type in patch_module_list:
-        org_forward = module_type.forward
-        module_type.forward = autocast_with_cast_output
-        module_type.org_forward = org_forward
-    try:
-        with autocast_ctx:
-            yield None
-    finally:
-        for module_type in patch_module_list:
-            module_type.forward = module_type.org_forward
-
-
 def autocast(disable=False):
     if disable:
         return contextlib.nullcontext()
@@ -211,9 +190,6 @@ def autocast(disable=False):
 
     if has_xpu() or has_mps() or cuda_no_autocast():
         return manual_cast(dtype_inference)
-
-    if dtype_inference == torch.float32 and dtype != torch.float32:
-        return precision_full_with_autocast(torch.autocast("cuda"))
 
     return torch.autocast("cuda")
 

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -110,6 +110,7 @@ device_codeformer: torch.device = None
 dtype: torch.dtype = torch.float16
 dtype_vae: torch.dtype = torch.float16
 dtype_unet: torch.dtype = torch.float16
+dtype_inference: torch.dtype = torch.float16
 unet_needs_upcast = False
 
 
@@ -131,21 +132,49 @@ patch_module_list = [
 ]
 
 
-def manual_cast_forward(self, *args, **kwargs):
-    org_dtype = torch_utils.get_param(self).dtype
-    self.to(dtype)
-    args = [arg.to(dtype) if isinstance(arg, torch.Tensor) else arg for arg in args]
-    kwargs = {k: v.to(dtype) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
-    result = self.org_forward(*args, **kwargs)
-    self.to(org_dtype)
-    return result
+def manual_cast_forward(target_dtype):
+    def forward_wrapper(self, *args, **kwargs):
+        org_dtype = torch_utils.get_param(self).dtype
+        if not target_dtype == org_dtype == dtype_inference:
+            self.to(target_dtype)
+            args = [
+                arg.to(target_dtype) 
+                if isinstance(arg, torch.Tensor) 
+                else arg 
+                for arg in args
+            ]
+            kwargs = {
+                k: v.to(target_dtype) 
+                if isinstance(v, torch.Tensor) 
+                else v 
+                for k, v in kwargs.items()
+            }
+        
+        result = self.org_forward(*args, **kwargs)
+        self.to(org_dtype)
+        
+        if target_dtype != dtype_inference:
+            if isinstance(result, tuple):
+                result = tuple(
+                    i.to(dtype_inference) 
+                    if isinstance(i, torch.Tensor) 
+                    else i 
+                    for i in result
+                )
+            elif isinstance(result, torch.Tensor):
+                result = result.to(dtype_inference)
+        return result
+    return forward_wrapper
 
 
 @contextlib.contextmanager
-def manual_cast():
+def manual_cast(target_dtype):
     for module_type in patch_module_list:
         org_forward = module_type.forward
-        module_type.forward = manual_cast_forward
+        if module_type == torch.nn.MultiheadAttention and has_xpu():
+            module_type.forward = manual_cast_forward(torch.float32)
+        else:
+            module_type.forward = manual_cast_forward(target_dtype)
         module_type.org_forward = org_forward
     try:
         yield None
@@ -161,14 +190,11 @@ def autocast(disable=False):
     if fp8 and device==cpu:
         return torch.autocast("cpu", dtype=torch.bfloat16, enabled=True)
 
-    if fp8 and (dtype == torch.float32 or shared.cmd_opts.precision == "full" or cuda_no_autocast()):
-        return manual_cast()
-
-    if has_mps() and shared.cmd_opts.precision != "full":
-        return manual_cast()
-
-    if dtype == torch.float32 or shared.cmd_opts.precision == "full":
+    if dtype == torch.float32 and shared.cmd_opts.precision == "full":
         return contextlib.nullcontext()
+
+    if has_xpu() or has_mps() or cuda_no_autocast():
+        return manual_cast(dtype_inference)
 
     return torch.autocast("cuda")
 

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -185,11 +185,14 @@ def autocast(disable=False):
     if fp8 and device==cpu:
         return torch.autocast("cpu", dtype=torch.bfloat16, enabled=True)
 
-    if dtype == torch.float32:
-        return contextlib.nullcontext()
-
     if has_xpu() or has_mps() or cuda_no_autocast():
-        return manual_cast(dtype_inference)
+        return manual_cast(dtype)
+
+    if fp8 and dtype_inference == torch.float32:
+        return manual_cast(dtype)
+
+    if dtype == torch.float32 or dtype_inference == torch.float32:
+        return contextlib.nullcontext()
 
     return torch.autocast("cuda")
 

--- a/modules/shared_init.py
+++ b/modules/shared_init.py
@@ -29,6 +29,7 @@ def initialize():
 
     devices.dtype = torch.float32 if cmd_opts.no_half else torch.float16
     devices.dtype_vae = torch.float32 if cmd_opts.no_half or cmd_opts.no_half_vae else torch.float16
+    devices.dtype_inference = torch.float32 if cmd_opts.precision == 'full' else devices.dtype
 
     shared.device = devices.device
     shared.weight_load_location = None if cmd_opts.lowram else "cpu"


### PR DESCRIPTION
## Description
* Improved the efficiency of manual cast with type checking.
* Apply the behavior of precision=full into manual cast
  * Also ensure fp8 can be used with precision=full on autocastable devices. <br> (With manual cast, which is as fast as autocast + output upcast. I just chose the simples one)
* Use float32 for MHA layer in ipex since some computation in it is not good for IPEX devices.
* Have checked this implementation can be used on NV Cuda/Apple M/Intel ARC. With latest ipex, Arc A770 can use manual cast with fp8 features.
* Manual Cast on A770 is now faster then autocast('xpu'), even with ipex.optimize.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
