### PR TITLE
hires button, fix seeds

### DIFF
--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -67,13 +67,16 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
 
     geninfo = json.loads(generation_info)
     all_seeds = geninfo["all_seeds"]
+    all_subseeds = geninfo["all_subseeds"]
 
     image_info = gallery[gallery_index] if 0 <= gallery_index < len(gallery) else gallery[0]
     p.firstpass_image = infotext_utils.image_from_url_text(image_info)
 
     gallery_index_from_end = len(gallery) - gallery_index
     seed = all_seeds[-gallery_index_from_end if gallery_index_from_end < len(all_seeds) + 1 else 0]
-    p.script_args = modules.scripts.scripts_txt2img.set_named_arg(p.script_args, 'ScriptSeed', 'seed', seed)
+    subseed = all_subseeds[-gallery_index_from_end if gallery_index_from_end < len(all_seeds) + 1 else 0]
+    p.seed = seed
+    p.subseed = subseed
 
     with closing(p):
         processed = modules.scripts.scripts_txt2img.run(p, *p.script_args)


### PR DESCRIPTION
## Description
follow up of https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/15ec54dd969d6dc3fea7790ca5cce5badcfda426 Have upscale button use the same seed as hires fix.

that doesn't actually work
`seed` is set by the `seed script` in the `setup()`
too late to modify it using `modules.scripts.scripts_txt2img.set_named_arg`, I have to directly modify `p.seed`

you forget about `sub seeds`

I've been having trouble getting all 3 out put
normal hires fix (the old input accordion)
manual hires fix (txt2img -> upscale -> image)
and 2 stage hires fix (this nuw button)
to be the match (pixel perfect)
> at this point I am not sure if I messed up or has something changed

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
