### PR TITLE
Logging: set formatter correctly for fallback logger too

### DIFF
--- a/modules/logging_config.py
+++ b/modules/logging_config.py
@@ -36,19 +36,20 @@ def setup_logging(loglevel):
         # Already configured, do not interfere
         return
 
+    formatter = logging.Formatter(
+        '%(asctime)s %(levelname)s [%(name)s] %(message)s',
+        '%Y-%m-%d %H:%M:%S',
+    )
+
     if os.environ.get("SD_WEBUI_RICH_LOG"):
         from rich.logging import RichHandler
         handler = RichHandler()
     else:
         handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
 
     if TqdmLoggingHandler:
         handler = TqdmLoggingHandler(handler)
-
-    formatter = logging.Formatter(
-        '%(asctime)s %(levelname)s [%(name)s] %(message)s',
-        '%Y-%m-%d %H:%M:%S',
-    )
 
     handler.setFormatter(formatter)
 


### PR DESCRIPTION
## Description

I had been silly in #14538 and the fallback logger wrapped by the Tqdm logger didn't have a formatter configured. It does now.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
