### PR TITLE
more Hr button fix

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -230,7 +230,7 @@ def restore_old_hires_fix_params(res):
     res['Hires resize-2'] = height
 
 
-def parse_generation_parameters(x: str):
+def parse_generation_parameters(x: str, skip_fields: list[str] | None = None):
     """parses generation parameters string, the one you see in text field under the picture in UI:
 ```
 girl with an artist's beret, determined, blue eyes, desert scene, computer monitors, heavy makeup, by Alphonse Mucha and Charlie Bowater, ((eyeshadow)), (coquettish), detailed, intricate
@@ -240,6 +240,8 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     returns a dict with field values
     """
+    if skip_fields is None:
+        skip_fields = shared.opts.infotext_skip_pasting
 
     res = {}
 
@@ -356,8 +358,8 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     infotext_versions.backcompat(res)
 
-    skip = set(shared.opts.infotext_skip_pasting)
-    res = {k: v for k, v in res.items() if k not in skip}
+    for key in skip_fields:
+        res.pop(key, None)
 
     return res
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1227,8 +1227,11 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             if not state.processing_has_refined_job_count:
                 if state.job_count == -1:
                     state.job_count = self.n_iter
-
-                shared.total_tqdm.updateTotal((self.steps + (self.hr_second_pass_steps or self.steps)) * state.job_count)
+                if getattr(self, 'txt2img_upscale', False):
+                    total_steps = (self.hr_second_pass_steps or self.steps) * state.job_count
+                else:
+                    total_steps = (self.steps + (self.hr_second_pass_steps or self.steps)) * state.job_count
+                shared.total_tqdm.updateTotal(total_steps)
                 state.job_count = state.job_count * 2
                 state.processing_has_refined_job_count = True
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -70,7 +70,7 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     image_info = gallery[gallery_index] if 0 <= gallery_index < len(gallery) else gallery[0]
     p.firstpass_image = infotext_utils.image_from_url_text(image_info)
 
-    parameters = parse_generation_parameters(geninfo.get('infotexts')[gallery_index])
+    parameters = parse_generation_parameters(geninfo.get('infotexts')[gallery_index], [])
     p.seed = parameters.get('Seed', -1)
     p.subseed = parameters.get('Variation seed', -1)
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -77,7 +77,7 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     subseed = all_subseeds[-gallery_index_from_end if gallery_index_from_end < len(all_seeds) + 1 else 0]
     p.seed = seed
     p.subseed = subseed
-
+    p.override_settings['save_images_before_highres_fix'] = False
     with closing(p):
         processed = modules.scripts.scripts_txt2img.run(p, *p.script_args)
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -64,6 +64,7 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     p.enable_hr = True
     p.batch_size = 1
     p.n_iter = 1
+    p.txt2img_upscale = True
 
     geninfo = json.loads(generation_info)
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -88,18 +88,13 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
 
     new_gallery = []
     for i, image in enumerate(gallery):
-        fake_image = Image.new(mode="RGB", size=(1, 1))
-
         if i == gallery_index:
-            already_saved_as = getattr(processed.images[0], 'already_saved_as', None)
-            if already_saved_as is not None:
-                fake_image.already_saved_as = already_saved_as
-            else:
-                fake_image = processed.images[0]
+            geninfo["infotexts"][gallery_index: gallery_index+1] = processed.infotexts
+            new_gallery.extend(processed.images)
         else:
+            fake_image = Image.new(mode="RGB", size=(1, 1))
             fake_image.already_saved_as = image["name"]
-
-        new_gallery.append(fake_image)
+            new_gallery.append(fake_image)
 
     geninfo["infotexts"][gallery_index] = processed.info
 

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -93,7 +93,7 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
             new_gallery.extend(processed.images)
         else:
             fake_image = Image.new(mode="RGB", size=(1, 1))
-            fake_image.already_saved_as = image["name"]
+            fake_image.already_saved_as = image["name"].rsplit('?', 1)[0]
             new_gallery.append(fake_image)
 
     geninfo["infotexts"][gallery_index] = processed.info


### PR DESCRIPTION
## Description

some more fixes to hires fix button

- disable saving images before highres fix <br>makes no sense to save first pass image again
- allow hires pass to update the existing gallery as opposed to setting all the other images to black <br>this allows the user to perform Hr on multiple images from a first pass batch
- allow hr pass to retrun and update multiple images <br>this is basically just for compatibility with my extension https://github.com/w-e-w/sd-webui-hires-fix-tweaks which allows you to generate multiple hr pass images
- add `p.txt2img_upscale` attribute as indicator of using `txt2img_upscale()`
- fix console total progress bar when using txt2img_upscale

note commit [parse_generation_parameters skip_fields](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14645/commits/d224fed0ce16e6f1507b0da29e7495ab2b0035e4) from
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14645

example
first pass of 2 images
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/a5a29dc4-c7ca-418c-a576-e66d68d81c64)
select 1st image (not counting the grid) for hr pass (with hr batch count of 3 using my extension)
job finished and and retruns / updates the 1st image with 3 new hr pass images
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/1af511c0-af84-4388-b721-ea32cc5ea9e7)

---

https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14645
I made a PR for geninfo from Infotexts (the sutff below)
PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14645 will merge in order for the multiple image returning to work, otherwise when saving or retrieving seed info will be wrong

### Request
can `connect_reuse_seed()` be be changed to fetch information from `elem_id=f'generation_info_{self.tabname}'` to `f'html_info_{self.script.tabname}` parse the info text as opposed the hidden json
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/cf2772fab0af5573da775e7437e6acdca424f26e/modules/processing_scripts/seed.py#L80-L83
example can be seen with what I did in my extension
https://github.com/w-e-w/sd-webui-hires-fix-tweaks/blob/3f9254ffb2d49f52e80989737dbb8c3bdbce445f/hires_fix_tweaks/ui.py#L13-L28
the reason being that remove the need of updating all the other geninfo parameters to just updateing the `infotext`
when an extension wishes to return extra images

otherwise the following code (and possibly some more logic) needs to be added too the PR too make 
`allowe to return multiple images` properly work
```py
            geninfo["all_prompts"][gallery_index: gallery_index + 1] = processed.all_prompts
            geninfo["all_negative_prompts"][gallery_index: gallery_index + 1] = processed.all_negative_prompts
            geninfo["all_seeds"][gallery_index: gallery_index + 1] = processed.all_seeds
            geninfo["all_subseeds"][gallery_index: gallery_index + 1] = processed.all_subseeds
```
I believe this simplification applies to not just my extension
and I don't really see advantage of doing it the current way with the hidden json
I can make a PR if you agree, if you don't then this PR probably needs the above code added

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
