### PR TITLE
[Bug] Fix tab indexes are reseted after restart UI

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -532,7 +532,7 @@ def create_ui():
 
                     if category == "image":
                         with gr.Tabs(elem_id="mode_img2img"):
-                            img2img_selected_tab = gr.State(0)
+                            img2img_selected_tab = gr.Number(value=0, visible=False)
 
                             with gr.TabItem('img2img', id='img2img', elem_id="img2img_img2img_tab") as tab_img2img:
                                 init_img = gr.Image(label="Image for img2img", elem_id="img2img_image", show_label=False, source="upload", interactive=True, type="pil", tool="editor", image_mode="RGBA", height=opts.img2img_editor_height)
@@ -613,7 +613,7 @@ def create_ui():
                     elif category == "dimensions":
                         with FormRow():
                             with gr.Column(elem_id="img2img_column_size", scale=4):
-                                selected_scale_tab = gr.State(value=0)
+                                selected_scale_tab = gr.Number(value=0, visible=False)
 
                                 with gr.Tabs():
                                     with gr.Tab(label="Resize to", elem_id="img2img_tab_resize_to") as tab_scale_to:

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -5,7 +5,7 @@ import modules.infotext_utils as parameters_copypaste
 
 def create_ui():
     dummy_component = gr.Label(visible=False)
-    tab_index = gr.State(value=0)
+    tab_index = gr.Number(value=0, visible=False)
 
     with gr.Row(equal_height=False, variant='compact'):
         with gr.Column(variant='compact'):


### PR DESCRIPTION
## Description

When you selected in web browser tab `img2img->Resize by`, or `Extras->Batch Process`, then you restart webui, the internal state of tabs' indexes are reseted. It also happened in one my extension, where I used the same pattern of tab_index, it is really annoying

I've found it happens because of `gr.State` component. I've changed it on invisible `gr.Number`, and the bug is gone. So I decided to make a PR


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
