### PR TITLE
Add # to the invalid_filename_chars list

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -321,7 +321,7 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
     return res
 
 
-invalid_filename_chars = '<>:"/\\|?*\n\r\t'
+invalid_filename_chars = '#<>:"/\\|?*\n\r\t'
 invalid_filename_prefix = ' '
 invalid_filename_postfix = ' .'
 re_nonletters = re.compile(r'[\s' + string.punctuation + ']+')


### PR DESCRIPTION
## Description

Simply adds the `#` character to the invalid_filename_chars list, which causes it to get replaced by `_` in filenames.

Reason is due to a Gradio bug, hashtags in filenames will display as a broken image in the result gallery when the image is saved.  This can happen when you have a hashtag in your prompt, lora, etc. if the prompt, lora, or etc. is saved to the filename.

#5271 #5470 (These issues are closed but the problem persists)

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6970043/5afacead-a1b5-4f75-aee8-b7d1aa9ff7fa)

***Before change***
![cat](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6970043/358c6dec-20b5-44a0-b55c-299b30e5a911)
_(sped up a bit)_

The image _is_ saved correctly, but can't be displayed.
Filename: ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6970043/24b8c7d6-38c1-4285-8095-f496cf095d7f)

***After change***
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6970043/4e6f3eae-13d8-404f-b5d8-8253fa24eb0f)

The image is displayed and still saved, expect with `#` replaced by `_`.
Filename: ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/6970043/f95bc15f-2b2b-4c63-b0da-b9ce20e0787c)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
