### PR TITLE
geninfo from Infotexts

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -230,7 +230,7 @@ def restore_old_hires_fix_params(res):
     res['Hires resize-2'] = height
 
 
-def parse_generation_parameters(x: str):
+def parse_generation_parameters(x: str, skip_fields: list[str] | None = None):
     """parses generation parameters string, the one you see in text field under the picture in UI:
 ```
 girl with an artist's beret, determined, blue eyes, desert scene, computer monitors, heavy makeup, by Alphonse Mucha and Charlie Bowater, ((eyeshadow)), (coquettish), detailed, intricate
@@ -240,6 +240,8 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     returns a dict with field values
     """
+    if skip_fields is None:
+        skip_fields = shared.opts.infotext_skip_pasting
 
     res = {}
 
@@ -356,8 +358,8 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     infotext_versions.backcompat(res)
 
-    skip = set(shared.opts.infotext_skip_pasting)
-    res = {k: v for k, v in res.items() if k not in skip}
+    for key in skip_fields:
+        res.pop(key, None)
 
     return res
 

--- a/modules/processing_scripts/seed.py
+++ b/modules/processing_scripts/seed.py
@@ -88,7 +88,7 @@ def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: 
         try:
             gen_info = json.loads(gen_info_string)
             infotext = gen_info.get('infotexts')[index]
-            gen_parameters = infotext_utils.parse_generation_parameters(infotext)
+            gen_parameters = infotext_utils.parse_generation_parameters(infotext, [])
             res = int(gen_parameters.get('Variation seed' if is_subseed else 'Seed', -1))
         except Exception:
             if gen_info_string:

--- a/modules/processing_scripts/seed.py
+++ b/modules/processing_scripts/seed.py
@@ -6,6 +6,7 @@ from modules import scripts, ui, errors
 from modules.infotext_utils import PasteField
 from modules.shared import cmd_opts
 from modules.ui_components import ToolButton
+from modules import infotext_utils
 
 
 class ScriptSeed(scripts.ScriptBuiltinUI):
@@ -77,7 +78,6 @@ class ScriptSeed(scripts.ScriptBuiltinUI):
             p.seed_resize_from_h = seed_resize_from_h
 
 
-
 def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: gr.Textbox, is_subseed):
     """ Connects a 'reuse (sub)seed' button's click event so that it copies last used
         (sub)seed value from generation info the to the seed field. If copying subseed and subseed strength
@@ -85,21 +85,14 @@ def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: 
 
     def copy_seed(gen_info_string: str, index):
         res = -1
-
         try:
             gen_info = json.loads(gen_info_string)
-            index -= gen_info.get('index_of_first_image', 0)
-
-            if is_subseed and gen_info.get('subseed_strength', 0) > 0:
-                all_subseeds = gen_info.get('all_subseeds', [-1])
-                res = all_subseeds[index if 0 <= index < len(all_subseeds) else 0]
-            else:
-                all_seeds = gen_info.get('all_seeds', [-1])
-                res = all_seeds[index if 0 <= index < len(all_seeds) else 0]
-
-        except json.decoder.JSONDecodeError:
+            infotext = gen_info.get('infotexts')[index]
+            gen_parameters = infotext_utils.parse_generation_parameters(infotext)
+            res = int(gen_parameters.get('Variation seed' if is_subseed else 'Seed', -1))
+        except Exception:
             if gen_info_string:
-                errors.report(f"Error parsing JSON generation info: {gen_info_string}")
+                errors.report(f"Error retrieving seed from generation info: {gen_info_string}", exc_info=True)
 
         return [res, gr.update()]
 

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -40,8 +40,9 @@ def save_files(js_data, images, do_make_zip, index):
     import csv
     filenames = []
     fullfns = []
+    parsed_infotexts = []
 
-    #quick dictionary to class object conversion. Its necessary due apply_filename_pattern requiring it
+    # quick dictionary to class object conversion. Its necessary due apply_filename_pattern requiring it
     class MyObject:
         def __init__(self, d=None):
             if d is not None:
@@ -49,16 +50,14 @@ def save_files(js_data, images, do_make_zip, index):
                     setattr(self, key, value)
 
     data = json.loads(js_data)
-
     p = MyObject(data)
+
     path = shared.opts.outdir_save
     save_to_dirs = shared.opts.use_save_to_dirs_for_ui
     extension: str = shared.opts.samples_format
     start_index = 0
-    only_one = False
 
     if index > -1 and shared.opts.save_selected_only and (index >= data["index_of_first_image"]):  # ensures we are looking at a specific non-grid picture, and we have save_selected_only
-        only_one = True
         images = [images[index]]
         start_index = index
 
@@ -74,10 +73,12 @@ def save_files(js_data, images, do_make_zip, index):
             image = image_from_url_text(filedata)
 
             is_grid = image_index < p.index_of_first_image
-            i = 0 if is_grid else (image_index - p.index_of_first_image)
 
             p.batch_index = image_index-1
-            fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=p.all_seeds[i], prompt=p.all_prompts[i], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
+
+            parameters = parameters_copypaste.parse_generation_parameters(data["infotexts"][image_index])
+            parsed_infotexts.append(parameters)
+            fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=parameters['Seed'], prompt=parameters['Prompt'], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
 
             filename = os.path.relpath(fullfn, path)
             filenames.append(filename)
@@ -86,12 +87,12 @@ def save_files(js_data, images, do_make_zip, index):
                 filenames.append(os.path.basename(txt_fullfn))
                 fullfns.append(txt_fullfn)
 
-        writer.writerow([data["prompt"], data["seed"], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], data["negative_prompt"]])
+        writer.writerow([parsed_infotexts[0]['Prompt'], parsed_infotexts[0]['Seed'], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], parsed_infotexts[0]['Negative prompt']])
 
     # Make Zip
     if do_make_zip:
-        zip_fileseed = p.all_seeds[index-1] if only_one else p.all_seeds[0]
-        namegen = modules.images.FilenameGenerator(p, zip_fileseed, p.all_prompts[0], image, True)
+        p.all_seeds = [parameters['Seed'] for parameters in parsed_infotexts]
+        namegen = modules.images.FilenameGenerator(p, parsed_infotexts[0]['Seed'], parsed_infotexts[0]['Prompt'], image, True)
         zip_filename = namegen.apply(shared.opts.grid_zip_filename_pattern or "[datetime]_[[model_name]]_[seed]-[seed_last]")
         zip_filepath = os.path.join(path, f"{zip_filename}.zip")
 

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -76,7 +76,7 @@ def save_files(js_data, images, do_make_zip, index):
 
             p.batch_index = image_index-1
 
-            parameters = parameters_copypaste.parse_generation_parameters(data["infotexts"][image_index])
+            parameters = parameters_copypaste.parse_generation_parameters(data["infotexts"][image_index], [])
             parsed_infotexts.append(parameters)
             fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=parameters['Seed'], prompt=parameters['Prompt'], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
 


### PR DESCRIPTION
## Description
per prior discussion
switch the source of information to the more reliable infotexts
reduce the complexity of updateing geninfo

- reuse seed form infotexts
- save_files using info from infotexts
- add a new arg `skip_fields` to parse_generation_parameters, defaults to `shared.opts.infotext_skip_pasting`<br>set to `[]` to not skip any fields or set to custom `list[str]` for special use case<br><br>if this this is a new function I would do it the other way around<br>set default to `[]` and pass `shared.opts.infotext_skip_pasting` wheing using for `applying infotext`<br>but it is possible some extension is relying on the current behavior<br>that is why it is implemented this way as to not changing current behavior

I'm not sure if we use gen input in some other place if so they will have to be updated too

related
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14626

---

minor behavioral changes
previously when saving single images using the save button the info written to CSV is always the info of the first image regardless of the image chosen to be saved,
I think this is a bug so I modified the code so that it will write the corresponding info to the CSV of the chosen image

---

there's also something that I'm a bit puzzled,
when saving zip we also save all the images as individual files alongside the zip file
basically are saving the files twice
is this intended?

---

<details><summary>copied from prior discussion for documentation purposes</summary>
<p>

```
w-e-w — 2024/01/12 21:08
I still don't like geninfo is created in stages of the pipeline and then have to be updated individually
and different entries have different rules

I really think it should be consolidated into one object link to one image
(which basically is what infotexts is already) 
AUTOMATIC — 2024/01/12 21:17
as in, an array, where each ittem correspons to each image in the gallery?
w-e-w — 2024/01/12 21:18
the issue is not with the array the issue is with other things such as all_seeds
when grid is returned to the gallery
all_seeds is not updated
geninfo['index_of_first_image'] is set to 1
same logic with subseed
AUTOMATIC — 2024/01/12 21:19
what I mean it, now geninfo is a dict with info about all images
what it can be, is a list, where each item is a dict wuth info about one image
w-e-w — 2024/01/12 21:21
what it can be, is a list, where each item is a dict wuth info about one image
which is what  geninfo['infotexts'] already is
AUTOMATIC — 2024/01/12 21:21
right but you'd have to parse it
w-e-w — 2024/01/12 21:21
you also have to parse json string back to dict
AUTOMATIC — 2024/01/12 21:22
geninfo = {'images': [{"seed": 1, infotext: "...", ...}, {"seed": 2, infotext: "...", ...}]}
 
w-e-w — 2024/01/12 21:29
you could do that but that
but that also means that extension will also have to write code to update gen info

on the other hand if everything is just inside infotext
any extensions that already adds p.extra_generation_params will work automatically

unless you wish to rewrite the entire geninfo so that it based of generation_params

it is not that complicated, I hardly have to implement anything
I have a code for parseing infotext form html_info_txt2img
https://github.com/w-e-w/sd-webui-hires-fix-tweaks/blob/main/hires_fix_tweaks/ui.py#L13-L28
just a HTMLParser and generation_parameters_copypaste.parse_generation_parameters 
AUTOMATIC — 2024/01/12 21:32
so your suggestion is to keep everything as it is, but use infotexts field to get info, and forget about other fields?
w-e-w — 2024/01/12 21:32
exactly
I don't really see the advantage of keeping them separate
AUTOMATIC — 2024/01/12 21:32
what about extensions that use all_seeds and expect it to be correct?
w-e-w — 2024/01/12 21:33
hmmm, backwards compatibility issues
are there any extensions that use all_seeds?
w-e-w — 2024/01/12 21:42
the difference between all_seeds and what can be grabbed from infotexs is all_seeds is the seeds of all bach
while if you grab every seed info from every infotext in infotexts and is 
infotexs might have other images that are not stable diffusion images such as grid or detection maps
so they're are not equivalent
but I really not sure if anyone's actually using all_seeds apart from reuse seed in the ui 
 
to be honest I think lots of extension doesn't do a good job of updating geninfo
AUTOMATIC — 2024/01/12 21:43
we use it ourselfves when saving image too
ui_common.py, save_files
w-e-w — 2024/01/12 21:44
ourself is a small issue
we can modify it to make sure that it works with infotext
w-e-w — 2024/01/12 21:45
this is one of the reason I want to move to use only infotexts
because it simplifies extension development and reduces people forgetting to update stuff
w-e-w — 2024/01/12 21:54
even though all_seeds and infotexs are not equivalent
the difference doesn't even matter because if an extension wishes to
if it extension returns extra images they will update all_seeds otherwise it will cause issues
so if they are an exception that returns multiple images all_seeds basically is already "dirty"
 
so if an extension does rely on all_seeds
the extension is likely going to be very unstable
 
so I don't think it matters that much if this change breaks extension that specifically relies on all_seeds
because it's like they already broken by other things
AUTOMATIC — 2024/01/12 22:11
all right, it makes sense, let's use infotexts then
```

</p>
</details> 



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
