### PR TITLE
[bug] fix using wrong model caused by alias

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -260,11 +260,11 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
 
     loaded_networks.clear()
 
-    networks_on_disk = [available_network_aliases.get(name, None) for name in names]
+    networks_on_disk = [available_networks.get(name, None) if name.lower() in forbidden_network_aliases else available_network_aliases.get(name, None) for name in names]
     if any(x is None for x in networks_on_disk):
         list_available_networks()
 
-        networks_on_disk = [available_network_aliases.get(name, None) for name in names]
+        networks_on_disk = [available_networks.get(name, None) if name.lower() in forbidden_network_aliases else available_network_aliases.get(name, None) for name in names]
 
     failed_to_load_networks = []
 


### PR DESCRIPTION
## Description
* Try to slove using wrong lora model cased by alias. The forbidden_network_aliases seems only used in generating the model card, but not used during inference.
* changes in code: when name.lower() in forbidden_network_aliases, get network_on_dick from available_networks rather than available_network_aliases.

I'm training lora models and I have two models with same 'ss_output_name' but different filename (since I changed the filename after training). When I run inference on webui, I find the result doesn't match the model name I write in prompt. After adding code for displaying the model path for name in prompt, I found it is using the wrong model.

This bug may caused by:
For example, there is a model A.safetensors and 'ss_output_name' in metadate is 'A'. And there is a model B.safetensors which 'ss_output_name' in metadata is also 'A'. During constructing the available_network_aliases dict, A.safetensors is processed before B.safetensors. After processing B.safetensors, key 'A' in available_network_aliases dict is mapped to B.safetensors. Even through this alias is stored in forbidden_network_aliases, network_on_disk obj is still queried in available_network_aliases. When I use '\<lora:A:1\>' in prompt, it will call B.safetensors instead of A.safetensors.

## Screenshots/videos:
For reproducing the bug, I use two lora models from civitai.
[l0ngma1d.safetensors](https://civitai.com/api/download/models/282696?type=Model&format=SafeTensor)
[Yatogami Tohka(dal).safetensors](https://civitai.com/api/download/models/272171?type=Model&format=SafeTensor)
The original filename and 'ss_output_name' is same. For reproducing this bug, I changed the 'ss_output_name' in Yatogami Tohka(dal).safetensors to 'l0ngma1d'. And here are the models I used.
https://drive.google.com/drive/folders/1vRg9h2P3H28zTaz-9QZOS9Pw_3cI-bl9?usp=drive_link
### Generation parameters
l0ngma1d
```
<lora:l0ngma1d:1>, 1girl
Negative prompt: blur
Steps: 20, Sampler: DPM++ 2M SDE Karras, CFG scale: 7, Seed: 233, Size: 512x768, Model hash: fd0db59b48, Model: threeDelicacyWonton_v2, Clip skip: 2, Lora hashes: "l0ngma1d: 42ba22fee2d5", Version: v1.7.0-331-gcb5b335a
```
Yatogami Tohka(dal)
```
<lora:Yatogami Tohka(dal):1>, 1girl
Negative prompt: blur
Steps: 20, Sampler: DPM++ 2M SDE Karras, CFG scale: 7, Seed: 233, Size: 512x768, Model hash: fd0db59b48, Model: threeDelicacyWonton_v2, Clip skip: 2, Lora hashes: "Yatogami Tohka(dal): 06acbeef6ed5", Version: v1.7.0-331-gcb5b335a
```

### Inference with origin model
| l0ngma1d | Yatogami Tohka(dal) |
| :-: | :-: |
| ![l0ngma1d](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/e98e7a0a-7f46-4e9d-b7aa-e78151707e25) | ![Yatogami Tohka(dal)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/9f697818-c268-4a51-9574-d9c950d1c954) |

### Inference with modified model
| l0ngma1d | Yatogami Tohka(dal) |
| :-: | :-: |
| ![l0ngma1d_bug](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/ab766cc3-c127-430e-9c44-4c6607cc91e9) | ![Yatogami Tohka(dal)_bug](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/65b95919-eec6-4f65-97d4-0514d36e4184) |


### Inference with modified model (My code)
| l0ngma1d | Yatogami Tohka(dal) |
| :-: | :-: |
| ![l0ngma1d_correct](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/340bf205-6f08-4fbe-a18a-f937a1329bc9) | ![Yatogami Tohka(dal)_correct](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/36807427/763f220a-d09e-4912-8f3f-94daac3633d0) |

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
