### PR TITLE
callback postprocess_image_after_composite

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1029,6 +1029,11 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                 image = apply_overlay(image, p.paste_to, overlay_image)
 
+                if p.scripts is not None:
+                    pp = scripts.PostprocessImageArgs(image)
+                    p.scripts.postprocess_image_after_composite(p, pp)
+                    image = pp.image
+
                 if save_samples:
                     images.save_image(image, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p)
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -262,6 +262,15 @@ class Script:
 
         pass
 
+    def postprocess_image_after_composite(self, p, pp: PostprocessImageArgs, *args):
+        """
+        Called for every image after it has been generated.
+        Same as postprocess_image but after inpaint_full_res composite
+        So that it operates on the full image instead of the inpaint_full_res crop region.
+        """
+
+        pass
+
     def postprocess(self, p, processed, *args):
         """
         This function is called after processing ends for AlwaysVisible scripts.
@@ -855,6 +864,14 @@ class ScriptRunner:
                 script.postprocess_maskoverlay(p, ppmo, *script_args)
             except Exception:
                 errors.report(f"Error running postprocess_image: {script.filename}", exc_info=True)
+
+    def postprocess_image_after_composite(self, p, pp: PostprocessImageArgs):
+        for script in self.alwayson_scripts:
+            try:
+                script_args = p.script_args[script.args_from:script.args_to]
+                script.postprocess_image_after_composite(p, pp, *script_args)
+            except Exception:
+                errors.report(f"Error running postprocess_image_after_composite: {script.filename}", exc_info=True)
 
     def before_component(self, component, **kwargs):
         for callback, script in self.on_before_component_elem_id.get(kwargs.get("elem_id"), []):


### PR DESCRIPTION
## Description
new callback callback `postprocess_image_after_composite`
same as `postprocess_image` but after `image = apply_overlay(image, p.paste_to, overlay_image)`
this allows it to operate on the whole image as opposed to only the crop region when performing `inpaint_full_res`
> `inpaint_full_res` aka `inpaint area = only masked`

background I got a issue post on one of my extensions
- https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/issues/9

because the image region that it can operate in `postprocess_image` is cropped, the extension performs suboptimally
so I decided to add this call back after the composite result

this callback could be used for the other extensions if they need to operate on the entire image or for whatever reason they need to operate after most other post-processing extentions

actual usage pending merge to my extensions assuming that this PR is acceptable
- https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/pull/10

---

I'm bad at naming `postprocess_image_after_composite`
if anyone has better name it can be changed

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
