### PR TITLE
immediately stop on second interrupt

### DIFF
--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -107,8 +107,9 @@ class Toprow:
             )
 
             def interrupt_function():
-                if shared.state.job_count > 1 and shared.opts.interrupt_after_current:
+                if not shared.state.stopping_generation and shared.state.job_count > 1 and shared.opts.interrupt_after_current:
                     shared.state.stop_generating()
+                    gr.Info("Generation will stop after finishing this image, click again to stop immediately.")
                 else:
                     shared.state.interrupt()
 


### PR DESCRIPTION
## Description
an addition to
`Don't Interrupt in the middle (when using Interrupt button, if generating more than one image, stop after the generation of an image has finished, instead of immediately)`

- if the user presses the interrupt request twice, it will interrupt it immediately

- also add a message telling the user that the button has indeed been pressed
otherwise one might be confused on why the interrupt hasn't been processed and keep spamming the button like I did

note: the message might need some rephrasing

note: the usere could also clicke `Interrupt` and then `Skip` to to achieve a similar effect of immediately stoping, but I think double clicking is more intuitive

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/545d1734-56a8-43ab-a13f-92c0725d9237)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
