### PR TITLE
feature/add-model-to-log-file

### DIFF
--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -1,3 +1,4 @@
+import csv
 import dataclasses
 import json
 import html
@@ -37,14 +38,16 @@ def plaintext_to_html(text, classname=None):
 
 
 def update_logfile(logfile_path, fields):
-    import csv
-
     with open(logfile_path, "r", encoding="utf8", newline="") as file:
         reader = csv.reader(file)
         rows = list(reader)
 
     # blank file: leave it as is
     if not rows:
+        return
+
+    # file is already synced, do nothing
+    if len(rows[0]) == len(fields):
         return
 
     rows[0] = fields
@@ -60,7 +63,6 @@ def update_logfile(logfile_path, fields):
 
 
 def save_files(js_data, images, do_make_zip, index):
-    import csv
     filenames = []
     fullfns = []
     parsed_infotexts = []

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -132,7 +132,7 @@ def save_files(js_data, images, do_make_zip, index):
                 filenames.append(os.path.basename(txt_fullfn))
                 fullfns.append(txt_fullfn)
 
-        writer.writerow([parsed_infotexts[0]['Prompt'], parsed_infotexts[0]['Seed'], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], parsed_infotexts[0]['Negative prompt']])
+        writer.writerow([parsed_infotexts[0]['Prompt'], parsed_infotexts[0]['Seed'], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], parsed_infotexts[0]['Negative prompt'], data["sd_model_name"], data["sd_model_hash"]])
 
     # Make Zip
     if do_make_zip:

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -107,7 +107,7 @@ def save_files(js_data, images, do_make_zip, index):
     if os.path.exists(logfile_path):
         update_logfile(logfile_path, fields)
 
-    with open(os.path.join(shared.opts.outdir_save, "log.csv"), "a", encoding="utf8", newline='') as file:
+    with open(logfile_path, "a", encoding="utf8", newline='') as file:
         at_start = file.tell() == 0
         writer = csv.writer(file)
         if at_start:

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -38,6 +38,7 @@ def plaintext_to_html(text, classname=None):
 
 
 def update_logfile(logfile_path, fields):
+    """Update a logfile from old format to new format to maintain CSV integrity."""
     with open(logfile_path, "r", encoding="utf8", newline="") as file:
         reader = csv.reader(file)
         rows = list(reader)


### PR DESCRIPTION
## Description

When trying to reproduce an image, the information stored in "log.csv" is very useful. Unfortunately it's missing one key bit of information: what model you used.

This PR adds support for storing model information (name and hash) in the "log.csv" file. 

It also takes care of the scenario where there's a preexisting "log.csv" file that needs to be migrated.

Here's an issue that brings this up: #5021

## Screenshots/videos:

Here's the file read as a spreadsheet (I've omitted the prompt column). 

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/8881507/4b9a715b-82be-4ca8-9aaf-3e9fcdcae1ac)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
