### PR TITLE
feat: Adapt to PyTorch Lightning new version

### DIFF
--- a/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
+++ b/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
@@ -14,8 +14,10 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
-
+try:
+    from pytorch_lightning.utilities import rank_zero_only
+except:
+    from pytorch_lightning.utilities.distributed import rank_zero_only
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma
 from ldm.modules.distributions.distributions import normal_kl, DiagonalGaussianDistribution

--- a/modules/models/diffusion/ddpm_edit.py
+++ b/modules/models/diffusion/ddpm_edit.py
@@ -19,8 +19,10 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
-
+try:
+    from pytorch_lightning.utilities import rank_zero_only
+except:
+    from pytorch_lightning.utilities.distributed import rank_zero_only
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma
 from ldm.modules.distributions.distributions import normal_kl, DiagonalGaussianDistribution


### PR DESCRIPTION
## Description

If anyone wants to use a new version of PyTorch, something like 2.x, pytorch_lightning is also recommend upgrade.

however, the versions used by this project, and the stable-diffusion repository dependencies are too old.

One of the interfaces that will definitely be used has expired and is being deprecated.

https://lightning.ai/docs/pytorch/LTS/api/pytorch_lightning.utilities.distributed.html

```bash
pytorch_lightning.utilities.distributed.AllGatherGrad(*args, **kwargs)

Deprecated since version v1.8.0: This function has been deprecated in v1.8.0 in favor of torch.distributed.nn.functional.all_gather() and will be removed in v2.0.0.
```
Without breaking the compatibility of old versions for the time being, it is recommended to use this method for transition to support users who use new versions of PyTorch dependencies.

My personal suggestion is that as time goes by, there will be more and more compatibility issues. Locking the old version will not gain performance gains, and the stability will become lower and lower. Perhaps old dependencies should be upgraded one after another.

As for the upstream and downstream warehouse compatibility issues, there are many means and methods to solve them.There is no need to passively stay consistent with them and lose performance and experience.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
