### PR TITLE
chore: upgrade Clip version to a1d071733d7111c9c014f024669f959182114e33

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -339,7 +339,7 @@ def prepare_environment():
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.20')
-    clip_package = os.environ.get('CLIP_PACKAGE', "https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip")
+    clip_package = os.environ.get('CLIP_PACKAGE', "https://github.com/openai/CLIP/archive/a1d071733d7111c9c014f024669f959182114e33.zip")
     openclip_package = os.environ.get('OPENCLIP_PACKAGE', "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip")
 
     stable_diffusion_repo = os.environ.get('STABLE_DIFFUSION_REPO', "https://github.com/Stability-AI/stablediffusion.git")


### PR DESCRIPTION
## Description

The Clip version used by the project is https://github.com/openai/CLIP/commit/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1 , have 2 years ago.

I've test new "version" `a1d071733d7111c9c014f024669f959182114e33`, with two bugfixs:

- https://github.com/openai/CLIP/commit/3702849800aa56e2223035bccd1c6ef91c704ca8
- https://github.com/openai/CLIP/commit/a1d071733d7111c9c014f024669f959182114e33

## Screenshots/videos:


![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1500781/62b544ef-a375-4c53-82c4-598402573071)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1500781/c0273fa3-a7db-420b-a8b0-bf2cd1c1da80)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
