### PR TITLE
fix: xFormers version check

### DIFF
--- a/modules/errors.py
+++ b/modules/errors.py
@@ -125,7 +125,11 @@ Use --skip-version-check commandline argument to disable this check.
     if shared.xformers_available:
         import xformers
 
-        if version.parse(xformers.__version__) < version.parse(expected_xformers_version):
+        xformers_version = xformers.__version__
+        if '+' in xformers_version:
+            xformers_version = xformers_version.split('+')[0]
+
+        if version.parse(xformers_version) < version.parse(expected_xformers_version):
             print_error_explanation(f"""
 You are running xformers {xformers.__version__}.
 The program is tested to work with xformers {expected_xformers_version}.


### PR DESCRIPTION
## Description

The current project processing logic cannot correctly handle the version resolution of compiled and installed xfromers.

When judging and processing, added support for compiled and installed xfromers version

```bash
>>> xformers.__version__
'0.0.24+6600003.d20240116'
```

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1500781/5f1a6009-d46b-4bd6-957f-cc3a4f219c75)

it's ok


![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1500781/a8fb26e0-1bcd-44c9-8650-635dfa2dab20)

it's ok, too

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
