### PR TITLE
feat: skip Git Clone components when launch

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -407,11 +407,12 @@ def prepare_environment():
 
     os.makedirs(os.path.join(script_path, dir_repos), exist_ok=True)
 
-    git_clone(assets_repo, repo_dir('stable-diffusion-webui-assets'), "assets", assets_commit_hash)
-    git_clone(stable_diffusion_repo, repo_dir('stable-diffusion-stability-ai'), "Stable Diffusion", stable_diffusion_commit_hash)
-    git_clone(stable_diffusion_xl_repo, repo_dir('generative-models'), "Stable Diffusion XL", stable_diffusion_xl_commit_hash)
-    git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
-    git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
+    if os.environ.get('SKIP_LAUNCH_GIT_CLONE', None) is None:
+        git_clone(assets_repo, repo_dir('stable-diffusion-webui-assets'), "assets", assets_commit_hash)
+        git_clone(stable_diffusion_repo, repo_dir('stable-diffusion-stability-ai'), "Stable Diffusion", stable_diffusion_commit_hash)
+        git_clone(stable_diffusion_xl_repo, repo_dir('generative-models'), "Stable Diffusion XL", stable_diffusion_xl_commit_hash)
+        git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
+        git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
 
     startup_timer.record("clone repositores")
 

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -34,6 +34,7 @@ environment_whitelist = {
     "BLIP_COMMIT_HASH",
     "COMMANDLINE_ARGS",
     "IGNORE_CMD_ARGS_ERRORS",
+    "SKIP_LAUNCH_GIT_CLONE",
 }
 
 


### PR DESCRIPTION
## Description

When the project is started, the Git Clone of the components will be automatically performed. Is it possible that the relevant components will not be automatically downloaded and the component downloads will be handed over to other processes.

This allows users to complete the installation from a specified new location (mirror, local) or install at another point in time.

Especially in a docker environment, if we can decouple the relevant automated download functions of WebUI, it will be very convenient for subsequent distribution and deployment, and greatly reduce the problem of being unable to use it due to the environment.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
