### PR TITLE
[Bug] Fix extras big batch crashes

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -62,8 +62,6 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         else:
             image_data = image_placeholder
 
-        shared.state.assign_current_image(image_data)
-
         parameters, existing_pnginfo = images.read_info_from_image(image_data)
         if parameters:
             existing_pnginfo["parameters"] = parameters
@@ -91,6 +89,8 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
             if opts.enable_pnginfo:
                 pp.image.info = existing_pnginfo
                 pp.image.info["postprocessing"] = infotext
+
+            shared.state.assign_current_image(pp.image)
 
             if save_output:
                 fullfn, _ = images.save_image(pp.image, path=outpath, basename=basename, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=forced_filename, suffix=suffix)


### PR DESCRIPTION
I've found postprocessing in extras tab stably crashes for big batches. It happens because\
`shared.state.assign_current_image(image_data)`\
And later:\
`image_data.close()`\
Inside `postprocessing.py`

And also I think it's better to show processed image in preview instead of input image. I decided to fix this crash with using pp.image instead of image_data for preview

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
