### PR TITLE
[Bug] Keep postprocessing upscale selected tab after restart

### DIFF
--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -15,7 +15,7 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
     order = 1000
 
     def ui(self):
-        selected_tab = gr.State(value=0)
+        selected_tab = gr.Number(value=0, visible=False)
 
         with gr.Column():
             with FormRow():


### PR DESCRIPTION
Continuation of
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14637

I forgot about resize mode tabs "Scale by"/"Scale to" in Extras tab 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
