### PR TITLE
re-work multi --styles-file

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -88,7 +88,7 @@ parser.add_argument("--gradio-img2img-tool", type=str, help='does not do anythin
 parser.add_argument("--gradio-inpaint-tool", type=str, help="does not do anything")
 parser.add_argument("--gradio-allowed-path", action='append', help="add path to gradio's allowed_paths, make it possible to serve files from it", default=[data_path])
 parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
-parser.add_argument("--styles-file", type=str, help="filename to use for styles", default=os.path.join(data_path, 'styles.csv'))
+parser.add_argument("--styles-file", type=str, action='append', help="path or wildcard path of styles files, allow multiple entries.", default=[])
 parser.add_argument("--autolaunch", action='store_true', help="open the webui URL in the system's default browser upon launch", default=False)
 parser.add_argument("--theme", type=str, help="launches the UI with light or dark theme", default=None)
 parser.add_argument("--use-textbox-seed", action='store_true', help="use textbox for seeds in UI (no up/down, but possible to input long seeds)", default=False)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import gradio as gr
@@ -11,7 +12,7 @@ parser = shared_cmd_options.parser
 
 batch_cond_uncond = True  # old field, unused now in favor of shared.opts.batch_cond_uncond
 parallel_processing_allowed = True
-styles_filename = cmd_opts.styles_file
+styles_filename = cmd_opts.styles_file = cmd_opts.styles_file if len(cmd_opts.styles_file) > 0 else [os.path.join(data_path, 'styles.csv')]
 config_filename = cmd_opts.ui_settings_file
 hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}
 

--- a/modules/ui_prompt_styles.py
+++ b/modules/ui_prompt_styles.py
@@ -22,9 +22,12 @@ def save_style(name, prompt, negative_prompt):
     if not name:
         return gr.update(visible=False)
 
-    style = styles.PromptStyle(name, prompt, negative_prompt)
+    existing_style = shared.prompt_styles.styles.get(name)
+    path = existing_style.path if existing_style is not None else None
+
+    style = styles.PromptStyle(name, prompt, negative_prompt, path)
     shared.prompt_styles.styles[style.name] = style
-    shared.prompt_styles.save_styles(shared.styles_filename)
+    shared.prompt_styles.save_styles()
 
     return gr.update(visible=True)
 
@@ -34,7 +37,7 @@ def delete_style(name):
         return
 
     shared.prompt_styles.styles.pop(name, None)
-    shared.prompt_styles.save_styles(shared.styles_filename)
+    shared.prompt_styles.save_styles()
 
     return '', '', ''
 


### PR DESCRIPTION
## Description
- an alternative implementation to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14700
- for resolving  https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14681

---

users can specify multiple style file path by using `wildcards` and multiple entries of `--styles-file`

- possible to specify styles files from different directory
- the default styles file can be explicitly set by the user

## Changes

cmd arg `--styles-file` change action to `append` str whitch forms a list internally same as `--gradio-allowed-path`
if no `--styles-file` is set by the user is then defaults to `['styles.csv']`
`--styles-file` accepts `paths` or paths with wildcard `*`
also alow `?` to be used to match a single character (previously only `*` can be used), https://docs.python.org/3/library/fnmatch.html#module-fnmatch

### Default styles file path behavior
1. the first `--styles-file` entry is use as the default styles file path
2. if thers a `*` or `?` in the path, it is used as wildcard pattern, the first matching file is used as default sytyles
3. if no match is found, create a new `styles.csv` in the same dir as the first path

### other changes

- when saving a new style it will be save in the default styles file
- when saving a existing style, it will be saved to file it belongs to
- the order of the styles files in the styles dropdown can be controlled by the order of `--styles-file`

---

### cmd arg example
use multiple `--styles-file` all at once
```sh
--styles-file "B:\\styles_dir_1\main_styles_file.csv"
--styles-file "B:\\styles_dir_1\sub_styles_file.csv"
--styles-file "B:\\styles_dir_1\prfix_*.csv"
--styles-file "B:\\styles_dir_2\*_suffix.csv"
--styles-file "B:\\styles_dir_3\*.csv"
```
this example would load
`B:\\styles_dir_1\main_styles_file.csv` and use as default
`B:\\styles_dir_1\sub_styles_file.csv`
load every file in `styles_dir_1` matching `prefix_` and suffix `.csv`
load every file in `styles_dir_2` matching suffix `_suffix.csv`
loda every `.csv` in `styles_dir_3` 

---

@cjj1977 can you check if this satisfies your requirements

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
