### PR TITLE
improve get_crop_region

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -3,40 +3,15 @@ from PIL import Image, ImageFilter, ImageOps
 
 def get_crop_region(mask, pad=0):
     """finds a rectangular region that contains all masked ares in an image. Returns (x1, y1, x2, y2) coordinates of the rectangle.
-    For example, if a user has painted the top-right part of a 512x512 image", the result may be (256, 0, 512, 256)"""
-
-    h, w = mask.shape
-
-    crop_left = 0
-    for i in range(w):
-        if not (mask[:, i] == 0).all():
-            break
-        crop_left += 1
-
-    crop_right = 0
-    for i in reversed(range(w)):
-        if not (mask[:, i] == 0).all():
-            break
-        crop_right += 1
-
-    crop_top = 0
-    for i in range(h):
-        if not (mask[i] == 0).all():
-            break
-        crop_top += 1
-
-    crop_bottom = 0
-    for i in reversed(range(h)):
-        if not (mask[i] == 0).all():
-            break
-        crop_bottom += 1
-
-    return (
-        int(max(crop_left-pad, 0)),
-        int(max(crop_top-pad, 0)),
-        int(min(w - crop_right + pad, w)),
-        int(min(h - crop_bottom + pad, h))
-    )
+    For example, if a user has painted the top-right part of a 512x512 image, the result may be (256, 0, 512, 256)"""
+    mask_img = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
+    box = mask_img.getbbox()
+    if box:
+        x1, y1, x2, y2 = box
+    else:  # when no box is found
+        x1, y1 = mask_img.size
+        x2 = y2 = 0
+    return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask_img.size[0]), min(y2 + pad, mask_img.size[1])
 
 
 def expand_crop_region(crop_region, processing_width, processing_height, image_width, image_height):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1562,7 +1562,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             if self.inpaint_full_res:
                 self.mask_for_overlay = image_mask
                 mask = image_mask.convert('L')
-                crop_region = masking.get_crop_region(np.array(mask), self.inpaint_full_res_padding)
+                crop_region = masking.get_crop_region(mask, self.inpaint_full_res_padding)
                 crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
                 x1, y1, x2, y2 = crop_region
 


### PR DESCRIPTION
## Description
simplify and improve get_crop_region

test code

<details><summary>performance comparison code</summary>
<p>

```py
from PIL import Image, ImageDraw
import numpy as np
import timeit


def get_crop_region(mask, pad=0):
    """finds a rectangular region that contains all masked ares in an image. Returns (x1, y1, x2, y2) coordinates of the rectangle.
    For example, if a user has painted the top-right part of a 512x512 image, the result may be (256, 0, 512, 256)"""

    h, w = mask.shape

    crop_left = 0
    for i in range(w):
        if not (mask[:, i] == 0).all():
            break
        crop_left += 1

    crop_right = 0
    for i in reversed(range(w)):
        if not (mask[:, i] == 0).all():
            break
        crop_right += 1

    crop_top = 0
    for i in range(h):
        if not (mask[i] == 0).all():
            break
        crop_top += 1

    crop_bottom = 0
    for i in reversed(range(h)):
        if not (mask[i] == 0).all():
            break
        crop_bottom += 1

    return (
        int(max(crop_left-pad, 0)),
        int(max(crop_top-pad, 0)),
        int(min(w - crop_right + pad, w)),
        int(min(h - crop_bottom + pad, h))
    )


def current(in_image, pad=0):
    return get_crop_region(np.array(in_image), pad)


def new_method(mask, pad=0):
    mask_img = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
    box = mask_img.getbbox()
    if box:
        x1, y1, x2, y2 = box
    else:  # when no box is found
        x1, y1 = mask_img.size
        x2 = y2 = 0
    return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask_img.size[0]), min(y2 + pad, mask_img.size[1])

def new_method_with_np_input(mask, pad=0):
    # simulate if input is numpy array
    return new_method(np.array(mask), pad)


if __name__ == '__main__':
    img = Image.new('L', (1000, 1000), color='black')
    np_mask = np.array(img)

    padding = 10

    print(get_crop_region(np_mask, padding))            # (990, 990, 10, 10)
    print(current(img, padding))                        # (990, 990, 10, 10)
    print(new_method(img, padding))                     # (990, 990, 10, 10)
    print(new_method_with_np_input(img, padding))       # (990, 990, 10, 10)

    draw = ImageDraw.Draw(img)
    draw.ellipse((300, 400, 500, 600), fill='white')
    np_mask = np.array(img)

    print(get_crop_region(np_mask, padding))            # (290, 390, 511, 611)
    print(current(img, padding))                        # (290, 390, 511, 611)
    print(new_method(img, padding))                     # (290, 390, 511, 611)
    print(new_method_with_np_input(img, padding))       # (290, 390, 511, 611)

    iterations = 1000

    timeit_0 = timeit.timeit(lambda: get_crop_region(np_mask, padding), number=iterations)
    timeit_1 = timeit.timeit(lambda: current(img, padding), number=iterations)
    timeit_2 = timeit.timeit(lambda: new_method(img, padding), number=iterations)
    timeit_3 = timeit.timeit(lambda: new_method_with_np_input(img, padding), number=iterations)
    print(f"method_0 took {timeit_0:.6f} seconds for {iterations} iterations.")
    print(f"method_1 took {timeit_1:.6f} seconds for {iterations} iterations.")
    print(f"method_2 took {timeit_2:.6f} seconds for {iterations} iterations.")
    print(f"method_3 took {timeit_3:.6f} seconds for {iterations} iterations.")
    # method_0 took 3.534935 seconds for 1000 iterations.
    # method_1 took 4.385469 seconds for 1000 iterations.
    # method_2 took 0.224629 seconds for 1000 iterations.
    # method_3 took 0.967969 seconds for 1000 iterations.

```

</p>
</details> 

conclusion
all round faster even in compatibility mode

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
