### PR TITLE
Fix kohya-ss OFT network wrong device for eye and constraint

### DIFF
--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -57,12 +57,12 @@ class NetworkModuleOFT(network.NetworkModule):
 
     def calc_updown(self, orig_weight):
         oft_blocks = self.oft_blocks.to(orig_weight.device)
-        eye = torch.eye(self.block_size, device=self.oft_blocks.device)
+        eye = torch.eye(self.block_size, device=oft_blocks.device)
 
         if self.is_kohya:
             block_Q = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix
             norm_Q = torch.norm(block_Q.flatten())
-            new_norm_Q = torch.clamp(norm_Q, max=self.constraint)
+            new_norm_Q = torch.clamp(norm_Q, max=self.constraint.to(oft_blocks.device))
             block_Q = block_Q * ((new_norm_Q + 1e-8) / (norm_Q + 1e-8))
             oft_blocks = torch.matmul(eye + block_Q, (eye - block_Q).float().inverse())
 


### PR DESCRIPTION
## Description

This PR fixes a "Expected tensors to be on same device" error for kohya-ss OFT networks.
We send `eye` and `self.constraint` to the same device as oft_blocks before performing operations with them.

## Screenshots/videos:
N/A

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
