### PR TITLE
Removed forced overlay

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -928,7 +928,8 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                         images.save_image(image_without_cc, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p, suffix="-before-color-correction")
                     image = apply_color_correction(p.color_corrections[i], image)
 
-                image = apply_overlay(image, p.paste_to, i, p.overlay_images)
+                # Removed till we have a UI option for it. Nobody would miss this line.
+                #image = apply_overlay(image, p.paste_to, i, p.overlay_images)
 
                 if save_samples:
                     images.save_image(image, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p)


### PR DESCRIPTION
## Description

Currently, the WebUI overlays the original image over the AI-generated output, which can sometimes lead to noticeable discrepancies, especially around the mask's edges. This behavior limits the user's ability to fully appreciate and utilize the AI's creativity.

To improve this, I propose **removing the overlay entirely**, till we've a proper UI option for it, preferably unchecked by default. Or maybe no overylay at all; it is not really useful at all except for destroying what the AI generates.

Removing the overlay actually addresses many issues people were having on reddit with Inpainting somehow "not blending". They've no idea that WebUI was altering the generated output under the hood all this time.

## Screenshots/videos:


Here are the results with me trying to outpaint hair for a character:

Initial:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58893646/25b32fed-018b-4f56-a685-b97c244c1d25)
Mask:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58893646/34bd8f2c-fe3c-43ce-85d9-d2d6965ee39d)


### (Output BEFORE) Current WebUI (Overlays the raw output without informing the user):
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58893646/83e76905-f922-4391-a5c1-364e18296c13)
Might look good at first glance, but look closely at the edges of the mask.. oh, **there shouldn't be edges in the first place**. This becomes much more noticeable when outpainting limbs and complex structures instead of hair.
.
.
### (Output AFTER) **After removing the overlay code:**
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58893646/ddfd29c0-6c2b-4c3c-8694-99559822d145)
RAW image out of the model. Seemless blend. Much smoother. That's how the AI generated it, so why mess it up with some weird cropped overylay, whoever decided that was a great idea?

Notice how the AI modified the unmasked part of the initial, like the eyes and face, but it can easily be fixed with 2 seconds of a photoshop eraser:

### **Final**:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58893646/d94f717a-742f-47b5-9431-939879c9c701)
Erase the parts of the inpaint you don't want with a smooth photoshop brush with the original behind it.

Note: Removing overlay could be useful in cases where the user also **liked** the face or eyes (or any features) that the AI generated, so we should give users full control over the generated image instead of forcing them to have their AI-gen's overlayed in WebUI and destroy what the model originally got us.

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
