### PR TITLE
Another hr button fix 

### DIFF
--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -60,10 +60,10 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     assert len(gallery) > 0, 'No image to upscale'
     assert 0 <= gallery_index < len(gallery), f'Bad image index: {gallery_index}'
 
-    p = txt2img_create_processing(id_task, request, *args)
-    p.enable_hr = True
+    p = txt2img_create_processing(id_task, request, *args, force_enable_hr=True)
     p.batch_size = 1
     p.n_iter = 1
+    # txt2img_upscale attribute that signifies this is called by txt2img_upscale
     p.txt2img_upscale = True
 
     geninfo = json.loads(generation_info)


### PR DESCRIPTION
## Description

use `force_enable_hr` to set `p.enable_hr = True` in `txt2img_create_processing`
allow `Script.setup()` have access to the correct value

add a comment for p.txt2img_upscale

<details><summary>old</summary>
<p>

## Description

1. [rework set_named_arg](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/118a2273ed63e7eaedd399bbd5189512da7488f2)

- the identifying a script using `class name` is problematic as currently as there's no convention to keep unique names with there `script class name`
in base webui alone we have multiple scripts that are all called Scripts
not to mention lots of extensions may use the same Script name for the Script
change to using the scrip internal `name`

![2024-01-22 18_51_30_697](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/30a032b7-7d48-4827-9db6-5460a34e6441)
> the first tree is scripts from web UI that are just named Scripts, 

- and as opposed to returning none when there is an issue like script or element id is not found, raise runtime error

- even though comparing the element ID using `>` is convenient as it allows you to ignore stuff like the prefix `txt2img_` in `txt2img_seed` but this would cause a potential issue in that depending on the order of your arg
for example if you have two elements args with IDs of `seed` and `subseed`
if the order of the args is `['seed', 'subseed']` theneverything function as normal
but if the order is `['subseed', 'seed']` when matching for `seed` it be match with `subseed`
hence changed to using `==`

2. adding two new helper functions for extracting script args and setting script args
- - [update_script_args](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/f0ef4e8b6ce74713f007c72af837131f421f88f4) functions similar to `set_named_arg` but for the entire args
- - [get_script_args](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/6b07a935dfd15acc7822e3fd596dadef2994f78c)

3. [rework `txt2img_upscale` (Hr button) p create argument](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/96d6e3e76bfa114379857e2f82483ef19719ccc6)
- - update all the arguments before p is actually created so that `Script.setup()` works with correct args
- - as it is possible for a certain extensions to utilize `enable_hr` `batch_size` ... in there `Script.setup()`
- - - I was using `enable_hr` in `Script.setup()` of my extension, and noticed that the value is not set properly

- update the entire seed script arg, previously only seed and subseed were read from infotext, now everything is form about seed infotext
- - this means when using Hr button, the `seed UI` is completely ignored

</p>
</details> 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
