### PR TITLE
Compact infotext system, Compact soft inpainting infotext

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -24,7 +24,7 @@ info_json_keys = set()
 
 def info_json_dumps(data):
     """encode data into json string, but swap single and double quotes to reduce escaping issues"""
-    return json.dumps(data, ensure_ascii=False).translate(quote_swap)
+    return json.dumps(data, ensure_ascii=False, separators=(',', ':')).translate(quote_swap)
 
 
 def info_json_loads(info_json):

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -386,7 +386,10 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     for key in info_json_keys:
         if key in res:
-            res[key] = info_json_loads(res[key])
+            try:
+                res[key] = info_json_loads(res[key])
+            except Exception:
+                print(f'Error parsing "{key}: {res[key]}"')
 
     infotext_versions.backcompat(res)
 

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -18,6 +18,34 @@ re_param = re.compile(re_param_code)
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")
 type_of_gr_update = type(gr.update())
+quote_swap = str.maketrans('\'"', '"\'')
+info_json_keys = set()
+
+
+def info_json_dumps(data):
+    """encode data into json string, but swap single and double quotes to reduce escaping issues"""
+    return json.dumps(data, ensure_ascii=False).translate(quote_swap)
+
+
+def info_json_loads(info_json):
+    """decode json string into info data, but swap single and double quotes to reduce escaping issues"""
+    return json.loads(info_json.translate(quote_swap))
+
+
+def build_infotext(info: dict):
+    for info_json_key in info_json_keys:
+        if info_json_key in info:
+            info[info_json_key] = info_json_dumps(info[info_json_key])
+    return ", ".join([k if k == v else f'{k}: {quote(v)}' for k, v in info.items() if v is not None])
+
+
+def register_info_json(key):
+    """register an infotext key as infojson
+    after a key is registered, a json compatible data structure like dict or list can be used as a value in
+    generation_parameters and extra_generation_parameters
+    """
+    global info_json_keys
+    info_json_keys.add(key)
 
 
 class ParamBinding:
@@ -355,6 +383,10 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     if "Cache FP16 weight for LoRA" not in res and res["FP8 weight"] != "Disable":
         res["Cache FP16 weight for LoRA"] = False
+
+    for key in info_json_keys:
+        if key in res:
+            res[key] = info_json_loads(res[key])
 
     infotext_versions.backcompat(res)
 

--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -84,7 +84,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
                 basename = ''
                 forced_filename = None
 
-            infotext = ", ".join([k if k == v else f'{k}: {infotext_utils.quote(v)}' for k, v in pp.info.items() if v is not None])
+            infotext = infotext_utils.build_infotext(pp.info)
 
             if opts.enable_pnginfo:
                 pp.image.info = existing_pnginfo

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -747,7 +747,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
         "User": p.user if opts.add_user_name_to_info else None,
     }
 
-    generation_params_text = ", ".join([k if k == v else f'{k}: {infotext_utils.quote(v)}' for k, v in generation_params.items() if v is not None])
+    generation_params_text = infotext_utils.build_infotext(generation_params)
 
     prompt_text = p.main_prompt if use_main_prompt else all_prompts[index]
     negative_prompt_text = f"\nNegative prompt: {p.main_negative_prompt if use_main_prompt else all_negative_prompts[index]}" if all_negative_prompts[index] else ""


### PR DESCRIPTION
## Description

in some cases the infotext amount is getting a bit out of hand
particularly in the cases where an extension has multiple parameters that needs to be individually entered into Intel text
as infotext key name is required to be unique across all webui the common practice in this case for extension is to add a prefix or suffix to the key name

but this has the issue of making the infotext excessively long
- one example of this is https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14208
when using this built-in extension you will get an infotext like this
```
1girl
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 1282321148, Size: 528x528, Model hash: 54ef3e3610, Model: meinamix_meinaV11, VAE hash: 235745af8d, VAE: vae-ft-mse-840000-ema-pruned.ckpt, Denoising strength: 0.75, Soft inpainting enabled: True, Soft inpainting schedule bias: 1, Soft inpainting preservation strength: 0.5, Soft inpainting transition contrast boost: 4, Soft inpainting mask influence: 0, Soft inpainting difference threshold: 0.5, Soft inpainting difference contrast: 2, Mask blur: 4, Version: v1.7.0-384-g8a6a4ad8
```

to solve this issue I implemented a method that I named `info_json`
basically it goes back to the idea of using structural data, and as the name suggests json
the basic idea is that if all these information can be encoded as a dictionary within "One infotax entry"
this will remove the need of using multiple long prefixes and enable the possibility of using acronyms as sub keys in the dictory
the data structure will will have to be encoded befor combineing into infotext and decode back to data structure on parse

there's one problem with using Json string directly in info text, due to how infotax is encoded the double quotes in json string will have to be escaped, this will cause extra clutter in the info text defeating the purpose compacting intotext
**to solve this issue double quotes in single quotes are swap**

### implementation and demonstration this system with Soft Inpainting

to utilize this system an only have to register a infotext key as a `info_json_key` by using
`infotext_utils.register_info_json('Soft Inpainting')`
after this when writing `p.extra_generation_params` the extension can directly write a a `list` or `dict` in to infotext `p.extra_generation_params`
the system will automatically encode the infotext to info_json and decode it in `parse_generation_parameters`

in the implementation of this PR I've compacted the Soft Inpainting infotext to this
```
1girl
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 1282321148, Size: 528x528, Model hash: 54ef3e3610, Model: meinamix_meinaV11, VAE hash: 235745af8d, VAE: vae-ft-mse-840000-ema-pruned.ckpt, Denoising strength: 0.75, Soft Inpainting: "{'sb':1,'ps':0.5,'tcb':4,'mi':0,'dt':0.5,'dc':2}", Mask blur: 4, Version: v1.7.0-387-g28cc18cb
```
- `Soft inpainting enabled` is is signified by the existence of `Soft Inpainting: "{...}"
- `Schedule bias` -> `sb`
- `Preservation strength` -> `ps`
- `Transition contrast boost` -> `tcb`
- `Mask influence` -> `mi`
- `Difference threshold` -> `dt`
- `Difference contrast` -> `dc`

while using acronyms does reduce readability of the infotext, but in general people won't be reading this in a text manually, and when they do even with the full name they still have to have knowledge about webUI elements so I think using acronyms is acceptable

- **Backwards compatibility with the old infotext IS implemented**

note: I've also [remove space after comma and colon](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/c7fbcb5789378e3130457f97b074cf5d413f7eff) in json string maybe this is a bit overkill this can be reverted or made as an option?

---

this system is actually relatively easily achievable in extensions without implementing it in web UI
I have been using this in multiple extensions
the only difference is that, I have to perform the encoding myself and then add an additional decoding step to `on_infotext_pasted` callback, 
but if this system is implemented directly into web UI it would be more easy for future extensions to adapt to the new system
[example](https://github.com/w-e-w/sd-webui-hires-fix-tweaks/blob/0c9f67b70a56ab2ba261b33e9a736ce80e67d57d/hires_fix_tweaks/hr_modules/hr_batch_seed.py#L97-L101)

## Screenshots/videos:
current infotext
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/e2b69ef2-c87e-4bce-95c6-ae9eceebab33)
compacted with info_json
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/0a385918-f66d-4d61-942c-a5d163043bfa)
as you can see lots of space is saved

---

### other changes

consolidated the concatenating of infotext in `modules.processing` and `modules.postprocessing` to `infotext_utils.build_infotext(dict)`
 
---

if this PR is accepted I would like to also perform the same procedure to some other infotext
like
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14497

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
