### PR TITLE
XYZ filter blank for number axes

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -554,6 +554,8 @@ class Script(scripts.Script):
                 valslist_ext = []
 
                 for val in valslist:
+                    if val.strip() == '':
+                        continue
                     m = re_range.fullmatch(val)
                     mc = re_range_count.fullmatch(val)
                     if m is not None:
@@ -576,6 +578,8 @@ class Script(scripts.Script):
                 valslist_ext = []
 
                 for val in valslist:
+                    if val.strip() == '':
+                        continue
                     m = re_range_float.fullmatch(val)
                     mc = re_range_count_float.fullmatch(val)
                     if m is not None:


### PR DESCRIPTION
## Description

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14739

filrer out axis val that with only blank or spaces when axis is `int` or `float` type (like int axis `seed`)

does not perform on string type axis like sting axis `Prompt S/R`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
