### PR TITLE
minor fix to #14525

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -251,7 +251,6 @@ def list_extensions(settings_file):
     except Exception:
         errors.report(f'\nCould not load settings\nThe config file "{settings_file}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
         os.replace(settings_file, os.path.join(script_path, "tmp", "config.json"))
-        settings = {}
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
     disable_all_extensions = settings.get('disable_all_extensions', 'none')

--- a/modules/options.py
+++ b/modules/options.py
@@ -198,6 +198,8 @@ class Options:
         try:
             with open(filename, "r", encoding="utf8") as file:
                 self.data = json.load(file)
+        except FileNotFoundError:
+            self.data = {}
         except Exception:
             errors.report(f'\nCould not load settings\nThe config file "{filename}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
             os.replace(filename, os.path.join(script_path, "tmp", "config.json"))


### PR DESCRIPTION
## Description
- minor fix to #14525
- separate file found not found exception as to not print error message on first launch
- remove redundant `settings = {}`


## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
