### PR TITLE
rework set_named_arg

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -939,13 +939,14 @@ class ScriptRunner:
             except Exception:
                 errors.report(f"Error running setup: {script.filename}", exc_info=True)
 
-    def set_named_arg(self, args, script_name, arg_elem_id, value):
+    def set_named_arg(self, args, script_name, arg_elem_id, value, fuzzy=False):
         """Locate an arg of a specific script in script_args and set its value
         Args:
             args: all script args of process p, p.script_args
             script_name: the name target script name to
             arg_elem_id: the elem_id of the target arg
             value: the value to set
+            fuzzy: if True, arg_elem_id can be a substring of the control.elem_id else exact match
         Returns:
             Updated script args
         when script_name in not found or arg_elem_id is not found in script controls, raise RuntimeError
@@ -955,7 +956,7 @@ class ScriptRunner:
             raise RuntimeError(f"script {script_name} not found")
 
         for i, control in enumerate(script.controls):
-            if arg_elem_id == control.elem_id:
+            if arg_elem_id in control.elem_id if fuzzy else arg_elem_id == control.elem_id:
                 index = script.args_from + i
 
                 if isinstance(args, tuple):

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -939,22 +939,33 @@ class ScriptRunner:
             except Exception:
                 errors.report(f"Error running setup: {script.filename}", exc_info=True)
 
-    def set_named_arg(self, args, script_type, arg_elem_id, value):
-        script = next((x for x in self.scripts if type(x).__name__ == script_type), None)
+    def set_named_arg(self, args, script_name, arg_elem_id, value):
+        """Locate an arg of a specific script in script_args and set its value
+        Args:
+            args: all script args of process p, p.script_args
+            script_name: the name target script name to
+            arg_elem_id: the elem_id of the target arg
+            value: the value to set
+        Returns:
+            Updated script args
+        when script_name in not found or arg_elem_id is not found in script controls, raise RuntimeError
+        """
+        script = next((x for x in self.scripts if x.name == script_name), None)
         if script is None:
-            return
+            raise RuntimeError(f"script {script_name} not found")
 
         for i, control in enumerate(script.controls):
-            if arg_elem_id in control.elem_id:
+            if arg_elem_id == control.elem_id:
                 index = script.args_from + i
 
-                if isinstance(args, list):
+                if isinstance(args, tuple):
+                    return args[:index] + (value,) + args[index + 1:]
+                elif isinstance(args, list):
                     args[index] = value
                     return args
-                elif isinstance(args, tuple):
-                    return args[:index] + (value,) + args[index+1:]
                 else:
-                    return None
+                    raise RuntimeError(f"args is not a list or tuple, but {type(args)}")
+        raise RuntimeError(f"arg_elem_id {arg_elem_id} not found in script {script_name}")
 
 
 scripts_txt2img: ScriptRunner = None


### PR DESCRIPTION
- extracted from https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14728

change identifying a script from using Scripts class name to Scripts internal name an as not all Script have unique names

raise RuntimeError when there's issue

reason the identifying a script using `class name` is problematic as currently as there's no convention to using unique names with there `Script class name`
in base webui alone we have multiple scripts that are all called Scripts
not to mention lots of extensions use the same Script name for the Script

hence the change to using the scrip internal `name`

using `==` to match `elem_id`

- and as opposed to returning none when there is an issue like script or element id is not found, raise runtime error

- even though comparing the element ID using `in` is convenient as it allows you to ignore stuff like the prefix `txt2img_` in `txt2img_seed` but this would cause a potential issue in that depending on the order of your arg
for example if you have two elements args with IDs of `seed` and `subseed`
if the order of the args is `['seed', 'subseed']` then everything function as normal
but if the order is `['subseed', 'seed']` when matching for `seed` it be match with `subseed`
hence changed to using `==`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
