### PR TITLE
fix CLIP Interrogator topN regex

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -17,7 +17,7 @@ clip_model_name = 'ViT-L/14'
 
 Category = namedtuple("Category", ["name", "topn", "items"])
 
-re_topn = re.compile(r"\.top(\d+)\.")
+re_topn = re.compile(r"\.top(\d+)$")
 
 def category_types():
     return [f.stem for f in Path(shared.interrogator.content_dir).glob('*.txt')]


### PR DESCRIPTION
## Description

- fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14771
cause was in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/04a561c11c9bf9a00d7f9b50ca3f7962aa59ba6e#diff-18e2fdc55596d04ed849a0156d1e00faae5a67d26f0df478e375cda5d3c8ff99L72-R76

the match string was change form `filename` to `filename.stem` which does not include file extension (`.txt`)
after the change, the regular expression was not updated accordingly after the change

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
