### PR TITLE
Add NPU Support

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -3,7 +3,7 @@ import contextlib
 from functools import lru_cache
 
 import torch
-from modules import errors, shared
+from modules import errors, shared, npu_specific
 
 if sys.platform == "darwin":
     from modules import mac_specific
@@ -40,6 +40,9 @@ def get_optimal_device_name():
     if has_xpu():
         return xpu_specific.get_xpu_device_string()
 
+    if npu_specific.has_npu:
+        return npu_specific.get_npu_device_string()
+
     return "cpu"
 
 
@@ -66,6 +69,9 @@ def torch_gc():
 
     if has_xpu():
         xpu_specific.torch_xpu_gc()
+
+    if npu_specific.has_npu:
+        npu_specific.torch_npu_gc()
 
 
 def enable_tf32():
@@ -164,4 +170,3 @@ def first_time_calculation():
     x = torch.zeros((1, 1, 3, 3)).to(device, dtype)
     conv2d = torch.nn.Conv2d(1, 1, (3, 3)).to(device, dtype)
     conv2d(x)
-

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -143,13 +143,17 @@ def initialize_rest(*, reload_script_modules=False):
         its optimization may be None because the list of optimizaers has neet been filled
         by that time, so we apply optimization again.
         """
+        from modules import devices
+        # Work around due to bug in torch_npu, revert me after fixed, @see https://gitee.com/ascend/pytorch/issues/I8KECW?from=project-issue
+        if devices.npu_specific.has_npu:
+            import torch
+            torch.npu.set_device(0)
 
         shared.sd_model  # noqa: B018
 
         if sd_hijack.current_optimizer is None:
             sd_hijack.apply_optimizations()
 
-        from modules import devices
         devices.first_time_calculation()
     if not shared.cmd_opts.skip_load_model_at_start:
         Thread(target=load_model).start()

--- a/modules/npu_specific.py
+++ b/modules/npu_specific.py
@@ -1,0 +1,34 @@
+import importlib
+import torch
+
+from modules import shared
+
+
+def check_for_npu():
+    if importlib.util.find_spec("torch_npu") is None:
+        return False
+    import torch_npu
+    torch_npu.npu.set_device(0)
+
+    try:
+        # Will raise a RuntimeError if no NPU is found
+        _ = torch.npu.device_count()
+        return torch.npu.is_available()
+    except RuntimeError:
+        return False
+
+
+def get_npu_device_string():
+    if shared.cmd_opts.device_id is not None:
+        return f"npu:{shared.cmd_opts.device_id}"
+    return "npu:0"
+
+
+def torch_npu_gc():
+    # Work around due to bug in torch_npu, revert me after fixed, @see https://gitee.com/ascend/pytorch/issues/I8KECW?from=project-issue
+    torch.npu.set_device(0)
+    with torch.npu.device(get_npu_device_string()):
+        torch.npu.empty_cache()
+
+
+has_npu = check_for_npu()

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -151,6 +151,10 @@ class EmbeddingDatabase:
         return embedding
 
     def get_expected_shape(self):
+        # workaround
+        if devices.npu_specific.has_npu:
+            import torch
+            torch.npu.set_device(0)
         vec = shared.sd_model.cond_stage_model.encode_embedding_init_text(",", 1)
         return vec.shape[1]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ accelerate
 basicsr
 blendmodes
 clean-fid
+cloudpickle
+decorator
 einops
 fastapi>=0.90.1
 gfpgan
@@ -26,9 +28,11 @@ resize-right
 
 safetensors
 scikit-image>=0.19
+synr==0.5.0
 timm
 tomesd
 torch
 torchdiffeq
 torchsde
+tornado
 transformers==4.30.2

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -4,6 +4,8 @@ accelerate==0.21.0
 basicsr==1.4.2
 blendmodes==2022
 clean-fid==0.1.35
+cloudpickle==3.0.0
+decorator==5.1.1
 einops==0.4.1
 fastapi==0.94.0
 gfpgan==1.3.8
@@ -23,10 +25,12 @@ realesrgan==0.3.0
 resize-right==0.0.2
 safetensors==0.3.1
 scikit-image==0.21.0
+synr==0.5.0
 timm==0.9.2
 tomesd==0.1.3
 torch
 torchdiffeq==0.2.3
 torchsde==0.2.6
+tornado==6.4
 transformers==4.30.2
 httpx==0.24.1

--- a/webui.sh
+++ b/webui.sh
@@ -159,6 +159,10 @@ then
     if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
     then
         export TORCH_COMMAND="pip install torch==2.0.1+rocm5.4.2 torchvision==0.15.2+rocm5.4.2 --index-url https://download.pytorch.org/whl/rocm5.4.2"
+    elif echo "$gpu_info" | grep -q "Huawei" && [[ -z "${TORCH_COMMAND}" ]]
+    then
+        export TORCH_COMMAND="pip install torch==2.1.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu; pip install torch_npu"
+    
     fi
 fi
 


### PR DESCRIPTION
# Description

This PR enables users to leverage the Ascend NPU for using features including txt2img, img2img, etc.

#13263 

## Screenshots/videos:

Verified on NPU, prompt is `panda`:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/ead6e505-9f84-4cfe-a94e-594000ebf081)
 
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/454986f6-85a9-40c0-aa3b-9f06dd4613fb)

Verified on Windows with cpu, prompt is `sitting panda`:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/21d2809f-11d9-4ee8-8199-716203581a3e)

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/c955c897-cd2e-458b-8167-b957af1a5aa8)



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

```bash
(python310) root@ascend-01:/root/project/own/stable-diffusion-webui# python -m pytest -vv --verify-base-url test                 
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.6, pytest-7.4.4, pluggy-1.4.0 -- /root/miniconda/envs/python310/bin/python
cachedir: .pytest_cache
baseurl: http://127.0.0.1:7862/
rootdir: /root/project/own/stable-diffusion-webui
configfile: pyproject.toml
plugins: cov-4.1.0, base-url-2.0.0
collected 29 items                                                                                                                                                         

test/test_extras.py::test_simple_upscaling_performed PASSED                                                                                                          [  3%]
test/test_extras.py::test_png_info_performed PASSED                                                                                                                  [  6%]
test/test_extras.py::test_interrogate_performed PASSED                                                                                                               [ 10%]
test/test_img2img.py::test_img2img_simple_performed PASSED                                                                                                           [ 13%]
test/test_img2img.py::test_inpainting_masked_performed PASSED                                                                                                        [ 17%]
test/test_img2img.py::test_inpainting_with_inverted_masked_performed PASSED                                                                                          [ 20%]
test/test_img2img.py::test_img2img_sd_upscale_performed PASSED                                                                                                       [ 24%]
test/test_txt2img.py::test_txt2img_simple_performed PASSED                                                                                                           [ 27%]
test/test_txt2img.py::test_txt2img_with_negative_prompt_performed PASSED                                                                                             [ 31%]
test/test_txt2img.py::test_txt2img_with_complex_prompt_performed PASSED                                                                                              [ 34%]
test/test_txt2img.py::test_txt2img_not_square_image_performed PASSED                                                                                                 [ 37%]
test/test_txt2img.py::test_txt2img_with_hrfix_performed PASSED                                                                                                       [ 41%]
test/test_txt2img.py::test_txt2img_with_tiling_performed PASSED                                                                                                      [ 44%]
test/test_txt2img.py::test_txt2img_with_restore_faces_performed PASSED                                                                                               [ 48%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[PLMS] PASSED                                                                                       [ 51%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[DDIM] PASSED                                                                                       [ 55%]
test/test_txt2img.py::test_txt2img_with_vanilla_sampler_performed[UniPC] PASSED                                                                                      [ 58%]
test/test_txt2img.py::test_txt2img_multiple_batches_performed PASSED                                                                                                 [ 62%]
test/test_txt2img.py::test_txt2img_batch_performed PASSED                                                                                                            [ 65%]
test/test_utils.py::test_options_write PASSED                                                                                                                        [ 68%]
test/test_utils.py::test_get_api_url[sdapi/v1/cmd-flags] PASSED                                                                                                      [ 72%]
test/test_utils.py::test_get_api_url[sdapi/v1/samplers] PASSED                                                                                                       [ 75%]
test/test_utils.py::test_get_api_url[sdapi/v1/upscalers] PASSED                                                                                                      [ 79%]
test/test_utils.py::test_get_api_url[sdapi/v1/sd-models] PASSED                                                                                                      [ 82%]
test/test_utils.py::test_get_api_url[sdapi/v1/hypernetworks] PASSED                                                                                                  [ 86%]
test/test_utils.py::test_get_api_url[sdapi/v1/face-restorers] PASSED                                                                                                 [ 89%]
test/test_utils.py::test_get_api_url[sdapi/v1/realesrgan-models] PASSED                                                                                              [ 93%]
test/test_utils.py::test_get_api_url[sdapi/v1/prompt-styles] PASSED                                                                                                  [ 96%]
test/test_utils.py::test_get_api_url[sdapi/v1/embeddings] PASSED                                                                                                     [100%]

====================================================================== 29 passed in 870.87s (0:14:30) ======================================================================
```

  