### PR TITLE
add tooltip create_submit_box

### DIFF
--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -96,9 +96,9 @@ class Toprow:
         with gr.Row(elem_id=f"{self.id_part}_generate_box", elem_classes=["generate-box"] + (["generate-box-compact"] if self.is_compact else []), render=not self.is_compact) as submit_box:
             self.submit_box = submit_box
 
-            self.interrupt = gr.Button('Interrupt', elem_id=f"{self.id_part}_interrupt", elem_classes="generate-box-interrupt")
-            self.skip = gr.Button('Skip', elem_id=f"{self.id_part}_skip", elem_classes="generate-box-skip")
-            self.submit = gr.Button('Generate', elem_id=f"{self.id_part}_generate", variant='primary')
+            self.interrupt = gr.Button('Interrupt', elem_id=f"{self.id_part}_interrupt", elem_classes="generate-box-interrupt", tooltip="End generation immediately or after completing current batch")
+            self.skip = gr.Button('Skip', elem_id=f"{self.id_part}_skip", elem_classes="generate-box-skip", tooltip="Stop generation of current batch and continues onto next batch")
+            self.submit = gr.Button('Generate', elem_id=f"{self.id_part}_generate", variant='primary', tooltip="Right click generate forever menu")
 
             self.skip.click(
                 fn=lambda: shared.state.skip(),


### PR DESCRIPTION
## Description
add tooltip to 
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/0b18054f-8173-4e63-b9e6-ba1e1926fcc2)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f63b26c6-fab4-4559-a861-8f0b01a09784)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/3c5fe33d-011d-42a2-b160-c74c469a314a)

request by https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14793#issuecomment-1914973678

in my opinion I don't like the way it looks and the phrasing could be better I'm bad with words
I find it to be a little bit in the way
but I do agree that the meaning of these buttons should be clarify and the hidden contacts menu should be known to the user
if there's a way to set a longer delay for this particular tooltip then I think it will be less obnoxious

issue
this also adds a tooltip to other generate buttons, like the one on extra tab
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f6a429bc-c40c-4084-b6bd-cf55481d9ed2)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
