### PR TITLE
Fix potential autocast NaNs in image upscale

### DIFF
--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -6,7 +6,7 @@ import torch
 import tqdm
 from PIL import Image
 
-from modules import images, shared, torch_utils
+from modules import devices, images, shared, torch_utils
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,8 @@ def upscale_pil_patch(model, img: Image.Image) -> Image.Image:
     with torch.no_grad():
         tensor = pil_image_to_torch_bgr(img).unsqueeze(0)  # add batch dimension
         tensor = tensor.to(device=param.device, dtype=param.dtype)
-        return torch_bgr_to_pil_image(model(tensor))
+        with devices.without_autocast():
+            return torch_bgr_to_pil_image(model(tensor))
 
 
 def upscale_with_model(


### PR DESCRIPTION
## Description
Bugfix for potential autocast NaNs in image upscale split off from Pull Request #14794

Discussion in that other pull request now confirms this works for others for preventing the black screen NaNs with Float32 upscaler model architectures [[1]](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14794#issuecomment-1917370231) [[2]](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14794#issuecomment-1917636350). The performance impacts for Float16 converted models was also recently confirmed to be minimal after some recent changes [[3]](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14794#issuecomment-1918225942).

Float32 upscaler models may now be slower, since they will be processed more than before in Float32 instead of autocast, but this seems necessary to fix the NaNs. In the future, I imagine this performance impact could be lifted by supporting BFloat16 upscaling, which Spandrel seems to support for every model architecture unlike Float16.

_**Spandrel Arch supporting Float32/BFloat16 only:** CodeFormer, DAT, GFPGAN, GRL, HAT, SRFormer, SwinIR_

_**Spandrel Arch supporting Float32/Float16/BFloat16:** Compact, ESRGAN, RealESRGAN, OmniSR, SPAN_
_Note: Float16 support for ESRGAN and others requires the additional changes in #14794. Currently of the currently supported model types, prefer_half which triggers float16 model conversion only seems to be enabled for realesrgan_model.py but not esrgan_model.py_

* * **Fixed an autocast NaN during upscaling I've noticed rarely on my system during Hires fix as mentioned in:**
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14710#issuecomment-1910731285
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14794

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
