### PR TITLE
[WIP] Asynchronous model mover for lowvram

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -269,3 +269,43 @@ def first_time_calculation():
     x = torch.zeros((1, 1, 3, 3)).to(device, dtype)
     conv2d = torch.nn.Conv2d(1, 1, (3, 3)).to(device, dtype)
     conv2d(x)
+
+
+def get_stream_impl():
+    if torch.cuda.is_available():
+        return torch.cuda.Stream
+
+    if has_xpu():
+        return torch.xpu.Stream
+
+    return None
+
+
+def get_stream_wrapper():
+    if torch.cuda.is_available():
+        return torch.cuda.stream
+
+    if has_xpu():
+        return torch.xpu.stream
+
+    return None
+
+
+def get_event_impl():
+    if torch.cuda.is_available():
+        return torch.cuda.Event
+
+    if has_xpu():
+        return torch.xpu.Event
+
+    return None
+
+
+def get_current_stream():
+    if torch.cuda.is_available():
+        return torch.cuda.current_stream(device)
+
+    if has_xpu():
+        return torch.xpu.current_stream(device)
+
+    return None

--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -10,7 +10,7 @@ import torch.hub
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 
-from modules import devices, paths, shared, lowvram, modelloader, errors, torch_utils
+from modules import devices, paths, shared, modelloader, errors, torch_utils
 
 blip_image_eval_size = 384
 clip_model_name = 'ViT-L/14'
@@ -186,6 +186,7 @@ class InterrogateModels:
         res = ""
         shared.state.begin(job="interrogate")
         try:
+            from modules import lowvram
             lowvram.send_everything_to_cpu()
             devices.torch_gc()
 

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -1,5 +1,6 @@
 import torch
-from modules import devices, shared
+from torch.utils.weak import WeakIdKeyDictionary
+from modules import devices, shared, patches
 
 module_in_gpu = None
 cpu = torch.device("cpu")
@@ -7,16 +8,142 @@ cpu = torch.device("cpu")
 stream_impl = devices.get_stream_impl()
 stream_wrapper = devices.get_stream_wrapper()
 
+def device_as_key(device):
+    if isinstance(device, str):
+        if ":" in device:
+            return device
+        return f"{device}:0"
+    return f"{device.type}:{device.index or 0}"
+
+class SmartTensorMoverPatches:
+    def __init__(self):
+        self.memo = WeakIdKeyDictionary()
+        self.model_mover_stream = stream_impl(device=devices.device)
+
+        self.linear_original = patches.patch(__name__, torch.nn.functional, 'linear', self.create_wrapper(torch.nn.functional.linear))
+        self.conv2d_original = patches.patch(__name__, torch.nn.functional, 'conv2d', self.create_wrapper(torch.nn.functional.conv2d))
+        self.conv3d_original = patches.patch(__name__, torch.nn.functional, 'conv3d', self.create_wrapper(torch.nn.functional.conv3d))
+        self.group_norm_original = patches.patch(__name__, torch.nn.functional, 'group_norm', self.create_wrapper(torch.nn.functional.group_norm, type=2))
+        self.layer_norm_original = patches.patch(__name__, torch.nn.functional, 'layer_norm', self.create_wrapper(torch.nn.functional.layer_norm, type=2))
+
+    def create_wrapper(self, original, type=1):
+        if type == 2:
+            def wrapper(input, arg1, weight, bias, *args, **kwargs):
+                dest_device = input.device
+                dest_device_key = device_as_key(dest_device)
+                # dest_dtype = input.dtype
+                current_stream = devices.get_current_stream()
+
+                new_weight = self.memo.get(weight, {})
+                new_bias = self.memo.get(bias, {})
+                if (
+                    getattr(weight, "want_smart_move", False)
+                    or dest_device_key in new_weight
+                ):
+                    weight, weight_event = self.move(
+                        weight, device=dest_device, memo=new_weight
+                    )
+                    current_stream.wait_event(weight_event)
+
+                if (
+                    getattr(bias, "want_smart_move", False)
+                    or dest_device_key in new_bias
+                ):
+                    bias, bias_event = self.move(
+                        bias, device=dest_device, memo=new_bias
+                    )
+                    current_stream.wait_event(bias_event)
+
+                return original(input, arg1, weight, bias, *args, **kwargs)
+            return wrapper
+        else:
+            def wrapper(input, weight, bias, *args, **kwargs):
+                dest_device = input.device
+                dest_device_key = device_as_key(dest_device)
+                # dest_dtype = input.dtype
+                current_stream = devices.get_current_stream()
+
+                if weight is not None:
+                    new_weight = self.memo.get(weight, {})
+                    if (
+                        getattr(weight, "want_smart_move", False)
+                        or dest_device_key in new_weight
+                    ):
+                        weight, weight_event = self.move(
+                            weight, device=dest_device, memo=new_weight
+                        )
+                        current_stream.wait_event(weight_event)
+
+                if bias is not None:
+                    new_bias = self.memo.get(bias, {})
+                    if (
+                        getattr(bias, "want_smart_move", False)
+                        or dest_device_key in new_bias
+                    ):
+                        bias, bias_event = self.move(
+                            bias, device=dest_device, memo=new_bias
+                        )
+                        bias = bias.to(dtype=input.dtype, non_blocking=True)
+                        current_stream.wait_event(bias_event)
+
+                return original(input, weight, bias, *args, **kwargs)
+
+            return wrapper
+
+    def __contains__(self, tensor):
+        return tensor in self.memo
+
+    def move(self, tensor, device=None, memo=None, forget=False):
+        device = device or tensor.device
+        device_key = device_as_key(device)
+        # dtype = dtype or tensor.dtype
+        memo_tensor = memo or self.memo.get(tensor, {})
+        new_tensor = memo_tensor.get(device_key, None)
+        if new_tensor is None:
+            with stream_wrapper(stream=self.model_mover_stream):
+                new_tensor = (
+                    tensor.to(device=device, non_blocking=True),
+                    self.model_mover_stream.record_event(),
+                )
+            if not forget:
+                memo_tensor[device_key] = new_tensor
+                self.memo[tensor] = memo_tensor
+        if forget:
+            self.forget(tensor)
+        return new_tensor
+
+    def forget(self, tensor):
+        if tensor in self.memo:
+            del self.memo[tensor]
+
+    def forget_batch(self, tensors):
+        for tensor in tensors:
+            if tensor in self.memo:
+                self.forget(tensor)
+
+    def forget_all(self):
+        self.memo.clear()
+
+    def close(self):
+        patches.undo(__name__, torch.nn.functional, 'linear')
+        patches.undo(__name__, torch.nn.functional, 'conv2d')
+        patches.undo(__name__, torch.nn.functional, 'conv3d')
+        patches.undo(__name__, torch.nn.functional, 'group_norm')
+        patches.undo(__name__, torch.nn.functional, 'layer_norm')
+
+mover = SmartTensorMoverPatches()
+
+
 class ModelMover:
     @classmethod
-    def register(cls, model, lookahead_distance=1):
-        instance = cls(model, lookahead_distance)
+    def register(cls, model, max_prefetch=1):
+        instance = cls(model, max_prefetch)
         setattr(model, 'lowvram_model_mover', instance)
         return instance
 
-    def __init__(self, model, lookahead_distance=1):
+    def __init__(self, model, max_prefetch=1):
         self.model = model
-        self.lookahead_distance = lookahead_distance
+        self.lookahead_distance = max_prefetch
         self.hook_handles = []
         self.submodules_list = self.get_module_list()
         self.submodules_indexer = {}
@@ -40,31 +167,137 @@ class ModelMover:
             handle.remove()
 
     def _pre_forward_hook(self, module, _):
+        with torch.profiler.record_function("lowvram prehook"):
+            with stream_wrapper(stream=self.model_mover_stream):
+                idx = self.submodules_indexer[module]
+                for i in range(idx, idx + self.lookahead_distance):
+                    submodule = self.submodules_list[i % len(self.submodules_list)]
+                    if submodule in self.module_movement_events:
+                        # already in GPU
+                        continue
+                    submodule.to(devices.device, non_blocking=True)
+                    self.module_movement_events[submodule] = self.model_mover_stream.record_event()
 
-        with stream_wrapper(stream=self.model_mover_stream):
-            idx = self.submodules_indexer[module]
-            for i in range(idx, idx + self.lookahead_distance):
-                submodule = self.submodules_list[i % len(self.submodules_list)]
-                if submodule in self.module_movement_events:
-                    # already in GPU
-                    continue
+            this_event = self.module_movement_events.get(module, None)
+            if this_event is not None:
+                self.default_stream.wait_event(this_event)
+            else:
+                print(f"Module {module.__name__} was not moved to GPU. Taking slow path")
                 submodule.to(devices.device, non_blocking=True)
-                self.module_movement_events[submodule] = self.model_mover_stream.record_event()
-
-        this_event = self.module_movement_events.get(module, None)
-        if this_event is not None:
-            self.default_stream.wait_event(this_event)
-        else:
-            print(f"Module {module.__name__} was not moved to GPU. Taking slow path")
-            submodule.to(devices.device, non_blocking=True)
 
     def _post_forward_hook(self, module, _1, _2):
-        with stream_wrapper(stream=self.model_mover_stream):
-            del self.module_movement_events[module]
-            module.to(cpu, non_blocking=True)
+        with torch.profiler.record_function("lowvram posthook"):
+            with stream_wrapper(stream=self.model_mover_stream):
+                del self.module_movement_events[module]
+                module.to(cpu, non_blocking=True)
 
 
-class DiffModelMover(ModelMover):
+class SmartModelMover:
+    @classmethod
+    def register(cls, model, vram_allowance=0, max_prefetch=10):
+        instance = cls(model, vram_allowance, max_prefetch)
+        setattr(model, "lowvram_model_mover", instance)
+        return instance
+
+    def __init__(self, model, vram_allowance=0, max_prefetch=10):
+        self.model = model
+        self.vram_allowance = vram_allowance * 1024 * 1024
+        self.vram_allowance_remaining = vram_allowance * 1024 * 1024
+        self.max_prefetch = max_prefetch
+        self.hook_handles = []
+        self.submodules_list = self.get_module_list()
+        # self.submodules_list = [k for c in submodules_list for k in self.get_childrens(c)]
+        self.parameters_list = [[p for p in x.parameters()] for x in self.submodules_list]
+        self.parameters_sizes = [sum([p.numel() * p.element_size() for p in x]) for x in self.parameters_list]
+        self.online_modules = set()
+        self.online_module_count = 0
+        self.submodules_indexer = {}
+
+        for i, module in enumerate(self.submodules_list):
+            self.submodules_indexer[module] = i
+
+    def test_children(self, op):
+        return op.__class__.__name__ in ['Conv2d', 'Conv3d', 'Linear', 'GroupNorm', 'LayerNorm']
+
+    def get_childrens(self, container):
+        if isinstance(container, torch.nn.Sequential):
+            # return [c for c in container]
+            return [cc for c in container for cc in self.get_childrens(c)]
+        if 'children' in dir(container):
+            childrens = [cc for c in container.children() for cc in self.get_childrens(c)]
+            if len(childrens) > 0:
+                return childrens
+        return [container]
+
+    def drain_allowance(self, idx):
+        parameters_len = len(self.parameters_list)
+
+        if self.vram_allowance <= 0:
+            while self.online_module_count < self.max_prefetch:
+                param = self.parameters_list[idx]
+                self.online_modules.add(idx)
+                self.online_module_count += 1
+                yield param
+                idx = (idx + 1) % parameters_len
+            return
+
+        while self.vram_allowance_remaining > 0 and (self.max_prefetch < 1 or self.online_module_count < self.max_prefetch):
+            param = self.parameters_list[idx]
+
+            if len(param) == 0 or idx in self.online_modules:
+                self.online_modules.add(idx)
+                self.online_module_count += 1
+                idx = (idx + 1) % parameters_len
+                continue
+
+            param_size = self.parameters_sizes[idx]
+            if (
+                param_size > self.vram_allowance_remaining
+                and self.online_module_count > 0
+            ):
+                break
+            self.vram_allowance_remaining -= param_size
+            self.online_modules.add(idx)
+            self.online_module_count += 1
+            yield param
+            idx = (idx + 1) % parameters_len
+
+    def fill_allowance(self, idx):
+        if self.vram_allowance > 0:
+            self.vram_allowance_remaining += self.parameters_sizes[idx]
+        self.online_modules.remove(idx)
+        self.online_module_count -= 1
+
+    def get_module_list(self):
+        return []
+
+    def install(self):
+        for submodule in self.submodules_list:
+            self.hook_handles.append(
+                submodule.register_forward_pre_hook(self._pre_forward_hook)
+            )
+            self.hook_handles.append(
+                submodule.register_forward_hook(self._post_forward_hook)
+            )
+
+    def uninstall(self):
+        for handle in self.hook_handles:
+            handle.remove()
+
+    def _pre_forward_hook(self, module, *args, **kwargs):
+        idx = self.submodules_indexer[module]
+        for parameters in self.drain_allowance(idx):
+            for param in parameters:
+                mover.move(param, device=devices.device)
+
+    def _post_forward_hook(self, module, *args, **kwargs):
+        idx = self.submodules_indexer[module]
+
+        mover.forget_batch(self.parameters_list[idx])
+        self.fill_allowance(idx)
+
+
+class DiffModelMover(SmartModelMover):
     def get_module_list(self):
         modules = []
         modules.append(self.model.time_embed)
@@ -83,6 +316,8 @@ def send_everything_to_cpu():
         module_in_gpu.to(cpu)
 
     module_in_gpu = None
+
+    mover.forget_all()
 
 
 def is_needed(sd_model):
@@ -113,19 +348,6 @@ def setup_for_low_vram(sd_model, use_medvram):
         be in CPU
         """
         global module_in_gpu
-
-        try:
-            name = module._get_name()
-        except:
-            try:
-                name = module.__name__
-            except:
-                try:
-                    name = module.__class__.__name__
-                except:
-                    name = str(module)
-
-        print(f"Moving {module.__module__}.{name} to GPU")
 
         module = parents.get(module, module)
 
@@ -219,7 +441,7 @@ def setup_for_low_vram(sd_model, use_medvram):
         diff_model.input_blocks, diff_model.middle_block, diff_model.output_blocks, diff_model.time_embed = stored
 
         # install hooks for bits of third model
-        mover = DiffModelMover.register(diff_model, lookahead_distance=8)
+        mover = DiffModelMover.register(diff_model, max_prefetch=5)
         mover.install()
 
 

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -9,7 +9,7 @@ stream_impl = devices.get_stream_impl()
 stream_wrapper = devices.get_stream_wrapper()
 
 
-use_streamlined_lowvram = not shared.opts.use_non_streamlined_lowvram and stream_impl is not None and stream_wrapper is not None
+use_streamlined_lowvram = torch.cuda.is_available() and not shared.opts.use_non_streamlined_lowvram and stream_impl is not None and stream_wrapper is not None
 
 
 def is_same_device(device1, device2):

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -558,7 +558,7 @@ def setup_for_low_vram(sd_model, use_medvram):
         # install hooks for bits of third model
 
         if stream_impl is not None and stream_wrapper is not None:
-            mp = DiffSmartModelMover.register(diff_model, max_prefetch=70)
+            mp = DiffSmartModelMover.register(diff_model, vram_allowance=512, max_prefetch=70)
             mp.install()
             mp.preload()
         else:

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -96,19 +96,19 @@ class RTTensorMoverPatches:
             del self.stash[k]
 
     def _wrapper_default(self, original):
-        def wrapper(input, weight, bias, *args, **kwargs):
+        def wrapper(input, weight, bias=None, *args, **kwargs):
             with self.wrap_weight_biases(input, weight, bias) as (w, b):
                 return original(input, w, b, *args, **kwargs)
         return wrapper
 
     def _wrapper_group_norm(self, original):
-        def wrapper(input, num_groups, weight, bias, *args, **kwargs):
+        def wrapper(input, num_groups, weight=None, bias=None, *args, **kwargs):
             with self.wrap_weight_biases(input, weight, bias) as (w, b):
                 return original(input, num_groups, w, b, *args, **kwargs)
         return wrapper
 
     def _wrapper_layer_norm(self, original):
-        def wrapper(input, normalized_shape, weight, bias, *args, **kwargs):
+        def wrapper(input, normalized_shape, weight=None, bias=None, *args, **kwargs):
             with self.wrap_weight_biases(input, weight, bias) as (w, b):
                 return original(input, normalized_shape, w, b, *args, **kwargs)
         return wrapper

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager, nullcontext
 import torch
 from torch.utils.weak import WeakIdKeyDictionary
 from modules import devices, shared, patches
@@ -9,11 +10,21 @@ stream_impl = devices.get_stream_impl()
 stream_wrapper = devices.get_stream_wrapper()
 
 
-class SmartTensorMoverPatches:
+def is_same_device(device1, device2):
+    tensor1_device_type = device1.type
+    tensor2_device_type = device2.type
+    tensor1_device_index = device1.index or 0
+    tensor2_device_index = device2.index or 0
+    return (
+        tensor1_device_type == tensor2_device_type
+        and tensor1_device_index == tensor2_device_index
+    )
+
+class RTTensorMoverPatches:
     def __init__(self):
-        self.memo = WeakIdKeyDictionary()
-        self.cleanup_memo = WeakIdKeyDictionary()
-        self.model_mover_stream = stream_impl(device=devices.device)
+        self.mover_stream = stream_impl(device=devices.device)
+        self.calc_stream = stream_impl(device=devices.device)
+        self.stash = {}
 
         self.linear_original = patches.patch(
             __name__,
@@ -46,111 +57,57 @@ class SmartTensorMoverPatches:
             self.create_wrapper(torch.nn.functional.layer_norm, type=2),
         )
 
+    @contextmanager
+    def wrap_weight_biases(self, input, weight, bias):
+        if not is_same_device(input.device, devices.device):
+            yield (weight, bias)
+            return
+
+        moved = False
+        before_calc_event, after_calc_event = None, None
+        with stream_wrapper(stream=self.mover_stream):
+            if weight is not None and not is_same_device(weight.device, input.device):
+                weight = weight.to(device=input.device, copy=True, non_blocking=weight.is_pinned())
+                moved = True
+            if bias is not None and not is_same_device(bias.device, input.device):
+                bias = bias.to(device=input.device, copy=True, non_blocking=bias.is_pinned())
+                moved = True
+            before_calc_event = self.mover_stream.record_event()
+
+        if not moved:
+            yield (weight, bias)
+            return
+
+        with stream_wrapper(stream=self.calc_stream):
+            if before_calc_event is not None:
+                self.calc_stream.wait_event(before_calc_event)
+            yield (weight, bias)
+            after_calc_event = self.calc_stream.record_event()
+            self.stash[id(after_calc_event)] = (weight, bias, after_calc_event)
+
+        to_remove = []
+        for k, (w, b, e) in self.stash.items():
+            if e.query():
+                to_remove.append(k)
+
+        for k in to_remove:
+            del self.stash[k]
+
     def create_wrapper(self, original, type=1):
         if type == 2:
 
             def wrapper(input, arg1, weight, bias, *args, **kwargs):
-                record_cleanup_weight, record_cleanup_bias = False, False
-                current_stream = devices.get_current_stream()
-
-                if weight is not None:
-                    new_weight, weight_event = self.memo.get(weight, (None, None))
-                    if weight_event is not None:
-                        weight = new_weight
-                        record_cleanup_weight = True
-                        current_stream.wait_event(weight_event)
-
-                if bias is not None:
-                    new_bias, bias_event = self.memo.get(bias, (None, None))
-                    if bias_event is not None:
-                        bias = new_bias
-                        record_cleanup_bias = True
-                        current_stream.wait_event(bias_event)
-
-                result = original(input, arg1, weight, bias, *args, **kwargs)
-
-                if record_cleanup_weight:
-                    self.cleanup_memo[weight] = current_stream.record_event()
-
-                if record_cleanup_bias:
-                    self.cleanup_memo[bias] = current_stream.record_event()
-
-                return result
+                with self.wrap_weight_biases(input, weight, bias) as (w, b):
+                    return original(input, arg1, w, b, *args, **kwargs)
 
             return wrapper
         else:
 
             def wrapper(input, weight, bias, *args, **kwargs):
-                record_cleanup_weight, record_cleanup_bias = False, False
-                current_stream = devices.get_current_stream()
-
-                if weight is not None:
-                    new_weight, weight_event = self.memo.get(weight, (None, None))
-                    if weight_event is not None:
-                        weight = new_weight
-                        record_cleanup_weight = True
-                        current_stream.wait_event(weight_event)
-
-                if bias is not None:
-                    new_bias, bias_event = self.memo.get(bias, (None, None))
-                    if bias_event is not None:
-                        bias = new_bias
-                        record_cleanup_bias = True
-                        current_stream.wait_event(bias_event)
-
-                result = original(input, weight, bias, *args, **kwargs)
-
-                if record_cleanup_weight:
-                    self.cleanup_memo[weight] = current_stream.record_event()
-
-                if record_cleanup_bias:
-                    self.cleanup_memo[bias] = current_stream.record_event()
-
-                return result
+                with self.wrap_weight_biases(input, weight, bias) as (w, b):
+                    return original(input, w, b, *args, **kwargs)
 
             return wrapper
-
-    def __contains__(self, tensor):
-        return tensor in self.memo
-
-    def move(self, tensor, device=None):
-        device = device or tensor.device
-        memo_tensor, memo_event = self.memo.get(tensor, (None, None))
-
-        if memo_tensor is not None:
-            return memo_tensor, memo_event
-
-        with stream_wrapper(stream=self.model_mover_stream):
-            new_tensor = tensor.to(device=device, copy=True, non_blocking=True)
-            new_event = self.model_mover_stream.record_event()
-            self.memo[tensor] = (new_tensor, new_event)
-
-        return self.memo[tensor]
-
-    def _forget(self, tensor, tensor_on_device=None):
-        if tensor_on_device is not None:
-            tensor_used_event = self.cleanup_memo.get(tensor_on_device, None)
-            if tensor_used_event is not None:
-                self.model_mover_stream.wait_event(tensor_used_event)
-                self.cleanup_memo.pop(tensor_on_device, None)
-        del self.memo[tensor]
-
-    def forget(self, tensor):
-        on_device_tensor = self.memo.get(tensor, None)
-        self._forget(tensor, on_device_tensor)
-
-    def forget_batch(self, tensors):
-        for tensor in tensors:
-            tensor_on_device, _ = self.memo.get(tensor, (None, None))
-            if tensor_on_device is not None:
-                self._forget(tensor, tensor_on_device)
-
-    def forget_all(self):
-        for (tensor_on_device, _) in self.memo.values():
-            if tensor_on_device in self.cleanup_memo:
-                self.model_mover_stream.wait_event(self.cleanup_memo[tensor_on_device])
-        self.cleanup_memo.clear()
-        self.memo.clear()
 
     def close(self):
         patches.undo(__name__, torch.nn.functional, "linear")
@@ -160,242 +117,21 @@ class SmartTensorMoverPatches:
         patches.undo(__name__, torch.nn.functional, "layer_norm")
 
 
-mover = None
+rtmover = None
 if stream_impl is not None and stream_wrapper is not None:
-    mover = SmartTensorMoverPatches()
+    rtmover = RTTensorMoverPatches()
 
 
-class ModelMover:
-    @classmethod
-    def register(cls, model, max_prefetch=1):
-        instance = cls(model, max_prefetch)
-        model.lowvram_model_mover = instance
-        return instance
-
-    def __init__(self, model, max_prefetch=1):
-        self.model = model
-        self.lookahead_distance = max_prefetch
-        self.hook_handles = []
-        self.submodules_list = self.get_module_list()
-
-        for c in self.submodules_list:
-            c._apply(lambda x: x.pin_memory())
-
-        self.submodules_indexer = {}
-        self.module_movement_events = {}
-        self.default_stream = devices.get_current_stream()
-        self.model_mover_stream = stream_impl(device=devices.device)
-
-        for i, module in enumerate(self.submodules_list):
-            self.submodules_indexer[module] = i
-
-    def get_module_list(self):
-        return []
-
-    def install(self):
-        for i in range(len(self.submodules_list)):
-            self.hook_handles.append(
-                self.submodules_list[i].register_forward_pre_hook(
-                    self._pre_forward_hook
-                )
-            )
-            self.hook_handles.append(
-                self.submodules_list[i].register_forward_hook(self._post_forward_hook)
-            )
-
-    def uninstall(self):
-        for handle in self.hook_handles:
-            handle.remove()
-
-    def _pre_forward_hook(self, module, _):
-        with stream_wrapper(stream=self.model_mover_stream):
-            idx = self.submodules_indexer[module]
-            for i in range(idx, idx + self.lookahead_distance):
-                submodule = self.submodules_list[i % len(self.submodules_list)]
-                if submodule in self.module_movement_events:
-                    # already in GPU
-                    continue
-                submodule.to(devices.device, non_blocking=True)
-                self.module_movement_events[submodule] = (
-                    self.model_mover_stream.record_event()
-                )
-
-        this_event = self.module_movement_events.get(module, None)
-        if this_event is not None:
-            self.default_stream.wait_event(this_event)
-        else:
-            print(
-                f"Module {module.__name__} was not moved to GPU. Taking slow path"
-            )
-            submodule.to(devices.device, non_blocking=True)
-
-    def _post_forward_hook(self, module, _1, _2):
-        with stream_wrapper(stream=self.model_mover_stream):
-            del self.module_movement_events[module]
-            module.to(cpu, non_blocking=True)
+def calc_wrapper():
+    if rtmover is not None:
+        return stream_wrapper(stream=rtmover.calc_stream)
+    return nullcontext()
 
 
-class SmartModelMover:
-    @classmethod
-    def register(cls, model, vram_allowance=0, max_prefetch=10):
-        instance = cls(model, vram_allowance, max_prefetch)
-        model.lowvram_model_mover = instance
-        return instance
-
-    def __init__(self, model, vram_allowance=0, max_prefetch=10):
-        self.model = model
-        self.vram_allowance = vram_allowance * 1024 * 1024
-        self.vram_allowance_remaining = vram_allowance * 1024 * 1024
-        self.max_prefetch = max_prefetch
-        self.hook_handles = []
-        submodules_list = self.get_module_list()
-
-        for c in submodules_list:
-            c._apply(lambda x: x.pin_memory())
-
-        self.submodules_list = [
-            k for c in submodules_list for k in self.get_childrens(c)
-        ]
-        self.parameters_list = [
-            list(x.parameters()) for x in self.submodules_list
-        ]
-        self.parameters_sizes = [
-            sum([p.numel() * p.element_size() for p in x]) for x in self.parameters_list
-        ]
-        self.online_modules = set()
-        self.online_module_count = 0
-        self.submodules_indexer = {}
-
-        for i, module in enumerate(self.submodules_list):
-            self.submodules_indexer[module] = i
-
-    def test_children(self, op):
-        return op.__class__.__name__ in [
-            "Conv2d",
-            "Conv3d",
-            "Linear",
-            "GroupNorm",
-            "LayerNorm",
-        ]
-
-    def get_childrens(self, container):
-        if isinstance(container, torch.nn.Sequential):
-            # return [c for c in container]
-            return [cc for c in container for cc in self.get_childrens(c)]
-        if "children" in dir(container):
-            childrens = [
-                cc for c in container.children() for cc in self.get_childrens(c)
-            ]
-            if len(childrens) > 0:
-                return childrens
-        return [container]
-
-    def drain_allowance(self, idx):
-        parameters_len = len(self.parameters_list)
-
-        # no vram limitation is set
-        if self.vram_allowance <= 0:
-            # fetch up to max_prefetch parameters
-            while self.online_module_count < self.max_prefetch and self.online_module_count < parameters_len:
-                param = self.parameters_list[idx]
-                self.online_modules.add(idx)
-                self.online_module_count += 1
-                yield param
-                idx = (idx + 1) % parameters_len
-            return
-
-        # if there is still vram allowance, and it has not reached max_prefetch
-        while self.vram_allowance_remaining > 0 and (
-            self.max_prefetch < 1 or self.online_module_count < self.max_prefetch
-        ) and self.online_module_count < parameters_len:
-            param = self.parameters_list[idx]
-            param_size = self.parameters_sizes[idx]
-
-            # empty module or already online
-            if len(param) == 0 or idx in self.online_modules:
-                self.online_modules.add(idx)
-                self.online_module_count += 1
-                idx = (idx + 1) % parameters_len
-                continue
-
-            # if the parameter size is bigger than the remaining vram allowance, and there are already online modules
-            if (
-                param_size > self.vram_allowance_remaining
-                and self.online_module_count > 0
-            ):
-                return
-            self.vram_allowance_remaining -= param_size
-            self.online_modules.add(idx)
-            self.online_module_count += 1
-            yield param
-            idx = (idx + 1) % parameters_len
-
-    def fill_allowance(self, idx):
-        if self.vram_allowance > 0:
-            self.vram_allowance_remaining += self.parameters_sizes[idx]
-        self.online_modules.remove(idx)
-        self.online_module_count -= 1
-
-    def get_module_list(self):
-        return []
-
-    def install(self):
-        for submodule in self.submodules_list:
-            self.hook_handles.append(
-                submodule.register_forward_pre_hook(self._pre_forward_hook)
-            )
-            self.hook_handles.append(
-                submodule.register_forward_hook(self._post_forward_hook)
-            )
-
-    def uninstall(self):
-        for handle in self.hook_handles:
-            handle.remove()
-
-        for idx in self.online_modules:
-            mover.forget_batch(self.parameters_list[idx])
-
-    def preload(self):
-        idx = 0
-        for parameters in self.drain_allowance(idx):
-            for param in parameters:
-                mover.move(param, device=devices.device)
-
-    def _pre_forward_hook(self, module, *args, **kwargs):
-        idx = self.submodules_indexer[module]
-        for parameters in self.drain_allowance(idx):
-            for param in parameters:
-                mover.move(param, device=devices.device)
-
-    def _post_forward_hook(self, module, *args, **kwargs):
-        idx = self.submodules_indexer[module]
-
-        mover.forget_batch(self.parameters_list[idx])
-        self.fill_allowance(idx)
-
-
-class DiffModelMover(ModelMover):
-    def get_module_list(self):
-        modules = []
-        modules.append(self.model.time_embed)
-        for block in self.model.input_blocks:
-            modules.append(block)
-        modules.append(self.model.middle_block)
-        for block in self.model.output_blocks:
-            modules.append(block)
-        return modules
-
-
-class DiffSmartModelMover(SmartModelMover):
-    def get_module_list(self):
-        modules = []
-        modules.append(self.model.time_embed)
-        for block in self.model.input_blocks:
-            modules.append(block)
-        modules.append(self.model.middle_block)
-        for block in self.model.output_blocks:
-            modules.append(block)
-        return modules
+def calc_sync():
+    if rtmover is not None:
+        return rtmover.calc_stream.synchronize()
+    return nullcontext()
 
 
 def send_everything_to_cpu():
@@ -530,9 +266,13 @@ def setup_for_low_vram(sd_model, use_medvram):
         # install hooks for bits of third model
 
         if stream_impl is not None and stream_wrapper is not None:
-            mp = DiffSmartModelMover.register(diff_model, vram_allowance=512, max_prefetch=70)
-            mp.install()
-            mp.preload()
+            # put it into pinned memory to achieve data transfer overlap
+            diff_model.time_embed._apply(lambda x: x.pin_memory())
+            for block in diff_model.input_blocks:
+                block._apply(lambda x: x.pin_memory())
+            diff_model.middle_block._apply(lambda x: x.pin_memory())
+            for block in diff_model.output_blocks:
+                block._apply(lambda x: x.pin_memory())
         else:
             diff_model.time_embed.register_forward_pre_hook(send_me_to_gpu)
             for block in diff_model.input_blocks:

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -160,7 +160,9 @@ class SmartTensorMoverPatches:
         patches.undo(__name__, torch.nn.functional, "layer_norm")
 
 
-mover = SmartTensorMoverPatches()
+mover = None
+if stream_impl is not None and stream_wrapper is not None:
+    mover = SmartTensorMoverPatches()
 
 
 class ModelMover:

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -298,7 +298,7 @@ class SmartModelMover:
         # no vram limitation is set
         if self.vram_allowance <= 0:
             # fetch up to max_prefetch parameters
-            while self.online_module_count < self.max_prefetch:
+            while self.online_module_count < self.max_prefetch and self.online_module_count < parameters_len:
                 param = self.parameters_list[idx]
                 self.online_modules.add(idx)
                 self.online_module_count += 1
@@ -309,7 +309,7 @@ class SmartModelMover:
         # if there is still vram allowance, and it has not reached max_prefetch
         while self.vram_allowance_remaining > 0 and (
             self.max_prefetch < 1 or self.online_module_count < self.max_prefetch
-        ):
+        ) and self.online_module_count < parameters_len:
             param = self.parameters_list[idx]
             param_size = self.parameters_sizes[idx]
 

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager, nullcontext
 import torch
-from torch.utils.weak import WeakIdKeyDictionary
 from modules import devices, shared, patches
 
 module_in_gpu = None
@@ -86,7 +85,7 @@ class RTTensorMoverPatches:
             self.stash[id(after_calc_event)] = (weight, bias, after_calc_event)
 
         to_remove = []
-        for k, (w, b, e) in self.stash.items():
+        for k, (_, _, e) in self.stash.items():
             if e.query():
                 to_remove.append(k)
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -782,7 +782,9 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
         sd_models.apply_token_merging(p.sd_model, p.get_token_merging_ratio())
 
-        res = process_images_inner(p)
+        with lowvram.calc_wrapper():
+            res = process_images_inner(p)
+        lowvram.calc_sync()
 
     finally:
         sd_models.apply_token_merging(p.sd_model, 0)

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -446,7 +446,13 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
                     module.fp16_weight = module.weight.data.clone().cpu().half()
                     if module.bias is not None:
                         module.fp16_bias = module.bias.data.clone().cpu().half()
-                module.to(torch.float8_e4m3fn)._apply(lambda x: x.pin_memory())
+                module.to(torch.float8_e4m3fn)._apply(
+                    lambda x: (
+                        x.pin_memory()
+                        if not x.is_sparse and x.device.type == "cpu"
+                        else x
+                    )
+                )
         model.first_stage_model = first_stage
         timer.record("apply fp8")
     else:

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -448,7 +448,7 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
                         module.fp16_bias = module.bias.data.clone().cpu().half()
                 module.to(torch.float8_e4m3fn)._apply(
                     lambda x: (
-                        x.pin_memory()
+                        x.pin_memory(device=devices.device)
                         if not x.is_sparse and x.device.type == "cpu"
                         else x
                     )

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -446,7 +446,7 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
                     module.fp16_weight = module.weight.data.clone().cpu().half()
                     if module.bias is not None:
                         module.fp16_bias = module.bias.data.clone().cpu().half()
-                module.to(torch.float8_e4m3fn)
+                module.to(torch.float8_e4m3fn)._apply(lambda x: x.pin_memory())
         model.first_stage_model = first_stage
         timer.record("apply fp8")
     else:

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -216,6 +216,7 @@ options_templates.update(options_section(('optimizations', "Optimizations", "sd"
     "batch_cond_uncond": OptionInfo(True, "Batch cond/uncond").info("do both conditional and unconditional denoising in one batch; uses a bit more VRAM during sampling, but improves speed; previously this was controlled by --always-batch-cond-uncond commandline argument"),
     "fp8_storage": OptionInfo("Disable", "FP8 weight", gr.Radio, {"choices": ["Disable", "Enable for SDXL", "Enable"]}).info("Use FP8 to store Linear/Conv layers' weight. Require pytorch>=2.1.0."),
     "cache_fp16_weight": OptionInfo(False, "Cache FP16 weight for LoRA").info("Cache fp16 weight when enabling FP8, will increase the quality of LoRA. Use more system ram."),
+    "use_non_streamlined_lowvram": OptionInfo(False, "Use non-streamlined low VRAM mode").info("Do not use the streamlined mode for low VRAM cards. For devices that do not support concurrently copy memory between host and device while executing a kernel. Significantly decreases performance."),
 }))
 
 options_templates.update(options_section(('compatibility', "Compatibility", "sd"), {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -217,6 +217,7 @@ options_templates.update(options_section(('optimizations', "Optimizations", "sd"
     "fp8_storage": OptionInfo("Disable", "FP8 weight", gr.Radio, {"choices": ["Disable", "Enable for SDXL", "Enable"]}).info("Use FP8 to store Linear/Conv layers' weight. Require pytorch>=2.1.0."),
     "cache_fp16_weight": OptionInfo(False, "Cache FP16 weight for LoRA").info("Cache fp16 weight when enabling FP8, will increase the quality of LoRA. Use more system ram."),
     "use_non_streamlined_lowvram": OptionInfo(False, "Use non-streamlined low VRAM mode").info("Do not use the streamlined mode for low VRAM cards. For devices that do not support concurrently copy memory between host and device while executing a kernel. Significantly decreases performance."),
+    "lowvram_max_loaded_module": OptionInfo(3, "Maximum number of loaded modules in low VRAM mode", gr.Slider, {"minimum": 1, "maximum": 40, "step": 1}).info("Maximum number of loaded modules in low VRAM mode. Decrease this value if you encounter out of memory error."),
 }))
 
 options_templates.update(options_section(('compatibility', "Compatibility", "sd"), {


### PR DESCRIPTION
## Description

* This is an attempt to speed up `--lowvram` by taking the model moving out of the forward loop. 
* The model moving is made asynchronous, by creating a separate CUDA stream dedicated for moving the model, and utilizing CUDA event for synchronoizing back to the default stream.
* A lookahead buffer zone is designed, to make the model moving process faster than the forward phase, so in the meanwhile the GPU always has something to do.

I'm getting a 3.7it/s on a 3060 Laptop with half of the VRAM compared to `--medvram`. It was originally 1.65it/s. As a reference, the medvram speed was 5.8it/s.

## Concerns

* This is still a prototype, and not all original semantics are followed.
* CUDA stream and CUDA events are used. They are CUDA specific. I think there are similar things on IPEX, but nothing similar on DML.
* The size of the lookahead buffer is a tweakable settings. A larger buffer would increase the VRAM usage; a smaller buffer would probably make the forward a bit slower. The generation speed gained by larger buffer has a limit.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
