### PR TITLE
Button for refresh extensions list

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -548,6 +548,7 @@ def create_ui():
                     extensions_disable_all = gr.Radio(label="Disable all extensions", choices=["none", "extra", "all"], value=shared.opts.disable_all_extensions, elem_id="extensions_disable_all")
                     extensions_disabled_list = gr.Text(elem_id="extensions_disabled_list", visible=False, container=False)
                     extensions_update_list = gr.Text(elem_id="extensions_update_list", visible=False, container=False)
+                    refresh = gr.Button(value='Refresh', variant="compact")
 
                 html = ""
 
@@ -566,7 +567,8 @@ def create_ui():
                 with gr.Row(elem_classes="progress-container"):
                     extensions_table = gr.HTML('Loading...', elem_id="extensions_installed_html")
 
-                ui.load(fn=extension_table, inputs=[], outputs=[extensions_table])
+                ui.load(fn=extension_table, inputs=[], outputs=[extensions_table], show_progress=False)
+                refresh.click(fn=extension_table, inputs=[], outputs=[extensions_table], show_progress=False)
 
                 apply.click(
                     fn=apply_and_restart,


### PR DESCRIPTION
## Description

Many times I face with problem: loading of extensions list is stacked. (Endless "Loading...") Maybe it because of few webui windows opened in different machine, idk. I've added this little button to load them manually, because it's very annoying bug for me

## Screenshots/videos:
![Screenshot_20240207_160952](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/ee19f77b-004a-4a9a-9e7f-11964871f25f)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
