### PR TITLE
Check extensions list on Apply

### DIFF
--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -1,5 +1,5 @@
 
-function extensions_apply(_disabled_list, _update_list, disable_all) {
+function extensions_apply(_disabled_list, _update_list, disable_all, extensions_table) {
     var disable = [];
     var update = [];
 
@@ -15,7 +15,7 @@ function extensions_apply(_disabled_list, _update_list, disable_all) {
 
     restart_reload();
 
-    return [JSON.stringify(disable), JSON.stringify(update), disable_all];
+    return [JSON.stringify(disable), JSON.stringify(update), disable_all, extensions_table];
 }
 
 function extensions_check() {

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -23,8 +23,9 @@ def check_access():
     assert not shared.cmd_opts.disable_extension_access, "extension access disabled because of command line flags"
 
 
-def apply_and_restart(disable_list, update_list, disable_all):
+def apply_and_restart(disable_list, update_list, disable_all, extensions_table):
     check_access()
+    assert "Loading..." not in extensions_table
 
     disabled = json.loads(disable_list)
     assert type(disabled) == list, f"wrong disable_list data for apply_and_restart: {disable_list}"
@@ -571,7 +572,7 @@ def create_ui():
                 apply.click(
                     fn=apply_and_restart,
                     _js="extensions_apply",
-                    inputs=[extensions_disabled_list, extensions_update_list, extensions_disable_all],
+                    inputs=[extensions_disabled_list, extensions_update_list, extensions_disable_all, extensions_table],
                     outputs=[],
                 )
 


### PR DESCRIPTION
## Description

There is creepy bug: when extension list is stacked (endless "Loading..." and user presses "Apply and restart UI", ui enables every extension, and with high probability ui cannot start because of few extension. And you need to run webui in disabled extensions mode, and check which extensions you want to use again


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
