### PR TITLE
Support inference with LyCORIS BOFT networks

### DIFF
--- a/extensions-builtin/Lora/lyco_helpers.py
+++ b/extensions-builtin/Lora/lyco_helpers.py
@@ -66,29 +66,3 @@ def factorization(dimension: int, factor:int=-1) -> tuple[int, int]:
         n, m = m, n
     return m, n
 
-# from https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/boft.py
-def butterfly_factor(dimension: int, factor: int = -1) -> tuple[int, int]:
-    """
-    m = 2k
-    n = 2**p
-    m*n = dim
-    """
-
-    # Find the first solution and check if it is even doable
-    m = n = 0
-    while m <= factor:
-        m += 2
-        while dimension % m != 0 and m < dimension:
-            m += 2
-        if m > factor:
-            break
-        if sum(int(i) for i in f"{dimension//m:b}") == 1:
-            n = dimension // m
-
-    if n == 0:
-        raise ValueError(
-            f"It is impossible to decompose {dimension} with factor {factor} under BOFT constrains."
-        )
-
-    #log_butterfly_factorize(dimension, factor, (dimension // n, n))
-    return dimension // n, n

--- a/extensions-builtin/Lora/lyco_helpers.py
+++ b/extensions-builtin/Lora/lyco_helpers.py
@@ -66,3 +66,29 @@ def factorization(dimension: int, factor:int=-1) -> tuple[int, int]:
         n, m = m, n
     return m, n
 
+# from https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/boft.py
+def butterfly_factor(dimension: int, factor: int = -1) -> tuple[int, int]:
+    """
+    m = 2k
+    n = 2**p
+    m*n = dim
+    """
+
+    # Find the first solution and check if it is even doable
+    m = n = 0
+    while m <= factor:
+        m += 2
+        while dimension % m != 0 and m < dimension:
+            m += 2
+        if m > factor:
+            break
+        if sum(int(i) for i in f"{dimension//m:b}") == 1:
+            n = dimension // m
+
+    if n == 0:
+        raise ValueError(
+            f"It is impossible to decompose {dimension} with factor {factor} under BOFT constrains."
+        )
+
+    #log_butterfly_factorize(dimension, factor, (dimension // n, n))
+    return dimension // n, n

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -57,6 +57,9 @@ class NetworkModuleOFT(network.NetworkModule):
             self.constraint = self.alpha * self.out_dim
             self.num_blocks = self.dim
             self.block_size = self.out_dim // self.dim
+        elif self.is_boft:
+            self.constraint = None
+            self.block_size, self.block_num = butterfly_factor(self.out_dim, self.dim)
         else:
             self.constraint = None
             self.block_size, self.num_blocks = factorization(self.out_dim, self.dim)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -40,7 +40,9 @@ class NetworkModuleOFT(network.NetworkModule):
             self.is_boft = False
             if weights.w["oft_diag"].dim() == 4:
                 self.is_boft = True
-        self.rescale = weight.w.get('rescale', None)
+        self.rescale = weights.w.get('rescale', None)
+        if self.rescale is not None:
+            self.rescale = self.rescale.reshape(-1, *[1]*(self.org_module[0].weight.dim() - 1))
 
         is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
         is_conv = type(self.sd_module) in [torch.nn.Conv2d]

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -22,6 +22,8 @@ class NetworkModuleOFT(network.NetworkModule):
         self.org_module: list[torch.Module] = [self.sd_module]
 
         self.scale = 1.0
+        self.is_kohya = False
+        self.is_boft = False
 
         # kohya-ss
         if "oft_blocks" in weights.w.keys():
@@ -31,13 +33,11 @@ class NetworkModuleOFT(network.NetworkModule):
             self.dim = self.oft_blocks.shape[0] # lora dim
         # LyCORIS OFT
         elif "oft_diag" in weights.w.keys():
-            self.is_kohya = False
             self.oft_blocks = weights.w["oft_diag"]
             # self.alpha is unused
             self.dim = self.oft_blocks.shape[1] # (num_blocks, block_size, block_size)
 
             # LyCORIS BOFT
-            self.is_boft = False
             if weights.w["oft_diag"].dim() == 4:
                 self.is_boft = True
         self.rescale = weights.w.get('rescale', None)

--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -96,7 +96,7 @@ class NetworkModuleOFT(network.NetworkModule):
                 bi = R[i] # b_num, b_size, b_size
                 if i == 0:
                     # Apply multiplier/scale and rescale into first weight
-                    bi = bi * scale + (1 - scale) * eye 
+                    bi = bi * scale + (1 - scale) * eye
                     #if self.rescaled:
                     #    bi = bi * self.rescale
                 inp = rearrange(inp, "(c g k) ... -> (c k g) ...", g=2, k=2**i * r_b)


### PR DESCRIPTION
## Description

This draft PR adds support for inference of BOFT networks trained with the dev branch of [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS). The implementation is based on @KohakuBlueleaf's implementation here: https://github.com/KohakuBlueleaf/LyCORIS/blob/dev/lycoris/modules/boft.py

Since the name "oft_diag" is the same between OFT and BOFT, I think the simplest way to differentiate the two is the dimension of the weights (OFT: 3, BOFT: 4).

The calc_updown code is slightly modified from the get_weight function in the original. I'm not sure what to do about the scale parameter so I leave it at 1.0.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
