### PR TITLE
if extensions page not loaded, prevent apply

### DIFF
--- a/javascript/extensions.js
+++ b/javascript/extensions.js
@@ -2,8 +2,11 @@
 function extensions_apply(_disabled_list, _update_list, disable_all) {
     var disable = [];
     var update = [];
-
-    gradioApp().querySelectorAll('#extensions input[type="checkbox"]').forEach(function(x) {
+    const extensions_input = gradioApp().querySelectorAll('#extensions input[type="checkbox"]');
+    if (extensions_input.length == 0) {
+        throw Error("Extensions page not yet loaded.");
+    }
+    extensions_input.forEach(function(x) {
         if (x.name.startsWith("enable_") && !x.checked) {
             disable.push(x.name.substring(7));
         }


### PR DESCRIPTION
## Description

- alternative to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14858

since they are built-in extensions we can make the assumption that they will be at least one or more extensions

if length is 0 then throws an error

> also if for whatever reason there is no extensions then this doesn't matter anymore

to manually test this you can put a breakpoint in
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/d69a7944c9ad5a086d99cf9220a3a2742a1194f3/modules/ui_extensions.py#L136

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/fcc73a50-391b-4794-a144-812323c33055)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
