### PR TITLE
util.walk_files extensions case insensitive

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -42,7 +42,7 @@ def walk_files(path, allowed_extensions=None):
         for filename in sorted(files, key=natural_sort_key):
             if allowed_extensions is not None:
                 _, ext = os.path.splitext(filename)
-                if ext not in allowed_extensions:
+                if ext.lower() not in allowed_extensions:
                     continue
 
             if not shared.opts.list_hidden_files and ("/." in root or "\\." in root):


### PR DESCRIPTION
## Description

`util.walk_files` extensions case insensitive
- fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14877

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
