### PR TITLE
fix prepare_tcmalloc (fix: #14227)(Fixed memory leak issue in Ubuntu 22.04 or modern linux environment)

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -226,30 +226,48 @@ fi
 # Try using TCMalloc on Linux
 prepare_tcmalloc() {
     if [[ "${OSTYPE}" == "linux"* ]] && [[ -z "${NO_TCMALLOC}" ]] && [[ -z "${LD_PRELOAD}" ]]; then
+        # check glibc version
+        LIBC_LIB="$(PATH=/usr/sbin:$PATH ldconfig -p | grep -P "libc.so.6" | head -n 1)"
+        LIBC_INFO=$(echo ${LIBC_LIB} | awk '{print $NF}')
+        LIBC_VER=$(echo $(${LIBC_INFO} | awk 'NR==1 {print $NF}') | grep -oP '\d+\.\d+')
+        echo "glibc version is $LIBC_VER"
+        libc_vernum=$(expr $LIBC_VER)
+        # Since 2.34 libpthread is integrated into libc.so
+        libc_v234=2.34
         # Define Tcmalloc Libs arrays
         TCMALLOC_LIBS=("libtcmalloc(_minimal|)\.so\.\d" "libtcmalloc\.so\.\d")
-
         # Traversal array
         for lib in "${TCMALLOC_LIBS[@]}"
         do
-          #Determine which type of tcmalloc library the library supports
-          TCMALLOC="$(PATH=/usr/sbin:$PATH ldconfig -p | grep -P $lib | head -n 1)"
-          TC_INFO=(${TCMALLOC//=>/})
-          if [[ ! -z "${TC_INFO}" ]]; then
-              echo "Using TCMalloc: ${TC_INFO}"
-              #Determine if the library is linked to libptthread and resolve undefined symbol: ptthread_Key_Create
-              if ldd ${TC_INFO[2]} | grep -q 'libpthread'; then
-                echo "$TC_INFO is linked with libpthread,execute LD_PRELOAD=${TC_INFO}"
-                export LD_PRELOAD="${TC_INFO}"
-                break
-              else
-                echo "$TC_INFO is not linked with libpthreadand will trigger undefined symbol: ptthread_Key_Create error"
-              fi
-          else
-              printf "\e[1m\e[31mCannot locate TCMalloc (improves CPU memory usage)\e[0m\n"
-          fi
+            # Determine which type of tcmalloc library the library supports
+            TCMALLOC="$(PATH=/usr/sbin:$PATH ldconfig -p | grep -P $lib | head -n 1)"
+            TC_INFO=(${TCMALLOC//=>/})
+            if [[ ! -z "${TC_INFO}" ]]; then
+                echo "Check TCMalloc: ${TC_INFO}"
+                # Determine if the library is linked to libptthread and resolve undefined symbol: ptthread_key_create
+                if [ $(echo "$libc_vernum < $libc_v234" | bc) -eq 1 ]; then
+                    # glibc < 2.33 pthread_key_create into libpthead.so. check linking libpthread.so...
+                    if ldd ${TC_INFO[2]} | grep -q 'libpthread'; then
+                        echo "$TC_INFO is linked with libpthread,execute LD_PRELOAD=${TC_INFO[2]}"
+                        # set fullpath LD_PRELOAD (To be on the safe side)
+                        export LD_PRELOAD="${TC_INFO[2]}"
+                        break
+                    else
+                        echo "$TC_INFO is not linked with libpthread will trigger undefined symbol: pthread_Key_create error"
+                    fi
+                else
+                    # Version 2.34 of libc.so (glibc) includes the pthead library IN GLIBC. (USE ubuntu 22.04 and modern linux system and WSL)
+                    # libc.so(glibc) is linked with a library that works in ALMOST ALL Linux userlands. SO NO CHECK!
+                    echo "$TC_INFO is linked with libc.so,execute LD_PRELOAD=${TC_INFO[2]}"
+                    # set fullpath LD_PRELOAD (To be on the safe side)
+                    export LD_PRELOAD="${TC_INFO[2]}"
+                    break
+                fi
+            fi
         done
-
+        if [[ -z "${LD_PRELOAD}" ]]; then
+            printf "\e[1m\e[31mCannot locate TCMalloc. Do you have tcmalloc or gperftools installed on your system? (improves CPU memory usage)\e[0m\n"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Description

Probrem: 
Dear...
tcmalloc is not preloaded in the ubuntu 22.04LTS environment + dev branch, causing a memory leak and eventually causing the entire Webui to be OOMed (OOMKiller on Linux).

This is caused by changes in webui.sh that were merged into #14277.

Change #14277 seems to check if tcmalloc links libpthread, but modern Linux systems (ubuntu, fedora, suse, arch,WSL etcetc......) come with glibc (libc.so) version 2.34 or higher . 

Starting with glibc 2.34, pthreads are integrated into libc.so(glibc).

In any case, the problem is that due to the change in #14277, even though tcmalloc is available, it is not written to LD_PRELOAD, and as a result, tcmalloc is not used.

My merge respects the changes in #14277, but also ensures that tcmalloc is automatically and properly preloaded on modern Linux systems.

Specifically, refer to the libc.so version and apply the contents of #14277 if it is 2.34 or lower, and perform the same processing as 1.7.0 if it is 2.34 or higher.
(Since there are VARIOUS Linux systems, we have changed LD_PRELOAD to specify the full path to libtcmalloc just to be sure.)


### Why do we need tcmalloc?
It appears that Python's memory allocator is very conservative, so it may not be freed even if it is no longer referenced. 
tcmalloc alleviates this situation.

see also-> https://github.com/vladmandic/automatic/discussions/1357#discussioncomment-6124869

## Screenshots/videos:

###pure dev branch
can not found libtcmalloc ????
![01_devrepo_tcmalloc_notfound](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/e48a0c16-b142-41fa-8fee-ea8acabf01f8)

tcmalloc is unable to PRELOAD!!!
This can be easily seen by looking at /proc/PID/maps
![02_devrepo_tcmalloc_notpreload](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/95997932-194a-4a2b-8d02-3f0045811663)

After generating the image 5 times, if you switch the checkpoint and generate it 5 times again, the memory situation will be like this.
![03_devrepo_memover](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/7186ea76-1fb9-49d8-a05a-9fd9b9de5642)

And finally it was terminated by OOMKiller
![04_devrepo_oom_dead](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/fd7728bd-2fff-4637-b083-9f57acd8f5c6)


### after merge this patch

I started checking the glibc version, so the appropriate processing is being performed.
![05_fixrepo_tcmalloc_found](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/1ae030c0-4dcf-4ca9-ba9d-52f620c0321e)

If you look at maps, tcmalloc is correctly mapped to memory.
![06_fixrepo_tcmalloc_preloadok](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/8b155371-e586-4c3b-b8d4-b886d1550b51)

After generating the image 5 times, if you switch the checkpoint and generate it 5 times again again again....
In my environment, it became stable at about 9GB to 12GB.
![07_fixrepo_result_memory](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/22044684/c8737e98-260c-4f3c-b931-fdfb0d159a13)


## Checklist:

- [x]  I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

### PS
Remember that tcmalloc is only a mitigation measure.
It's possible that there are still some memory references left somewhere.
I'm not very familiar with python so I can't track it down. (I'm a C/C++ speaker).
I'm sorry, thank you.


