### PR TITLE
extensions tab table row hover highlight

### DIFF
--- a/style.css
+++ b/style.css
@@ -846,6 +846,20 @@ table.popup-table .link{
     display: inline-block;
 }
 
+/* extensions tab table row hover highlight */
+
+#extensions tr:hover td,
+#config_state_extensions tr:hover td,
+#available_extensions tr:hover td {
+    background: rgba(0, 0, 0, 0.15)
+}
+
+.dark #extensions tr:hover td ,
+.dark #config_state_extensions tr:hover td ,
+.dark #available_extensions tr:hover td {
+    background: rgba(255, 255, 255, 0.15)
+}
+
 /* replace original footer with ours */
 
 footer {


### PR DESCRIPTION
## Description
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14882

Add tab table row hover highlight for extensions tab `Installed` `Available` `Backup/Restore` sub tabs

tested with
`Default` `freddyaboulton/dracula_revamped` `NoCrypt/miku` thems in both `light` and `dark` mode
## Screenshots/videos:

| Header | Light | Dark |
|--------|--------|--------|
| Dafault | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/9eff4f3c-3fb2-4d30-a5e1-24b2a9dbf91f) | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/e25a96da-6967-497b-a623-263b7c3c6f22) |
| dracula | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/fb486673-3e7b-4394-b982-a465ffe18a9d) | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f872f2c0-f124-4fb5-953c-ddba3b95abf0) |
| miku | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/a44b9ff5-8d50-4f71-b3c3-7a33c5cc32ee) | ![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d002c297-95a9-4ccd-b979-35bbcabf0fe9) |


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
