### PR TITLE
Always add timestamp to displayed image

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -35,12 +35,7 @@ def save_pil_to_file(self, pil_image, dir=None, format="png"):
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)
-        filename = already_saved_as
-
-        if not shared.opts.save_images_add_number:
-            filename += f'?{os.path.getmtime(already_saved_as)}'
-
-        return filename
+        return f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
 
     if shared.opts.temp_dir != "":
         dir = shared.opts.temp_dir


### PR DESCRIPTION
## Description
When `Add number to filename when saving` is enabled, generating an image, deleting it, then generating another with the same filename, results in the browser displaying the original image form the cache. This fixes that.

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
