### PR TITLE
fix extra-network-control--enabled color

### DIFF
--- a/style.css
+++ b/style.css
@@ -851,13 +851,13 @@ table.popup-table .link{
 #extensions tr:hover td,
 #config_state_extensions tr:hover td,
 #available_extensions tr:hover td {
-    background: rgba(0, 0, 0, 0.15)
+    background: rgba(0, 0, 0, 0.15);
 }
 
 .dark #extensions tr:hover td ,
 .dark #config_state_extensions tr:hover td ,
 .dark #available_extensions tr:hover td {
-    background: rgba(255, 255, 255, 0.15)
+    background: rgba(255, 255, 255, 0.15);
 }
 
 /* replace original footer with ours */
@@ -1513,12 +1513,12 @@ body.resizing .resize-handle {
     background-color: var(--input-placeholder-color);
 }
 
-.dark .extra-network-control .extra-network-control--enabled {
-    background-color: var(--neutral-700);
+.extra-network-control .extra-network-control--enabled {
+    background-color: rgba(0, 0, 0, 0.15);
 }
 
 .dark .extra-network-control .extra-network-control--enabled {
-    background-color: var(--neutral-300);
+    background-color: rgba(255, 255, 255, 0.15);
 }
 
 /* ==== REFRESH ICON ACTIONS ==== */


### PR DESCRIPTION
## Description
- fix extra-network-control--enabled color

the color for `extra-network-control--enabled` css is broken, 
there's duplicate rules for dark mode but none for light mode
I also change it to use transparency so that it looks better

Note
Personally I'm not too keen on highlighting icon whn enabled, I think it's unnecessary
hover highlighting might be a thing
this PR is more about fix the broken CSS so I did not remove it

## Screenshots/videos:
| | Light | Dark |
|--------|--------|--------|
| Disable | ![2024-02-12 04_04_27_807](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/f9ec7838-304a-4f90-8cad-5aa652584485) ![2024-02-12 04_04_30_889](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/a156b119-c4b8-4daf-be9e-ef7fa3332923) ![2024-02-12 04_04_33_387](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/18d2c31b-998a-4ad7-b5f1-35572d01a75f) | ![2024-02-12 04_04_07_921 chrome](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/a64a5c8c-8760-4e07-a493-005db10fabd1) ![2024-02-12 04_04_20_539](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d83dadc6-b565-472a-bd22-048fe23e0396) ![2024-02-12 04_04_25_093](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/de6d2b8f-6ab4-4b56-8363-e6378e18d870) |
| Enable | ![2024-02-12 04_04_28_963](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/7ee40d82-b671-4c10-ae57-0db46ee93248) ![2024-02-12 04_04_32_116](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c35e7a12-d238-40f3-8890-6b0bd4c36081) ![2024-02-12 04_04_34_536](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/c254300a-7e01-483b-b09a-6d6f785c580a) | ![2024-02-12 04_04_16_175](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/82ab9863-883f-4ecc-955e-c8bb70f19501) ![2024-02-12 04_04_22_395](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/3f0e8f12-ecad-4f67-a52a-28815685e2ad) ![2024-02-12 04_04_26_190](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/52bc6385-92a4-43c3-8f11-0512725bd89f) |

other minor changes
- also add forgotten semicolon for #14885

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
