### PR TITLE
I think this makes Lora result better but definately needs peer review

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -10,7 +10,7 @@ from modules.paths import data_path
 from modules import shared, ui_tempdir, script_callbacks, processing
 from PIL import Image
 
-re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'
+re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|>$)'
 re_param = re.compile(re_param_code)
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
 re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")


### PR DESCRIPTION
## Description

I've been using parse_generation_parameters in my own python project to decode parameters and found that it returns loras with a dangling '>'.  I think this will fix it.  Needs peer review though as my regex isn't great.

## Screenshots/videos:


## Checklist:

- [yes ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [yes ] I have performed a self-review of my own code
- [yes ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [yes ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
