### PR TITLE
Use original App Title in progress bar

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -45,8 +45,15 @@ function formatTime(secs) {
     }
 }
 
+
+var originalAppTitle = undefined;
+
+onUiLoaded(function() {
+    originalAppTitle = document.title;
+});
+
 function setTitle(progress) {
-    var title = 'Stable Diffusion';
+    var title = originalAppTitle;
 
     if (opts.show_progress_in_title && progress) {
         title = '[' + progress.trim() + '] ' + title;


### PR DESCRIPTION
## Description

If an extension makes other gradio apps inside webui (with `gr.mount_gradio_app(app, newAppUI, path=path)`) and uses progressbar inside, this script overrides title to "Stable Diffusion". This PR fixes it


- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
