### PR TITLE
Only trigger interrupt on `Esc` when interrupt button visible

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,8 +167,10 @@ document.addEventListener('keydown', function(e) {
         const lightboxModal = document.querySelector('#lightboxModal');
         if (!globalPopup || globalPopup.style.display === 'none') {
             if (document.activeElement === lightboxModal) return;
-            interruptButton.click();
-            e.preventDefault();
+            if (interruptButton.style.display !== 'none') {
+                interruptButton.click();
+                e.preventDefault();
+            }
         }
     }
 });


### PR DESCRIPTION
## Description

Fixes an issue where if the `Esc` key is pressed and no lightbox modal is on screen, it will lock up the UI by triggering an interrupt when it shouldn't.

Closes this issue here: https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/89

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
