### PR TITLE
Gracefully handle mtime read exception from cache

### DIFF
--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -21,7 +21,10 @@ def calculate_sha256(filename):
 
 def sha256_from_cache(filename, title, use_addnet_hash=False):
     hashes = cache("hashes-addnet") if use_addnet_hash else cache("hashes")
-    ondisk_mtime = os.path.getmtime(filename)
+    try:
+        ondisk_mtime = os.path.getmtime(filename)
+    except FileNotFoundError:
+        return None
 
     if title not in hashes:
         return None


### PR DESCRIPTION
## Description

When a file's mtime is attempted to be read from the cache, but the resultant file does not actually exist (in the case of a symlink), currently this causes the entire Checkpoints/LoRA/etc UI to be forced into Gradio's error state. This fixes that by handling the exception here.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
