### PR TITLE
Fix the bugs that search/reload will disappear when using other ExtraNetworks extensions

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -625,7 +625,7 @@ function scheduleAfterScriptsCallbacks() {
 document.addEventListener("DOMContentLoaded", function() {
     var mutationObserver = new MutationObserver(function(m) {
         if (!executedAfterScripts &&
-            gradioApp().querySelectorAll("[id$='_extra_search']").length == 8) {
+            gradioApp().querySelectorAll("[id$='_extra_search']").length >= 6) {
             executedAfterScripts = true;
             scheduleAfterScriptsCallbacks();
         }


### PR DESCRIPTION
## Description
When disable built-in lora or enable some other ExtraNetworks extensions. The ui callback will not setup for reload/search.
Change the check to >=6 which is Hypernet+TI+ckpt * 2.
To allow more extranetworks or disable the built-in lora.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
