### PR TITLE
option "open image button" open the actual dir

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -284,6 +284,8 @@ options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
     "sd_webui_modal_lightbox_icon_opacity": OptionInfo(1, "Full page image viewer: control icon unfocused opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
     "sd_webui_modal_lightbox_toolbar_opacity": OptionInfo(0.9, "Full page image viewer: tool bar opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("can be any valid CSS value, for example 768px or 20em").needs_reload_ui(),
+    "button_open_image_actual_dir": OptionInfo(True, '"Open images output directory" button opens the actual directory of the image rather than the output root folder'),
+    "button_open_image_actual_dir_temp": OptionInfo(False, '"Open images output directory" button opens the actual directory even for temp images'),
 }))
 
 options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -284,8 +284,7 @@ options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
     "sd_webui_modal_lightbox_icon_opacity": OptionInfo(1, "Full page image viewer: control icon unfocused opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
     "sd_webui_modal_lightbox_toolbar_opacity": OptionInfo(0.9, "Full page image viewer: tool bar opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("can be any valid CSS value, for example 768px or 20em").needs_reload_ui(),
-    "button_open_image_actual_dir": OptionInfo(True, '"Open images output directory" button opens the actual directory of the image rather than the output root folder'),
-    "button_open_image_actual_dir_temp": OptionInfo(False, '"Open images output directory" button opens the actual directory even for temp images'),
+    "open_dir_button_choice": OptionInfo("Subdirectory", "What directory the [📂] button opens", gr.Radio, {"choices": ["Output Root", "Subdirectory", "Subdirectory (even temp dir)"]}),
 }))
 
 options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -169,11 +169,9 @@ def create_output_panel(tabname, outdir, toprow=None):
             return
 
         try:
-            if shared.opts.button_open_image_actual_dir and 0 <= index < len(images):
-                image = images[index]
-                image_path = image["name"].rsplit('?', 1)[0]
-                image_dir = os.path.split(image_path)[0]
-                if shared.opts.button_open_image_actual_dir_temp or not ui_tempdir.is_gradio_temp_path(image_dir):
+            if 'Sub' in shared.opts.open_dir_button_choice:
+                image_dir = os.path.split(images[index]["name"].rsplit('?', 1)[0])[0]
+                if 'temp' in shared.opts.open_dir_button_choice or not ui_tempdir.is_gradio_temp_path(image_dir):
                     f = image_dir
         except Exception:
             pass

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -9,7 +9,7 @@ import sys
 import gradio as gr
 import subprocess as sp
 
-from modules import call_queue, shared
+from modules import call_queue, shared, ui_tempdir
 from modules.infotext_utils import image_from_url_text
 import modules.images
 from modules.ui_components import ToolButton
@@ -164,29 +164,45 @@ class OutputPanel:
 def create_output_panel(tabname, outdir, toprow=None):
     res = OutputPanel()
 
-    def open_folder(f):
+    def open_folder(f, images=None, index=None):
+        if shared.cmd_opts.hide_ui_dir_config:
+            return
+
+        try:
+            if shared.opts.button_open_image_actual_dir and 0 <= index < len(images):
+                image = images[index]
+                image_path = image["name"].rsplit('?', 1)[0]
+                image_dir = os.path.split(image_path)[0]
+                if shared.opts.button_open_image_actual_dir_temp or not ui_tempdir.is_gradio_temp_path(image_dir):
+                    f = image_dir
+        except Exception:
+            pass
+
         if not os.path.exists(f):
-            print(f'Folder "{f}" does not exist. After you create an image, the folder will be created.')
+            msg = f'Folder "{f}" does not exist. After you create an image, the folder will be created.'
+            print(msg)
+            gr.Info(msg)
             return
         elif not os.path.isdir(f):
-            print(f"""
+            msg = f"""
 WARNING
 An open_folder request was made with an argument that is not a folder.
 This could be an error or a malicious attempt to run code on your computer.
 Requested path was: {f}
-""", file=sys.stderr)
+"""
+            print(msg, file=sys.stderr)
+            gr.Warning(msg)
             return
 
-        if not shared.cmd_opts.hide_ui_dir_config:
-            path = os.path.normpath(f)
-            if platform.system() == "Windows":
-                os.startfile(path)
-            elif platform.system() == "Darwin":
-                sp.Popen(["open", path])
-            elif "microsoft-standard-WSL2" in platform.uname().release:
-                sp.Popen(["wsl-open", path])
-            else:
-                sp.Popen(["xdg-open", path])
+        path = os.path.normpath(f)
+        if platform.system() == "Windows":
+            os.startfile(path)
+        elif platform.system() == "Darwin":
+            sp.Popen(["open", path])
+        elif "microsoft-standard-WSL2" in platform.uname().release:
+            sp.Popen(["wsl-open", path])
+        else:
+            sp.Popen(["xdg-open", path])
 
     with gr.Column(elem_id=f"{tabname}_results"):
         if toprow:
@@ -213,8 +229,12 @@ Requested path was: {f}
                     res.button_upscale = ToolButton('✨', elem_id=f'{tabname}_upscale', tooltip="Create an upscaled version of the current image using hires fix settings.")
 
             open_folder_button.click(
-                fn=lambda: open_folder(shared.opts.outdir_samples or outdir),
-                inputs=[],
+                fn=lambda images, index: open_folder(shared.opts.outdir_samples or outdir, images, index),
+                _js="(y, w) => [y, selected_gallery_index()]",
+                inputs=[
+                    res.gallery,
+                    open_folder_button,  # placeholder for index
+                ],
                 outputs=[],
             )
 

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -81,3 +81,18 @@ def cleanup_tmpdr():
 
             filename = os.path.join(root, name)
             os.remove(filename)
+
+
+def is_gradio_temp_path(path):
+    """
+    Check if the path is a temp dir used by gradio
+    """
+    path = Path(path)
+    if shared.opts.temp_dir and path.is_relative_to(shared.opts.temp_dir):
+        return True
+    if gradio_temp_dir := os.environ.get("GRADIO_TEMP_DIR"):
+        if path.is_relative_to(gradio_temp_dir):
+            return True
+    if path.is_relative_to(Path(tempfile.gettempdir()) / "gradio"):
+        return True
+    return False


### PR DESCRIPTION
## Description
one of the things that annoys me no end is that the `open image button` don't actually opens the actual output dir but the output root
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d34deb6e-aa99-479d-969c-d75c292abd3e)
this is annoying for people that uses subdirectories, this is one extra click for every time they use `open image button`
also since we would navigate in the the suvdir the next time we click the button it opens a new windwos causing lots of extra windows to be open

this PR makes it so it will to open the actual directory and not output root

I decided to enable this option by default because I feel like it's more natural option 

this also would be useful if one has images up to different directories (such as the grid images)

user can select which directory to open
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/aff5aa63-1e99-412d-9bbd-19a434e8d368)

- `Output root` will always open the main output root (effectively disabling this PR)
- `Subdirectory` will open the the actual directory
- `Subdirectory (even temp dir)` same as `Subdirectory` but will also open the temp dir (when image is not always saved)

if possible I like to squeeze this into 1.8 RC

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
