### PR TITLE
Error handling for unsupported transparency

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -548,6 +548,12 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
         else:
             pnginfo_data = None
 
+        # Error handling for unsupported transparency in RGB mode
+        if (image.mode == "RGB" and
+            "transparency" in image.info and
+            isinstance(image.info["transparency"], bytes)):
+            del image.info["transparency"]
+
         image.save(filename, format=image_format, quality=opts.jpeg_quality, pnginfo=pnginfo_data)
 
     elif extension.lower() in (".jpg", ".jpeg", ".webp"):


### PR DESCRIPTION
## Description

When input images (palette mode) have transparency (bytes) in info, the output images (RGB mode) will inherit it, causing ValueError in Pillow:PIL/PngImagePlugin.py#1364 when trying to unpack this bytes.

This commit check the PNG mode and transparency info, removing transparency if it's RGB mode and transparency is bytes

## Reproduce

Test file
![634115967](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/15169455/852d51eb-8840-408e-b17a-c179bcf7d35b)

1. Goto Extras
2. Goto Batch Process
3. Run process on test file

## Screenshots/videos:

Before
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/15169455/2e23e8e5-4626-4491-8688-ed84c03b0fd7)

After
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/15169455/00ed0582-f972-4d88-826b-1e794155a918)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
