### PR TITLE
Protect alphas_cumprod during refiner switchover

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -915,33 +915,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if p.n_iter > 1:
                 shared.state.job = f"Batch {n+1} out of {p.n_iter}"
 
-            def rescale_zero_terminal_snr_abar(alphas_cumprod):
-                alphas_bar_sqrt = alphas_cumprod.sqrt()
-
-                # Store old values.
-                alphas_bar_sqrt_0 = alphas_bar_sqrt[0].clone()
-                alphas_bar_sqrt_T = alphas_bar_sqrt[-1].clone()
-
-                # Shift so the last timestep is zero.
-                alphas_bar_sqrt -= (alphas_bar_sqrt_T)
-
-                # Scale so the first timestep is back to the old value.
-                alphas_bar_sqrt *= alphas_bar_sqrt_0 / (alphas_bar_sqrt_0 - alphas_bar_sqrt_T)
-
-                # Convert alphas_bar_sqrt to betas
-                alphas_bar = alphas_bar_sqrt**2  # Revert sqrt
-                alphas_bar[-1] = 4.8973451890853435e-08
-                return alphas_bar
-
-            if hasattr(p.sd_model, 'alphas_cumprod') and hasattr(p.sd_model, 'alphas_cumprod_original'):
-                p.sd_model.alphas_cumprod = p.sd_model.alphas_cumprod_original.to(shared.device)
-
-                if opts.use_downcasted_alpha_bar:
-                    p.extra_generation_params['Downcast alphas_cumprod'] = opts.use_downcasted_alpha_bar
-                    p.sd_model.alphas_cumprod = p.sd_model.alphas_cumprod.half().to(shared.device)
-                if opts.sd_noise_schedule == "Zero Terminal SNR":
-                    p.extra_generation_params['Noise Schedule'] = opts.sd_noise_schedule
-                    p.sd_model.alphas_cumprod = rescale_zero_terminal_snr_abar(p.sd_model.alphas_cumprod).to(shared.device)
+            sd_models.apply_alpha_schedule_override(p.sd_model, p)
 
             with devices.without_autocast() if devices.unet_needs_upcast else devices.autocast():
                 samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -181,10 +181,8 @@ def apply_refiner(cfg_denoiser):
     cfg_denoiser.p.extra_generation_params['Refiner'] = refiner_checkpoint_info.short_title
     cfg_denoiser.p.extra_generation_params['Refiner switch at'] = refiner_switch_at
 
-    alphas_cumprod = cfg_denoiser.p.sd_model.alphas_cumprod
     with sd_models.SkipWritingToConfig():
         sd_models.reload_model_weights(info=refiner_checkpoint_info)
-    cfg_denoiser.p.sd_model.alphas_cumprod = alphas_cumprod
 
     devices.torch_gc()
     cfg_denoiser.p.setup_conds()

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -181,8 +181,12 @@ def apply_refiner(cfg_denoiser):
     cfg_denoiser.p.extra_generation_params['Refiner'] = refiner_checkpoint_info.short_title
     cfg_denoiser.p.extra_generation_params['Refiner switch at'] = refiner_switch_at
 
+    alphas_cumprod_original = cfg_denoiser.p.sd_model.alphas_cumprod_original
+    alphas_cumprod = cfg_denoiser.p.sd_model.alphas_cumprod
     with sd_models.SkipWritingToConfig():
         sd_models.reload_model_weights(info=refiner_checkpoint_info)
+    cfg_denoiser.p.sd_model.alphas_cumprod_original = alphas_cumprod_original
+    cfg_denoiser.p.sd_model.alphas_cumprod = alphas_cumprod
 
     devices.torch_gc()
     cfg_denoiser.p.setup_conds()

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -181,11 +181,9 @@ def apply_refiner(cfg_denoiser):
     cfg_denoiser.p.extra_generation_params['Refiner'] = refiner_checkpoint_info.short_title
     cfg_denoiser.p.extra_generation_params['Refiner switch at'] = refiner_switch_at
 
-    alphas_cumprod_original = cfg_denoiser.p.sd_model.alphas_cumprod_original
     alphas_cumprod = cfg_denoiser.p.sd_model.alphas_cumprod
     with sd_models.SkipWritingToConfig():
         sd_models.reload_model_weights(info=refiner_checkpoint_info)
-    cfg_denoiser.p.sd_model.alphas_cumprod_original = alphas_cumprod_original
     cfg_denoiser.p.sd_model.alphas_cumprod = alphas_cumprod
 
     devices.torch_gc()


### PR DESCRIPTION
## Description

* There is currently a bug, mentioned in #14978, where when the refiner switches on, the first step it performs uses the original alphas_cumprod schedule, which causes problems if zero SNR is enabled.
* This stores and re-applies the model alphas_cumprod when refiner switchover happens.  This fixes outputs in rare cases where the change in noise schedules is significant enough to change the called timestep to something outside of the range of the refiner.

## Screenshots/videos:
Before fix, image generated on DPM++ 2M, overridden with Karras schedule and sigma_max of 1500, 50 steps:
![99942-36463525-(best quality, high quality,_1 5) by strange-fox, solo, anthro, male, rat, manly, clothed, jacket, shirt, detailed background, n](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/faf03e8a-a750-4cae-a6c2-54941fe253e0)
This specific schedule causes one of the sampling steps to be changed from timestep 190 to timestep 200.  The highest timestep a typical refiner is trained for is 199 (last 200, zero indexed), so this is out of the range for the model and causes extra noise in the output.

After the fix is applied:
![99943-36463525-(best quality, high quality,_1 5) by strange-fox, solo, anthro, male, rat, manly, clothed, jacket, shirt, detailed background, n](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/ae5e3f7f-7f2f-48b2-99f9-f9806f831614)
The resulting image looks much cleaner (particularly the background at the top left).

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
