### PR TITLE
Add training support and change lspci for Ascend NPU

### DIFF
--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -95,6 +95,7 @@ class HypernetworkModule(torch.nn.Module):
                         zeros_(b)
                     else:
                         raise KeyError(f"Key {weight_init} is not defined as initialization!")
+        devices.torch_npu_set_device()
         self.to(devices.device)
 
     def fix_old_state_dict(self, state_dict):

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -230,7 +230,7 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
             for fixes in self.hijack.fixes:
                 for _position, embedding in fixes:
                     used_embeddings[embedding.name] = embedding
-
+            devices.torch_npu_set_device()
             z = self.process_tokens(tokens, multipliers)
             zs.append(z)
 

--- a/webui.sh
+++ b/webui.sh
@@ -158,7 +158,7 @@ then
     if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
     then
         export TORCH_COMMAND="pip install torch==2.0.1+rocm5.4.2 torchvision==0.15.2+rocm5.4.2 --index-url https://download.pytorch.org/whl/rocm5.4.2"
-    elif eval "npu-smi info"
+    elif npu-smi info 2>/dev/null
     then
         export TORCH_COMMAND="pip install torch==2.1.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu; pip install torch_npu==2.1.0"
     

--- a/webui.sh
+++ b/webui.sh
@@ -158,9 +158,9 @@ then
     if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
     then
         export TORCH_COMMAND="pip install torch==2.0.1+rocm5.4.2 torchvision==0.15.2+rocm5.4.2 --index-url https://download.pytorch.org/whl/rocm5.4.2"
-    elif echo "$gpu_info" | grep -q "Huawei" && [[ -z "${TORCH_COMMAND}" ]]
+    elif eval "npu-smi info"
     then
-        export TORCH_COMMAND="pip install torch==2.1.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu; pip install torch_npu"
+        export TORCH_COMMAND="pip install torch==2.1.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu; pip install torch_npu==2.1.0"
     
     fi
 fi


### PR DESCRIPTION
## Description

- `gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display")` shows the iBMC chip VGA support for Ascend NPU because Ascend NPU has no ability of VGA or Display. So "npu-smi info" is more suitable to comfirm Ascend NPU exists.
- support training of embedding and hypernetwork.

## Screenshots/videos:
- train embedding
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/7f47f3e3-1bc9-48a8-ac9a-9278f2e0f4e1)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/0de49785-1996-43f3-834e-c0a961d8d198)

- train hypernetwork
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/4a7a7493-86a7-452b-bd11-f1fb6fd74585)
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/25071151/928825d2-b7af-4cda-bd88-b5edb6ccc9e6)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
