### PR TITLE
load extra networks html on create_ui

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -649,13 +649,18 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
 
     related_tabs = []
 
-    for page in ui.stored_extra_pages:
+    def create_html():
+        ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
+
+    create_html()
+
+    for i, page in enumerate(ui.stored_extra_pages):
         with gr.Tab(page.title, elem_id=f"{tabname}_{page.extra_networks_tabname}", elem_classes=["extra-page"]) as tab:
             with gr.Column(elem_id=f"{tabname}_{page.extra_networks_tabname}_prompts", elem_classes=["extra-page-prompts"]):
                 pass
 
             elem_id = f"{tabname}_{page.extra_networks_tabname}_cards_html"
-            page_elem = gr.HTML('Loading...', elem_id=elem_id)
+            page_elem = gr.HTML(ui.pages_contents[i], elem_id=elem_id)
             ui.pages.append(page_elem)
             editor = page.create_user_metadata_editor(ui, tabname)
             editor.create_ui()
@@ -685,16 +690,6 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
 
         button_refresh = gr.Button("Refresh", elem_id=f"{tabname}_{page.extra_networks_tabname}_extra_refresh_internal", visible=False)
         button_refresh.click(fn=refresh, inputs=[], outputs=ui.pages).then(fn=lambda: None, _js="function(){ " + f"applyExtraNetworkFilter('{tabname}_{page.extra_networks_tabname}');" + " }")
-
-    def create_html():
-        ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
-
-    def pages_html():
-        if not ui.pages_contents:
-            create_html()
-        return ui.pages_contents
-
-    interface.load(fn=pages_html, inputs=[], outputs=ui.pages)
 
     return ui
 


### PR DESCRIPTION
## Description
After updating to 1.8 RC I've found two sad news for me.
1) Reload button became invisible, and clickable only after loading html. So it's not possible to click on it if "Loading..." stocked. I think the problem in old Gradio, `.load` callbacks don't work in any cases. The bug is the same as in this PR:  https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14857 Also not only I have this bug, I saw it for few youtube guys
2) Due to new folder system default extra networks page contains all models, and hides them only folder selected. And so the bug with endless loading converted from "randomly" to "stable" :) And I'm not able to load any extra networks on my laptop. (I use laptop to connect to my pc). The PC is significantly more powerful so the bug doesn't appear there

I tried to fix it, and found it's possible to load networks in `create_ui` time, with no "Loading..." placeholder. Al least I didn't find any  errors in python and js consoles for default networks

Maybe you've added it because of webui loading time. So maybe I should add the option for this?

## Screenshots/videos:
![Screenshot_20240222_015816](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/a8e65bcd-6e12-47d6-a812-e37b262a1f09)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
