### PR TITLE
Fix #14591 using translated content to do categories mapping

### DIFF
--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -55,8 +55,8 @@ onOptionsChanged(function() {
     });
 
     opts._categories.forEach(function(x) {
-        var section = x[0];
-        var category = x[1];
+        var section = localization[x[0]] ?? x[0];
+        var category = localization[x[1]] ?? x[1];
 
         var span = document.createElement('SPAN');
         span.textContent = category;


### PR DESCRIPTION
## Description

* Fix the category-section mapping are not working when localization is applied
* This change applies localization before conducting the category-section mapping, allowing the mapping to be done correctly when localization is applied.
* Fix #14591 

## Screenshots/videos:
The layout after applying the fix:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/21131439/d3cb28cd-d702-4fb9-8ec4-b06994e10ea8)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)