### PR TITLE
Bring back progress bar hiding

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -3,6 +3,15 @@ import gradio as gr
 
 from modules import localization, shared, scripts, util
 from modules.paths import script_path, data_path
+from modules.shared import cmd_opts
+
+
+css_hide_progressbar = """
+.margin svg { display:none!important; }
+.margin::before { content:"Loading..." }
+.progress-bar { display:none!important; }
+.progress-text { display:none!important; }
+"""
 
 
 def webpath(fn):
@@ -40,6 +49,9 @@ def css_html():
     user_css = os.path.join(data_path, "user.css")
     if os.path.exists(user_css):
         head += stylesheet(user_css)
+
+    if not cmd_opts.no_progressbar_hiding:
+        head += f'<style>{css_hide_progressbar}</style>'
 
     return head
 


### PR DESCRIPTION
## Description

* As state in cmd help, `we hide it because it slows down ML if you have hardware acceleration in browser`.
* During the rework of `ui.py` and the update of Gradio, the `cmd_opts.no_progressbar_hiding` is not functioning.
* This pr hiding progress bar by overriding css property. Just like before #4759 
ref: https://github.com/gradio-app/gradio/blob/16fbe9cd0cffa9f2a824a0165beb43446114eec7/js/statustracker/static/index.svelte


## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/21131439/9c532ee3-ffee-4eb6-9507-c23dffed4ca2)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
