### PR TITLE
fix: the `split_threshold` parameter does not work when running Split oversized images

### DIFF
--- a/scripts/postprocessing_split_oversized.py
+++ b/scripts/postprocessing_split_oversized.py
@@ -61,7 +61,7 @@ class ScriptPostprocessingSplitOversized(scripts_postprocessing.ScriptPostproces
             ratio = (pp.image.height * width) / (pp.image.width * height)
             inverse_xy = True
 
-        if ratio >= 1.0 and ratio > split_threshold:
+        if ratio >= 1.0 or ratio > split_threshold:
             return
 
         result, *others = split_pic(pp.image, inverse_xy, width, height, overlap_ratio)


### PR DESCRIPTION

## Description

`if ratio >= 1.0 and ratio > split_threshold:`
The `and` here should be `or`


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
