### PR TITLE
fix(sec): upgrade gradio to 2023-11-06

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ clean-fid
 einops
 fastapi>=0.90.1
 gfpgan
-gradio==3.41.2
+gradio==2023-11-06
 inflection
 jsonmerge
 kornia


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gradio 3.41.2
- [CVE-2023-51449](https://www.oscs1024.com/hd/CVE-2023-51449)


### What did I do？
Upgrade gradio from 3.41.2 to 2023-11-06 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS