### PR TITLE
register_tmp_file also for mtime

### DIFF
--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -35,7 +35,9 @@ def save_pil_to_file(self, pil_image, dir=None, format="png"):
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)
-        return f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
+        filename_with_mtime = f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
+        register_tmp_file(shared.demo, filename_with_mtime)
+        return filename_with_mtime
 
     if shared.opts.temp_dir != "":
         dir = shared.opts.temp_dir


### PR DESCRIPTION
## Description

I've found in my extension `OutputPanel`'s save button doesn't work, because of timestamp in filename. I doubled `register_tmp_file` function inside `save_pil_to_file` also for filename with timestamp

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
