### PR TITLE
Use `absolute` path for normalized filepath

### DIFF
--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -7,7 +7,7 @@ import shlex
 from pathlib import Path
 
 
-normalized_filepath = lambda filepath: str(Path(filepath).resolve())
+normalized_filepath = lambda filepath: str(Path(filepath).absolute())
 
 commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
 sys.argv += shlex.split(commandline_args)


### PR DESCRIPTION
## Description

Small oversight I made as part of https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14934. `resolve` was changing paths to use the symlink, causing there to be multiple representations of a path (it should use a single representation, that representation being the path as it appears to the user).

Fixes these issues (upscalers being listed twice due to multiple path representations, and symlinks/junctions breaking due to using the linked path and thus falling "outside" the Gradio directory):
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/313
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/282
https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/14942#discussioncomment-8550050

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
