### PR TITLE
fix repeated upscaler models + cmd flag for dat models

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -53,6 +53,7 @@ parser.add_argument("--gfpgan-models-path", type=normalized_filepath, help="Path
 parser.add_argument("--esrgan-models-path", type=normalized_filepath, help="Path to directory with ESRGAN model file(s).", default=os.path.join(models_path, 'ESRGAN'))
 parser.add_argument("--bsrgan-models-path", type=normalized_filepath, help="Path to directory with BSRGAN model file(s).", default=os.path.join(models_path, 'BSRGAN'))
 parser.add_argument("--realesrgan-models-path", type=normalized_filepath, help="Path to directory with RealESRGAN model file(s).", default=os.path.join(models_path, 'RealESRGAN'))
+parser.add_argument("--dat-models-path", type=normalized_filepath, help="Path to directory with DAT model file(s).", default=os.path.join(models_path, 'DAT'))
 parser.add_argument("--clip-models-path", type=normalized_filepath, help="Path to directory with CLIP model file(s).", default=None)
 parser.add_argument("--xformers", action='store_true', help="enable xformers for cross attention layers")
 parser.add_argument("--force-enable-xformers", action='store_true', help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work")

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -7,7 +7,7 @@ import shlex
 from pathlib import Path
 
 
-normalized_filepath = lambda filepath: str(Path(filepath).resolve())
+normalized_filepath = lambda filepath: str(Path(filepath).absolute())
 
 commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
 sys.argv += shlex.split(commandline_args)


### PR DESCRIPTION
## Description

Alternative fix for repeated models if symlink is used https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15035

I think it's better to not resolve every paths. It's not only about upscalers. this normalized_filepath touches SD, VAE, LORA etc models too. If someone wants to change symlink with not restarting the webui, the previous implementation wont allow it. So I think this way is better

+ cmd flag for dat models


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
