### PR TITLE
upscaler_utils: Reduce logging

### DIFF
--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -69,10 +69,10 @@ def upscale_with_model(
         for y, h, row in grid.tiles:
             newrow = []
             for x, w, tile in row:
-                logger.debug("Tile (%d, %d) %s...", x, y, tile)
+                # logger.debug("Tile (%d, %d) %s...", x, y, tile)
                 output = upscale_pil_patch(model, tile)
                 scale_factor = output.width // tile.width
-                logger.debug("=> %s (scale factor %s)", output, scale_factor)
+                # logger.debug("=> %s (scale factor %s)", output, scale_factor)
                 newrow.append([x * scale_factor, w * scale_factor, output])
                 p.update(1)
             newtiles.append([y * scale_factor, h * scale_factor, newrow])


### PR DESCRIPTION
## Description

* upscale_with_model: Comment out debug logging so it's available if needed but not outputting debug lines for every single tile (noise).

## Screenshots/videos:

This is excessive:
```
2024-03-02 07:50:34 DEBUG [modules.modelloader] Loaded <spandrel.__helpers.model_descriptor.ImageModelDescriptor object at 0x000001E855FC8760> from F:\stablediffusion\stable-diffusion-webui-1-8-0-rc\models\ESRGAN\BSRGANx2.pth (device=None, half=False, dtype=None)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (0, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBC10>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEEB30> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (166, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBCA0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEC340> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (332, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCB9A0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEEA10> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (499, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBB20>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FED420> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (665, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBD30>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEDFF0> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (832, 0) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBBE0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEF9D0> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (0, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBAF0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEE800> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (166, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E855FCBBB0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEE560> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (332, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFA00>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEE6E0> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (499, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFFD0>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FED300> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (665, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFD30>...
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FECFA0> (scale factor 2)
2024-03-02 07:50:34 DEBUG [modules.upscaler_utils] Tile (832, 166) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFB20>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FED780> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (0, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF760>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FED570> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (166, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FEF50>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FECD60> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (332, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF8B0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEE260> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (499, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF9A0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEE020> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (665, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF880>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEDEA0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (832, 332) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF790>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEC220> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (0, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FD330>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FED180> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (166, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FD2D0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855FEC0A0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (332, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FED10>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855444A30> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (499, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FECE0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855444CD0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (665, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF100>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855444BB0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (832, 499) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF040>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E855446350> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (0, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF1F0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D73D0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (166, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF0D0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D7DC0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (332, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF3A0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D7F70> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (499, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF370>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D77F0> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (665, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF4F0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D6800> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (832, 665) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF4C0>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D7C70> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (0, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF640>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D5D50> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (166, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FF610>...
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E6FC2D6230> (scale factor 2)
2024-03-02 07:50:35 DEBUG [modules.upscaler_utils] Tile (332, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFDC0>...
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E8553FFAF0> (scale factor 2)
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] Tile (499, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FFC70>...
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E8553FF430> (scale factor 2)
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] Tile (665, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FD240>...
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E8553FEC50> (scale factor 2)
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] Tile (832, 832) <PIL.Image.Image image mode=RGB size=192x192 at 0x1E8553FD210>...
2024-03-02 07:50:36 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=384x384 at 0x1E8553FD1B0> (scale factor 2)
tiled upscale: 100%|████████████████████████████████████████████████████████████████████████| 36/36 [00:01<00:00, 20.07it/s]
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
