### PR TITLE
Fixed installation Error

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -44,7 +44,7 @@ fi
 # python3 executable
 if [[ -z "${python_cmd}" ]]
 then
-    python_cmd="python3"
+    python_cmd="python3.10"
 fi
 
 # git executable


### PR DESCRIPTION
using Fedora39, Nobara39 i couldn't install torch using python 3.12 (default), all i did was change the webui.sh to use python3.10 instead of python3 because this is only compatible with python 3.10
##Description

* Fix installation process.
* simply changed line 47 python_cmd="python3" to python_cmd="python3.10".
* python3 (right now 3.12) isn't compatible.
    do not i used a custom repository to install python 3.10 on my system using
    ```sudo dnf config-manager --add-repo https://download.fedoraproject.org/pub/fedora/linux/testing/37/x86_64/os/Packages/```
    then ```sudo dnf install python310```
    then ```python3.10 -m pip install --upgrade pip```
* this fixed the issue i was having during installation on Nobara39 and in a Fedora39 in a VM.
* hope i was of any help, cheers.

## Screenshots/videos:
![Screenshot_20240302_174439](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/141313218/c8000fa0-6bcf-4999-b0a2-af257ffe907e)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
