### PR TITLE
fix_jpeg_live_preview

### DIFF
--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -162,5 +162,7 @@ class State:
             errors.record_exception()
 
     def assign_current_image(self, image):
+        if shared.opts.live_previews_image_format == 'jpeg' and image.mode == 'RGBA':
+            image = image.convert('RGB')
         self.current_image = image
         self.id_live_preview += 1


### PR DESCRIPTION
## Description

If user set in the setttings live preview format to jpeg, it produces error connected with RGBA mode, if any extension uses live preview

- https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content/issues/4

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
