### PR TITLE
[fix] can't load webui if selected wrong extra option in ui

### DIFF
--- a/extensions-builtin/extra-options-section/scripts/extra_options_section.py
+++ b/extensions-builtin/extra-options-section/scripts/extra_options_section.py
@@ -50,7 +50,7 @@ class ExtraOptionsSection(scripts.Script):
                             with FormColumn():
                                 try:
                                     comp = ui_settings.create_setting_component(setting_name)
-                                except KeyError as e:
+                                except KeyError:
                                     errors.report(f"Can't add extra options for {setting_name} in ui")
                                     continue
 


### PR DESCRIPTION
## Description

There is a bug: you can add an option from extension, e.g. `controlnet_show_batch_images_in_ui`, and after restart webui won't able to start, due to KeyError. It happens because this option was declared in `on_ui_settings` callback. I've found the solution, if the author of extension wants to be able to add their option in settings in ui, they need to use option template instead of callback, like w-e-w does in their [nudenet_nsfw_censor_scripts/settings.py](https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/blob/main/scripts/nudenet_nsfw_censor_scripts/settings.py) (fix in my extension: https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content/commit/e8a91701db9329ce6ea8385d98e17a9155704d1f) Maybe it's needed to add recommendation to not use `on_ui_settings` callback

My PR fixes 2 things:
- prevent webui crashing if can't find settings (e.g. extension was disabled)
- prevent user to add settings which are not available on `create_ui` moment 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
