### PR TITLE
Improved default handling

### DIFF
--- a/extensions-builtin/Lora/network_oft.py
+++ b/extensions-builtin/Lora/network_oft.py
@@ -27,7 +27,7 @@ class NetworkModuleOFT(network.NetworkModule):
         # kohya-ss/New LyCORIS OFT/BOFT
         if "oft_blocks" in weights.w.keys():
             self.oft_blocks = weights.w["oft_blocks"] # (num_blocks, block_size, block_size)
-            self.alpha = weights.w.get("alpha", None) # alpha is constraint
+            self.rescale = weights.w.get('rescale', torch.tensor([1.0])) # Improved default handling
             self.dim = self.oft_blocks.shape[0] # lora dim
         # Old LyCORIS OFT
         elif "oft_diag" in weights.w.keys():


### PR DESCRIPTION


## Description

* using get with a default value directly in the attribute assignment simplifies the code and avoids the need for conditional checks later
* self.alpha = weights.w.get("alpha", None) # alpha is constraint >>> self.rescale = weights.w.get('rescale', torch.tensor([1.0]))
* reduce redundancy

## Screenshots/videos:


## Checklist:

- [x ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x ] I have performed a self-review of my own code
- [x ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
