### PR TITLE
fix extract_style_text_from_prompt #15132

### DIFF
--- a/modules/styles.py
+++ b/modules/styles.py
@@ -42,7 +42,7 @@ def extract_style_text_from_prompt(style_text, prompt):
     stripped_style_text = style_text.strip()
 
     if "{prompt}" in stripped_style_text:
-        left, right = stripped_style_text.split("{prompt}", 2)
+        left, _, right = stripped_style_text.partition("{prompt}")
         if stripped_prompt.startswith(left) and stripped_prompt.endswith(right):
             prompt = stripped_prompt[len(left):len(stripped_prompt)-len(right)]
             return True, prompt


### PR DESCRIPTION
## Description

- fix #15132

I belive this is cause by the user have more then one `{prompt}` in there style, 
> I am pretty sure that you're not meant to have more then 1 `{prompt}` so I believe this is a user error

the maxsplit is set to 2 for no reason, I guess this was a minor mistake during initial implementation, since you are unpacking it into 2 vars

I change it to use `str.partition()` for clarity (and also last I checked partition slightly performs better split)

### note
not my lint

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
