### PR TITLE
Only override emphasis if actually used in prompt

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -8,7 +8,7 @@ import sys
 
 import gradio as gr
 from modules.paths import data_path
-from modules import shared, ui_tempdir, script_callbacks, processing, infotext_versions, images
+from modules import shared, ui_tempdir, script_callbacks, processing, infotext_versions, images, prompt_parser
 from PIL import Image
 
 sys.modules['modules.generation_parameters_copypaste'] = sys.modules[__name__]  # alias for old name
@@ -356,7 +356,10 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     if "Cache FP16 weight for LoRA" not in res and res["FP8 weight"] != "Disable":
         res["Cache FP16 weight for LoRA"] = False
 
-    if "Emphasis" not in res:
+    prompt_attention = prompt_parser.parse_prompt_attention(prompt)
+    prompt_attention += prompt_parser.parse_prompt_attention(negative_prompt)
+    prompt_uses_emphasis = len(prompt_attention) != len([p for p in prompt_attention if p[1] == 1.0 or p[0] == 'BREAK'])
+    if "Emphasis" not in res and prompt_uses_emphasis:
         res["Emphasis"] = "Original"
 
     if "Refiner switch by sampling steps" not in res:


### PR DESCRIPTION
## Description

Prevents `emphasis` from being overriden to `Original` when no emphasis is actually used in the prompt. This makes sense to do for SDXL users especially. I currently have this setting set to `No norm`, and if I read the infotext from a generated image with no emphasis used, I shouldn't need to remove this from the override section any time I want to adjust the weights -- this resolves that.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
