### PR TITLE
simplification of ExtraOptionsSection initialization

### DIFF
--- a/extensions-builtin/extra-options-section/scripts/extra_options_section.py
+++ b/extensions-builtin/extra-options-section/scripts/extra_options_section.py
@@ -6,11 +6,13 @@ from modules.ui_components import FormColumn
 
 
 class ExtraOptionsSection(scripts.Script):
+    class ExtraOptionsSection(scripts.Script):
     section = "extra_options"
 
     def __init__(self):
-        self.comps = None
-        self.setting_names = None
+        self.comps = []
+        self.setting_names = []
+
 
     def title(self):
         return "Extra options"


### PR DESCRIPTION
Directly initializes comps and setting_names as empty lists, it simplifies the code by removing the need to check if they are none before using them.

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [ x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x ] I have performed a self-review of my own code
- [x ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
