### PR TITLE
edit-attention: deselect surrounding whitespace

### DIFF
--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -64,6 +64,14 @@ function keyupEditAttention(event) {
             selectionEnd++;
         }
 
+        // deselect surrounding whitespace
+        while (target.value.slice(selectionStart, selectionStart + 1) == " " && selectionStart < selectionEnd) {
+            selectionStart++;
+        }
+        while (target.value.slice(selectionEnd - 1, selectionEnd) == " " && selectionEnd > selectionStart) {
+            selectionEnd--;
+        }
+
         target.setSelectionRange(selectionStart, selectionEnd);
         return true;
     }

--- a/javascript/edit-attention.js
+++ b/javascript/edit-attention.js
@@ -65,10 +65,10 @@ function keyupEditAttention(event) {
         }
 
         // deselect surrounding whitespace
-        while (target.value.slice(selectionStart, selectionStart + 1) == " " && selectionStart < selectionEnd) {
+        while (text[selectionStart] == " " && selectionStart < selectionEnd) {
             selectionStart++;
         }
-        while (target.value.slice(selectionEnd - 1, selectionEnd) == " " && selectionEnd > selectionStart) {
+        while (text[selectionEnd - 1] == " " && selectionEnd > selectionStart) {
             selectionEnd--;
         }
 


### PR DESCRIPTION
## Description

Deselects any surrounding whitespace when editing prompt attention, which will _only_ apply when whitespace is not part of the delimiters option (meaning this won't affect anything for most users since whitespace is part of the [default set of delimiters](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/58f7410c9d9d41d95e227fbb629099f27261a726/modules/shared_options.py#L273C58-L273C59) -- but it's a nice QoL for those that don't include it).

## Screenshots/videos:

<details><summary>Before</summary>
<p>

![before](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/f9719f63-c139-4644-bd1e-8154ac86da42)


</p>
</details> 

<details><summary>After</summary>
<p>

![after](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122327233/3d521dd5-a911-4c83-b51c-f4c3bcaa32d1)


</p>
</details> 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
