### PR TITLE
chore: fix font not loaded

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /* temporary fix to load default gradio font in frontend instead of backend */
 
-@import url('webui-assets/css/sourcesanspro.css');
+@import url('/webui-assets/css/sourcesanspro.css');
 
 
 /* temporary fix to hide gradio crop tool until it's fixed https://github.com/gradio-app/gradio/issues/3810 */


### PR DESCRIPTION
fix #15182

## Description

It's a bug relative to 2f98a35fc4508494355c01ec45f5bec725f570a6

UI is looking for `http://localhost:7863/file=/app/webui-assets/css/sourcesanspro.css` but the assets repo is mounted at `http://localhost:7863/webui-assets`. It is because `style.css` is loaded at `http://localhost:7863/file=/app/style.css` and `@import url()` with relative path.

## Screenshots/videos:


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
