### PR TITLE
Avoid error from None in get_learned_conditioning

### DIFF
--- a/modules/sd_models_xl.py
+++ b/modules/sd_models_xl.py
@@ -13,8 +13,8 @@ def get_learned_conditioning(self: sgm.models.diffusion.DiffusionEngine, batch: 
     for embedder in self.conditioner.embedders:
         embedder.ucg_rate = 0.0
 
-    width = getattr(batch, 'width', 1024)
-    height = getattr(batch, 'height', 1024)
+    width = getattr(batch, 'width', 1024) or 1024
+    height = getattr(batch, 'height', 1024) or 1024
     is_negative_prompt = getattr(batch, 'is_negative_prompt', False)
     aesthetic_score = shared.opts.sdxl_refiner_low_aesthetic_score if is_negative_prompt else shared.opts.sdxl_refiner_high_aesthetic_score
 


### PR DESCRIPTION
## Description
the default width/height in prompt_parser.SdConditioning is None
In some case (especially custom script), this will cause error when running some custom scripts with SDXL model with hires-fix.

So I add a check to ensure there is no None value.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
