### PR TITLE
Add entry to MassFileLister  after writing metadata

### DIFF
--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -133,8 +133,10 @@ class UserMetadataEditor:
         filename = item.get("filename", None)
         basename, ext = os.path.splitext(filename)
 
-        with open(basename + '.json', "w", encoding="utf8") as file:
+        metadata_path = basename + '.json'
+        with open(metadata_path, "w", encoding="utf8") as file:
             json.dump(metadata, file, indent=4, ensure_ascii=False)
+        self.page.lister.update_file_entry(metadata_path)
 
     def save_user_metadata(self, name, desc, notes):
         user_metadata = self.get_user_metadata(name)
@@ -200,6 +202,3 @@ class UserMetadataEditor:
             inputs=[self.edit_name_input],
             outputs=[]
         )
-
-
-

--- a/modules/util.py
+++ b/modules/util.py
@@ -81,6 +81,17 @@ class MassFileListerCachedDir:
         self.files = {x[0].lower(): x for x in files}
         self.files_cased = {x[0]: x for x in files}
 
+    def update_entry(self, filename):
+        """Add a file to the cache"""
+        file_path = os.path.join(self.dirname, filename)
+        try:
+            stat = os.stat(file_path)
+            entry = (filename, stat.st_mtime, stat.st_ctime)
+            self.files[filename.lower()] = entry
+            self.files_cased[filename] = entry
+        except FileNotFoundError as e:
+            print(f'MassFileListerCachedDir.add_entry: "{file_path}" {e}')
+
 
 class MassFileLister:
     """A class that provides a way to check for the existence and mtime/ctile of files without doing more than one stat call per file."""
@@ -136,3 +147,9 @@ class MassFileLister:
     def reset(self):
         """Clear the cache of all directories."""
         self.cached_dirs.clear()
+
+    def update_file_entry(self, path):
+        """Update the cache for a specific directory."""
+        dirname, filename = os.path.split(path)
+        if cached_dir := self.cached_dirs.get(dirname):
+            cached_dir.update_entry(filename)


### PR DESCRIPTION
## Description
- fix #15184

cause: for newly created user metadata as it is not cashed in `MassFileLister` webui thinks the metadate dose not exist when updateing `cardClicked` after it has been saved

currently user have to `Refresh` the extra networks to get `activation text` working

fix: add file entry to `MassFileLister`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
