### PR TITLE
allow interrupt generation in command line (Ctrl+C)

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -125,3 +125,4 @@ parser.add_argument("--skip-load-model-at-start", action='store_true', help="if 
 parser.add_argument("--unix-filenames-sanitization", action='store_true', help="allow any symbols except '/' in filenames. May conflict with your browser and file system")
 parser.add_argument("--filenames-max-length", type=int, default=128, help='maximal length of filenames of saved images. If you override it, it can conflict with your file system')
 parser.add_argument("--no-prompt-history", action='store_true', help="disable read prompt from last generation feature; settings this argument will not create '--data_path/params.txt' file")
+parser.add_argument("--allow-interrupt-generation-in-command-line", action='store_true', help="set interrupt generation flag on KeyboardInterrupt signal (Ctrl+C)")

--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -161,7 +161,7 @@ def configure_sigint_handler():
 
         os._exit(0)
 
-    if not os.environ.get("COVERAGE_RUN"):
+    if not (os.environ.get("COVERAGE_RUN") or shared.cmd_opts.allow_interrupt_generation_in_command_line):
         # Don't install the immediate-quit handler when running under coverage,
         # as then the coverage report won't be generated.
         signal.signal(signal.SIGINT, sigint_handler)

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -2,12 +2,16 @@ import datetime
 import logging
 import threading
 import time
+import os
 
 from modules import errors, shared, devices
 from typing import Optional
 
 log = logging.getLogger(__name__)
-if shared.cmd_opts.allow_interrupt_generation_in_command_line:
+
+if shared.cmd_opts.allow_interrupt_generation_in_command_line\
+        and shared.cmd_opts.loglevel is None\
+        and not os.environ.get("SD_WEBUI_LOG_LEVEL"):
     log.setLevel(logging.INFO)
 
 

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -7,6 +7,8 @@ from modules import errors, shared, devices
 from typing import Optional
 
 log = logging.getLogger(__name__)
+if shared.cmd_opts.allow_interrupt_generation_in_command_line:
+    log.setLevel(logging.INFO)
 
 
 class State:

--- a/webui.py
+++ b/webui.py
@@ -121,17 +121,25 @@ def webui():
         timer.startup_record = startup_timer.dump()
         print(f"Startup time: {startup_timer.summary()}.")
 
-        try:
-            while True:
-                server_command = shared.state.wait_for_server_command(timeout=5)
-                if server_command:
-                    if server_command in ("stop", "restart"):
-                        break
-                    else:
-                        print(f"Unknown server command: {server_command}")
-        except KeyboardInterrupt:
-            print('Caught KeyboardInterrupt, stopping...')
-            server_command = "stop"
+        while True:
+            try:
+                while True:
+                    server_command = shared.state.wait_for_server_command(timeout=5)
+                    if server_command:
+                        if server_command in ("stop", "restart"):
+                            break
+                        else:
+                            print(f"Unknown server command: {server_command}")
+                break
+            except KeyboardInterrupt:
+                if shared.cmd_opts.allow_interrupt_generation_in_command_line and shared.state.job != "" and not shared.state.interrupted:
+                    print('Caught KeyboardInterrupt, interrupting generation...')
+                    shared.state.interrupt()
+                else:
+                    print('Caught KeyboardInterrupt, stopping...')
+                    server_command = "stop"
+                    break
+
 
         if server_command == "stop":
             print("Stopping server...")


### PR DESCRIPTION
## Description

Ctrl+C in console will set interrupt flag, if `--allow-interrupt-generation-in-command-line` cmd option is used

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
