### PR TITLE
fix "Restore progress" button

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -136,8 +136,7 @@ function showSubmitInterruptingPlaceholder(tabname) {
 function showRestoreProgressButton(tabname, show) {
     var button = gradioApp().getElementById(tabname + "_restore_progress");
     if (!button) return;
-
-    button.style.display = show ? "flex" : "none";
+    button.style.setProperty('display', show ? 'flex' : 'none', 'important');
 }
 
 function submit() {
@@ -209,6 +208,7 @@ function restoreProgressTxt2img() {
     var id = localGet("txt2img_task_id");
 
     if (id) {
+        showSubmitInterruptingPlaceholder('txt2img');
         requestProgress(id, gradioApp().getElementById('txt2img_gallery_container'), gradioApp().getElementById('txt2img_gallery'), function() {
             showSubmitButtons('txt2img', true);
         }, null, 0);
@@ -223,6 +223,7 @@ function restoreProgressImg2img() {
     var id = localGet("img2img_task_id");
 
     if (id) {
+        showSubmitInterruptingPlaceholder('img2img');
         requestProgress(id, gradioApp().getElementById('img2img_gallery_container'), gradioApp().getElementById('img2img_gallery'), function() {
             showSubmitButtons('img2img', true);
         }, null, 0);


### PR DESCRIPTION
## Description

the `Restore progress` button dose not show when it should
the cause seem to be that the `display = "flex"` property is overwritten by something else (what I'm not sure)

fix using `setProperty` and giveing it the priority important fixes this issue of it not showing

### other changes

after the `Restore progress` is clicked if the server is still generating then show the `interrupt | skip` buttons
this allow the user to use interrupt or skip the current job if they wish

---

related conversation
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15210#issuecomment-1988682941

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
