### PR TITLE
fix ui-config for InputAccordion [custom_script_source]

### DIFF
--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -104,6 +104,8 @@ class UiLoadsave:
             apply_field(x, 'value', check_dropdown, getattr(x, 'init_field', None))
 
         if type(x) == InputAccordion:
+            if hasattr(x, 'custom_script_source'):
+                x.accordion.custom_script_source = x.custom_script_source
             if x.accordion.visible:
                 apply_field(x.accordion, 'visible')
             apply_field(x, 'value')


### PR DESCRIPTION
## Description

If `InputAccordion` is under script's ui, its value is loaded from non custom script path. But when default is changed, it saves by custom script path, and wont be loaded next time. Also it's not happened with invisible checkbox, and the InputAccordion works as disabled dispite visual checkbox is on

Also i've fixed this condition:
```python
if isinstance(obj, gr.Accordion) and isinstance(x, InputAccordion) and field == 'value':
  field = 'open'
```
- It's always false because obj can't be `gr.Accordion` and `InputAccordion` at the same time. 
- `InputAccordion` is a child of `gr.Checkbox` and doesn't have `open` field


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
