### PR TITLE
featch only active branch updates for extensions

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -156,6 +156,8 @@ class Extension:
     def check_updates(self):
         repo = Repo(self.path)
         for fetch in repo.remote().fetch(dry_run=True):
+            if self.branch and fetch.name != f'{repo.remote().name}/{self.branch}':
+                continue
             if fetch.flags != fetch.HEAD_UPTODATE:
                 self.can_update = True
                 self.status = "new commits"


### PR DESCRIPTION
## Description

Many times webui's extension update feature show false-positive update avaliable, because the author pushed new commits into not your branch. Tested on recent reactor's `evolve` branch update, while `main` branch isn't updated: https://github.com/Gourieff/sd-webui-reactor/commits/evolve/ https://github.com/Gourieff/sd-webui-reactor/commit/9989610fa777ff5b0930811a66242744a9101b22


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
