### PR TITLE
Automatically Set the Scale by value when user selects an Upscale Model

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -101,6 +101,7 @@ options_templates.update(options_section(('upscaling', "Upscaling", "postprocess
     "DAT_tile": OptionInfo(192, "Tile size for DAT upscalers.", gr.Slider, {"minimum": 0, "maximum": 512, "step": 16}).info("0 = no tiling"),
     "DAT_tile_overlap": OptionInfo(8, "Tile overlap for DAT upscalers.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}).info("Low values = visible seam"),
     "upscaler_for_img2img": OptionInfo(None, "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}),
+    "scaleBy_from_upscaler": OptionInfo(False, "Automatically set the Scale by factor based on the name of the selected Upscaler.").info("Will not change the value when no matching pattern is found."),
 }))
 
 options_templates.update(options_section(('face-restoration', "Face restoration", "postprocessing"), {

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -4,6 +4,30 @@ import modules.infotext_utils as parameters_copypaste
 from modules.ui_components import ResizeHandleRow
 
 
+def hook_scale_update(inputs):
+    resize = upscaler = None
+    for script in inputs:
+        if script.label == "Resize":
+            resize = script
+        elif script.label == "Upscaler 1":
+            upscaler = script
+        elif resize and upscaler:
+            break
+
+    def update_scale(upscaler: str, slider: float):
+        if upscaler[1] in ('x', 'X'):
+            try:
+                scale = int(upscaler[0])
+                return gr.update(value=scale)
+            except ValueError:
+                return gr.update(value=slider)
+
+        return gr.update(value=slider)
+
+    if resize and upscaler:
+        upscaler.input(update_scale, inputs=[upscaler, resize], outputs=[resize])
+
+
 def create_ui():
     dummy_component = gr.Label(visible=False)
     tab_index = gr.Number(value=0, visible=False)
@@ -23,6 +47,7 @@ def create_ui():
                     show_extras_results = gr.Checkbox(label='Show result images', value=True, elem_id="extras_show_extras_results")
 
             script_inputs = scripts.scripts_postproc.setup_ui()
+            hook_scale_update(script_inputs)
 
         with gr.Column():
             toprow = ui_toprow.Toprow(is_compact=True, is_img2img=False, id_part="extras")

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -5,6 +5,9 @@ from modules.ui_components import ResizeHandleRow
 
 
 def hook_scale_update(inputs):
+    import re
+    pattern = r'(\d)[xX]|[xX](\d)'
+
     resize = upscaler = None
     for script in inputs:
         if script.label == "Resize":
@@ -15,14 +18,17 @@ def hook_scale_update(inputs):
             break
 
     def update_scale(upscaler: str, slider: float):
-        if upscaler[1] in ('x', 'X'):
-            try:
-                scale = int(upscaler[0])
-                return gr.update(value=scale)
-            except ValueError:
-                return gr.update(value=slider)
+        match = re.search(pattern, upscaler)
 
-        return gr.update(value=slider)
+        if match:
+            if match.group(1):
+                return gr.update(value=int(match.group(1)))
+
+            else:
+                return gr.update(value=int(match.group(2)))
+
+        else:
+            return gr.update(value=slider)
 
     if resize and upscaler:
         upscaler.input(update_scale, inputs=[upscaler, resize], outputs=[resize])

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -53,7 +53,8 @@ def create_ui():
                     show_extras_results = gr.Checkbox(label='Show result images', value=True, elem_id="extras_show_extras_results")
 
             script_inputs = scripts.scripts_postproc.setup_ui()
-            hook_scale_update(script_inputs)
+            if getattr(shared.opts, 'scaleBy_from_upscaler', False):
+                hook_scale_update(script_inputs)
 
         with gr.Column():
             toprow = ui_toprow.Toprow(is_compact=True, is_img2img=False, id_part="extras")


### PR DESCRIPTION
## Description
<p align="right">
<sup><i>Edited</i></sup>
</p>

<ins>What you're trying to accomplish</ins>
Since the majority of the upscale models are named with its scaling factor *(**eg.** `4x-UltraSharp` or `DAT x2`)*, this PR makes it automatically set the appropriate `Scale by` value when user selects a model with that pattern.

<ins>A summary of changes in code</ins>
When setting up the UI, add a function that utilizes the `gradio` `input` method to check for the above condition via `re`, then set the value if possible. This feature is toggleable in the **Settings**.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
