### PR TITLE
Make imageviewer event listeners browser consistent

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -131,19 +131,15 @@ function setupImageForLightbox(e) {
     e.style.cursor = 'pointer';
     e.style.userSelect = 'none';
 
-    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-
-    // For Firefox, listening on click first switched to next image then shows the lightbox.
-    // If you know how to fix this without switching to mousedown event, please.
-    // For other browsers the event is click to make it possiblr to drag picture.
-    var event = isFirefox ? 'mousedown' : 'click';
-
-    e.addEventListener(event, function(evt) {
+    e.addEventListener('mousedown', function(evt) {
         if (evt.button == 1) {
             open(evt.target.src);
             evt.preventDefault();
             return;
         }
+    }, true);
+
+    e.addEventListener('click', function(evt) {
         if (!opts.js_modal_lightbox || evt.button != 0) return;
 
         modalZoomSet(gradioApp().getElementById('modalImage'), opts.js_modal_lightbox_initially_zoomed);


### PR DESCRIPTION
## Description

Fixes two issues:
- The issue mentioned in the comment seems no longer applicable in the current Gradio version with Firefox, at least as far as I could tell in testing. This is removed and thus makes the picture draggable in Firefox.
- When the event listener was set to `click` in Chrome, and the MMB button was used, but autoscroll was enabled, it prevented the image from being opened in a new tab. This uses `mousedown` in all browsers so not to interfere with autoscroll.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
