### PR TITLE
prevent alt menu for firefox

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -839,29 +839,30 @@ onUiLoaded(async() => {
         document.addEventListener("keydown", handleMoveKeyDown);
         document.addEventListener("keyup", handleMoveKeyUp);
 
+
         // Prevent firefox to open toolbar on pressing alt
-        if (hotkeysConfig.canvas_hotkey_zoom === "Alt") {
-            let isAltPressed = false;
+        let isAltPressed = false;
 
-            function handleAltKeyDown(e) {
-                if (!activeElement) return;
-                if (e.code === "AltLeft" || e.code === "AltRight") {
-                    isAltPressed = true;
-                } else {
-                    isAltPressed = false;
-                }
-            }
-
-            function handleAltKeyUp(e) {
-                if (isAltPressed) {
-                    e.preventDefault();
-                }
+        function handleAltKeyDown(e) {
+            if (!activeElement) return;
+            if (hotkeysConfig.canvas_hotkey_zoom !== "Alt") return;
+            if (e.code === "AltLeft" || e.code === "AltRight") {
+                isAltPressed = true;
+            } else {
                 isAltPressed = false;
             }
-
-            document.addEventListener("keydown", handleAltKeyDown);
-            document.addEventListener("keyup", handleAltKeyUp);
         }
+
+        function handleAltKeyUp(e) {
+            if (hotkeysConfig.canvas_hotkey_zoom !== "Alt") return;
+            if (isAltPressed) {
+                e.preventDefault();
+            }
+            isAltPressed = false;
+        }
+
+        document.addEventListener("keydown", handleAltKeyDown);
+        document.addEventListener("keyup", handleAltKeyUp);
 
 
         // Detect zoom level and update the pan speed.

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -966,3 +966,26 @@ onUiLoaded(async() => {
     // Add integration with Inpaint Anything
     // applyZoomAndPanIntegration("None", ["#ia_sam_image", "#ia_sel_mask"]);
 });
+
+
+onUiLoaded(function() {
+    let isAltPressed = false;
+
+    function handleAltKeyDown(e) {
+        if (e.code === "AltLeft" || e.code === "AltRight") {
+            isAltPressed = true;
+        } else {
+            isAltPressed = false;
+        }
+    }
+
+    function handleAltKeyUp(e) {
+        if (isAltPressed) {
+            e.preventDefault();
+        }
+        isAltPressed = false;
+    }
+
+    document.addEventListener("keydown", handleAltKeyDown);
+    document.addEventListener("keyup", handleAltKeyUp);
+});

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -841,24 +841,24 @@ onUiLoaded(async() => {
 
 
         // Prevent firefox to open toolbar on pressing alt
-        let isAltPressed = false;
+        let wasAltPressed = false;
 
         function handleAltKeyDown(e) {
             if (!activeElement) return;
             if (hotkeysConfig.canvas_hotkey_zoom !== "Alt") return;
             if (e.code === "AltLeft" || e.code === "AltRight") {
-                isAltPressed = true;
+                wasAltPressed = true;
             } else {
-                isAltPressed = false;
+                wasAltPressed = false;
             }
         }
 
         function handleAltKeyUp(e) {
             if (hotkeysConfig.canvas_hotkey_zoom !== "Alt") return;
-            if (isAltPressed) {
+            if (wasAltPressed || (activeElement && e.key === "Alt")) {
                 e.preventDefault();
             }
-            isAltPressed = false;
+            wasAltPressed = false;
         }
 
         document.addEventListener("keydown", handleAltKeyDown);

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -846,7 +846,7 @@ onUiLoaded(async() => {
         function handleAltKeyDown(e) {
             if (!activeElement) return;
             if (hotkeysConfig.canvas_hotkey_zoom !== "Alt") return;
-            if (e.code === "AltLeft" || e.code === "AltRight") {
+            if (e.key === "Alt") {
                 wasAltPressed = true;
             } else {
                 wasAltPressed = false;

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -839,6 +839,31 @@ onUiLoaded(async() => {
         document.addEventListener("keydown", handleMoveKeyDown);
         document.addEventListener("keyup", handleMoveKeyUp);
 
+        // Prevent firefox to open toolbar on pressing alt
+        if (hotkeysConfig.canvas_hotkey_zoom === "Alt") {
+            let isAltPressed = false;
+
+            function handleAltKeyDown(e) {
+                if (!activeElement) return;
+                if (e.code === "AltLeft" || e.code === "AltRight") {
+                    isAltPressed = true;
+                } else {
+                    isAltPressed = false;
+                }
+            }
+
+            function handleAltKeyUp(e) {
+                if (isAltPressed) {
+                    e.preventDefault();
+                }
+                isAltPressed = false;
+            }
+
+            document.addEventListener("keydown", handleAltKeyDown);
+            document.addEventListener("keyup", handleAltKeyUp);
+        }
+
+
         // Detect zoom level and update the pan speed.
         function updatePanPosition(movementX, movementY) {
             let panSpeed = 2;
@@ -965,27 +990,4 @@ onUiLoaded(async() => {
 
     // Add integration with Inpaint Anything
     // applyZoomAndPanIntegration("None", ["#ia_sam_image", "#ia_sel_mask"]);
-});
-
-
-onUiLoaded(function() {
-    let isAltPressed = false;
-
-    function handleAltKeyDown(e) {
-        if (e.code === "AltLeft" || e.code === "AltRight") {
-            isAltPressed = true;
-        } else {
-            isAltPressed = false;
-        }
-    }
-
-    function handleAltKeyUp(e) {
-        if (isAltPressed) {
-            e.preventDefault();
-        }
-        isAltPressed = false;
-    }
-
-    document.addEventListener("keydown", handleAltKeyDown);
-    document.addEventListener("keyup", handleAltKeyUp);
 });


### PR DESCRIPTION
## Description

Firefox opens menu bar in the top of window "File, Edit, View, etc" by default. It can be disabled by https://support.mozilla.org/en-US/questions/1278533. But I think it's better to just prevent defaults for alt key at all


## Screenshots/videos:

![Screenshot_20240315_120242](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/20bdcfb0-1128-4e12-8e0a-5fb250393306)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
