### PR TITLE
handle 0 wheel deltaY

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -793,7 +793,7 @@ onUiLoaded(async() => {
 
         targetElement.addEventListener("wheel", e => {
             // change zoom level
-            const operation = e.deltaY > 0 ? "-" : "+";
+            const operation = (e.deltaY || -e.wheelDelta) > 0 ? "-" : "+";
             changeZoomLevel(operation, e);
 
             // Handle brush size adjustment with ctrl key pressed


### PR DESCRIPTION
## Description

I had a strange bug. When I was scrolling on remote PC via VNC remote desktop, I wasn't able to zoom out. I've found it's because deltaX was always 0. If I do it with real mouse - everything is OK

It's not really necessary to fix it in this way, this bug is rare and it's a problem of VNC. But I think nothing will be wrong with this change

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
