### PR TITLE
little fixes zoom.js

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -280,7 +280,7 @@ onUiLoaded(async() => {
         const targetElement = gradioApp().querySelector(elemId);
 
         if (!targetElement) {
-            console.log("Element not found");
+            console.log("Element not found", elemId);
             return;
         }
 
@@ -939,9 +939,9 @@ onUiLoaded(async() => {
 
     }
 
-    elementIDs.sketch && applyZoomAndPan(elementIDs.sketch, false);
-    elementIDs.inpaint && applyZoomAndPan(elementIDs.inpaint, false);
-    elementIDs.inpaintSketch && applyZoomAndPan(elementIDs.inpaintSketch, false);
+    applyZoomAndPan(elementIDs.sketch, false);
+    applyZoomAndPan(elementIDs.inpaint, false);
+    applyZoomAndPan(elementIDs.inpaintSketch, false);
 
     // Make the function global so that other extensions can take advantage of this solution
     const applyZoomAndPanIntegration = async(id, elementIDs) => {


### PR DESCRIPTION
## Description

Did not have time to push into https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15286
`elementIDs.sketch &&` etc are not necessary because they're strings and always true. `applyZoomAndPan` already checks is element doesn't exist


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
