### PR TITLE
Tweak diskcache limits

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -20,6 +20,14 @@ def dump_cache():
     pass
 
 
+def make_cache(subsection: str) -> diskcache.Cache:
+    return diskcache.Cache(
+        os.path.join(cache_dir, subsection),
+        size_limit=2**32,  # 4 GB, culling oldest first
+        disk_min_file_size=2**18,  # keep up to 256KB in Sqlite
+    )
+
+
 def convert_old_cached_data():
     try:
         with open(cache_filename, "r", encoding="utf8") as file:
@@ -37,7 +45,7 @@ def convert_old_cached_data():
         for subsection, keyvalues in data.items():
             cache_obj = caches.get(subsection)
             if cache_obj is None:
-                cache_obj = diskcache.Cache(os.path.join(cache_dir, subsection))
+                cache_obj = make_cache(subsection)
                 caches[subsection] = cache_obj
 
             for key, value in keyvalues.items():
@@ -64,7 +72,7 @@ def cache(subsection):
 
             cache_obj = caches.get(subsection)
             if not cache_obj:
-                cache_obj = diskcache.Cache(os.path.join(cache_dir, subsection))
+                cache_obj = make_cache(subsection)
                 caches[subsection] = cache_obj
 
     return cache_obj


### PR DESCRIPTION
## Description

By default, Diskcache has a limit of 1 GB (after which it starts discarding oldest objects (by default)), bump that up to 4 GB. Could make it unlimited with a larger number.
Also, probably okay to keep objects up to 256 KB in the Sqlite database.

Nb: I couldn't test this locally right now, and I just missed adding these as a review comment in #15287, sorry.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
