### PR TITLE
fix metadata.ini

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -71,7 +71,7 @@ class ExtensionMetadata:
 
         for requirement in listed_requirements:
             loaded_requirements = (x for x in requirement.split("|") if x in loaded_extensions)
-            relevant_requirement = next(loaded_requirements, listed_requirements[0])
+            relevant_requirement = next(loaded_requirements, requirement)
             res.append(relevant_requirement)
 
         return res


### PR DESCRIPTION
## Description

Why did you make it? It's completely broken

```ini
Requires = xvsd sd-webui-controlnet | sd_forge_controlnet , 98jhr
```
```python
print('!!!', listed_requirements)
for requirement in listed_requirements:
    loaded_requirements = (x for x in requirement.split("|") if x in loaded_extensions)
    relevant_requirement = next(loaded_requirements, listed_requirements[0])
    print('!!!', f'requirement={requirement}', f'relevant_requirement={relevant_requirement}')
    res.append(relevant_requirement)
```
```
!!! ['xvsd', 'sd-webui-controlnet', '|', 'sd_forge_controlnet', '98jhr']
!!! requirement=xvsd relevant_requirement=xvsd
!!! requirement=sd-webui-controlnet relevant_requirement=sd-webui-controlnet
!!! requirement=| relevant_requirement=xvsd
!!! requirement=sd_forge_controlnet relevant_requirement=xvsd
!!! requirement=98jhr relevant_requirement=xvsd
*** Extension "sd-webui-cn-in-extras-tab" requires "xvsd" which is not installed.
*** Extension "sd-webui-cn-in-extras-tab" requires "xvsd" which is not installed.
*** Extension "sd-webui-cn-in-extras-tab" requires "xvsd" which is not installed.
*** Extension "sd-webui-cn-in-extras-tab" requires "xvsd" which is not installed.
```


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
