### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 /gfpgan/weights/*.pth
 /ui-config.json
 /outputs
+/output
 /config.json
 /log
 /webui.settings.bat


### PR DESCRIPTION
## Description

* A newly installed WebUI will set /output as default output dir now instead of /outputs. So it's better to add it to gitignore.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
