### PR TITLE
restore outputs path

### DIFF
--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -32,6 +32,6 @@ models_path = os.path.join(data_path, "models")
 extensions_dir = os.path.join(data_path, "extensions")
 extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
 config_states_dir = os.path.join(script_path, "config_states")
-default_output_dir = os.path.join(data_path, "output")
+default_output_dir = os.path.join(data_path, "outputs")
 
 roboto_ttf_file = os.path.join(modules_path, 'Roboto-Regular.ttf')


### PR DESCRIPTION
## Description

`output` back to `outputs`

I made a typo in
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14446

only notice after seeing
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15305

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
