### PR TITLE
Escape btn_copy_path filename

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -10,6 +10,7 @@ from modules.images import read_info_from_image, save_image_with_geninfo
 import gradio as gr
 import json
 import html
+import re
 from fastapi.exceptions import HTTPException
 
 from modules.infotext_utils import image_from_url_text
@@ -236,7 +237,7 @@ class ExtraNetworksPage:
             )
             onclick = html.escape(onclick)
 
-        btn_copy_path = self.btn_copy_path_tpl.format(**{"filename": item["filename"]})
+        btn_copy_path = self.btn_copy_path_tpl.format(**{"filename": re.sub(r"[\\\"']", r"\\\g<0>", item["filename"])})
         btn_metadata = ""
         metadata = item.get("metadata")
         if metadata:


### PR DESCRIPTION
Escapes `\`, `"`, and `'`.
Fixes #15309
## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
