### PR TITLE
escape brackets in lora random prompt generator

### DIFF
--- a/extensions-builtin/Lora/ui_edit_user_metadata.py
+++ b/extensions-builtin/Lora/ui_edit_user_metadata.py
@@ -149,6 +149,8 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
 
             v = random.random() * max_count
             if count > v:
+                for x in "({[]})":
+                    tag = tag.replace(x, '\\' + x)
                 res.append(tag)
 
         return ", ".join(sorted(res))


### PR DESCRIPTION
## Description

Now If inside lora tags there are brackets, it generates prompt with no escaping them

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
