### PR TITLE
Add Size as an XYZ Grid option

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -106,6 +106,17 @@ def apply_upscale_latent_space(p, x, xs):
         opts.data["use_scale_latent_for_hires_fix"] = False
 
 
+def apply_size(p, x: str, xs) -> None:
+    try:
+        width, _, height = x.partition('x')
+        width = int(width.strip())
+        height = int(height.strip())
+        p.width = width
+        p.height = height
+    except ValueError:
+        print(f"Invalid size in XYZ plot: {x}")
+
+
 def find_vae(name: str):
     if name.lower() in ['auto', 'automatic']:
         return modules.sd_vae.unspecified
@@ -271,6 +282,7 @@ axis_options = [
     AxisOption("Refiner switch at", float, apply_field('refiner_switch_at')),
     AxisOption("RNG source", str, apply_override("randn_source"), choices=lambda: ["GPU", "CPU", "NV"]),
     AxisOption("FP8 mode", str, apply_override("fp8_storage"), cost=0.9, choices=lambda: ["Disable", "Enable for SDXL", "Enable"]),
+    AxisOption("Size", str, apply_size),
 ]
 
 


### PR DESCRIPTION
## Description

Via https://github.com/adieyal/sd-dynamic-prompts/issues/747.

Modifying the image size wasn't an option for XYZ grid variations; it is now.

## Screenshots/videos:

<img width="849" alt="Screenshot 2024-03-22 at 11 13 39" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/58669/c21987da-1ed5-47a8-b6c1-2e95f013323c">

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
