### PR TITLE
interrupt upscale

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -60,6 +60,9 @@ class Upscaler:
             if img.width >= dest_w and img.height >= dest_h:
                 break
 
+            if shared.state.interrupted:
+                break
+
             shape = (img.width, img.height)
 
             img = self.do_upscale(img, selected_model)

--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -69,6 +69,8 @@ def upscale_with_model(
         for y, h, row in grid.tiles:
             newrow = []
             for x, w, tile in row:
+                if shared.state.interrupted:
+                    return img
                 output = upscale_pil_patch(model, tile)
                 scale_factor = output.width // tile.width
                 newrow.append([x * scale_factor, w * scale_factor, output])


### PR DESCRIPTION
## Description

after pressing "interrupt" button, for example inside inpaint tab, upscaling with ai still will be used, if `opts.upscaler_for_img2img` is overridden. It takes a ton of time for upscaling e.g. 512p -> 4k, especially for DAT upscalers. It can be stopped only is server is stopped

I've added two checks for interruption flag inside `do_upscale` and `upscale`. It still upscales images, but with Lanczos


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
