### PR TITLE
Fix CodeFormer weight

### DIFF
--- a/modules/codeformer_model.py
+++ b/modules/codeformer_model.py
@@ -50,7 +50,7 @@ class FaceRestorerCodeFormer(face_restoration_utils.CommonFaceRestoration):
 
         def restore_face(cropped_face_t):
             assert self.net is not None
-            return self.net(cropped_face_t, w=w, adain=True)[0]
+            return self.net(cropped_face_t, weight=w, adain=True)[0]
 
         return self.restore_with_helper(np_image, restore_face)
 


### PR DESCRIPTION
## Description
CodeFormer weight slider in Extras Tab had no impact on result, due to wrong agument name for spandrel CodeFormer net forward.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
