### PR TITLE
Fix: Remove script callbacks in ordered_callbacks_map

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -439,6 +439,9 @@ def remove_current_script_callbacks():
     for callback_list in callback_map.values():
         for callback_to_remove in [cb for cb in callback_list if cb.script == filename]:
             callback_list.remove(callback_to_remove)
+    for ordered_callbacks_list in ordered_callbacks_map.values():
+        for callback_to_remove in [cb for cb in ordered_callbacks_list if cb.script == filename]:
+            ordered_callbacks_list.remove(callback_to_remove)
 
 
 def remove_callbacks_for_function(callback_func):


### PR DESCRIPTION
## Description

* This PR fixes script callbacks persisting after `script_callbacks.remove_current_script_callbacks()` is called. This would cause unexpected behavior by having extension callbacks not update in subsequent runs.

* The problem was that `remove_callbacks()` did not remove callbacks from ordered_callbacks_map dict. We iterate through ordered_callbacks_map like callbacks_map to remove the script's callbacks.

* The bug was introduced in commit 7e5e673.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
