### PR TITLE
Use HF_ENDPOINT variable for HuggingFace domain with default

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -8,6 +8,7 @@ import re
 import safetensors.torch
 from omegaconf import OmegaConf, ListConfig
 from os import mkdir
+from os import getenv
 from urllib import request
 import ldm.modules.midas as midas
 
@@ -151,7 +152,8 @@ def list_models():
     if shared.cmd_opts.no_download_sd_model or cmd_ckpt != shared.sd_model_file or os.path.exists(cmd_ckpt):
         model_url = None
     else:
-        model_url = "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
+        hugging_host = getenv('HF_ENDPOINT', 'https://huggingface.co')
+        model_url = f"{hugging_host}/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
 
     model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"])
 


### PR DESCRIPTION
Modified the list_models function to dynamically construct the model URL by using an environment variable for the HuggingFace domain. This allows for greater flexibility in specifying the domain and ensures that the modification is also compatible with the Hub client library. By supporting different environments or requirements without hardcoding the domain name, this change facilitates the use of custom HuggingFace domains not only within our code but also when interacting with the Hub client library.

## Description

Add `HF_ENDPOINT` variable with default value `https://huggingface.co`. With that setting we could use JFrog Artifactory to proxying Hugging Face models and load them from internal cache.

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1109787/8d7bc001-e063-4205-b508-e9fa0ef9ae02)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
