### PR TITLE
re-add update_file_entry

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -148,6 +148,11 @@ class MassFileLister:
         """Clear the cache of all directories."""
         self.cached_dirs.clear()
 
+    def update_file_entry(self, path):
+        """Update the cache for a specific directory."""
+        dirname, filename = os.path.split(path)
+        if cached_dir := self.cached_dirs.get(dirname):
+            cached_dir.update_entry(filename)
 
 def topological_sort(dependencies):
     """Accepts a dictionary mapping name to its dependencies, returns a list of names ordered according to dependencies.


### PR DESCRIPTION
## Description
- `MassFileLister.update_file_entry` from https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15199
- was accidentally removed in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15205/
see diff https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15205/files#diff-c39b942d8f8620d46d314db8301189b8d6195fc97aedbeb124a33694b738d69cL151-R173

thanks to report from @Dasor92
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/9fd0cd6a805ee0a0a0651de41d4c6154407a045f#commitcomment-140684337

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
