### PR TITLE
create_infotext allow index and callable, re-work Hires prompt infotext

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -704,7 +704,9 @@ def program_version():
 
 
 def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iteration=0, position_in_batch=0, use_main_prompt=False, index=None, all_negative_prompts=None, all_hr_prompts=None, all_hr_negative_prompts=None):
-    if index is None:
+    if use_main_prompt:
+        index = 0
+    elif index is None:
         index = position_in_batch + iteration * p.batch_size
 
     if all_negative_prompts is None:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -704,6 +704,50 @@ def program_version():
 
 
 def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iteration=0, position_in_batch=0, use_main_prompt=False, index=None, all_negative_prompts=None):
+    """
+    this function is used to generate the infotext that is stored in the generated images, it's contains the parameters that are required to generate the imagee
+    Args:
+        p: StableDiffusionProcessing
+        all_prompts: list[str]
+        all_seeds: list[int]
+        all_subseeds: list[int]
+        comments: list[str]
+        iteration: int
+        position_in_batch: int
+        use_main_prompt: bool
+        index: int
+        all_negative_prompts: list[str]
+
+    Returns: str
+
+    Extra generation params
+    p.extra_generation_params dictionary allows for additional parameters to be added to the infotext
+    this can be use by the base webui or extensions.
+    To add a new entry, add a new key value pair, the dictionary key will be used as the key of the parameter in the infotext
+    the value generation_params can be defined as:
+        - str | None
+        - List[str|None]
+        - callable func(**kwargs) -> str | None
+
+    When defined as a string, it will be used as without extra processing; this is this most common use case.
+
+    Defining as a list allows for parameter that changes across images in the job, for example, the 'Seed' parameter.
+    The list should have the same length as the total number of images in the entire job.
+
+    Defining as a callable function allows parameter cannot be generated earlier or when extra logic is required.
+    For example 'Hires prompt', due to reasons the hr_prompt might be changed by process in the pipeline or extensions
+    and may vary across different images, defining as a static string or list would not work.
+
+    The function takes locals() as **kwargs, as such will have access to variables like 'p' and 'index'.
+    the base signature of the function should be:
+        func(**kwargs) -> str | None
+    optionally it can have additional arguments that will be used in the function:
+        func(p, index, **kwargs) -> str | None
+    note: for better future compatibility even though this function will have access to all variables in the locals(),
+        it is recommended to only use the arguments present in the function signature of create_infotext.
+    For actual implementation examples, see StableDiffusionProcessingTxt2Img.init > get_hr_prompt.
+    """
+
     if use_main_prompt:
         index = 0
     elif index is None:

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -756,6 +756,16 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
         "User": p.user if opts.add_user_name_to_info else None,
     }
 
+    for key, value in generation_params.items():
+        try:
+            if isinstance(value, list):
+                generation_params[key] = value[index]
+            elif callable(value):
+                generation_params[key] = value(**locals())
+        except Exception:
+            errors.report(f'Error creating infotext for key "{key}"', exc_info=True)
+            generation_params[key] = None
+
     if all_hr_prompts := all_hr_prompts or getattr(p, 'all_hr_prompts', None):
         generation_params['Hires prompt'] = all_hr_prompts[index] if all_hr_prompts[index] != all_prompts[index] else None
     if all_hr_negative_prompts := all_hr_negative_prompts or getattr(p, 'all_hr_negative_prompts', None):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -608,7 +608,7 @@ class Processed:
             "version": self.version,
         }
 
-        return json.dumps(obj)
+        return json.dumps(obj, default=lambda o: None)
 
     def infotext(self, p: StableDiffusionProcessing, index):
         return create_infotext(p, self.all_prompts, self.all_seeds, self.all_subseeds, comments=[], position_in_batch=index % self.batch_size, iteration=index // self.batch_size)


### PR DESCRIPTION
## Description
- as mentioned briefly in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15269 I plan to rework create_infotext

this PR allows for generation parameters be a list string or callable, this enables much more flexibility and extensibility on how future infotax can be written
- for detail, reference the docstring https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/e3aabe6959c2088f6b6e917b4f84185ae95a3af6

- this PR also includes reworking of the `Hires prompt infotext` from https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15269, it is now implemented as a callable outside this funcrion

with this PR will be easier to add new parameters without directly adding extra bulk to this function

---

further work in future PR after this is merged
with this PR is possible to clean up some of the non-shared parameters from within the function
fore example `Token merging ratio hr` only applicablefor txt2img when hires fix is enabled, it seems appropriate to move the definition out of this shared function

### other changes
- when `use_main_prompt` is true `index is set to `0`
I believe this makes sense
- `Processed.js > json.dumps` will output None when encountering non-zerizable objects such as functions
- add docstring for create_infotext

---

note
I initially was planning for this to be done before before 1.9-RC, as this includes the removal of the two new arguments `all_hr_prompts` and `all_hr_negative_prompts` that I added in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15269, reason being if there are pushed to master then back was completely would ideally need to be kept
if possible I would like this to be pushed to 1.9-RC

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
