### PR TITLE
error handling paste_field callables

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -8,7 +8,7 @@ import sys
 
 import gradio as gr
 from modules.paths import data_path
-from modules import shared, ui_tempdir, script_callbacks, processing, infotext_versions, images, prompt_parser
+from modules import shared, ui_tempdir, script_callbacks, processing, infotext_versions, images, prompt_parser, errors
 from PIL import Image
 
 sys.modules['modules.generation_parameters_copypaste'] = sys.modules[__name__]  # alias for old name
@@ -488,7 +488,11 @@ def connect_paste(button, paste_fields, input_comp, override_settings_component,
 
         for output, key in paste_fields:
             if callable(key):
-                v = key(params)
+                try:
+                    v = key(params)
+                except Exception:
+                    errors.report(f"Error executing {key}", exc_info=True)
+                    v = None
             else:
                 v = params.get(key, None)
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -739,12 +739,17 @@ class ScriptRunner:
         def onload_script_visibility(params):
             title = params.get('Script', None)
             if title:
-                title_index = self.titles.index(title)
-                visibility = title_index == self.script_load_ctr
-                self.script_load_ctr = (self.script_load_ctr + 1) % len(self.titles)
-                return gr.update(visible=visibility)
-            else:
-                return gr.update(visible=False)
+                try:
+                    title_index = self.titles.index(title)
+                    visibility = title_index == self.script_load_ctr
+                    self.script_load_ctr = (self.script_load_ctr + 1) % len(self.titles)
+                    return gr.update(visible=visibility)
+                except ValueError:
+                    params['Script'] = None
+                    massage = f'Cannot find Script: "{title}"'
+                    print(massage)
+                    gr.Warning(massage)
+            return gr.update(visible=False)
 
         self.infotext_fields.append((dropdown, lambda x: gr.update(value=x.get('Script', 'None'))))
         self.infotext_fields.extend([(script.group, onload_script_visibility) for script in self.selectable_scripts])


### PR DESCRIPTION
## Description
when an infotext paste_field is a callable, if it and throws an exception then it can stop all other valid infotext from beeing read

in webui when a selectable drop down Script is not found
it will throw like so
<details><summary>Traceback</summary>
<p>

```py
Traceback (most recent call last):
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\gradio\routes.py", line 488, in run_predict
    output = await app.get_blocks().process_api(
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1431, in process_api
    result = await self.call_function(
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1103, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\anyio\to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\gradio\utils.py", line 707, in wrapper
    response = f(*args, **kwargs)
  File "B:\GitHub\stable-diffusion-webui\modules\infotext_utils.py", line 491, in paste_func
    v = key(params)
  File "B:\GitHub\stable-diffusion-webui\modules\scripts.py", line 742, in onload_script_visibility
    title_index = self.titles.index(title)
ValueError: 'does not exist' is not in list
```

</p>
</details> 

this generally won't happen with built-in Scripts
but can happen for 3rd-party user install scripts

test infotext that will throw
```
1girl
Model hash: a, Seed: 100, Script: does not exist
```

I think it's better to handle the issue

in this PR I added
- specialized handling when the script is not found, Warning message 
- general purpose handling of all paste_field callables


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
