### PR TITLE
Fix cls.__module__ value in extension script

### DIFF
--- a/extensions-builtin/hypertile/scripts/hypertile_xyz.py
+++ b/extensions-builtin/hypertile/scripts/hypertile_xyz.py
@@ -1,7 +1,7 @@
 from modules import scripts
 from modules.shared import opts
 
-xyz_grid = [x for x in scripts.scripts_data if x.script_class.__module__ == "xyz_grid.py"][0].module
+xyz_grid = [x for x in scripts.scripts_data if x.script_class.__module__ == "scripts.xyz_grid"][0].module
 
 def int_applier(value_name:str, min_range:int = -1, max_range:int = -1):
     """

--- a/modules/script_loading.py
+++ b/modules/script_loading.py
@@ -14,7 +14,7 @@ def load_module(path):
     module_spec = importlib.util.spec_from_file_location(full_module_name, path)
     module = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(module)
-    loaded_scripts[full_module_name] = module
+    loaded_scripts[path] = module
     sys.modules[full_module_name] = module
     return module
 

--- a/modules/script_loading.py
+++ b/modules/script_loading.py
@@ -9,15 +9,13 @@ loaded_scripts = {}
 
 
 def load_module(path):
-    module_spec = importlib.util.spec_from_file_location(os.path.basename(path), path)
+    module_name, _ = os.path.splitext(os.path.basename(path))
+    full_module_name = "scripts." + module_name
+    module_spec = importlib.util.spec_from_file_location(full_module_name, path)
     module = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(module)
-
-    loaded_scripts[path] = module
-
-    module_name, _ = os.path.splitext(os.path.basename(path))
-    sys.modules["scripts." + module_name] = module
-
+    loaded_scripts[full_module_name] = module
+    sys.modules[full_module_name] = module
     return module
 
 


### PR DESCRIPTION
## Description

Minimal reproduction: https://github.com/Mikubill/sd-webui-controlnet/pull/2753

Adding following file to the extension script/ folder will cause A1111 report script loading error
```python
from __future__ import annotations
from dataclasses import dataclass


@dataclass
class PreprocessorParameter:
    label: str
```

Error log:
```
*** Error loading script: repro.py
    Traceback (most recent call last):
      File "D:\stable-diffusion-webui\modules\scripts.py", line 508, in load_scripts
        script_module = script_loading.load_module(scriptfile.path)
      File "D:\stable-diffusion-webui\modules\script_loading.py", line 14, in load_module
        module_spec.loader.exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "D:\stable-diffusion-webui\extensions\sd-webui-controlnet\scripts\repro.py", line 6, in <module>
        class PreprocessorParameter:
      File "C:\Program Files\Python310\lib\dataclasses.py", line 1185, in dataclass
        return wrap(cls)
      File "C:\Program Files\Python310\lib\dataclasses.py", line 1176, in wrap
        return _process_class(cls, init, repr, eq, order, unsafe_hash,
      File "C:\Program Files\Python310\lib\dataclasses.py", line 945, in _process_class
        and _is_type(type, cls, dataclasses, dataclasses.KW_ONLY,
      File "C:\Program Files\Python310\lib\dataclasses.py", line 712, in _is_type
        ns = sys.modules.get(cls.__module__).__dict__
    AttributeError: 'NoneType' object has no attribute '__dict__'
```

The root issue is that `cls.__module__` is assigned to be file name in `script_loading.py::load_module`. This PR fixes the `cls.__module__` so that dataclass along with `__future__.annotations` can be used together.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
