### PR TITLE
fix: remove_callbacks_for_function should also remove from the ordered map

### DIFF
--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -448,6 +448,9 @@ def remove_callbacks_for_function(callback_func):
     for callback_list in callback_map.values():
         for callback_to_remove in [cb for cb in callback_list if cb.callback == callback_func]:
             callback_list.remove(callback_to_remove)
+    for ordered_callback_list in ordered_callbacks_map.values():
+        for callback_to_remove in [cb for cb in ordered_callback_list if cb.callback == callback_func]:
+            ordered_callback_list.remove(callback_to_remove)
 
 
 def on_app_started(callback, *, name=None):


### PR DESCRIPTION
## Description

Like `remove_current_script_callback()` just before it, also remove from the `ordered_callbacks_map` to keep the callback map and ordered callback map in sync.

In the recent changes concerning allowing the callbacks to be ordered, a second map of callbacks `ordered_callbacks_map` was created to hold a sorted list of callbacks. When an extension removes one of its callbacks from the list, make sure the ordered list is kept in sync with the unordered list.

https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15428 fixed `remove_current_script_callbacks()` but `remove_callbacks_for_function()` also needs the same logic.

This was discovered by using the controlnet extension and noticing the start and ending control step was being lost after the first run. 

Fixes controlnet bug https://github.com/Mikubill/sd-webui-controlnet/issues/2752

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
