### PR TITLE
Fix images do not match / Coordinate 'right' is less than 'left'

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -9,8 +9,8 @@ def get_crop_region(mask, pad=0):
     if box:
         x1, y1, x2, y2 = box
     else:  # when no box is found
-        x1 = y1 = 0
-        x2, y2 = mask_img.size
+        x1, y1 = mask_img.size
+        x2 = y2 = 0
     return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask_img.size[0]), min(y2 + pad, mask_img.size[1])
 
 

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -9,8 +9,8 @@ def get_crop_region(mask, pad=0):
     if box:
         x1, y1, x2, y2 = box
     else:  # when no box is found
-        x1, y1 = mask_img.size
-        x2 = y2 = 0
+        x1 = y1 = 0
+        x2, y2 = mask_img.size
     return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask_img.size[0]), min(y2 + pad, mask_img.size[1])
 
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1537,23 +1537,24 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             if self.mask_blur_x > 0 or self.mask_blur_y > 0:
                 self.extra_generation_params["Mask blur"] = self.mask_blur
 
-            if image_mask.size != (self.width, self.height):
-                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
-
             if self.inpaint_full_res:
                 self.mask_for_overlay = image_mask
                 mask = image_mask.convert('L')
                 crop_region = masking.get_crop_region(mask, self.inpaint_full_res_padding)
-                crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
-                x1, y1, x2, y2 = crop_region
-
-                mask = mask.crop(crop_region)
-                image_mask = images.resize_image(2, mask, self.width, self.height)
-                self.paste_to = (x1, y1, x2-x1, y2-y1)
-
+                if crop_region[0] >= crop_region[2] and crop_region[1] >= crop_region[3]:
+                    crop_region = None
+                    image_mask = None
+                    self.mask_for_overlay = None
+                else:
+                    crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    x1, y1, x2, y2 = crop_region
+                    mask = mask.crop(crop_region)
+                    image_mask = images.resize_image(2, mask, self.width, self.height)
+                    self.paste_to = (x1, y1, x2-x1, y2-y1)
                 self.extra_generation_params["Inpaint area"] = "Only masked"
                 self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
             else:
+                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
                 np_mask = np.array(image_mask)
                 np_mask = np.clip((np_mask.astype(np.float32)) * 2, 0, 255).astype(np.uint8)
                 self.mask_for_overlay = Image.fromarray(np_mask)
@@ -1579,6 +1580,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 image = images.resize_image(self.resize_mode, image, self.width, self.height)
 
             if image_mask is not None:
+                if self.mask_for_overlay.size != (image.width, image.height):
+                    self.mask_for_overlay = images.resize_image(self.resize_mode, self.mask_for_overlay, image.width, image.height)
                 image_masked = Image.new('RGBa', (image.width, image.height))
                 image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(self.mask_for_overlay.convert('L')))
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1537,6 +1537,9 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             if self.mask_blur_x > 0 or self.mask_blur_y > 0:
                 self.extra_generation_params["Mask blur"] = self.mask_blur
 
+            if image_mask.size != (self.width, self.height):
+                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
+
             if self.inpaint_full_res:
                 self.mask_for_overlay = image_mask
                 mask = image_mask.convert('L')
@@ -1551,7 +1554,6 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 self.extra_generation_params["Inpaint area"] = "Only masked"
                 self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
             else:
-                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
                 np_mask = np.array(image_mask)
                 np_mask = np.clip((np_mask.astype(np.float32)) * 2, 0, 255).astype(np.uint8)
                 self.mask_for_overlay = Image.fromarray(np_mask)


### PR DESCRIPTION
## Description

I provide the webui as a cloud-based service to a large number of users, and I have been encountering this error frequently:

```
    Traceback (most recent call last):
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/call_queue.py", line 57, in f
        res = list(func(*args, **kwargs))
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/call_queue.py", line 36, in f
        res = func(*args, **kwargs)
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/img2img.py", line 235, in img2img
        processed = process_images(p)
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/processing.py", line 785, in process_images
        res = process_images_inner(p)
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/processing.py", line 855, in process_images_inner
        p.init(p.all_prompts, p.all_seeds, p.all_subseeds)
      File "/data/app/aigc-worker/models/dev/webui-1.8.0/modules/processing.py", line 1590, in init
        image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(self.mask_for_overlay.convert('L')))
      File "/root/miniconda3/envs/webui/lib/python3.10/site-packages/PIL/Image.py", line 1732, in paste
        self.im.paste(im, box, mask.im)
    ValueError: images do not match
```

(aka: `Coordinate 'right' is less than 'left'`)

After parameter localization, I found two ways to reproduce the issue.

#### Reproduction Path 1
* Select `img2img`/`Inpaint Upload`
* Upload the image and mask separately, with the mask size being different from the image
* Select `only masked` in the `inpaint area`
* Click generate

#### Reproduction Path 2
* Use `img2img` / `inpaint`, upload the image and randomly paint a mask
* Change the resize to width or height, making it different from the uploaded image size
* Select `only masked` in the `inpaint area`
* In the `script` below, select `SD upscale` with the default 2x scaling
* Click generate

The specific code is located here [code](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/processing.py#L1612-L1620)

```
class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
    ...
    def init(self, all_prompts, all_seeds, all_subseeds):
            ...
            if self.inpaint_full_res:
                self.mask_for_overlay = image_mask
                mask = image_mask.convert('L')
                crop_region = masking.get_crop_region(mask, self.inpaint_full_res_padding)
                crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
                x1, y1, x2, y2 = crop_region

                mask = mask.crop(crop_region)
                image_mask = images.resize_image(2, mask, self.width, self.height)
                self.paste_to = (x1, y1, x2-x1, y2-y1)
            ...
```

Here, the self.mask_for_overlay is not resized to the size of `self.width` and `self.height`, leading to the following exception:

```
class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
    ...
    def init(self, all_prompts, all_seeds, all_subseeds):
            ...
            if image_mask is not None:
                image_masked = Image.new('RGBa', (image.width, image.height))
                image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(self.mask_for_overlay.convert('L')))
            ...
```

These users, when using the `img2img`/`Inpaint Upload` mode, have a slight difference in the size of `init_img_inpaint` and `init_mask_inpaint`, only a few percentage points. I guess they used some non-standard extensions or created the mask in a third-party tool, resulting in a slight difference in the size of `init_mask_inpaint` and `init_img_inpaint`.

Originally, I attributed this issue to user input errors, but recently, more and more users have reported this problem. Now I think it is a sufficient optimization item to improve the user experience of webui.

This change should be harmless, and the implementation of `get_crop_region` may indeed contain some typos.

This should be the same issue as described in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14331

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)