### PR TITLE
numpy DeprecationWarning product -> prod

### DIFF
--- a/modules/textual_inversion/image_embedding.py
+++ b/modules/textual_inversion/image_embedding.py
@@ -43,7 +43,7 @@ def lcg(m=2**32, a=1664525, c=1013904223, seed=0):
 
 def xor_block(block):
     g = lcg()
-    randblock = np.array([next(g) for _ in range(np.product(block.shape))]).astype(np.uint8).reshape(block.shape)
+    randblock = np.array([next(g) for _ in range(np.prod(block.shape))]).astype(np.uint8).reshape(block.shape)
     return np.bitwise_xor(block.astype(np.uint8), randblock & 0x0F)
 
 


### PR DESCRIPTION
## Description
not important PR

`np.product` is an alias of ``np.prod` since 6 years ago
https://github.com/numpy/numpy/blame/e47cbb69bebf36007c3ea009aee03e4bfe3b3f3d/numpy/core/fromnumeric.py#L3734-L3743

```py
stable-diffusion-webui\modules\textual_inversion\image_embedding.py:123: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
```

so no reason not to switch

---

also not important
the test in this file

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/adadb4e3c7382bf3e4f7519126cd6c70f4f8557b/modules/textual_inversion/image_embedding.py#L180-L183

is broken due to
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/adadb4e3c7382bf3e4f7519126cd6c70f4f8557b/modules/textual_inversion/image_embedding.py#L134

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
