### PR TITLE
fix x1 upscalers

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -57,7 +57,7 @@ class Upscaler:
         dest_h = int((img.height * scale) // 8 * 8)
 
         for _ in range(3):
-            if img.width >= dest_w and img.height >= dest_h:
+            if img.width >= dest_w and img.height >= dest_h and scale != 1:
                 break
 
             if shared.state.interrupted:


### PR DESCRIPTION
## Description

E.g. `1x_JPEG_80-100`,  `1x_NMKD-h264Texturize_500k`. In webui 1.7 they were broken. 
![изображение](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/1192fe32-08db-4e47-87d4-85cd21f1a708)

This patch doesn't affect on resize_image, it ignores 1.0 upscale separately

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
