### PR TITLE
Allow webui.sh to be runnable from arbitrary directories containing a .git file

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -113,13 +113,13 @@ then
     exit 1
 fi
 
-if [[ -d .git ]]
+if [[ -d "$SCRIPT_DIR/.git" ]]
 then
     printf "\n%s\n" "${delimiter}"
     printf "Repo already cloned, using it as install directory"
     printf "\n%s\n" "${delimiter}"
-    install_dir="${PWD}/../"
-    clone_dir="${PWD##*/}"
+    install_dir="${SCRIPT_DIR}/../"
+    clone_dir="${SCRIPT_DIR##*/}"
 fi
 
 # Check prerequisites


### PR DESCRIPTION
## Description
Extension of https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/5a32d4fcb195f7ee5be2617d9f776c01fd0437b7 and related to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14632. 
Ensure the check for .git applies to the correct `$SCRIPT_DIR` file location instead of checking the current directory. If the script is executed from somewhere that also contains a `.git` directory, e.g. a user's `$HOME` that has dotfile management with git or a wrapper project, the `$install_dir` and `$clone_dir` variables will currently be reset to `$PWD` and cause further misbehavior.

To recreate:
1. Clone the repository to a location.
2. Navigate to a new directory.
3. `mkdir .git` in the new directory if it does not exist already.
4. `sh /path/to/webui/webui.sh`.
5. Script runs incorrectly and fails upon attempting to execute the (non-existent) `launch.py`.
<details>
<summary>Output</summary>

```
################################################################
Install script for stable-diffusion + Web UI
Tested on Debian 11 (Bullseye), Fedora 34+ and openSUSE Leap 15.4 or newer.
################################################################

################################################################
Running on user user
################################################################

################################################################
Repo already cloned, using it as install directory
################################################################

################################################################
Create and activate python venv
################################################################

################################################################
Launching launch.py...
################################################################
glibc version is 2.39
Check TCMalloc: libtcmalloc_minimal.so.4
libtcmalloc_minimal.so.4 is linked with libc.so,execute LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4
python3: can't open file '/home/user/test/launch.py': [Errno 2] No such file or directory
```

</details>

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
