### PR TITLE
Add avif support

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -13,6 +13,8 @@ import numpy as np
 import piexif
 import piexif.helper
 from PIL import Image, ImageFont, ImageDraw, ImageColor, PngImagePlugin, ImageOps
+# pillow_avif needs to be imported somewhere in code for it to work
+import pillow_avif # noqa: F401
 import string
 import json
 import hashlib
@@ -569,6 +571,16 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
             })
 
             piexif.insert(exif_bytes, filename)
+    elif extension.lower() == '.avif':
+        if opts.enable_pnginfo and geninfo is not None:
+            exif_bytes = piexif.dump({
+                "Exif": {
+                    piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(geninfo or "", encoding="unicode")
+                },
+            })
+
+
+        image.save(filename,format=image_format, exif=exif_bytes)
     elif extension.lower() == ".gif":
         image.save(filename, format=image_format, comment=geninfo)
     else:
@@ -747,7 +759,6 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
             exif_comment = exif_comment.decode('utf8', errors="ignore")
 
         if exif_comment:
-            items['exif comment'] = exif_comment
             geninfo = exif_comment
     elif "comment" in items: # for gif
         geninfo = items["comment"].decode('utf8', errors="ignore")

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ torch
 torchdiffeq
 torchsde
 transformers==4.30.2
+pillow-avif-plugin==1.4.3

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -29,3 +29,4 @@ torchdiffeq==0.2.3
 torchsde==0.2.6
 transformers==4.30.2
 httpx==0.24.1
+pillow-avif-plugin==1.4.3


### PR DESCRIPTION
## Description
Avif is more efficient for storage compared to .jpeg or .webp


Adds .avif support for genrated images and for parsing exif data 
Exif data is stored in `UserComment` similar to .jpeg, .webp

I have also removed the second "user comment" field from image info for formats other than png, it looks same as png now.


It adds [`pillow-avif-plugin`](https://github.com/fdintino/pillow-avif-plugin/) to dependencies [because avif isn't supported by pillow yet](https://github.com/python-pillow/Pillow/pull/5201)

Resolves: #8133



## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
