### PR TITLE
get_crop_region_v2

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -1,17 +1,39 @@
 from PIL import Image, ImageFilter, ImageOps
 
 
-def get_crop_region(mask, pad=0):
-    """finds a rectangular region that contains all masked ares in an image. Returns (x1, y1, x2, y2) coordinates of the rectangle.
-    For example, if a user has painted the top-right part of a 512x512 image, the result may be (256, 0, 512, 256)"""
-    mask_img = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
-    box = mask_img.getbbox()
-    if box:
+def get_crop_region_v2(mask, pad=0):
+    """
+    Finds a rectangular region that contains all masked ares in a mask.
+    Returns None if mask is completely black mask (all 0)
+
+    Parameters:
+    mask: PIL.Image.Image L mode or numpy 1d array
+    pad: int number of pixels that the region will be extended on all sides
+    Returns: (x1, y1, x2, y2) | None
+
+    Introduced post 1.9.0
+    """
+    mask = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
+    if box := mask.getbbox():
         x1, y1, x2, y2 = box
-    else:  # when no box is found
-        x1, y1 = mask_img.size
-        x2 = y2 = 0
-    return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask_img.size[0]), min(y2 + pad, mask_img.size[1])
+        return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask.size[0]), min(y2 + pad, mask.size[1]) if pad else box
+
+
+def get_crop_region(mask, pad=0):
+    """
+    Same function as get_crop_region_v2 but handles completely black mask (all 0) differently
+    when mask all black still return coordinates but the coordinates may be invalid ie x2>x1 or y2>y1
+    Notes: it is possible for the coordinates to be "valid" again if pad size is sufficiently large
+    (mask_size.x-pad, mask_size.y-pad, pad, pad)
+
+    Extension developer should use get_crop_region_v2 instead unless for compatibility considerations.
+    """
+    mask = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
+    if box := get_crop_region_v2(mask, pad):
+        return box
+    x1, y1 = mask.size
+    x2 = y2 = 0
+    return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask.size[0]), min(y2 + pad, mask.size[1])
 
 
 def expand_crop_region(crop_region, processing_width, processing_height, image_width, image_height):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1611,19 +1611,23 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             if self.inpaint_full_res:
                 self.mask_for_overlay = image_mask
                 mask = image_mask.convert('L')
-                crop_region = masking.get_crop_region(mask, self.inpaint_full_res_padding)
-                if crop_region[0] >= crop_region[2] and crop_region[1] >= crop_region[3]:
-                    crop_region = None
-                    image_mask = None
-                    self.mask_for_overlay = None
-                else:
+                crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
+                if crop_region:
                     crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)
+                    self.inpaint_full_res = False
                     self.paste_to = (x1, y1, x2-x1, y2-y1)
-                self.extra_generation_params["Inpaint area"] = "Only masked"
-                self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
+                    self.extra_generation_params["Inpaint area"] = "Only masked"
+                    self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
+                else:
+                    crop_region = None
+                    image_mask = None
+                    self.mask_for_overlay = None
+                    massage = 'Unable to perform "Inpaint Only mask" because mask is blank, switch to img2img mode.'
+                    model_hijack.comments.append(massage)
+                    logging.info(massage)
             else:
                 image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
                 np_mask = np.array(image_mask)


### PR DESCRIPTION
## Description

this is essentially a follow-up to
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15534
- ~~https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15579 (irrelevant now)~~

changes

- include `self.extra_generation_params` in the if block as after converting the task to img2img they are no longer applicable
- add `get_crop_region_v2` and simplify the `processing` using `get_crop_region_v2`
- rework `get_crop_region` to be base on `get_crop_region_v2` (behavior is not changed)
- more detailed doc string

reasons of makeing the `v2`

`get_crop_region` out put is inconsist
even though invalid coordinates can be used to detect it region is all black, but it's not guaranteed
it's possible for in output coordinate to become valid when the pad is sufficiently large
I don't realistically see any use of the invalid coordinates

`v2` would consistently retruns None when the mask is blank else valid coordinates

---

for the record they're at least two instances of extensions using this function
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d9bee6ab-d7e2-42f0-ac39-13de5c749b1e)

maybe consideration adding a deprecation warning in `get_crop_region`


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
