### PR TITLE
fix mistake in #15583

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1617,7 +1617,6 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)
-                    self.inpaint_full_res = False
                     self.paste_to = (x1, y1, x2-x1, y2-y1)
                     self.extra_generation_params["Inpaint area"] = "Only masked"
                     self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
@@ -1625,6 +1624,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                     crop_region = None
                     image_mask = None
                     self.mask_for_overlay = None
+                    self.inpaint_full_res = False
                     massage = 'Unable to perform "Inpaint Only mask" because mask is blank, switch to img2img mode.'
                     model_hijack.comments.append(massage)
                     logging.info(massage)


### PR DESCRIPTION
## Description
sorry my bad, I made a mistake in
- #15583
```py
self.inpaint_full_res = False
```
this line should be in else block not if

this line really doesn't matter for webui it self as I believe it's never used later on and likely doesn't matter even for extensions
but to be safe set to false just in case if something in the future or an extension decides to check the value

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
