### PR TITLE
Fix corrupt model initial load loop

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -60,18 +60,19 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
         else:
             sd_version = lora_on_disk.sd_version
 
-        if shared.opts.lora_show_all or not enable_filter:
-            pass
-        elif sd_version == network.SdVersion.Unknown:
-            model_version = network.SdVersion.SDXL if shared.sd_model.is_sdxl else network.SdVersion.SD2 if shared.sd_model.is_sd2 else network.SdVersion.SD1
-            if model_version.name in shared.opts.lora_hide_unknown_for_versions:
+        if shared.sd_model is not None:  # still show LoRA in case an error occurs during initial model loading
+            if shared.opts.lora_show_all or not enable_filter:
+                pass
+            elif sd_version == network.SdVersion.Unknown:
+                model_version = network.SdVersion.SDXL if shared.sd_model.is_sdxl else network.SdVersion.SD2 if shared.sd_model.is_sd2 else network.SdVersion.SD1
+                if model_version.name in shared.opts.lora_hide_unknown_for_versions:
+                    return None
+            elif shared.sd_model.is_sdxl and sd_version != network.SdVersion.SDXL:
                 return None
-        elif shared.sd_model.is_sdxl and sd_version != network.SdVersion.SDXL:
-            return None
-        elif shared.sd_model.is_sd2 and sd_version != network.SdVersion.SD2:
-            return None
-        elif shared.sd_model.is_sd1 and sd_version != network.SdVersion.SD1:
-            return None
+            elif shared.sd_model.is_sd2 and sd_version != network.SdVersion.SD2:
+                return None
+            elif shared.sd_model.is_sd1 and sd_version != network.SdVersion.SD1:
+                return None
 
         return item
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -659,10 +659,11 @@ def get_empty_cond(sd_model):
 
 
 def send_model_to_cpu(m):
-    if m.lowvram:
-        lowvram.send_everything_to_cpu()
-    else:
-        m.to(devices.cpu)
+    if m is not None:
+        if m.lowvram:
+            lowvram.send_everything_to_cpu()
+        else:
+            m.to(devices.cpu)
 
     devices.torch_gc()
 


### PR DESCRIPTION
## Description
Fix corrupt model initial load loop

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15568

- fix initial corrupt model load loop

if for some reason the initial loading model at loading phase of webui  is corrupted
after entering this state the user will not be able to load even a good model is selected, due the the unload_model_weights  > send_model_to_cpu > m.lowvram attribute check will fail becaules m is None
webui will be stuck in the loop unable to recover without manual intervention

- show LoRA on extra networks tab if sd_model failed to load

---

this issue can for the most part be simulated by setting the value `config.json > sd_model_checkpoint` path of a know corrupted model
> a corrupted model can be simulated by creating a new file and name it to `whatever.safetensors`

---

Testing with theis PR
I was able to change the model even the initial settings at load is pointing to a corrupted model,
and after switching to a good model, image generation seem to work properly.

---

other possibly related issue
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15595
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15584

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
