### PR TITLE
Initial model download integrity

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -23,6 +23,7 @@ def load_file_from_url(
     model_dir: str,
     progress: bool = True,
     file_name: str | None = None,
+    hash_prefix: str | None = None,
 ) -> str:
     """Download a file from `url` into `model_dir`, using the file present if possible.
 
@@ -36,11 +37,11 @@ def load_file_from_url(
     if not os.path.exists(cached_file):
         print(f'Downloading: "{url}" to {cached_file}\n')
         from torch.hub import download_url_to_file
-        download_url_to_file(url, cached_file, progress=progress)
+        download_url_to_file(url, cached_file, progress=progress, hash_prefix=hash_prefix)
     return cached_file
 
 
-def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None, ext_blacklist=None) -> list:
+def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None, ext_blacklist=None, hash_prefix=None) -> list:
     """
     A one-and done loader to try finding the desired models in specified directories.
 
@@ -49,6 +50,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
     @param model_path: The location to store/find models in.
     @param command_path: A command-line argument to search for models in first.
     @param ext_filter: An optional list of filename extensions to filter by
+    @param hash_prefix: the expected sha256 of the model_url
     @return: A list of paths containing the desired model(s)
     """
     output = []
@@ -78,7 +80,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
 
         if model_url is not None and len(output) == 0:
             if download_name is not None:
-                output.append(load_file_from_url(model_url, model_dir=places[0], file_name=download_name))
+                output.append(load_file_from_url(model_url, model_dir=places[0], file_name=download_name, hash_prefix=hash_prefix))
             else:
                 output.append(model_url)
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -149,10 +149,12 @@ def list_models():
     cmd_ckpt = shared.cmd_opts.ckpt
     if shared.cmd_opts.no_download_sd_model or cmd_ckpt != shared.sd_model_file or os.path.exists(cmd_ckpt):
         model_url = None
+        expected_sha256 = None
     else:
         model_url = f"{shared.hf_endpoint}/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
+        expected_sha256 = '6ce0161689b3853acaa03779ec93eafe75a02f4ced659bee03f50797806fa2fa'
 
-    model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"])
+    model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"], hash_prefix=expected_sha256)
 
     if os.path.exists(cmd_ckpt):
         checkpoint_info = CheckpointInfo(cmd_ckpt)


### PR DESCRIPTION
## Description
Initial model download integrity

recently they seems to be several instances of for whatever reason the "default auto downlaod model" when no model is found being corrupted on download

the file we download by default is `v1-5-pruned-emaonly.safetensors`
page url https://huggingface.co/runwayml/stable-diffusion-v1-5/blob/main/v1-5-pruned-emaonly.safetensors
sha256: `6ce0161689b3853acaa03779ec93eafe75a02f4ced659bee03f50797806fa2fa`

issue post of corrupted models

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15568
```
Loading weights [ff3a2961a8] from M:\z\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors
```
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15575
```
Loading weights [7f008929e1] from F:\A1111 Web UI Autoinstaller\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors
```

As corrupted  model could have serious consequences causing webui to enter a "unable to switch model loop" it makes sense to check for the Integrity of the file

> - see details and possible fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15600

---

the `download_url_to_file` utility we used to download the model will automatically delete the model if the hash does not match

- along with if the hash dose not match and is deleted webui would still be able to launch, just not able to generate images

in these cases users can either retry downloading the model by restarting web UI
download the models manually
or possibly install model downloader extensions to help them download other models

clarification
there is no risk of user files be accidentally deleted
the Integrity check it's only performed on the model that is currently being downloaded


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
