### PR TITLE
Add KL Optimal scheduler

### DIFF
--- a/modules/sd_schedulers.py
+++ b/modules/sd_schedulers.py
@@ -31,6 +31,15 @@ def sgm_uniform(n, sigma_min, sigma_max, inner_model, device):
     return torch.FloatTensor(sigs).to(device)
 
 
+def kl_optimal(n, sigma_min, sigma_max, device):
+    alpha_min = torch.arctan(torch.tensor(sigma_min, device=device))
+    alpha_max = torch.arctan(torch.tensor(sigma_max, device=device))
+    sigmas = torch.empty((n+1,), device=device)
+    for i in range(n+1):
+        sigmas[i] = torch.tan((i/n) * alpha_min + (1.0-i/n) * alpha_max)
+    return sigmas
+
+
 schedulers = [
     Scheduler('automatic', 'Automatic', None),
     Scheduler('uniform', 'Uniform', uniform, need_inner_model=True),
@@ -38,6 +47,7 @@ schedulers = [
     Scheduler('exponential', 'Exponential', k_diffusion.sampling.get_sigmas_exponential),
     Scheduler('polyexponential', 'Polyexponential', k_diffusion.sampling.get_sigmas_polyexponential, default_rho=1.0),
     Scheduler('sgm_uniform', 'SGM Uniform', sgm_uniform, need_inner_model=True, aliases=["SGMUniform"]),
+    Scheduler('kl_optimal', 'KL Optimal', kl_optimal),
 ]
 
 schedulers_map = {**{x.name: x for x in schedulers}, **{x.label: x for x in schedulers}}

--- a/modules/sd_schedulers.py
+++ b/modules/sd_schedulers.py
@@ -34,9 +34,8 @@ def sgm_uniform(n, sigma_min, sigma_max, inner_model, device):
 def kl_optimal(n, sigma_min, sigma_max, device):
     alpha_min = torch.arctan(torch.tensor(sigma_min, device=device))
     alpha_max = torch.arctan(torch.tensor(sigma_max, device=device))
-    sigmas = torch.empty((n+1,), device=device)
-    for i in range(n+1):
-        sigmas[i] = torch.tan((i/n) * alpha_min + (1.0-i/n) * alpha_max)
+    step_indices = torch.arange(n + 1, device=device)
+    sigmas = torch.tan(step_indices / n * alpha_min + (1.0 - step_indices / n) * alpha_max)
     return sigmas
 
 


### PR DESCRIPTION
## Description

* Adds a new scheduler called "KL Optimal", based on what is noted as an optimal scheduler in Sabour, et. al, "[Align Your Steps](https://research.nvidia.com/labs/toronto-ai/AlignYourSteps/)", theorem 3.1.
* (technobabble) "The optimal schedule $t^*$ minimizing the KL-divergence between $p(\mathrm{x}, t_{\text{min}})$ and the distribution of $\bar{\mathrm{x}}_{t\_{\text{min}}}$"
* Seems to substantially improve sample quality over the uniform and EDM/Karras scheduler, and also converges much faster, especially on ZSNR models.
* Might need CFG skipped on the first sampling step on ZSNR models on some prompts (and doing this often improves sample quality regardless).  Recommend waiting until after #15607 is merged to merge this.

## Screenshots/videos:
**Note: These grids have CFG skipped on the first step unless otherwise specified.**
Test grid for 50 steps: Comparing different noise schedulers, and also including sigma max of 4500 (approximately the default for ZSNR) and 160 in the comparison (an alternative that I find works well for other schedulers, spending less time at extremely high sigmas):
![xyz_grid-1523-2057651393-(best quality, high quality,_1 2) by strange-fox, by fabercastel, by hydaus, (digital painting _(artwork_), photography _(artwor](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/1d5f6552-7ef7-46b8-b1ce-2cad940bc188)
All samplers perform adequately on this one.  Most notably, KL Optimal functions better at the higher sigma max value, where Karras is somewhat washed out/smoother.

Test grid for 25 steps:
![xyz_grid-1524-2057651393-(best quality, high quality,_1 2) by strange-fox, by fabercastel, by hydaus, (digital painting _(artwork_), photography _(artwor](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/4ed60591-6a69-41be-b888-acb168dbaebc)
At 25 steps, Karras is an absolute mess at the higher default sigma max value.  Others all still look acceptable.

Test grid for 10 steps:
![xyz_grid-1525-2057651393-(best quality, high quality,_1 2) by strange-fox, by fabercastel, by hydaus, (digital painting _(artwork_), photography _(artwor](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/78bccc36-50ad-4ff6-847c-c3da6b83df38)
Complete failure case for Uniform and Karras.  KL Optimal doesn't look fantastic, but frankly it's better looking than a 10-step sample from a non-distilled model has any right to be.

Failure case when not skipping CFG (50 steps).  Probably ZSNR specific:
![xyz_grid-1521-2057651393-(best quality, high quality,_1 2) by strange-fox, by fabercastel, by hydaus, (digital painting _(artwork_), photography _(artwor](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/3135521f-8d3d-4082-a4be-eb2d6e18022c)
Not all prompts will do this, but this happens to be one of the ones that does.  The black "doors" surrounding the images in the KL Optimal column will render as a black border that encroaches on the whole image at lower step counts.  Higher step counts might stabilize this depending on prompt.  Skipping CFG on the first timestep is enough to reliably fix issues such as this.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
