### PR TITLE
dont send server address in a-href

### DIFF
--- a/html/footer.html
+++ b/html/footer.html
@@ -1,13 +1,13 @@
 <div>
-        <a href="{api_docs}">API</a>
+        <a href="{api_docs}" rel="noopener noreferrer">API</a>
          • 
-        <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui">Github</a>
+        <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui" rel="noopener noreferrer">Github</a>
          • 
-        <a href="https://gradio.app">Gradio</a>
+        <a href="https://gradio.app" rel="noopener noreferrer">Gradio</a>
          • 
-        <a href="#" onclick="showProfile('./internal/profile-startup'); return false;">Startup profile</a>
+        <a href="#" onclick="showProfile('./internal/profile-startup'); return false;" rel="noopener noreferrer">Startup profile</a>
          • 
-        <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false">Reload UI</a>
+        <a href="/" onclick="javascript:gradioApp().getElementById('settings_restart_gradio').click(); return false" rel="noopener noreferrer">Reload UI</a>
 </div>
 <br />
 <div class="versions">

--- a/html/licenses.html
+++ b/html/licenses.html
@@ -4,7 +4,7 @@
     #licenses pre { margin: 1em 0 2em 0;}
 </style>
 
-<h2><a href="https://github.com/invoke-ai/InvokeAI/blob/main/LICENSE">InvokeAI</a></h2>
+<h2><a href="https://github.com/invoke-ai/InvokeAI/blob/main/LICENSE" rel="noopener noreferrer">InvokeAI</a></h2>
 <small>Some code for compatibility with OSX is taken from lstein's repository.</small>
 <pre>
 MIT License
@@ -30,7 +30,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
 
-<h2><a href="https://github.com/Hafiidz/latent-diffusion/blob/main/LICENSE">LDSR</a></h2>
+<h2><a href="https://github.com/Hafiidz/latent-diffusion/blob/main/LICENSE" rel="noopener noreferrer">LDSR</a></h2>
 <small>Code added by contirubtors, most likely copied from this repository.</small>
 <pre>
 MIT License
@@ -56,7 +56,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
 
-<h2><a href="https://github.com/pharmapsychotic/clip-interrogator/blob/main/LICENSE">CLIP Interrogator</a></h2>
+<h2><a href="https://github.com/pharmapsychotic/clip-interrogator/blob/main/LICENSE" rel="noopener noreferrer">CLIP Interrogator</a></h2>
 <small>Some small amounts of code borrowed and reworked.</small>
 <pre>
 MIT License
@@ -82,7 +82,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
 
-<h2><a href="https://github.com/AminRezaei0x443/memory-efficient-attention/blob/main/LICENSE">Memory Efficient Attention</a></h2>
+<h2><a href="https://github.com/AminRezaei0x443/memory-efficient-attention/blob/main/LICENSE" rel="noopener noreferrer">Memory Efficient Attention</a></h2>
 <small>The sub-quadratic cross attention optimization uses modified code from the Memory Efficient Attention package that Alex Birch optimized for 3D tensors. This license is updated to reflect that.</small>
 <pre>
 MIT License
@@ -109,7 +109,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
 
-<h2><a href="https://github.com/huggingface/diffusers/blob/c7da8fd23359a22d0df2741688b5b4f33c26df21/LICENSE">Scaled Dot Product Attention</a></h2>
+<h2><a href="https://github.com/huggingface/diffusers/blob/c7da8fd23359a22d0df2741688b5b4f33c26df21/LICENSE" rel="noopener noreferrer">Scaled Dot Product Attention</a></h2>
 <small>Some small amounts of code borrowed and reworked.</small>
 <pre>
    Copyright 2023 The HuggingFace Team. All rights reserved.
@@ -329,7 +329,7 @@ SOFTWARE.
    limitations under the License.
 </pre>
 
-<h2><a href="https://github.com/explosion/curated-transformers/blob/main/LICENSE">Curated transformers</a></h2>
+<h2><a href="https://github.com/explosion/curated-transformers/blob/main/LICENSE" rel="noopener noreferrer">Curated transformers</a></h2>
 <small>The MPS workaround for nn.Linear on macOS 13.2.X is based on the MPS workaround for nn.Linear created by danieldk for Curated transformers</small>
 <pre>
 The MIT License (MIT)
@@ -355,7 +355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 </pre>
 
-<h2><a href="https://github.com/madebyollin/taesd/blob/main/LICENSE">TAESD</a></h2>
+<h2><a href="https://github.com/madebyollin/taesd/blob/main/LICENSE" rel="noopener noreferrer">TAESD</a></h2>
 <small>Tiny AutoEncoder for Stable Diffusion option for live previews</small>
 <pre>
 MIT License

--- a/modules/options.py
+++ b/modules/options.py
@@ -34,7 +34,7 @@ class OptionInfo:
         """If True, the setting will not be accessible via API"""
 
     def link(self, label, url):
-        self.comment_before += f"[<a href='{url}' target='_blank'>{label}</a>]"
+        self.comment_before += f"[<a href='{url}' target='_blank' rel='noopener noreferrer'>{label}</a>]"
         return self
 
     def js(self, label, js_func):

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -312,7 +312,7 @@ options_templates.update(options_section(('ui', "User interface", "ui"), {
     "ui_tab_order": OptionInfo([], "UI tab order", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
     "hidden_tabs": OptionInfo([], "Hidden UI tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
     "ui_reorder_list": OptionInfo([], "UI item order for txt2img/img2img tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared_items.ui_reorder_categories())}).info("selected items appear first").needs_reload_ui(),
-    "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
+    "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery' rel='noopener noreferrer'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
     "send_seed": OptionInfo(True, "Send seed when sending prompt or image to other interface"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -887,7 +887,7 @@ def create_ui():
 
     with gr.Blocks(analytics_enabled=False) as train_interface:
         with gr.Row(equal_height=False):
-            gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation.</p>")
+            gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\" rel='noopener noreferrer'>wiki</a></b> for detailed explanation.</p>")
 
         with ResizeHandleRow(variant="compact", equal_height=False):
             with gr.Tabs(elem_id="train_tabs"):
@@ -927,7 +927,7 @@ def create_ui():
                     return sorted(textual_inversion.textual_inversion_templates)
 
                 with gr.Tab(label="Train", id="train"):
-                    gr.HTML(value="<p style='margin-bottom: 0.7em'>Train an embedding or Hypernetwork; you must specify a directory with a set of 1:1 ratio images <a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\" style=\"font-weight:bold;\">[wiki]</a></p>")
+                    gr.HTML(value="<p style='margin-bottom: 0.7em'>Train an embedding or Hypernetwork; you must specify a directory with a set of 1:1 ratio images <a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\" style=\"font-weight:bold;\" rel='noopener noreferrer'>[wiki]</a></p>")
                     with FormRow():
                         train_embedding_name = gr.Dropdown(label='Embedding', elem_id="train_embedding", choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys()))
                         create_refresh_button(train_embedding_name, sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings, lambda: {"choices": sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys())}, "refresh_train_embedding_name")
@@ -1179,7 +1179,7 @@ def versions_html():
         xformers_version = "N/A"
 
     return f"""
-version: <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/{commit}">{tag}</a>
+version: <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/{commit}" rel='noopener noreferrer'>{tag}</a>
 &#x2000;•&#x2000;
 python: <span title="{sys.version}">{python_version}</span>
 &#x2000;•&#x2000;

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -129,7 +129,7 @@ def make_commit_link(commit_hash, remote, text=None):
         if remote.endswith(".git"):
             remote = remote[:-4]
         href = remote + "/commit/" + commit_hash
-        return f'<a href="{href}" target="_blank">{text}</a>'
+        return f'<a href="{href}" target="_blank" rel="noopener noreferrer">{text}</a>'
     else:
         return text
 
@@ -157,7 +157,7 @@ def extension_table():
         ext: extensions.Extension
         ext.read_info_from_repo()
 
-        remote = f"""<a href="{html.escape(ext.remote or '')}" target="_blank">{html.escape("built-in" if ext.is_builtin else ext.remote or '')}</a>"""
+        remote = f"""<a href="{html.escape(ext.remote or '')}" target="_blank" rel="noopener noreferrer">{html.escape("built-in" if ext.is_builtin else ext.remote or '')}</a>"""
 
         if ext.can_update:
             ext_status = f"""<label><input class="gr-check-radio gr-checkbox" name="update_{html.escape(ext.name)}" checked="checked" type="checkbox">{html.escape(ext.status)}</label>"""
@@ -211,7 +211,7 @@ def update_config_states_table(state_name):
         else:
             webui_commit_date = "<unknown>"
 
-        remote = f"""<a href="{html.escape(webui_remote)}" target="_blank">{html.escape(webui_remote or '')}</a>"""
+        remote = f"""<a href="{html.escape(webui_remote)}" target="_blank" rel="noopener noreferrer">{html.escape(webui_remote or '')}</a>"""
         commit_link = make_commit_link(webui_commit_hash, webui_remote)
         date_link = make_commit_link(webui_commit_hash, webui_remote, webui_commit_date)
 
@@ -285,7 +285,7 @@ def update_config_states_table(state_name):
             else:
                 ext_commit_date = "<unknown>"
 
-            remote = f"""<a href="{html.escape(ext_remote)}" target="_blank">{html.escape(ext_remote or '')}</a>"""
+            remote = f"""<a href="{html.escape(ext_remote)}" target="_blank" rel="noopener noreferrer">{html.escape(ext_remote or '')}</a>"""
             commit_link = make_commit_link(ext_commit_hash, ext_remote)
             date_link = make_commit_link(ext_commit_hash, ext_remote, ext_commit_date)
 
@@ -504,7 +504,7 @@ def refresh_available_extensions_from_data(hide_tags, sort_column, filter_text="
 
         code += f"""
             <tr>
-                <td><a href="{html.escape(url)}" target="_blank">{html.escape(name)}</a><br />{tags_text}</td>
+                <td><a href="{html.escape(url)}" target="_blank" rel="noopener noreferrer">{html.escape(name)}</a><br />{tags_text}</td>
                 <td>{html.escape(description)}<p class="info">
                 <span class="date_added">Update: {html.escape(update_time)}  Added: {html.escape(added)}  Created: {html.escape(create_time)}</span><span class="star_count">stars: <b>{stars}</b></a></p></td>
                 <td>{install_code}</td>

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -170,7 +170,7 @@ class UiSettings:
                     loadsave.create_ui()
 
                 with gr.TabItem("Sysinfo", id="sysinfo", elem_id="settings_tab_sysinfo"):
-                    gr.HTML('<a href="./internal/sysinfo-download" class="sysinfo_big_link" download>Download system info</a><br /><a href="./internal/sysinfo" target="_blank">(or open as text in a new page)</a>', elem_id="sysinfo_download")
+                    gr.HTML('<a href="./internal/sysinfo-download" class="sysinfo_big_link" download rel="noopener noreferrer">Download system info</a><br /><a href="./internal/sysinfo" target="_blank" rel="noopener noreferrer">(or open as text in a new page)</a>', elem_id="sysinfo_download")
 
                     with gr.Row():
                         with gr.Column(scale=1):


### PR DESCRIPTION
## Description

Gradio sets these tags automatically when generates hyperlinks from markdown `rel="noopener noreferrer"` I've added them into webui's html

You can see users' non-local server addresses (e.g. --share or their hosting) in github's repo statistics for example, when they go to the repo via Extensions tab. Other sites can see them too. This PR fixes this

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
