### PR TITLE
Add correct mimetype for .mjs files

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -38,6 +38,7 @@ warnings.filterwarnings("default" if opts.show_gradio_deprecation_warnings else 
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
 mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('application/javascript', '.mjs')
 
 # Likewise, add explicit content-type header for certain missing image types
 mimetypes.add_type('image/webp', '.webp')


### PR DESCRIPTION
## Description

We have https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/1c0a0c4c26f78c32095ebc7f8af82f5c04fca8c0/modules/ui_gradio_extensions.py#L22-L23 loading extension's javascript file as js module. However, without this PR, mjs is not sending out with correct mime type by FastAPI.

Blocking https://github.com/Mikubill/sd-webui-controlnet/pull/2822.

## Screenshots/videos:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/20929282/0abd1b7b-65e2-4198-9889-eede200b843f)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
