### PR TITLE
Allow old sampler names in API

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -48,6 +48,15 @@ def validate_sampler_name(name):
     return name
 
 
+def parse_old_sampler_name(name):
+    for scheduler in sd_schedulers.schedulers:
+        for scheduler_name in [scheduler.label, scheduler.name, *(scheduler.aliases or [])]:
+            if name.endswith(" " + scheduler_name):
+                return name[0:-(len(scheduler_name) + 1)], scheduler_name
+
+    return name, "Automatic"
+
+
 def setUpscalers(req: dict):
     reqDict = vars(req)
     reqDict['extras_upscaler_1'] = reqDict.pop('upscaler_1', None)
@@ -438,14 +447,18 @@ class Api:
         self.apply_infotext(txt2imgreq, "txt2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
 
         selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
+        sampler, scheduler = parse_old_sampler_name(txt2imgreq.sampler_name or txt2imgreq.sampler_index)
 
         populate = txt2imgreq.copy(update={  # Override __init__ params
-            "sampler_name": validate_sampler_name(txt2imgreq.sampler_name or txt2imgreq.sampler_index),
+            "sampler_name": validate_sampler_name(sampler),
             "do_not_save_samples": not txt2imgreq.save_images,
             "do_not_save_grid": not txt2imgreq.save_images,
         })
         if populate.sampler_name:
             populate.sampler_index = None  # prevent a warning later on
+
+        if not populate.scheduler:
+            populate.scheduler = scheduler
 
         args = vars(populate)
         args.pop('script_name', None)
@@ -502,15 +515,19 @@ class Api:
         self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
 
         selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
+        sampler, scheduler = parse_old_sampler_name(img2imgreq.sampler_name or img2imgreq.sampler_index)
 
         populate = img2imgreq.copy(update={  # Override __init__ params
-            "sampler_name": validate_sampler_name(img2imgreq.sampler_name or img2imgreq.sampler_index),
+            "sampler_name": validate_sampler_name(sampler),
             "do_not_save_samples": not img2imgreq.save_images,
             "do_not_save_grid": not img2imgreq.save_images,
             "mask": mask,
         })
         if populate.sampler_name:
             populate.sampler_index = None  # prevent a warning later on
+
+        if not populate.scheduler:
+            populate.scheduler = scheduler
 
         args = vars(populate)
         args.pop('include_init_images', None)  # this is meant to be done by "exclude": True in model, but it's for a reason that I cannot determine.


### PR DESCRIPTION
Allows using the pre-#15333 sampler names in API requests.
Fixes #15603

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
