### PR TITLE
fix extra batch mode P Transparency

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -62,11 +62,13 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         else:
             image_data = image_placeholder
 
+        image_data = image_data if image_data.mode in ("RGBA", "RGB") else image_data.convert("RGB")
+
         parameters, existing_pnginfo = images.read_info_from_image(image_data)
         if parameters:
             existing_pnginfo["parameters"] = parameters
 
-        initial_pp = scripts_postprocessing.PostprocessedImage(image_data if image_data.mode in ("RGBA", "RGB") else image_data.convert("RGB"))
+        initial_pp = scripts_postprocessing.PostprocessedImage(image_data)
 
         scripts.scripts_postproc.run(initial_pp, args)
 


### PR DESCRIPTION
## Description
fix
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6534

when `enable_pnginfo` using extra "batch" the `existing_pnginfo` will also be restored
> note: issue is only in `Batch process` not single
> I believe gradio image component already does a conversion once as a result this issue does not occur when using `Single image`

when converting a none RGB mode image to `RGB` some `existing_pnginfo` keys will also have to be converted to make it work
this is the case with a `P` mode image with `Transparency` key

the issue is we currently extract the `existing_pnginfo` "before" we convert the image into `RGB` mode

as suche the `existing_pnginfo` we restore later will have the old unconverted `existing_pnginfo` from `P` mode

in the case of `P` -> to `RGB` if `Transparency : 0` key exist, it will have to be converted in to a 3 value tuple `(0, 0, 0)`
this is why some users are seeing error
```py
*** Arguments: ('task(io7z85oegmsjbmy)', 1.0, <PIL.Image.Image image mode=RGBA size=119x152 at 0x1EAA924E8F0>, [<tempfile._TemporaryFileWrapper object at 0x000001EAA924E350>], '', '', True, True, 0.0, 2, 0.0, 512, 512, True, 'R-ESRGAN 4x+ Anime6B', 'None', 0, False, 1, False, 1, 0, False, 0.5, 0.2, False, 0.9
, 0.15, 0.5, False, False, 384, 768, 4096, 409600, 'Maximize area', 0.1, False, ['Horizontal'], False, ['Deepbooru']) {}
    Traceback (most recent call last):
      File "B:\GitHub\stable-diffusion-webui\modules\call_queue.py", line 57, in f
        res = list(func(*args, **kwargs))
      File "B:\GitHub\stable-diffusion-webui\modules\call_queue.py", line 36, in f
        res = func(*args, **kwargs)
      File "B:\GitHub\stable-diffusion-webui\modules\postprocessing.py", line 131, in run_postprocessing_webui
        return run_postprocessing(*args, **kwargs)
      File "B:\GitHub\stable-diffusion-webui\modules\postprocessing.py", line 96, in run_postprocessing
        fullfn, _ = images.save_image(pp.image, path=outpath, basename=basename, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=forced_filename, suffix=suffix)
      File "B:\GitHub\stable-diffusion-webui\modules\images.py", line 728, in save_image
        _atomically_save_image(image, fullfn_without_extension, extension)
      File "B:\GitHub\stable-diffusion-webui\modules\images.py", line 712, in _atomically_save_image
        save_image_with_geninfo(image_to_save, info, temp_file_path, extension, existing_pnginfo=params.pnginfo, pnginfo_section_name=pnginfo_section_name)
      File "B:\GitHub\stable-diffusion-webui\modules\images.py", line 584, in save_image_with_geninfo
        image.save(filename, format=image_format, quality=opts.jpeg_quality, pnginfo=pnginfo_data)
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\PIL\Image.py", line 2432, in save
        save_handler(self, fp, filename)
      File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\PIL\PngImagePlugin.py", line 1364, in _save
        red, green, blue = transparency   #  <---- the unconverted transparency key from P mode is just 0, the not the expected (0, 0, 0)
    TypeError: cannot unpack non-iterable int object

```

---

the easiest solution I found is to convert the image to the to our desired mode before parseing the info with `read_info_from_image()`

I have tested with the 4 formats of images generated by webui (png jpg webp avif) the info (the parts we wish to preserve) read after conversion seems to be intact

---
test images
[test images.zip](https://github.com/AUTOMATIC1111/stable-diffusion-webui/files/15161990/test.images.zip)
test from #15421 #6534
2 p mode image with and without transparency key

before the PR the image with transparency key should faile to save using `extra batch`
should be fixed after the PR


---

note
I'm not an expert on image formats it's it is possible this modification can potentially messed up other things


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
