### PR TITLE
Add the "bundled" string as a shorthash for bundled textual inversions

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -229,6 +229,7 @@ def load_network(name, network_on_disk):
     for emb_name, data in bundle_embeddings.items():
         embedding = textual_inversion.create_embedding_from_data(data, emb_name, filename=network_on_disk.filename + "/" + emb_name)
         embedding.loaded = None
+        embedding.shorthash = 'bundled'
         embeddings[emb_name] = embedding
 
     net.bundle_embeddings = embeddings


### PR DESCRIPTION
## Description

This will thus show "bundled" in the info text for a textual inversion where the shorthash would normally be shown when a bundled TI is applied. This provides the user with feedback that a TI was used; otherwise there would be no such feedback.

I am unclear if setting such a shorthash will have other knock-on effects; all I did was run a generation to show that it showed up correctly, and the tests.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
