### PR TITLE
use gradio theme colors in css

### DIFF
--- a/style.css
+++ b/style.css
@@ -780,9 +780,9 @@ table.popup-table .link{
     position:absolute;
     display:block;
     padding:0px 0;
-    border:2px solid #a55000;
+    border:2px solid var(--primary-800);
     border-radius:8px;
-    box-shadow:1px 1px 2px #CE6400;
+    box-shadow:1px 1px 2px var(--primary-500);
     width: 200px;
 }
 
@@ -799,7 +799,7 @@ table.popup-table .link{
 }
 
 .context-menu-items a:hover{
-    background: #a55000;
+    background: var(--primary-700);
 }
 
 


### PR DESCRIPTION
## Description

I was overriding gradio primary color variables to make them non-orange, and found that sdwebui uses hardcoded orange color for right-click generation button menu


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
