### PR TITLE
more old sampler scheduler compatibility

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -842,6 +842,9 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
 
         sd_models.apply_token_merging(p.sd_model, p.get_token_merging_ratio())
 
+        # backwards compatibility, fix sampler and scheduler if invalid
+        sd_samplers.fix_p_invalid_sampler_and_scheduler(p)
+
         res = process_images_inner(p)
 
     finally:

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-
+import logging
 from modules import sd_samplers_kdiffusion, sd_samplers_timesteps, sd_samplers_lcm, shared, sd_samplers_common, sd_schedulers
 
 # imports for functions that previously were here and are used by other modules
@@ -120,6 +120,13 @@ def get_sampler_and_scheduler(sampler_name, scheduler_name):
         found_scheduler = sd_schedulers.schedulers[0]
 
     return sampler.name, found_scheduler.label
+
+
+def fix_p_invalid_sampler_and_scheduler(p):
+    i_sampler_name, i_scheduler = p.sampler_name, p.scheduler
+    p.sampler_name, p.scheduler = get_sampler_and_scheduler(p.sampler_name, p.scheduler)
+    if p.sampler_name != i_sampler_name or i_scheduler != p.scheduler:
+        logging.warning(f'Sampler Scheduler autocorrection: "{i_sampler_name}" -> "{p.sampler_name}", "{i_scheduler}" -> "{p.scheduler}"')
 
 
 set_samplers()


### PR DESCRIPTION
## Description
this is an addition (not alternative) to the fix missionfloyd made
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15656

- due to sampler and scheduler is split in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15333 

issues similar to the start appearing in extensions
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15677

basically similar issues would occur to all extensions that calls `StableDiffusionProcessing` on ther own
as there are written for older verison of webui that have that sampler and scheduler combined

this change should not have any effect on any currently working implementations
only fixes those that are inputting invalid sampler scheduler

note:
this fix can not be implemented inside Scripts.callbacks as not all extensions will call the scripts


- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
