### PR TITLE
fix: correct PYTHONPATH for extentions installation proccess

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -10,6 +10,7 @@ import importlib.metadata
 import platform
 import json
 from functools import lru_cache
+from pathlib import Path
 
 from modules import cmd_args, errors
 from modules.paths_internal import script_path, extensions_dir
@@ -236,8 +237,16 @@ def run_extension_installer(extension_dir):
         stdout = run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env).strip()
         if stdout:
             print(stdout)
-    except Exception as e:
-        errors.report(str(e))
+    except Exception:
+        print(f'Failed to install {extension_dir} extension. Try again with another PYTHONPATH env.')
+        try:
+            env['PYTHONPATH'] = f"{str(Path(__file__).parent.parent.absolute().resolve())}{os.pathsep}{env.get('PYTHONPATH', '')}"
+            stdout = run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env).strip()
+            print(f'Successfuly {path_installer} executed.')
+            if stdout:
+                print(stdout)
+        except Exception as e:
+            errors.report(str(e))
 
 
 def list_extensions(settings_file):


### PR DESCRIPTION
## Description

* Corrected the PYTHONPATH environment variable to ensure it contains the correct stable-diffusion-webui root directory path during the extension installation process.
* Added a nested try/except block within the `run_extension_installer` function. The try block attempts to add the correct stable-diffusion-webui root path to the `PYTHONPATH` environment variable. It does this by converting the relative path (from `modules/launch_utils.py` to the project root) to an absolute path. The Path from the pathlib library is imported for this purpose.
* Code style has been checked with `python -m ruff check`
* I solved the problem that described in #15697

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
