### PR TITLE
use script_path for webui root in launch_utils

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -76,7 +76,7 @@ def git_tag():
     except Exception:
         try:
 
-            changelog_md = os.path.join(os.path.dirname(os.path.dirname(__file__)), "CHANGELOG.md")
+            changelog_md = os.path.join(script_path, "CHANGELOG.md")
             with open(changelog_md, "r", encoding="utf-8") as file:
                 line = next((line.strip() for line in file if line.strip()), "<none>")
                 line = line.replace("## ", "")
@@ -231,7 +231,7 @@ def run_extension_installer(extension_dir):
 
     try:
         env = os.environ.copy()
-        env['PYTHONPATH'] = f"{os.path.abspath('.')}{os.pathsep}{env.get('PYTHONPATH', '')}"
+        env['PYTHONPATH'] = f"{script_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
 
         stdout = run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env).strip()
         if stdout:


### PR DESCRIPTION
## Description

webui modules like launch to be imported correctly in extensions install.py when user run webui from a different cwd then webui root
fix
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15697

more sensible implementation of what is trying to achieve
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15704

`script_path` is difined relative to modules/paths_internal.p so won't be affected by cwd like the current `os.path.abspath('.')`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/1c0a0c4c26f78c32095ebc7f8af82f5c04fca8c0/modules/paths_internal.py#L16-L17


additional
also change the path for `CHANGELOG.md`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
