### PR TITLE
Parse lora weights from civitai resources

### DIFF
--- a/extensions-builtin/Lora/network.py
+++ b/extensions-builtin/Lora/network.py
@@ -81,7 +81,7 @@ class NetworkOnDisk:
 
     def get_alias(self):
         import networks
-        if shared.opts.lora_preferred_name == "Filename" or self.alias.lower() in networks.forbidden_network_aliases:
+        if (hasattr(shared.opts, "lora_preferred_name") and shared.opts.lora_preferred_name == "Filename") or self.alias.lower() in networks.forbidden_network_aliases:
             return self.name
         else:
             return self.alias

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -572,6 +572,7 @@ def list_available_networks():
     available_network_aliases.clear()
     forbidden_network_aliases.clear()
     available_network_hash_lookup.clear()
+    network_version_id_to_alias.clear()
     forbidden_network_aliases.update({"none": 1, "Addams": 1})
 
     os.makedirs(shared.cmd_opts.lora_dir, exist_ok=True)
@@ -603,11 +604,11 @@ def list_available_networks():
             try:
                 with open(json_path, "r", encoding="utf-8") as f:
                     model_json = json.load(f)
+                if "modelVersionId" in model_json:
+                    model_ver_id = str(model_json["modelVersionId"])
+                    network_version_id_to_alias[model_ver_id] = entry.get_alias()
             except (OSError, json.JSONDecodeError):
                 errors.report(f"Failed to load network json: {json_path}", exc_info=False)
-        if "modelVersionId" in model_json:
-            model_ver_id = str(model_json["modelVersionId"])
-            network_version_id_to_alias[model_ver_id] = entry.get_alias()
 
 re_network_name = re.compile(r"(.*)\s*\([0-9a-fA-F]+\)")
 

--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -1,4 +1,5 @@
 import gradio as gr
+import json
 import logging
 import os
 import re
@@ -596,6 +597,17 @@ def list_available_networks():
         available_network_aliases[name] = entry
         available_network_aliases[entry.alias] = entry
 
+        # Try to get modelVersionId from model json
+        json_path = os.path.join(os.path.dirname(filename), name + ".json")
+        if os.path.exists(json_path):
+            try:
+                with open(json_path, "r", encoding="utf-8") as f:
+                    model_json = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                errors.report(f"Failed to load network json: {json_path}", exc_info=False)
+        if "modelVersionId" in model_json:
+            model_ver_id = str(model_json["modelVersionId"])
+            network_version_id_to_alias[model_ver_id] = entry.get_alias()
 
 re_network_name = re.compile(r"(.*)\s*\([0-9a-fA-F]+\)")
 
@@ -642,5 +654,6 @@ loaded_bundle_embeddings = {}
 networks_in_memory = {}
 available_network_hash_lookup = {}
 forbidden_network_aliases = {}
+network_version_id_to_alias = {}
 
 list_available_networks()

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -245,13 +245,13 @@ Civitai resources: [{"type":"checkpoint","modelVersionId":290640},{"type":"Image
     x = x[x.find("Civitai resources:") + 19:]
     if "[" not in x or "]" not in x:
         return ""
-    
+
     x = x[x.find("["):x.find("]") + 1]
     try:
         resources = json.loads(x)
     except json.JSONDecodeError:
         return ""
-    
+
     prompt_resources = []
     for resource in resources:
         if "type" not in resource or "weight" not in resource or "modelVersionId" not in resource:

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -254,9 +254,7 @@ Civitai resources: [{"type":"checkpoint","modelVersionId":290640},{"type":"Image
 
     prompt_resources = []
     for resource in resources:
-        if "type" not in resource or "weight" not in resource or "modelVersionId" not in resource:
-            continue
-        if "ImageJobNetworkParams" not in resource["type"]:
+        if "weight" not in resource or "modelVersionId" not in resource:
             continue
 
         weight = resource["weight"]


### PR DESCRIPTION
## Description

* Enables directly parsing the Lora weights from the "Civitai resources:" string that is included in an image's metadata when downloaded from Civitai. You can see this in action by clicking the blue arrow to "Read generation params" or when clicking "Send to txt2img" and such
* Adds logic in `extensions-builtin/Lora/networks.py` to check for a `.json` file with the same name as a model's file, and extracts the `modelVersionId` which is what Civitai uses to identify a specific model + version
* Adds a function to `modules/infotext_utils.py` to handle parsing the resources string
* I've opened a separate [PR](https://github.com/BlafKing/sd-civitai-browser-plus/pull/279) to the Civitai browser plus plugin to record the `modelVersionId` in the model json, but this works regardless assuming you have a json file with the `modelVersionId` as one of the fields

Example prompt:
```
score_9, score_8_up, score_7_up, car, tree, hill
Negative prompt: score_6, score_5, score_4, simple background, black and white, mono color
Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 13.5, Seed: 839351144, Size: 832x1216, Clip skip: 2, Civitai resources: [{"type":"checkpoint","modelVersionId":290640},{"type":"ImageJobNetworkParams { Strength = 0.4, TriggerWord = , Type = lora }","weight":0.4,"modelVersionId":426797},{"type":"ImageJobNetworkParams { Strength = 0.4, TriggerWord = , Type = lora }","weight":0.4,"modelVersionId":135867},{"type":"embed","weight":1,"modelVersionId":94057},{"type":"embed","modelVersionId":250708},{"type":"embed","modelVersionId":250712}]
```

Final prompt:
```
score_9, score_8_up, score_7_up, car, tree, hill <lora:43stl1ght1ngXLP2:0.4> <lora:add-detail-xl:0.4>
```

## Screenshots/videos:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/143359807/f8b88a21-90bb-48f2-b7ae-ac2b5e1e3c3a

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
