### PR TITLE
Upgrade PIP during virtual environment creation

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -44,6 +44,7 @@ goto :show_stdout_stderr
 :activate_venv
 set PYTHON="%VENV_DIR%\Scripts\Python.exe"
 echo venv %PYTHON%
+%PYTHON% -m pip install --upgrade pip
 
 :skip_venv
 if [%ACCELERATE%] == ["True"] goto :accelerate


### PR DESCRIPTION
The default version of PIP with Python 3.10 does not record installation metadata properly for requirements installed using an url, resulting in invalid lines when PIP FREEZE is called.  For example, the packages clip and cstr are problematic.  This makes it difficult to recreate a stable diffusion virtual environment.  Upgrading PIP during virtual environment creation remedies this problem.  I have found this is corrected in v24 of PIP.

## Description

* Upgrade PIP during virtual environment creation so that PIP FREEZE will report accurate information
* Added PIP --upgrade command in batch file
* To reproduce this issue, review installation of clip and cstr, which report incorrect information in PIP FREEZE 

## Screenshots/videos:

* Before fix:
clip==1.0
cstr==0.1.0
* After fix:
clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
cstr @ git+https://github.com/WASasquatch/cstr@0520c29a18a7a869a6e5983861d6f7a4c86f8e9b

## Checklist:

- [x ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x ] I have performed a self-review of my own code
- [x ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
