### PR TITLE
Fix AttributeError

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -789,7 +789,10 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
         if exif_comment:
             geninfo = exif_comment
     elif "comment" in items: # for gif
-        geninfo = items["comment"].decode('utf8', errors="ignore")
+        if isinstance(items["comment"], bytes):
+            geninfo = items["comment"].decode('utf8', errors="ignore")
+        else:
+            geninfo = items["comment"]
 
     for field in IGNORED_INFO_KEYS:
         items.pop(field, None)


### PR DESCRIPTION
##Description
Fixed an error (AttributeError: 'str' object has no attribute 'decode') coming from line 792 in images.py when trying to upscale certain images. I'm unsure why certain images didn't need to be decoded. 

I changed **geninfo = items["comment"].decode('utf8', errors="ignore")** on line 792 to
         
        if isinstance(items["comment"], bytes):
            geninfo = items["comment"].decode('utf8', errors="ignore")
        else:
            geninfo = items["comment"]

This resolved the above error. I reattempted upscaling the directory that originally gave me this error and all the images were successfully upscaled with no further issues. I might have found the reason for this error. I ran some of the images that were causing it through metadata2go.com and noticed they all shared a similar formatted comment:

        b'Paint Tool -SAI- JPEG Encoder v1.00\x00'
        b'File written by Adobe Photoshop\xa8 5.2\x00'

I believe that the original code assumed the metadata would always be in bytes of data, which is then decoded into a string. For whatever reason, some of the images had metadata that was already a string, hence the 'str' object has no attribute 'decode' error. I have no idea what leads to this behavior. I'm assuming it's simply a result of how the metadata is handled originally and what technique is used to encode it. I'm not sure how you can reproduce this on a whim since you won't know this is an issue until you try to upscale an image.

metadata for an image that didn't cause the error:
![no error metadata](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122459494/d7f592d8-4af2-45e0-96ce-bdeda9e86e77)

metadata for an image that caused the error:
![error metadata](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122459494/635d64c7-e88a-4082-b6b4-6cd0bbfc81cf)






## Screenshots/videos:
Upscale attempt with original code:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122459494/47650c75-8113-4cf2-be38-b2b172022d79)

Upscale attempt with new code:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/122459494/ac51f102-a314-4c0c-befe-254a60d2936c)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
