### PR TITLE
Added --models-dir option

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -20,6 +20,7 @@ parser.add_argument("--dump-sysinfo", action='store_true', help="launch.py argum
 parser.add_argument("--loglevel", type=str, help="log level; one of: CRITICAL, ERROR, WARNING, INFO, DEBUG", default=None)
 parser.add_argument("--do-not-download-clip", action='store_true', help="do not download CLIP model even if it's not included in the checkpoint")
 parser.add_argument("--data-dir", type=normalized_filepath, default=os.path.dirname(os.path.dirname(os.path.realpath(__file__))), help="base path where all user data is stored")
+parser.add_argument("--models-dir", type=normalized_filepath, default=None, help="base path where models are stored; overrides --data-dir")
 parser.add_argument("--config", type=normalized_filepath, default=sd_default_config, help="path to config which constructs model",)
 parser.add_argument("--ckpt", type=normalized_filepath, default=sd_model_file, help="path to checkpoint of stable diffusion model; if specified, this checkpoint will be added to the list of checkpoints and loaded",)
 parser.add_argument("--ckpt-dir", type=normalized_filepath, default=None, help="Path to directory with stable diffusion checkpoints")

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -24,11 +24,13 @@ default_sd_model_file = sd_model_file
 # Parse the --data-dir flag first so we can use it as a base for our other argument default values
 parser_pre = argparse.ArgumentParser(add_help=False)
 parser_pre.add_argument("--data-dir", type=str, default=os.path.dirname(modules_path), help="base path where all user data is stored", )
+parser_pre.add_argument("--models-dir", type=str, default=None, help="base path where models are stored; overrides --data-dir", )
 cmd_opts_pre = parser_pre.parse_known_args()[0]
 
 data_path = cmd_opts_pre.data_dir
+models_override = cmd_opts_pre.models_dir
 
-models_path = os.path.join(data_path, "models")
+models_path = models_override if models_override else os.path.join(data_path, "models")
 extensions_dir = os.path.join(data_path, "extensions")
 extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
 config_states_dir = os.path.join(script_path, "config_states")


### PR DESCRIPTION
## Problem Statement

The --data-dir option sets the extensions and model folders for automatic1111.  This can be problematic if a user wishes to have a common models folder, but continue to maintain extensions in the application folder.  An option has been added that allows the models folder to be set independently while preserving the current functionality of --data-dir for backwards compatibility.

Users who maintain multiple installations or are regularly trying new extensions will find this feature useful.

## Summary

The --model-dir option overrides the location of the models directory for stable diffusion, so that models can be shared across multiple installations.  When --data-dir is specified alone, both the extensions and models folders are present in this folder.  --models-dir can be used independently, but when used with --data-dir, models are found in --models-dir, and extensions are under --data-dir.

## Description

* Add a command line option for setting the models folder independently from the extensions folder
* --models-dir was added as a command line option to **modules/cmd_args.py**
* all other changes in **modules/paths_internal.py**:
* no changes to functionality when --models-dir is not used
* when used alone, --models-dir specifies where to look for models folders
* when used with --data-dir, extensions are found in data-dir, but models are found in models-dir

## Screenshots/videos:

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

Tested with all permutations:
* no options specified
* --data-dir alone
* --models-dir alone
* --data-dir and --models-dir together
