### PR TITLE
When creating a virtual environment, upgrade pip in webui.bat/webui.sh

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -37,9 +37,14 @@ if %ERRORLEVEL% == 0 goto :activate_venv
 for /f "delims=" %%i in ('CALL %PYTHON% -c "import sys; print(sys.executable)"') do set PYTHON_FULLNAME="%%i"
 echo Creating venv in directory %VENV_DIR% using python %PYTHON_FULLNAME%
 %PYTHON_FULLNAME% -m venv "%VENV_DIR%" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :activate_venv
+if %ERRORLEVEL% == 0 goto :upgrade_pip
 echo Unable to create venv in directory "%VENV_DIR%"
 goto :show_stdout_stderr
+
+:upgrade_pip
+"%VENV_DIR%\Scripts\Python.exe" -m pip install --upgrade pip
+if %ERRORLEVEL% == 0 goto :activate_venv
+echo Warning: Failed to upgrade PIP version
 
 :activate_venv
 set PYTHON="%VENV_DIR%\Scripts\Python.exe"

--- a/webui.sh
+++ b/webui.sh
@@ -210,6 +210,7 @@ then
     if [[ ! -d "${venv_dir}" ]]
     then
         "${python_cmd}" -m venv "${venv_dir}"
+        "${venv_dir}"/bin/python -m pip install --upgrade pip
         first_launch=1
     fi
     # shellcheck source=/dev/null


### PR DESCRIPTION
The default version of PIP with Python 3.10 does not record installation metadata properly for requirements installed using an url (egg-style), resulting in invalid lines when PIP FREEZE is called. For example, the packages clip and cstr are problematic. This makes it difficult to recreate a stable diffusion virtual environment. Upgrading PIP during virtual environment creation remedies this problem. I have found this is corrected in v24 of PIP.

Pip will be upgraded upon immediately creating the virtual environment.  If the pip upgrade fails, this should not cause the script to fail (treat as a warning).  Once the environment is created, it will not attempt further updates to pip on subsequent executions.

## Description

* Upgrade PIP during virtual environment creation so that PIP FREEZE will report accurate information
* Added PIP --upgrade command to **webui.bat** and **webui.sh**
* To reproduce this issue, review installation of clip and cstr, which report incorrect information in PIP FREEZE
* Continues execution when pip upgrade fails (treated as a warning)
* Pip is not upgraded when the virtual environment is already present
* Should only ever upgrade the virtual environment (not the system environment)

## Screenshots/videos:

* Before fix:
clip==1.0
cstr==0.1.0
* After fix:
clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
cstr @ git+https://github.com/WASasquatch/cstr@0520c29a18a7a869a6e5983861d6f7a4c86f8e9b

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

*Note: tested on Windows and Darwin Linux (Mac)*
