### PR TITLE
use relative path for webui-assets css

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /* temporary fix to load default gradio font in frontend instead of backend */
 
-@import url('/webui-assets/css/sourcesanspro.css');
+@import url('webui-assets/css/sourcesanspro.css');
 
 
 /* temporary fix to hide gradio crop tool until it's fixed https://github.com/gradio-app/gradio/issues/3810 */


### PR DESCRIPTION
## Description

- fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15747
> font loading when --subpath option is used, and only traffic to subpath reaches webui instance, because it made path to CSS file absolute.

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
