### PR TITLE
Fix embedding model load error

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -61,7 +61,7 @@ class Embedding:
             "sd_checkpoint_name": self.sd_checkpoint_name,
         }
 
-        torch.save(embedding_data, filename)
+        torch.save(embedding_data, filename, _use_new_zipfile_serialization=False)
 
         if shared.opts.save_optimizer_state and self.optimizer_state_dict is not None:
             optimizer_saved_dict = {

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -68,7 +68,7 @@ class Embedding:
                 'hash': self.checksum(),
                 'optimizer_state_dict': self.optimizer_state_dict,
             }
-            torch.save(optimizer_saved_dict, f"{filename}.optim")
+            torch.save(optimizer_saved_dict, f"{filename}.optim", _use_new_zipfile_serialization=False)
 
     def checksum(self):
         if self.cached_checksum is not None:


### PR DESCRIPTION
repair a compatibility error , this error cause some embedding model could save but can`t be load correctly

## Description

* summary：fix a error witch could cause some embedding model can`t load (Especially use version after 1.8 to save&load)
* code change：in `modules/textual_inversion/textual_inversion.py` set `torch.save(model, device)`  param  `_use_new_zipfile_serialization=False` , after `pytorch=1.6`, this param is `True` as defult

*  [[Bug]: [1.9.0] Create Embedding FAILS](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15505)
* [[Bug]: Creating new embedding.pt fails pickle check](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15214)

## Screenshots/videos:
see commits and issues

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
