### PR TITLE
fix extention update when not on main branch

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -191,8 +191,9 @@ class Extension:
 
     def check_updates(self):
         repo = Repo(self.path)
+        branch_name = f'{repo.remote().name}/{self.branch}'
         for fetch in repo.remote().fetch(dry_run=True):
-            if self.branch and fetch.name != f'{repo.remote().name}/{self.branch}':
+            if self.branch and fetch.name != branch_name:
                 continue
             if fetch.flags != fetch.HEAD_UPTODATE:
                 self.can_update = True
@@ -200,7 +201,7 @@ class Extension:
                 return
 
         try:
-            origin = repo.rev_parse('origin')
+            origin = repo.rev_parse(branch_name)
             if repo.head.commit != origin:
                 self.can_update = True
                 self.status = "behind HEAD"
@@ -213,8 +214,10 @@ class Extension:
         self.can_update = False
         self.status = "latest"
 
-    def fetch_and_reset_hard(self, commit='origin'):
+    def fetch_and_reset_hard(self, commit=None):
         repo = Repo(self.path)
+        if commit is None:
+            commit = f'{repo.remote().name}/{self.branch}'
         # Fix: `error: Your local changes to the following files would be overwritten by merge`,
         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
         repo.git.fetch(all=True)


### PR DESCRIPTION
## Description

### issue

> I consider this issue to be quite severe, even though it doesn't currently impact normal users only advanced users and developers

currently if a user is using a branch of extension that is not the main branch
there will be an issue when they try to update the extension

in the `check_updates code()`
it checks for `origin = repo.rev_parse('origin')` whitch is the commit hash of the main branch and not the hash of the branch where the user is on

and later on when confirming the update `fetch_and_reset_hard()` will reset the extention repo to the commit of the main branch and Not the branch the usere is on

for normal users who never switches branches this is fine they should never encounter this issue

but for advanced users who knows how to use git that are deliberately on a different branch this would cause their extension to be hard reste the the master branch

or in development phase, where devs are working on a separate branch the could have there code accidentally hard reset (data loss) to 

in the future is possible some extensions might decide to maintain different version compatibility in different branches


if user is using a branch of extension that is not the main branch
the user will be reseted to the main branch

this will also prevent extensions from maintaining compatibility for different versions on different branches
as it will be reset the the main branch

### fix solution

`repo.rev_parse(f'{repo.remote().name}/{self.branch}')` when checking for update
and `repo.git.reset(f'{repo.remote().name}/{self.branch}', hard=True)` when applying the update


---

I have done my test and seems to work correctly
but if someone should probably verify again that I haven't screwed up

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
