### PR TITLE
scroll extensions table on overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -807,6 +807,8 @@ table.popup-table .link{
 
 #tab_extensions table{
     border-collapse: collapse;
+    overflow-x: auto;
+    display: block;
 }
 
 #tab_extensions table td, #tab_extensions table th{


### PR DESCRIPTION
## Description

Fixes look on tablets in vertical orientation, smartphones and just vertical monitors. It's scrollable

## Screenshots/videos:
Before:
![Screenshot 2024-05-18 at 09-08-35 Stable Diffusion](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/eba31ab4-1967-48d0-9d21-16c57c335303)

After:
![Screenshot 2024-05-18 at 09-10-48 Stable Diffusion](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/33491867/ef612678-8998-4e66-9ce0-5b11a561dca8)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
