### PR TITLE
[Performance] Run live preview inference on a cudastream

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -72,10 +72,6 @@ def decode_first_stage(model, x):
     return samples_to_images_tensor(x, approx_index, model)
 
 
-def sample_to_image(samples, index=0, approximation=None):
-    return single_sample_to_image(samples[index], approximation)
-
-
 if torch.cuda.is_available():
     lp_stream = torch.cuda.Stream()
     live_preview_stream_context = torch.cuda.stream(lp_stream)
@@ -83,9 +79,17 @@ else:
     lp_stream = None
     live_preview_stream_context = nullcontext()
 
+def sample_to_image(samples, index=0, approximation=None):
+    with live_preview_stream_context:
+        sample = single_sample_to_image(samples[index], approximation, non_blocking=lp_stream is not None)
+    if lp_stream is not None:
+        lp_stream.synchronize()
+    return Image.fromarray(sample.numpy())
+
+
 def samples_to_image_grid(samples, approximation=None):
     with live_preview_stream_context:
-        sample_tensors = [single_sample_to_image(sample, approximation, non_blocking=True) for sample in samples]
+        sample_tensors = [single_sample_to_image(sample, approximation, non_blocking=lp_stream is not None) for sample in samples]
     if lp_stream is not None:
         lp_stream.synchronize()
     return images.image_grid([Image.fromarray(sample.numpy()) for sample in sample_tensors])

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -1,6 +1,5 @@
 import inspect
 from collections import namedtuple
-import numpy as np
 import torch
 from PIL import Image
 from modules import devices, images, sd_vae_approx, sd_samplers, sd_vae_taesd, shared, sd_models

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import namedtuple
+from contextlib import nullcontext
 import torch
 from PIL import Image
 from modules import devices, images, sd_vae_approx, sd_samplers, sd_vae_taesd, shared, sd_models


### PR DESCRIPTION
## Description

I have vastly improved the performance of live preview by making two changes:
* running the decode on its own CUDA stream which lets operations parallelize
* making the required DtoH transfer non-blocking

As a result, live preview (at least with TAESD) is **basically free now**.  On a 150 step, 512x512, batch 4 inference, it takes 25.1s to complete in total without live preview, and 25.7s to complete with live preview happening as often as it can (100ms delay, every step.  In practice it doesn't actually preview that fast, but I find it hard to imagine that this isn't fast enough for almost anyone.)

In its current state, ~~I am about as certain as I can be that this will cause problems for anyone who isn't using an NVIDIA card!~~ it shouldn't run at all on CPU, but I know torch with AMD backends still calls things "cuda" so I would love feedback on how well it works on different hardware, to see if attempting to use CUDA streams on AMD makes your card explode or something, so that something can be done about that.

## Screenshots/videos:

Delicious compute overlap:
![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/1313496/a0b750da-a2d9-41f3-9af5-71245e0f922d)
Stream 7 is the main/default cudastream, stream 13 is the live preview cudastream.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
