### PR TITLE
Use different torch versions for Intel and ARM Macs

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -11,7 +11,12 @@ fi
 
 export install_dir="$HOME"
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half-vae --use-cpu interrogate"
-export TORCH_COMMAND="pip install torch==2.1.0 torchvision==0.16.0"
 export PYTORCH_ENABLE_MPS_FALLBACK=1
+
+if [[ "$(sysctl -n machdep.cpu.brand_string)" =~ ^.*"Intel".*$ ]]; then
+    export TORCH_COMMAND="pip install torch==2.1.2 torchvision==0.16.2"
+else
+    export TORCH_COMMAND="pip install torch==2.3.0 torchvision==0.18.0"
+fi
 
 ####################################################################


### PR DESCRIPTION
## Description

PyTorch [2.3.0](https://github.com/pytorch/pytorch/releases/tag/v2.3.0) fixes some critical issues on MacOS (see details for MPS), including [this one](https://github.com/pytorch/pytorch/issues/122016) which is most problematic, since it [breaks all ancestral samplers](https://github.com/comfyanonymous/ComfyUI/issues/2992#issuecomment-2043306392) on MacOS 14.4+ (on both A1111 and Comfy).

Unfortunately, PyTorch dropped support for Intel Macs. The last version with x64 binaries is 2.2.0, but that version does not work properly on MacOS 14.4+. The last version of [PyTorch that works on Intel Macs with MacOS 14.4+](https://github.com/comfyanonymous/ComfyUI/issues/2992#issuecomment-2021435493) is 2.1.2.

I have added CPU check and different TORCH_COMMANDs for Intel and ARM.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

