### PR TITLE
ReloadUI backgroundColor --background-fill-primary

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -337,8 +337,8 @@ onOptionsChanged(function() {
 let txt2img_textarea, img2img_textarea = undefined;
 
 function restart_reload() {
+    document.body.style.backgroundColor = "var(--background-fill-primary)";
     document.body.innerHTML = '<h1 style="font-family:monospace;margin-top:20%;color:lightgray;text-align:center;">Reloading...</h1>';
-
     var requestPing = function() {
         requestGet("./internal/ping", {}, function(data) {
             location.reload();


### PR DESCRIPTION
## Description

during `ReloadUI` the webpage will true white regardless of dark or light mode
it's blindly annoying
this PR sets the backgroud color of the HTML `body` to the color defined by the theme `--background-fill-primary`

the `body` background color will be automatically removed by gradio once the page reloads
so no impact to anything else

note this solution is not a perfect soultion as during reload the page might still flash white for a brief period
but it is still better than constantly white during reload

## Screenshots/videos:

![2024-05-22 22_18_41_280 chrome](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/9e5276d8-0f43-48dd-b5e9-83fdcf6ac349)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
