### PR TITLE
Fix method 1 : pin Setuptools==69.5.1

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,3 +1,4 @@
+setuptools==69.5.1  # temp fix for compatibility with some old packages
 GitPython==3.1.32
 Pillow==9.5.0
 accelerate==0.21.0


### PR DESCRIPTION
- alternative to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15883
## Description
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15879
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15878
- `sd.webui.zip` https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15902

```py
ImportError: cannot import name 'packaging' from 'pkg_resources' (venv\lib\site-packages\pkg_resources\__init__.py)
```

the pkg_resources package was deprecated
https://github.com/pypa/setuptools/blob/5cbf12a9b63fd37985a4525617b46576b8ac3a7b/pkg_resources/__init__.py#L16-L17
and in `setuptools=70.0.0` there was a [change](https://github.com/pypa/setuptools/commit/e9995828311c5e0c843622ca2be85e7f09f1ff0d) that breaks packeages that imports uses `pkg_resources.packaging`

a quick fix FOR NOW would be to pin `Setuptools==69.5.1`

the real fix would be to update all dependencies to not use the deprecated pkg_resources

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
