### PR TITLE
Fix method 2 : patch__pkg_resources__packaging

### DIFF
--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -8,7 +8,24 @@ from threading import Thread
 from modules.timer import startup_timer
 
 
+def patch__pkg_resources__packaging():
+    """temp patch for setuptools >= 70.0.0"""
+    try:
+        import pkg_resources
+        try:
+            import pkg_resources.packaging
+        except ImportError:
+            try:
+                pkg_resources.packaging = importlib.import_module("pkg_resources.extern.packaging")
+            except ImportError:
+                print("Failed to import pkg_resources.packaging")
+    except ImportError:
+        pass
+
+
 def imports():
+    patch__pkg_resources__packaging()
+
     logging.getLogger("torch.distributed.nn").setLevel(logging.ERROR)  # sshh...
     logging.getLogger("xformers").addFilter(lambda record: 'A matching Triton is not available' not in record.getMessage())
 


### PR DESCRIPTION
- alternative to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15882

## Description
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15879
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15878
- `sd.webui.zip` https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15902

```py
ImportError: cannot import name 'packaging' from 'pkg_resources' (venv\lib\site-packages\pkg_resources\__init__.py)
```

the pkg_resources package was deprecated
https://github.com/pypa/setuptools/blob/5cbf12a9b63fd37985a4525617b46576b8ac3a7b/pkg_resources/__init__.py#L16-L17
and in `setuptools=70.0.0` there was a [change](https://github.com/pypa/setuptools/commit/e9995828311c5e0c843622ca2be85e7f09f1ff0d) that breaks packeages that imports uses `pkg_resources.packaging`

a fix for now can be done by patching `pkg_resources.extern.packaging` into `pkg_resources.packaging`

the real fix would be to update all dependencies to not use the deprecated pkg_resources

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
