### PR TITLE
Fix bug where file extension had an extra '.' under some circumstances

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -653,7 +653,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     # WebP and JPG formats have maximum dimension limits of 16383 and 65535 respectively. switch to PNG which has a much higher limit
     if (image.height > 65535 or image.width > 65535) and extension.lower() in ("jpg", "jpeg") or (image.height > 16383 or image.width > 16383) and extension.lower() == "webp":
         print('Image dimensions too large; saving as PNG')
-        extension = ".png"
+        extension = "png"
 
     if save_to_dirs is None:
         save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)


### PR DESCRIPTION
Fix bug where under some circumstances an extra `.` was inserted between the file base name and the file extension.

The bug is triggered when the `extension` argument is one of `"jpg"`, `"jpeg"`, or `"webp"`, and the image exceeds the format in question's width or height limit. Then the `extension` variable is set to `".png"`, resulting in the `fullfn` variable to evaluate to a string ending with `..png`.