### PR TITLE
javascript: add `onUiLoadedReady` when the UI is loaded and opts is ready.

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ function get_uiCurrentTabContent() {
 var uiUpdateCallbacks = [];
 var uiAfterUpdateCallbacks = [];
 var uiLoadedCallbacks = [];
+var uiLoadedReadyCallbacks = [];
 var uiTabChangeCallbacks = [];
 var optionsChangedCallbacks = [];
 var uiAfterUpdateTimeout = null;
@@ -58,6 +59,14 @@ function onAfterUiUpdate(callback) {
  */
 function onUiLoaded(callback) {
     uiLoadedCallbacks.push(callback);
+}
+
+/**
+ * Register callback to be called when the UI is loaded and opts is ready.
+ * The callback receives no arguments.
+ */
+function onUiLoadedReady(callback) {
+    uiLoadedReadyCallbacks.push(callback);
 }
 
 /**
@@ -104,7 +113,8 @@ var executedOnLoaded = false;
 
 document.addEventListener("DOMContentLoaded", function() {
     var mutationObserver = new MutationObserver(function(m) {
-        if (!executedOnLoaded && gradioApp().querySelector('#txt2img_prompt')) {
+        const firstOnLoaded = !executedOnLoaded && gradioApp().querySelector('#txt2img_prompt')
+        if (firstOnLoaded) {
             executedOnLoaded = true;
             executeCallbacks(uiLoadedCallbacks);
         }
@@ -115,6 +125,10 @@ document.addEventListener("DOMContentLoaded", function() {
         if (newTab && (newTab !== uiCurrentTab)) {
             uiCurrentTab = newTab;
             executeCallbacks(uiTabChangeCallbacks);
+        }
+
+        if (firstOnLoaded) {
+            executeCallbacks(uiLoadedReadyCallbacks);
         }
     });
     mutationObserver.observe(gradioApp(), {childList: true, subtree: true});

--- a/script.js
+++ b/script.js
@@ -113,7 +113,7 @@ var executedOnLoaded = false;
 
 document.addEventListener("DOMContentLoaded", function() {
     var mutationObserver = new MutationObserver(function(m) {
-        const firstOnLoaded = !executedOnLoaded && gradioApp().querySelector('#txt2img_prompt')
+        const firstOnLoaded = !executedOnLoaded && gradioApp().querySelector('#txt2img_prompt');
         if (firstOnLoaded) {
             executedOnLoaded = true;
             executeCallbacks(uiLoadedCallbacks);


### PR DESCRIPTION


## Description

```ts
/**
 * Register callback to be called when the UI is loaded and opts is ready.
 * The callback receives no arguments.
 */
function onUiLoadedReady(callback) {
    uiLoadedReadyCallbacks.push(callback);
}
```

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
