### PR TITLE
replace wsl-open with wslpath and explorer.exe

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -208,6 +208,6 @@ Requested path was: {path}
     elif platform.system() == "Darwin":
         subprocess.Popen(["open", path])
     elif "microsoft-standard-WSL2" in platform.uname().release:
-        subprocess.Popen(["wsl-open", path])
+        subprocess.Popen(["explorer.exe", subprocess.check_output(["wslpath", "-w", path])])
     else:
         subprocess.Popen(["xdg-open", path])


### PR DESCRIPTION
## Description

according to
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15926

using `wsl-open` directory don't work anymore

in the post he suggest using `wslview` from `wslu` but that requires installing an extra piece of software on system

I looked around and apparently one use can `wslpath` to convert a `wsl path` to `windows path` then call `explorer.exe` in wsl

```py
        subprocess.Popen(["explorer.exe", subprocess.check_output(["wslpath", "-w", path])])
```
> it is possible to make this into one subprocess call using bash but I didn't because I don't want to deal with escaping and quoting characters 

I have tested using a standalone script inside my WSL that this seems to work properly
I have not tested in full and across different flavors of wsl

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
