### PR TITLE
Allow escaping commas in XYZ grid

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -209,7 +209,10 @@ def list_to_csv_string(data_list):
 
 
 def csv_string_to_list_strip(data_str):
-    return list(map(str.strip, chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True))))
+    placeholder = "<<<COMMA>>>"
+    data_str = data_str.replace(r"\,", placeholder) # Replace escaped commas with the placeholder
+    values = chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True)))
+    return list(map(lambda s: s.replace(placeholder, ",").strip(), values))
 
 
 class AxisOption:

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -211,7 +211,7 @@ def list_to_csv_string(data_list):
 def csv_string_to_list_strip(data_str):
     placeholder = "<<<COMMA>>>"
     data_str = data_str.replace(r"\,", placeholder) # Replace escaped commas with the placeholder
-    values = chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True)))
+    values = chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True))
     return list(map(lambda s: s.replace(placeholder, ",").strip(), values))
 
 


### PR DESCRIPTION
## Description

Improves the XYZ parser to allow escaping commas.
In other words, `red dress, white shirt\, blue shorts` becomes `red dress` and `white shirt, blue shorts`.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
