### PR TITLE
multi size grid

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -54,11 +54,14 @@ def image_grid(imgs, batch_size=1, rows=None):
     params = script_callbacks.ImageGridLoopParams(imgs, cols, rows)
     script_callbacks.image_grid_callback(params)
 
-    w, h = imgs[0].size
-    grid = Image.new('RGB', size=(params.cols * w, params.rows * h), color='black')
+    w, h = map(max, zip(*(img.size for img in imgs)))
+    grid_background_color = ImageColor.getcolor(opts.grid_background_color, 'RGB')
+    grid = Image.new('RGB', size=(params.cols * w, params.rows * h), color=grid_background_color)
 
     for i, img in enumerate(params.imgs):
-        grid.paste(img, box=(i % params.cols * w, i // params.cols * h))
+        img_w, img_h = img.size
+        w_offset, h_offset = 0 if img_w == w else (w - img_w) // 2, 0 if img_h == h else (h - img_h) // 2
+        grid.paste(img, box=(i % params.cols * w + w_offset, i // params.cols * h + h_offset))
 
     return grid
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -375,16 +375,18 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
         end_index = start_index + len(xs) * len(ys)
         grid = images.image_grid(processed_result.images[start_index:end_index], rows=len(ys))
         if draw_legend:
-            grid = images.draw_grid_annotations(grid, processed_result.images[start_index].size[0], processed_result.images[start_index].size[1], hor_texts, ver_texts, margin_size)
+            grid_max_w, grid_max_h = map(max, zip(*(img.size for img in processed_result.images[start_index:end_index])))
+            grid = images.draw_grid_annotations(grid, grid_max_w, grid_max_h, hor_texts, ver_texts, margin_size)
         processed_result.images.insert(i, grid)
         processed_result.all_prompts.insert(i, processed_result.all_prompts[start_index])
         processed_result.all_seeds.insert(i, processed_result.all_seeds[start_index])
         processed_result.infotexts.insert(i, processed_result.infotexts[start_index])
 
-    sub_grid_size = processed_result.images[0].size
+    # sub_grid_size = processed_result.images[0].size
     z_grid = images.image_grid(processed_result.images[:z_count], rows=1)
+    z_sub_grid_max_w, z_sub_grid_max_h = map(max, zip(*(img.size for img in processed_result.images[:z_count])))
     if draw_legend:
-        z_grid = images.draw_grid_annotations(z_grid, sub_grid_size[0], sub_grid_size[1], title_texts, [[images.GridAnnotation()]])
+        z_grid = images.draw_grid_annotations(z_grid, z_sub_grid_max_w, z_sub_grid_max_h, title_texts, [[images.GridAnnotation()]])
     processed_result.images.insert(0, z_grid)
     # TODO: Deeper aspects of the program rely on grid info being misaligned between metadata arrays, which is not ideal.
     # processed_result.all_prompts.insert(0, processed_result.all_prompts[0])


### PR DESCRIPTION
## Description
fix issue with stiching grid with different size images
currently the base grid size of the stitched grid is based on the first image in the input images
if any dimension of a subsequent images are greater than the first image  this will result in subsequent images being cut off

- as shown in issue post https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15977

this can happen when using xyz grid with axis `Size`

- improved the grid stitching amd annotation of XYZ grid so that it will handle multiple images size
- the largest dimension of all the input images will be used as the base grid size
- if the sub image size is different from the base grid size, the then it will be offset to the center of the base grid
- backgroud of the grid respect the setting `shared.opts.grid_background_color`

> with more work it should be possible to remove the gaps between images but this will require more work on The annotation function so that it accepts a list of dimension for it to space out the labels correctly 
note: note that removing the gaps would also cause the grid to be misaligned, which some people may find annoying

some people might prefer the image to not be centered, but I do not implement this as an option
this could be done by just not calculating the offset
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15988/files#diff-7035c0b11c034183a4d5570fccaf498d0e1ceea6f1a70efffab2bf963703739aR62-R63

## Screenshots/videos:

Current (Issue)
![20240610-194523-723792 1 9588](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d627ef3e-3399-4559-a930-9040ffa42fad)
> the bottom of the right grid is cutoff

PR

![20240610-204611-448485 1 1fd1](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/5a8ce0a5-3b7d-4741-a0dd-55eb2ae14361)
![20240610-204541-857462 1 ce88](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/d29d7692-e1a9-45a7-83b7-b87309ed3289)
![20240610-204516-930990 1 dfd9](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/fd52b726-3534-469c-a480-adcd583aee07)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
