### PR TITLE
chore: tweak scrollbar color with the dark theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,6 +19,19 @@ div.gradio-image button[aria-label="Edit"] {
 
 }
 
+
+html:has(body.dark) {
+    /**
+     * The CSS variables --body-background-fill and --body-text-color are not apply to the HTML element with the dark theme
+     */
+    /* scrollbar-color: var(--body-text-color) var(--body-background-fill) */
+    scrollbar-color: #f3f4f6 #0b0f19;
+}
+
+body {
+    background: var(--body-background-fill, #0b0f19);
+}
+
 .block.padded:not(.gradio-accordion) {
     padding: 0 !important;
 }


### PR DESCRIPTION
## Description

tweak scrollbar color with the dark theme

## Screenshots/videos:

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/167966/e289ba1e-053b-49bd-865f-8ebc94bbc6a8)


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
