### PR TITLE
feat: Prevent screen sleep during generation

### DIFF
--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -76,6 +76,28 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     var dateStart = new Date();
     var wasEverActive = false;
     var parentProgressbar = progressbarContainer.parentNode;
+    var wakeLock = null;
+
+    var requestWakeLock = async function() {
+        if (!opts.prevent_screen_sleep_during_generation) return;
+        try {
+            wakeLock = await navigator.wakeLock.request('screen');
+            console.log('Wake Lock is active.');
+        } catch (err) {
+            console.log('Wake Lock is not supported.');
+        }
+    };
+
+    var releaseWakeLock = async function() {
+        if (!opts.prevent_screen_sleep_during_generation || !wakeLock) return;
+        try {
+            await wakeLock.release();
+            console.log('Wake Lock is released.');
+            wakeLock = null;
+        } catch (err) {
+            console.error('Wake Lock release failed', err);
+        }
+    };
 
     var divProgress = document.createElement('div');
     divProgress.className = 'progressDiv';
@@ -89,6 +111,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     var livePreview = null;
 
     var removeProgressBar = function() {
+        releaseWakeLock();
         if (!divProgress) return;
 
         setTitle("");
@@ -100,6 +123,8 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     };
 
     var funProgress = function(id_task) {
+        // Request the wake lock at the start of the progress
+        requestWakeLock();
         request("./internal/progress", {id_task: id_task, live_preview: false}, function(res) {
             if (res.completed) {
                 removeProgressBar();

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -82,9 +82,8 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
         if (!opts.prevent_screen_sleep_during_generation || wakeLock) return;
         try {
             wakeLock = await navigator.wakeLock.request('screen');
-            console.log('Wake Lock is active.');
         } catch (err) {
-            console.log('Wake Lock is not supported.');
+            console.error('Wake Lock is not supported.');
         }
     };
 
@@ -92,7 +91,6 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
         if (!opts.prevent_screen_sleep_during_generation || !wakeLock) return;
         try {
             await wakeLock.release();
-            console.log('Wake Lock is released.');
             wakeLock = null;
         } catch (err) {
             console.error('Wake Lock release failed', err);
@@ -123,7 +121,6 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     };
 
     var funProgress = function(id_task) {
-        // Request the wake lock at the start of the progress
         requestWakeLock();
         request("./internal/progress", {id_task: id_task, live_preview: false}, function(res) {
             if (res.completed) {

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -79,7 +79,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     var wakeLock = null;
 
     var requestWakeLock = async function() {
-        if (!opts.prevent_screen_sleep_during_generation) return;
+        if (!opts.prevent_screen_sleep_during_generation || wakeLock) return;
         try {
             wakeLock = await navigator.wakeLock.request('screen');
             console.log('Wake Lock is active.');

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -359,6 +359,7 @@ options_templates.update(options_section(('ui', "Live previews", "ui"), {
     "live_preview_refresh_period": OptionInfo(1000, "Progressbar and preview update period").info("in milliseconds"),
     "live_preview_fast_interrupt": OptionInfo(False, "Return image with chosen live preview method on interrupt").info("makes interrupts faster"),
     "js_live_preview_in_modal_lightbox": OptionInfo(False, "Show Live preview in full page image viewer"),
+    "prevent_screen_sleep_during_generation": OptionInfo(True, "Prevent screen sleep during generation"),
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters", "sd"), {


### PR DESCRIPTION
## Description

- Add a new option `opts.prevent_screen_sleep_during_generation`
- Added a new feature to request a wake lock to prevent the screen from going to sleep during ongoing image generation progress.

## Screenshots/videos:

- Started a long job and walked away.
- Came back to the screen still on, showing a job that could take more than 2 hours.
<img width="641" alt="Screenshot 2024-06-11 at 17 40 34" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/10471270/44b74911-2ccb-4b31-a494-4d423669f033">
- Setting page
<img width="591" alt="Screenshot 2024-06-11 at 17 43 30" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/10471270/984a1512-9e72-431b-9bc8-b6b8c0c8ae8d">

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
  - Unable to verify tests fully. My MacBook Pro M3pro on master without any changes does not pass all tests.
  - Changes in this PR are UI only. No changes to Python or other server-side code. It is unlikely that these changes will affect existing functionality.
