### PR TITLE
fix lora settings: item filename keyerror

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -18,6 +18,8 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
     def create_item(self, name, index=None, enable_filter=True):
         lora_on_disk = networks.available_networks.get(name)
         if lora_on_disk is None:
+            lora_on_disk = networks.available_network_aliases.get(name)
+        if lora_on_disk is None:
             return
 
         path, ext = os.path.splitext(lora_on_disk.filename)


### PR DESCRIPTION
## Description

Sometimes opening settings doesn't work due to this error:
```
stable-diffusion-webui/modules/ui_extra_networks_user_metadata.py", line 77, in get_card_html
    filename, _ = os.path.splitext(item["filename"])
KeyError: filename
```

It happens because lora's name is alias

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
