### PR TITLE
Fix AttributeError: 'ImageDraw' object has no attribute 'multiline_te…

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -168,9 +168,12 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
         for line in lines:
             fnt = initial_fnt
             fontsize = initial_fontsize
-            while drawing.multiline_textsize(line.text, font=fnt)[0] > line.allowed_width and fontsize > 0:
+            text_width, text_height = drawing.multiline_textbbox((0, 0), line.text, font=fnt)[2:]
+            while text_width > line.allowed_width and fontsize > 0:
                 fontsize -= 1
-                fnt = get_font(fontsize)
+                fnt = get_font(fontsize) 
+                text_width, text_height = drawing.multiline_textbbox((0, 0), line.text, font=fnt)[2:]
+
             drawing.multiline_text((draw_x, draw_y + line.size[1] / 2), line.text, font=fnt, fill=color_active if line.is_active else color_inactive, anchor="mm", align="center")
 
             if not line.is_active:


### PR DESCRIPTION
…xtsize' for Pillow >=10 when making grids.

Fixes AttributeError: 'ImageDraw' object has no attribute 'multiline_textsize' when using Pillow >10 trying to do X/Y/Z grids. This specially happens if using Python 3.12, where Pillow 10.1.0 is the least compatible version.

It changes multiline_textsize to multiline_textbbox, returning a tuple (left, top, right, bottom). text_width can be calculated as right - left and text_height as bottom - top.
Also adjust get_font to make it return a valid font object from a given font size.

Draft for now, since stable is using Python 3.10. It can be applied either if updating the Pillow library version in the requirements or if using Python 3.12.


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
