### PR TITLE
Fix sampler scheduler autocorrection warning

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -98,7 +98,7 @@ def get_hr_scheduler_from_infotext(d: dict):
 
 
 @functools.cache
-def get_sampler_and_scheduler(sampler_name, scheduler_name):
+def get_sampler_and_scheduler(sampler_name, scheduler_name, *, convert_automatic=True):
     default_sampler = samplers[0]
     found_scheduler = sd_schedulers.schedulers_map.get(scheduler_name, sd_schedulers.schedulers[0])
 
@@ -116,7 +116,7 @@ def get_sampler_and_scheduler(sampler_name, scheduler_name):
     sampler = all_samplers_map.get(name, default_sampler)
 
     # revert back to Automatic if it's the default scheduler for the selected sampler
-    if sampler.options.get('scheduler', None) == found_scheduler.name:
+    if convert_automatic and sampler.options.get('scheduler', None) == found_scheduler.name:
         found_scheduler = sd_schedulers.schedulers[0]
 
     return sampler.name, found_scheduler.label
@@ -124,7 +124,7 @@ def get_sampler_and_scheduler(sampler_name, scheduler_name):
 
 def fix_p_invalid_sampler_and_scheduler(p):
     i_sampler_name, i_scheduler = p.sampler_name, p.scheduler
-    p.sampler_name, p.scheduler = get_sampler_and_scheduler(p.sampler_name, p.scheduler)
+    p.sampler_name, p.scheduler = get_sampler_and_scheduler(p.sampler_name, p.scheduler, convert_automatic=False)
     if p.sampler_name != i_sampler_name or i_scheduler != p.scheduler:
         logging.warning(f'Sampler Scheduler autocorrection: "{i_sampler_name}" -> "{p.sampler_name}", "{i_scheduler}" -> "{p.scheduler}"')
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -382,7 +382,6 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
         processed_result.all_seeds.insert(i, processed_result.all_seeds[start_index])
         processed_result.infotexts.insert(i, processed_result.infotexts[start_index])
 
-    # sub_grid_size = processed_result.images[0].size
     z_grid = images.image_grid(processed_result.images[:z_count], rows=1)
     z_sub_grid_max_w, z_sub_grid_max_h = map(max, zip(*(img.size for img in processed_result.images[:z_count])))
     if draw_legend:


### PR DESCRIPTION
## Description

fix unnecessary sampler scheduler autocorrection warning
- caused by https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15681

from Discussions post
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/16053

user has reported erroneous scheduler autocorrection warning

essentially under certain circumstances such as
sampler `DPM++ 2M` + schedule `Karras` they will see the sampler scheduler autocorrection warning

this is because of default schedule for `DPM++ 2M` is `Karras`, and so the retruned schedule of `get_sampler_and_scheduler()` will be `Automatic` `Karras`
this triggers a false warning because `Automatic` != `Karras`

functionality wise It's harmless but it does confuse people

fix:
add new a arg `convert_automatic: bool`to  `get_sampler_and_scheduler()` that disables `revert back to Automatic if it's the default scheduler for the selected sampler` behavior

---

additional unrelated change that I decide to throw in
- in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15988 I forgot to remove one line of comment

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
