### PR TITLE
Fix implementation of float64 in torch_utils

### DIFF
--- a/modules/torch_utils.py
+++ b/modules/torch_utils.py
@@ -21,6 +21,6 @@ def get_param(model) -> torch.nn.Parameter:
 def float64(t: torch.Tensor):
     """return torch.float64 if device is not mps or xpu, else return torch.float32"""
     match t.device.type:
-        case 'mps', 'xpu':
+        case ('mps' | 'xpu'):
             return torch.float32
     return torch.float64

--- a/modules/torch_utils.py
+++ b/modules/torch_utils.py
@@ -21,6 +21,6 @@ def get_param(model) -> torch.nn.Parameter:
 def float64(t: torch.Tensor):
     """return torch.float64 if device is not mps or xpu, else return torch.float32"""
     match t.device.type:
-        case ('mps' | 'xpu'):
+        case 'mps' | 'xpu':
             return torch.float32
     return torch.float64


### PR DESCRIPTION
## Description

Implementation of float64 in torch_utils added in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15815 does not work as intended.

I was getting errors while testing PLMS, DDIM, DDIM CFG++ on my M3 Pro Mac.

`TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.`

This is fixed implementation of float64, which now works as it was intended.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
