### PR TITLE
ToggleLivePriview button in image viewer

### DIFF
--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -6,6 +6,8 @@ function closeModal() {
 function showModal(event) {
     const source = event.target || event.srcElement;
     const modalImage = gradioApp().getElementById("modalImage");
+    const modalToggleLivePreviewBtn = gradioApp().getElementById("modal_toggle_live_preview");
+    modalToggleLivePreviewBtn.innerHTML = opts.js_live_preview_in_modal_lightbox ? "&#x1F5C7;" : "&#x1F5C6;";
     const lb = gradioApp().getElementById("lightboxModal");
     modalImage.src = source.src;
     if (modalImage.style.display === 'none') {
@@ -152,6 +154,13 @@ function modalZoomToggle(event) {
     event.stopPropagation();
 }
 
+function modalLivePreviewToggle(event) {
+    const modalToggleLivePreview = gradioApp().getElementById("modal_toggle_live_preview");
+    opts.js_live_preview_in_modal_lightbox = !opts.js_live_preview_in_modal_lightbox;
+    modalToggleLivePreview.innerHTML = opts.js_live_preview_in_modal_lightbox ? "&#x1F5C7;" : "&#x1F5C6;";
+    event.stopPropagation();
+}
+
 function modalTileImageToggle(event) {
     const modalImage = gradioApp().getElementById("modalImage");
     const modal = gradioApp().getElementById("lightboxModal");
@@ -208,6 +217,14 @@ document.addEventListener("DOMContentLoaded", function() {
     modalSave.addEventListener("click", modalSaveImage, true);
     modalSave.title = "Save Image(s)";
     modalControls.appendChild(modalSave);
+
+    const modalToggleLivePreview = document.createElement('span');
+    modalToggleLivePreview.className = 'modalToggleLivePreview cursor';
+    modalToggleLivePreview.id = "modal_toggle_live_preview";
+    modalToggleLivePreview.innerHTML = "&#x1F5C6;";
+    modalToggleLivePreview.onclick = modalLivePreviewToggle;
+    modalToggleLivePreview.title = "Toggle live preview";
+    modalControls.appendChild(modalToggleLivePreview);
 
     const modalClose = document.createElement('span');
     modalClose.className = 'modalClose cursor';


### PR DESCRIPTION
## Description

Add a button to toggle setting `Show Live preview in full page image viewer` in side image viewer

the value is setting is used as default
the toggle button javascript dose not write / updates the settings

I am not too happy with the choice of icon and it's positioning
if anyone has better suggestions

## Screenshots/videos:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/assets/40751091/5d2ae30a-4d66-4bca-83c4-a45cb8eba3d5

---

some related ideas

- Generate button inside image viewer
- Hires fix upscall button inside image viewer (when on txt2img tab)
- Hires fix upscall hotkey (when on txt2img tab)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
