### PR TITLE
Fix SD2 loading

### DIFF
--- a/modules/sd_hijack_unet.py
+++ b/modules/sd_hijack_unet.py
@@ -138,11 +138,15 @@ CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.decode_first_stage', first_s
 CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.encode_first_stage', first_stage_sub, first_stage_cond)
 CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.get_first_stage_encoding', lambda orig_func, *args, **kwargs: orig_func(*args, **kwargs).float(), first_stage_cond)
 
+# Always make sure inputs to unet are in correct dtype
 CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.apply_model', apply_model)
 CondFunc('sgm.modules.diffusionmodules.wrappers.OpenAIWrapper.forward', apply_model)
 
 
 def timestep_embedding_cast_result(orig_func, timesteps, *args, **kwargs):
+    if not devices.unet_needs_upcast:
+        return orig_func(timesteps, *args, **kwargs)
+
     if devices.unet_needs_upcast and timesteps.dtype == torch.int64:
         dtype = torch.float32
     else:


### PR DESCRIPTION
## Description

Closes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16031

The bug was originally introduced in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15820

The original PR trys to map
```python
CondFunc('sgm.modules.diffusionmodules.openaimodel.timestep_embedding', lambda orig_func, timesteps, *args, **kwargs: orig_func(timesteps, *args, **kwargs).to(torch.float32 if timesteps.dtype == torch.int64 else devices.dtype_unet), unet_needs_upcast)
```
to
```python
def timestep_embedding_cast_result(orig_func, timesteps, *args, **kwargs):
    if devices.unet_needs_upcast and timesteps.dtype == torch.int64:
        dtype = torch.float32
    else:
        dtype = devices.dtype_unet
    return orig_func(timesteps, *args, **kwargs).to(dtype=dtype)
CondFunc('sgm.modules.diffusionmodules.openaimodel.timestep_embedding', timestep_embedding_cast_result)
```

However, if `unet_needs_upcast` is `False`, we should directly call the original function by the original impl. This PR patches this logic mismatch. 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
