### PR TITLE
fix sd2 switching

### DIFF
--- a/modules/sd_models_config.py
+++ b/modules/sd_models_config.py
@@ -31,7 +31,7 @@ def is_using_v_parameterization_for_sd2(state_dict):
 
     import ldm.modules.diffusionmodules.openaimodel
 
-    device = devices.cpu
+    device = devices.device
 
     with sd_disable_initialization.DisableInitialization():
         unet = ldm.modules.diffusionmodules.openaimodel.UNetModel(


### PR DESCRIPTION
Closes: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13763
I start webui with not sd 2.1 model, then I try to load sd 2.1 checkpoint, and I get "NotImplementedError"
If I've started webui with sd2 model in `--ckpt` flag, it works, even if I switch to other and back to sd2

This bug appeared in October, now I think it's connected with `device = devices.cpu` in `is_using_v_parameterization_for_sd2` inside this commit https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/d04e3e921e8ee71442a1f4a1d6e91c05b8238007#diff-b710a9b8e9fbcc5bc5a014f938c9c74564c1dcfc86929f0dc9ff643ba3fe7873R30


> NotImplementedError: No operator found for `memory_efficient_attention_forward` with inputs:
>      query       : shape=(1, 64, 5, 64) (torch.float32)
>      key         : shape=(1, 64, 5, 64) (torch.float32)
>      value       : shape=(1, 64, 5, 64) (torch.float32)
>      attn_bias   : <class 'NoneType'>
>      p           : 0.0
>
> `decoderF` is not supported because:
>     *device=cpu (supported: {'cuda'})*
>     attn_bias type is <class 'NoneType'>
>
> `flshattF@v2.3.6` is not supported because:
>     *device=cpu (supported: {'cuda'})*
>     dtype=torch.float32 (supported: {torch.float16, torch.bfloat16})
>
> `tritonflashattF` is not supported because:
>     *device=cpu (supported: {'cuda'})*
>     dtype=torch.float32 (supported: {torch.float16, torch.bfloat16})
>     operator wasn't built - see `python -m xformers.info` for more info
>     triton is not available
>     Only work on pre-MLIR triton for now
>
> `cutlassF` is not supported because:
>     *device=cpu (supported: {'cuda'})*
>
> `smallkF` is not supported because:
>     max(query.shape[-1] != value.shape[-1]) > 32
>     *device=cpu (supported: {'cuda'})*
>     unsupported embed per head: 64

After this patch the bug is gone for me

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
