### PR TITLE
stoping generation extras

### DIFF
--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -51,7 +51,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         shared.state.textinfo = name
         shared.state.skipped = False
 
-        if shared.state.interrupted:
+        if shared.state.interrupted or shared.state.stopping_generation:
             break
 
         if isinstance(image_placeholder, str):


### PR DESCRIPTION
## Description

If the option is enabled, extras batch generation now is stopped only of 1 times interruption button was clicked. I've fixed this. The behavior is still different between 1 and 2 clicks because interrupting of nn upscaled consider only 2nd click


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
