### PR TITLE
Prioritize python3.10 over python3 if both are available on Linux and Mac (with fallback)

### DIFF
--- a/webui-macos-env.sh
+++ b/webui-macos-env.sh
@@ -4,11 +4,6 @@
 # Please modify webui-user.sh to change these instead of this file #
 ####################################################################
 
-if [[ -x "$(command -v python3.10)" ]]
-then
-    python_cmd="python3.10"
-fi
-
 export install_dir="$HOME"
 export COMMANDLINE_ARGS="--skip-torch-cuda-test --upcast-sampling --no-half-vae --use-cpu interrogate"
 export PYTORCH_ENABLE_MPS_FALLBACK=1

--- a/webui.sh
+++ b/webui.sh
@@ -44,7 +44,11 @@ fi
 # python3 executable
 if [[ -z "${python_cmd}" ]]
 then
-    python_cmd="python3"
+  python_cmd="python3.10"
+fi
+if [[ ! -x "$(command -v "${python_cmd}")" ]]
+then
+  python_cmd="python3"
 fi
 
 # git executable


### PR DESCRIPTION
## Description

- prioritizes python3.10 over python3 if both are available
- ensure that a specified Python version is available; otherwise, fallback to python3
- removes redundant code from mac specific version
- tested on Mac and Ubuntu
- solves the problems noticed in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15799

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
