### PR TITLE
Ensure use of python from venv on Mac and Linux

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -217,6 +217,8 @@ then
     if [[ -f "${venv_dir}"/bin/activate ]]
     then
         source "${venv_dir}"/bin/activate
+        # ensure use of python from venv
+        python_cmd="${venv_dir}"/bin/python
     else
         printf "\n%s\n" "${delimiter}"
         printf "\e[1m\e[31mERROR: Cannot activate python venv, aborting...\e[0m"


### PR DESCRIPTION
## Description

If the user sets the full path to the Python executable in webui-user.sh, venv will be created as usual. Everything will work and look normal, but all packages will be actually installed globally.

It fixes https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16113

The reason for this behavior is that in this line

```
"${python_cmd}" -u "${LAUNCH_SCRIPT}" "$@"
```

python_cmd contains the full path and will be executed as

```
/opt/homebrew/bin/python3.10 -u launch. py
```

instead of 

```
python3.10 -u launch. py
```

This change ensures that the python executable from venv will be used, even if the user sets the full path. This change only affects users who use venv; it does not change anything if venv is not used.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
