### PR TITLE
fix Replace preview

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -26,6 +26,14 @@ function selected_gallery_index() {
     return all_gallery_buttons().findIndex(elem => elem.classList.contains('selected'));
 }
 
+function gallery_container_buttons(gallery_container) {
+    return gradioApp().querySelectorAll(`#${gallery_container} .thumbnail-item.thumbnail-small`);
+}
+
+function selected_gallery_index_id(gallery_container) {
+    return Array.from(gallery_container_buttons(gallery_container)).findIndex(elem => elem.classList.contains('selected'));
+}
+
 function extract_image_from_gallery(gallery) {
     if (gallery.length == 0) {
         return [null];

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -194,7 +194,7 @@ class UserMetadataEditor:
     def setup_ui(self, gallery):
         self.button_replace_preview.click(
             fn=self.save_preview,
-            _js="function(x, y, z){return [selected_gallery_index(), y, z]}",
+            _js=f"function(x, y, z){{return [selected_gallery_index_id('{self.tabname + '_gallery_container'}'), y, z]}}",
             inputs=[self.edit_name_input, gallery, self.edit_name_input],
             outputs=[self.html_preview, self.html_status]
         ).then(


### PR DESCRIPTION
## Description

- fix bug https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16115

- the cause is https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11808 when the `extra networks` are moved to tabs

1. when an extra networks tab is selected, the generation tabs is deselected
2. when a tab is deselected the tab and child elements on the tab such as gallery is not longer displayed
3. when something is not displayed the [`.offsetParent` property is `null`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent)

in `all_gallery_buttons()` we use the when not displayed offsetParent is `null` behavior to select only the gallery that is currently being displayed
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/a30b19dd5536f463222e484aef2daf466b49ee85/javascript/ui.js#L14

but this no longer works after #11808 as the tab gallery will always be `not displayed` when we switched to the extra networks tab to replace the preview

---

fix solution
Implement a different galleries selector base on element ID to directly to select the specific gallery 

---

I create a new function because I don't want to touch the existing `selected_gallery_index()` in case it breaks something else

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
