### PR TITLE
Return HTTP 400 instead of 404 on invalid sampler error

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -43,7 +43,7 @@ def script_name_to_index(name, scripts):
 def validate_sampler_name(name):
     config = sd_samplers.all_samplers_map.get(name, None)
     if config is None:
-        raise HTTPException(status_code=404, detail="Sampler not found")
+        raise HTTPException(status_code=400, detail="Sampler not found")
 
     return name
 


### PR DESCRIPTION
## Description

Due to a confusion I experienced while using it for my own project, I think it would be more accurate to give a 400 error instead of 404 on API design. Because this error is mostly related to the validation of the payload of the request. The endpoint which request made is actually exists. Please take a look at [HTTP 404](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) and [HTTP 400](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) error descriptions.

## Screenshots/videos:
No screenshots required.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
