### PR TITLE
Bump spandrel to 0.3.4

### DIFF
--- a/modules/gfpgan_model.py
+++ b/modules/gfpgan_model.py
@@ -36,13 +36,11 @@ class FaceRestorerGFPGAN(face_restoration_utils.CommonFaceRestoration):
             ext_filter=['.pth'],
         ):
             if 'GFPGAN' in os.path.basename(model_path):
-                model = modelloader.load_spandrel_model(
+                return modelloader.load_spandrel_model(
                     model_path,
                     device=self.get_device(),
                     expected_architecture='GFPGAN',
                 ).model
-                model.different_w = True  # see https://github.com/chaiNNer-org/spandrel/pull/81
-                return model
         raise ValueError("No GFPGAN model found")
 
     def restore(self, np_image):

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -23,7 +23,8 @@ pytorch_lightning==1.9.4
 resize-right==0.0.2
 safetensors==0.4.2
 scikit-image==0.21.0
-spandrel==0.1.6
+spandrel==0.3.4
+spandrel-extra-arches==0.1.1
 tomesd==0.1.3
 torch
 torchdiffeq==0.2.3


### PR DESCRIPTION
## Description

Upgrades Spandrel from 0.1.6 to 0.3.4 ([bunch of changes](https://github.com/chaiNNer-org/spandrel/compare/v0.1.6...v0.3.4)).

Spandrel's license changed to MIT, so non-permissively-licensed extra architectures (of which we use CodeFormer) are shipped in `spandrel-extra-arches`.

Seems to work on my Mac, at least.

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
