### PR TITLE
Fix noisy DS_Store files for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.ckpt
 *.safetensors
 *.pth
+.DS_Store
 /ESRGAN/*
 /SwinIR/*
 /repositories


### PR DESCRIPTION
## Description

When using this repository locally on MacOS, the OS litters the repository with `.DS_Store` files, which contain nothing other than custom folder settings, such as view options.

This means that any MacOS user contributing to the repository will need to manually remove these files or at least ensure they don't become part of a commit.

I've added `.DS_Store` to the `.gitignore` file, which will resolve this.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
