### PR TITLE
quote launch args in console log

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -461,7 +461,8 @@ def configure_for_tests():
 
 
 def start():
-    print(f"Launching {'API server' if '--nowebui' in sys.argv else 'Web UI'} with arguments: {' '.join(sys.argv[1:])}")
+    argsStr = ' '.join(f"'{x}'" if ' ' in x else x for x in sys.argv[1:])
+    print(f"Launching {'API server' if '--nowebui' in sys.argv else 'Web UI'} with arguments: {argsStr}")
     import webui
     if '--nowebui' in sys.argv:
         webui.api_only()


### PR DESCRIPTION
## Description

e.g. from extension's arg


before:
```
Launching Web UI with arguments: --topaz-photo-ai-exe ../Topaz Photo AI 3.0.4/Topaz Photo AI/tpai.sh
```
after:
```
Launching Web UI with arguments: --topaz-photo-ai-exe '../Topaz Photo AI 3.0.4/Topaz Photo AI/tpai.sh' 
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
