### PR TITLE
Py 3.9 compatibility

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import gradio as gr
 import logging
 import os

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -118,11 +118,10 @@ def apply_size(p, x: str, xs) -> None:
 
 
 def find_vae(name: str):
-    match name := name.lower().strip():
-        case 'auto', 'automatic':
-            return 'Automatic'
-        case 'none':
-            return 'None'
+    if name := name.strip().lower() in ('auto', 'automatic'):
+        return 'Automatic'
+    elif name == 'none':
+        return 'None'
     return next((k for k in modules.sd_vae.vae_dict if k.lower() == name), print(f'No VAE found for {name}; using Automatic') or 'Automatic')
 
 


### PR DESCRIPTION
## Description
since we are trying to keey compatibility with python 3.9 some changes need to be made

match case syntax in `xyz.find_vae()`
- same as https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16088

`from __future__ import annotations` for `extensions-builtin/Lora/networks.py`
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/c3d8b78b47dddb03bb4558d62c6eaffc167cc51b/extensions-builtin/Lora/networks.py#L596

---

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16168

this person was using python 3.9

---

push to RC

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
