### PR TITLE
do not send image size on paste inpaint

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -146,18 +146,19 @@ def connect_paste_params_buttons():
         destination_height_component = next(iter([field for field, name in fields if name == "Size-2"] if fields else []), None)
 
         if binding.source_image_component and destination_image_component:
+            need_send_dementions = destination_width_component and binding.tabname != 'inpaint'
             if isinstance(binding.source_image_component, gr.Gallery):
-                func = send_image_and_dimensions if destination_width_component else image_from_url_text
+                func = send_image_and_dimensions if need_send_dementions else image_from_url_text
                 jsfunc = "extract_image_from_gallery"
             else:
-                func = send_image_and_dimensions if destination_width_component else lambda x: x
+                func = send_image_and_dimensions if need_send_dementions else lambda x: x
                 jsfunc = None
 
             binding.paste_button.click(
                 fn=func,
                 _js=jsfunc,
                 inputs=[binding.source_image_component],
-                outputs=[destination_image_component, destination_width_component, destination_height_component] if destination_width_component else [destination_image_component],
+                outputs=[destination_image_component, destination_width_component, destination_height_component] if need_send_dementions else [destination_image_component],
                 show_progress=False,
             )
 


### PR DESCRIPTION
## Description

This PR fixes a very annoying behavior: inpating in image something in "only masked" mode. Press "🎨️" to "commit" the changes. And this button overrides size option. This is wrong

I've just excluded "inpaint" tab from pasting w and h. But there are others solutions:
1. Check "Inpaint area" == "Only masked" in source and ignore only for this case
2. Prioritize "Size" in metadata over image's size. I.e. if it has "Size" in metadata, paste it
3. Remove special handling of image's size at all, and handle it like other metadata. I don't know why you've added this behavior at all, because width and height are the same options like others

I would prefer the last

P.s. `shared.opts.send_size` has nothing with this case I think, because the behavior for "only masked" inpaint is wrong in any ways


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
