### PR TITLE
fix OSError: cannot write mode P as JPEG

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -113,7 +113,7 @@ def encode_pil_to_base64(image):
             image.save(output_bytes, format="PNG", pnginfo=(metadata if use_metadata else None), quality=opts.jpeg_quality)
 
         elif opts.samples_format.lower() in ("jpg", "jpeg", "webp"):
-            if image.mode == "RGBA":
+            if image.mode in ("RGBA", "P"):
                 image = image.convert("RGB")
             parameters = image.info.get('parameters', None)
             exif_bytes = piexif.dump({

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -162,7 +162,7 @@ class State:
             errors.record_exception()
 
     def assign_current_image(self, image):
-        if shared.opts.live_previews_image_format == 'jpeg' and image.mode == 'RGBA':
+        if shared.opts.live_previews_image_format == 'jpeg' and image.mode in ('RGBA', 'P'):
             image = image.convert('RGB')
         self.current_image = image
         self.id_live_preview += 1


### PR DESCRIPTION
## Description

I don't know is it possible to face with this bug in vanilla webui. I've faced when my extension used `encode_pil_to_base64` with 'P' image I'd uploaded, and save format was 'jpeg'. The same can happen with `assign_current_image`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
