### PR TITLE
fix checkpoint limit checking

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -800,7 +800,7 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
             already_loaded = loaded_model
             continue
 
-        if len(model_data.loaded_sd_models) > shared.opts.sd_checkpoints_limit > 0:
+        if len(model_data.loaded_sd_models) + 1 > shared.opts.sd_checkpoints_limit > 0:
             print(f"Unloading model {len(model_data.loaded_sd_models)} over the limit of {shared.opts.sd_checkpoints_limit}: {loaded_model.sd_checkpoint_info.title}")
             del model_data.loaded_sd_models[i]
             send_model_to_trash(loaded_model)


### PR DESCRIPTION
## Description

- Fix issue where loaded checkpoint model could exceed the limit that has been set in the setting "Maximum number of checkpoints loaded at the same time" which could make system crash because out of memory (RAM).  
- Adjust the model limit checking logic to count the new model too.
- Will fix this issue: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9323
- Tested working on stable-diffusion-webui version [1.10.0-RC](https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/tag/v1.10.0-RC). Reference: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/9323#issuecomment-2227539601

## Screenshots/videos:

![image](https://github.com/user-attachments/assets/eebc605d-cf73-4983-b3e3-b72fa544912f)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
