### PR TITLE
activate venv .bat

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -48,6 +48,7 @@ echo Warning: Failed to upgrade PIP version
 
 :activate_venv
 set PYTHON="%VENV_DIR%\Scripts\Python.exe"
+call "%VENV_DIR%\Scripts\activate.bat"
 echo venv %PYTHON%
 
 :skip_venv


### PR DESCRIPTION
## Description
activate the venv when running webui-user.bat

some stuff don't work if it's not activated
like [ninja](https://pypi.org/project/ninja/) when installed through pip

not sure if there is a reason we didn't activate it before

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
