### PR TITLE
fix upscale logic

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -56,8 +56,8 @@ class Upscaler:
         dest_w = int((img.width * scale) // 8 * 8)
         dest_h = int((img.height * scale) // 8 * 8)
 
-        for _ in range(3):
-            if img.width >= dest_w and img.height >= dest_h and scale != 1:
+        for i in range(3):
+            if img.width >= dest_w and img.height >= dest_h and (i > 0 or scale != 1):
                 break
 
             if shared.state.interrupted:


### PR DESCRIPTION
## Description

- issue reported by https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16234
> note the "infinite loop" description is incorrect

when using a `Non-1x upscaller` but if the `Scale` is set to `1x`, there will be no check for the current image size, and will casue the upscale to loop until the max range 3 is reached

desired behavior
|  | 1x model | 4x modle |
|--------|--------|--------|
| 1x scale| run 1 time | run 1 time |
| 4x scale | run 1 time | run 1 time | 
| 8x scale | run 1 time | run 2 time | 

current behavior
|  | 1x model | 4x modle |
|--------|--------|--------|
| 1x scale| run 1 time | run till max loop |
| 4x scale | run 1 time | run 1 time | 
| 8x scale | run 1 time | run 2 time | 

this PR fix the `4x model + 1x scale` -> `run till max loop` issue

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
