### PR TITLE
Fix inpaint only masked pixels are shifted

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -1,3 +1,4 @@
+import math
 from PIL import Image, ImageFilter, ImageOps
 
 
@@ -73,6 +74,43 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
             x1 -= x1
         if x2 >= image_width:
             x2 = image_width
+
+    return x1, y1, x2, y2
+
+
+def fix_crop_region_integer_scale(crop_region, processing_width, processing_height, image_width, image_height):
+    """expands crop region get_crop_region() to avoid non-integer scaling artifacts (different pixels size) after applying overlay"""
+
+    x1, y1, x2, y2 = crop_region
+
+    ratio_w = (x2 - x1) / processing_width
+    ratio_h = (y2 - y1) / processing_height
+
+    desired_w = math.ceil(ratio_w) * processing_width
+    diff_w = desired_w - (x2 - x1)
+    diff_w_l = diff_w // 2
+    diff_w_r = diff_w - diff_w_l
+    x1 -= diff_w_l
+    x2 += diff_w_r
+    if x1 < 0:
+        x2 -= x1
+        x1 -= x1
+    if x2 >= image_width:
+        x2 = image_width
+
+    desired_h = math.ceil(ratio_h) * processing_height
+    diff_h = desired_h - (y2 - y1)
+    diff_h_u = diff_h // 2
+    diff_h_d = diff_h - diff_h_u
+    y1 -= diff_h_u
+    y2 += diff_h_d
+    if y1 < 0:
+        y2 -= y1
+        y1 -= y1
+    if y2 >= image_height:
+        y2 = image_height
+
+    print(f"padding was increased by {max(diff_w_l, diff_w_r, diff_h_u, diff_h_d)} after integer upscale correction")
 
     return x1, y1, x2, y2
 

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -1,4 +1,3 @@
-import math
 from PIL import Image, ImageFilter, ImageOps
 
 
@@ -74,43 +73,6 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
             x1 -= x1
         if x2 >= image_width:
             x2 = image_width
-
-    return x1, y1, x2, y2
-
-
-def fix_crop_region_integer_scale(crop_region, processing_width, processing_height, image_width, image_height):
-    """expands crop region get_crop_region() to avoid non-integer scaling artifacts (different pixels size) after applying overlay"""
-
-    x1, y1, x2, y2 = crop_region
-
-    ratio_w = (x2 - x1) / processing_width
-    ratio_h = (y2 - y1) / processing_height
-
-    desired_w = math.ceil(ratio_w) * processing_width
-    diff_w = desired_w - (x2 - x1)
-    diff_w_l = diff_w // 2
-    diff_w_r = diff_w - diff_w_l
-    x1 -= diff_w_l
-    x2 += diff_w_r
-    if x1 < 0:
-        x2 -= x1
-        x1 -= x1
-    if x2 >= image_width:
-        x2 = image_width
-
-    desired_h = math.ceil(ratio_h) * processing_height
-    diff_h = desired_h - (y2 - y1)
-    diff_h_u = diff_h // 2
-    diff_h_d = diff_h - diff_h_u
-    y1 -= diff_h_u
-    y2 += diff_h_d
-    if y1 < 0:
-        y2 -= y1
-        y1 -= y1
-    if y2 >= image_height:
-        y2 = image_height
-
-    print(f"padding was increased by {max(diff_w_l, diff_w_r, diff_h_u, diff_h_d)} after integer upscale correction")
 
     return x1, y1, x2, y2
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -65,8 +65,12 @@ def apply_color_correction(correction, original_image):
 def uncrop(image, dest_size, paste_loc):
     x, y, w, h = paste_loc
     base_image = Image.new('RGBA', dest_size)
+    factor_x = w // image.size[0]
+    factor_y = h // image.size[1]
     image = images.resize_image(1, image, w, h)
-    base_image.paste(image, (x, y))
+    paste_x = max(x - factor_x, 0)
+    paste_y = max(y - factor_y, 0)
+    base_image.paste(image, (paste_x, paste_y))
     image = base_image
 
     return image
@@ -1639,6 +1643,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
                 if crop_region:
                     crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    if shared.opts.integer_only_masked:
+                        crop_region = masking.fix_crop_region_integer_scale(crop_region, self.width, self.height, mask.width, mask.height)
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -226,6 +226,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "integer_only_masked": OptionInfo(False, "Integer upscale in inpaint only masked").info("Correct inpaint padding for only masked to have integer upscaling after fitting cropped region in original image"),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -226,7 +226,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
-    "integer_only_masked": OptionInfo(False, "Integer upscale in inpaint only masked").info("Correct inpaint padding for only masked to have integer upscaling after fitting cropped region in original image"),
+    "img2img_inpaint_correct_paste_xy_side_length_threshold": OptionInfo(400, "If a side of generation resolution is bigger then the threshold, paste_xy will be corrected in only masked mode to fix shifting. The bigger resolution means less details are lost in downscaling step", gr.Slider, {"minimum": 0, "maximum": 1000, "step": 1}),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {


### PR DESCRIPTION
## Description

Fixes bug: pasted image is shifted right and down on factor number of pixels after it was upscaled by this factor

This bug wasn't seen very often because rounded scale factor was almost always 1, and mask blur by default hides this artifact

Also this PR adds option to correct padding to have integer upscale on applying overlay

## Screenshots/videos:
Original:
![original](https://github.com/user-attachments/assets/8d11f6d6-bc15-464b-94a0-9b14910e6d53)

Options: padding=28, mask_blur=0, resolution=451x451, bad quality because I've used LCM, do not care about it

Old behavior:
![old](https://github.com/user-attachments/assets/bcf8253a-0240-475c-92c6-a8e7f5376350)

Integer option on, but bug exists:
![integer_and_NO_fix](https://github.com/user-attachments/assets/b010f3bc-54e1-461c-9ac5-dce461eb0285)
Here scale factor become 2, and it started look like a disaster. And this can happen and happens in current behavior anciently, if scale factor > 1 and upscale non integer 

Integer option on and fixed bug:
![integer_and_fix](https://github.com/user-attachments/assets/8f27302d-2e8c-4e48-bb27-dc143b0f40d9)

Because this integer upscale correction can increase padding on 50-150 pixels, I've made it optional. If option is off, result is still better then the old behavior, but upscale is not integer (worse fit, better resolution):

Integer option off and fixed bug:
![fix](https://github.com/user-attachments/assets/76970b75-dbb0-44ec-8ae6-2323919d2c03)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
