### PR TITLE
clarify readme: weget ... chmod +x webui.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ python_cmd="python3.11"
 2. Navigate to the directory you would like the webui to be installed and execute the following command:
 ```bash
 wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh
+chmod +x webui.sh
 ```
 Or just clone the repo wherever you want:
 ```bash


### PR DESCRIPTION
## Description

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16248

when using the wget method of downloading webui.sh, webui.sh is not it's not set as executable
user we'll have to manually set it as executable

this PR adds `chomd +x webui.sh` after `wget`

## Screenshots/videos:

from
```bash
wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh

```
to 
```bash
wget -q https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui/master/webui.sh
chmod +x webui.sh
```


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
