### PR TITLE
Forbid too small crop region

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -1,3 +1,4 @@
+import math
 from PIL import Image, ImageFilter, ImageOps
 
 
@@ -73,6 +74,43 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
             x1 -= x1
         if x2 >= image_width:
             x2 = image_width
+
+    return x1, y1, x2, y2
+
+
+def fix_crop_region_integer_scale(crop_region, processing_width, processing_height, image_width, image_height):
+    """expands crop region get_crop_region() to avoid non-integer scaling artifacts (different pixels size) after applying overlay"""
+
+    x1, y1, x2, y2 = crop_region
+
+    ratio_w = (x2 - x1) / processing_width
+    ratio_h = (y2 - y1) / processing_height
+
+    desired_w = math.ceil(ratio_w) * processing_width
+    diff_w = desired_w - (x2 - x1)
+    diff_w_l = diff_w // 2
+    diff_w_r = diff_w - diff_w_l
+    x1 -= diff_w_l
+    x2 += diff_w_r
+    if x1 < 0:
+        x2 -= x1
+        x1 -= x1
+    if x2 >= image_width:
+        x2 = image_width
+
+    desired_h = math.ceil(ratio_h) * processing_height
+    diff_h = desired_h - (y2 - y1)
+    diff_h_u = diff_h // 2
+    diff_h_d = diff_h - diff_h_u
+    y1 -= diff_h_u
+    y2 += diff_h_d
+    if y1 < 0:
+        y2 -= y1
+        y1 -= y1
+    if y2 >= image_height:
+        y2 = image_height
+
+    print(f"padding was increased by {max(diff_w_l, diff_w_r, diff_h_u, diff_h_d)} after integer upscale correction")
 
     return x1, y1, x2, y2
 

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -90,6 +90,10 @@ def expand_too_small_crop_region(crop_region, processing_width, processing_heigh
         diff_w_r = diff_w - diff_w_l
         x1 -= diff_w_l
         x2 += diff_w_r
+        if x2 >= image_width:
+            diff = x2 - image_width
+            x2 -= diff
+            x1 -= diff
         if x1 < 0:
             x2 -= x1
             x1 -= x1
@@ -103,6 +107,10 @@ def expand_too_small_crop_region(crop_region, processing_width, processing_heigh
         diff_h_d = diff_h - diff_h_u
         y1 -= diff_h_u
         y2 += diff_h_d
+        if y2 >= image_height:
+            diff = y2 - image_height
+            y2 -= diff
+            y1 -= diff
         if y1 < 0:
             y2 -= y1
             y1 -= y1
@@ -129,6 +137,10 @@ def fix_crop_region_integer_scale(crop_region, processing_width, processing_heig
     diff_w_r = diff_w - diff_w_l
     x1 -= diff_w_l
     x2 += diff_w_r
+    if x2 >= image_width:
+        diff = x2 - image_width
+        x2 -= diff
+        x1 -= diff
     if x1 < 0:
         x2 -= x1
         x1 -= x1
@@ -141,6 +153,10 @@ def fix_crop_region_integer_scale(crop_region, processing_width, processing_heig
     diff_h_d = diff_h - diff_h_u
     y1 -= diff_h_u
     y2 += diff_h_d
+    if y2 >= image_height:
+        diff = y2 - image_height
+        y2 -= diff
+        y1 -= diff
     if y1 < 0:
         y2 -= y1
         y1 -= y1

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -78,6 +78,43 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
     return x1, y1, x2, y2
 
 
+def expand_too_small_crop_region(crop_region, processing_width, processing_height, image_width, image_height):
+    """expands crop region to not have width and height smaller then processing_width and processing_height"""
+
+    x1, y1, x2, y2 = crop_region
+
+    desired_w = processing_width
+    diff_w = desired_w - (x2 - x1)
+    if diff_w > 0:
+        diff_w_l = diff_w // 2
+        diff_w_r = diff_w - diff_w_l
+        x1 -= diff_w_l
+        x2 += diff_w_r
+        if x1 < 0:
+            x2 -= x1
+            x1 -= x1
+        if x2 >= image_width:
+            x2 = image_width
+
+    desired_h = processing_height
+    diff_h = desired_h - (y2 - y1)
+    if diff_h > 0:
+        diff_h_u = diff_h // 2
+        diff_h_d = diff_h - diff_h_u
+        y1 -= diff_h_u
+        y2 += diff_h_d
+        if y1 < 0:
+            y2 -= y1
+            y1 -= y1
+        if y2 >= image_height:
+            y2 = image_height
+
+    if diff_h > 0 or diff_w > 0:
+        print("Crop region was smaller then resolution and has been corrected")
+
+    return x1, y1, x2, y2
+
+
 def fix_crop_region_integer_scale(crop_region, processing_width, processing_height, image_width, image_height):
     """expands crop region get_crop_region() to avoid non-integer scaling artifacts (different pixels size) after applying overlay"""
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -65,8 +65,12 @@ def apply_color_correction(correction, original_image):
 def uncrop(image, dest_size, paste_loc):
     x, y, w, h = paste_loc
     base_image = Image.new('RGBA', dest_size)
+    factor_x = w // image.size[0]
+    factor_y = h // image.size[1]
     image = images.resize_image(1, image, w, h)
-    base_image.paste(image, (x, y))
+    paste_x = max(x - factor_x, 0)
+    paste_y = max(y - factor_y, 0)
+    base_image.paste(image, (paste_x, paste_y))
     image = base_image
 
     return image
@@ -1639,6 +1643,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
                 if crop_region:
                     crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    if shared.opts.integer_only_masked:
+                        crop_region = masking.fix_crop_region_integer_scale(crop_region, self.width, self.height, mask.width, mask.height)
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1643,6 +1643,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
                 if crop_region:
                     crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    if shared.opts.forbid_too_small_crop_region:
+                        crop_region = masking.expand_too_small_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
                     if shared.opts.integer_only_masked:
                         crop_region = masking.fix_crop_region_integer_scale(crop_region, self.width, self.height, mask.width, mask.height)
                     x1, y1, x2, y2 = crop_region

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -226,6 +226,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "forbid_too_small_crop_region": OptionInfo(False, "Forbid too small crop region").info("Correct inpaint padding for only masked to avoid crop region sides less then processing resolution"),
     "integer_only_masked": OptionInfo(False, "Integer upscale in inpaint only masked").info("Correct inpaint padding for only masked to have integer upscaling after fitting cropped region in original image"),
 }))
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -226,6 +226,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "integer_only_masked": OptionInfo(False, "Integer upscale in inpaint only masked").info("Correct inpaint padding for only masked to have integer upscaling after fitting cropped region in original image"),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {


### PR DESCRIPTION
## Description

Expands crop region if it is smaller then processing resolution. This can happen for example if was selected 60px mask, padding = 90, so crop region has 240px side. With this option it will be expanded to 512px to not lose "free" context which doesn't eat resolution. This behavior can be either desirable or not, so I've made an option

Can be installed after https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16243 due to conflicts. See commits tab to see commits related only to this patch


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
