### PR TITLE
pyenv-win compatibility

### DIFF
--- a/webui.bat
+++ b/webui.bat
@@ -13,16 +13,16 @@ set ERROR_REPORTING=FALSE
 
 mkdir tmp 2>NUL
 
-%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
+call %PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :check_pip
 echo Couldn't launch python
 goto :show_stdout_stderr
 
 :check_pip
-%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
+call %PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :start_venv
 if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
-%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
+call %PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :start_venv
 echo Couldn't install pip
 goto :show_stdout_stderr
@@ -61,7 +61,7 @@ set ACCELERATE="%VENV_DIR%\Scripts\accelerate.exe"
 if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch
-%PYTHON% launch.py %*
+call %PYTHON% launch.py %*
 if EXIST tmp/restart goto :skip_venv
 pause
 exit /b


### PR DESCRIPTION
webui.bat does not work for users using [pyenv-win](https://github.com/pyenv-win/pyenv-win)
the is because when using pyenv-win the `python` actually points to a bat script and so it needs to be `call` to function

credit to 
@stevenengland for bringing this to attention and providing a possible solution

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16205

@viking1304 for providing the reason of the issue
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16261#issuecomment-2250806110

# important I'm not sure if this fix should be applied
@viking1304 also provides an alternative (user side) fix by adding
```bat
set PYTHON=call python
```
this means that it is totally possible that other users of pyenvv are doing similar thing to get it working
### if this PR is merged, it will allow NEW user of webui using pyenv-win to work but may break it for existing users

---

maybe there's a way of making work for both, something like
> pseudo code
```bat
where %PYTHON%
if the first line of result of where %PYTHON% points to a bat then add `call` to the command
if not found (when the value is `call python`) or endes with .exe then do nothing
```


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
