### PR TITLE
Disable Hires checkpoint if same as First pass checkpoint 

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1259,7 +1259,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 if self.hr_checkpoint_info is None:
                     raise Exception(f'Could not find checkpoint with name {self.hr_checkpoint_name}')
 
-                self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
+                if shared.sd_model.sd_checkpoint_info == self.hr_checkpoint_info:
+                    self.hr_checkpoint_info = None
+                else:
+                    self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
 
             if self.hr_sampler_name is not None and self.hr_sampler_name != self.sampler_name:
                 self.extra_generation_params["Hires sampler"] = self.hr_sampler_name


### PR DESCRIPTION
## Description

currently Hires checkpoint is disabled when the value isset to `Use same checkpoint`

but Hires checkpoint should also be disabled when the specified checkpoint is same as Fisrt pass checkpoint 

this PR sets `self.hr_checkpoint_info` to `None` when HR and FP checkpoint are the same

<details><summary>outdated</summary>
<p>

- when `Hires checkpoint` is set to `Use same checkpoint`, `Hires checkpoint` is effectively disabled and will not be saved to infotext
- and when parseing infotext dose not contain `Hires checkpoint` then we know it should be set to `Use same checkpoint`

one would logically think if one selects the same `Hires checkpoint` as `Fisre pass checkpoint` the infotext will also not be included as it is redundant

but this is not the case, currently if the user selects the same `Hires checkpoint` as the `Fisre pass checkpoint` the `Hires checkpoint` will be saved to infotext as as there is no check to see if they are the same

> normally one wouldn't deliberately select the same checkpoint the would just use `Use same checkpoint`, but this could accidentally happen when one first changed the `Hires checkpoint then late decided to set the first pack checkpoint to the same one but then forgot to set the  `Hires checkpoint back to  `Use same checkpoint`

this PR adds a check when creating infotext to see if they are the same, and if so retruns `None` (don't write to infotext)

for easy comparison I stored `shared.sd_model.sd_checkpoint_info` to `p.sd_checkpoint_info` (new attr)
and implement `get_hires_checkpoint(p)` to do the comparison

---

we could remove [these 2 lines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/compare/dev...remove-Hires-checkpoint-infotext-if-same?expand=1#diff-1fe5b15d29310b37af0c4560da365990f4e6eee7b99bf3f041cfa18ebb11610fL890-R892) 
```py
    p.sd_model_name = shared.sd_model.sd_checkpoint_info.name_for_extra
    p.sd_model_hash = shared.sd_model.sd_model_hash
```
and modified other references to directly read from `p.sd_checkpoint_info`
I did not do so because I'm not sure if extension are relying on these attributes

</p>
</details> 


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
