### PR TITLE
fix image upscale on cpu

### DIFF
--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -41,7 +41,7 @@ def upscale_pil_patch(model, img: Image.Image) -> Image.Image:
     """
     param = torch_utils.get_param(model)
 
-    with torch.no_grad():
+    with torch.inference_mode():
         tensor = pil_image_to_torch_bgr(img).unsqueeze(0)  # add batch dimension
         tensor = tensor.to(device=param.device, dtype=param.dtype)
         with devices.without_autocast():


### PR DESCRIPTION
## Description
@AUTOMATIC1111 @akx 

- after https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16144
for some reason upscale using cpu will fail with
RuntimeError: Inplace update to inference tensor outside InferenceMode
switch from `no_grad` to `inference_mode` seems to have fixed it

I've mentioned this on discord and ask if anyone is able to reproduce this issue but no one give me a proper answer so I assume that it was something wrong with my system 
> when I was testing backthen I think this error only happens when using `torch+cuda` with `--use-cpu all` arg
> and it some how works in torch (cpu only)
> but when I retested just now both CPU and CUDA version of torch failed
> so I'm not entirely sure what's going on

now that someone has also reported on the same issue so I think it's not just me
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16274

as this issue could have quite a large impact for those people that are mainly using webui with CPU to upsacall image and not SD
I suggest a version 1.10.1 patch

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
