### PR TITLE
Add 'Skip CFG during early sampling' to the XYZ_grid script

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -167,6 +167,7 @@ class StableDiffusionProcessing:
     denoising_strength: float = None
     ddim_discretize: str = None
     s_min_uncond: float = None
+    skip_early_cond: float = None
     s_churn: float = None
     s_tmax: float = None
     s_tmin: float = None
@@ -253,6 +254,7 @@ class StableDiffusionProcessing:
 
     def fill_fields_from_opts(self):
         self.s_min_uncond = self.s_min_uncond if self.s_min_uncond is not None else opts.s_min_uncond
+        self.skip_early_cond = self.skip_early_cond if self.skip_early_cond is not None else opts.skip_early_cond
         self.s_churn = self.s_churn if self.s_churn is not None else opts.s_churn
         self.s_tmin = self.s_tmin if self.s_tmin is not None else opts.s_tmin
         self.s_tmax = (self.s_tmax if self.s_tmax is not None else opts.s_tmax) or float('inf')
@@ -554,6 +556,7 @@ class Processed:
         self.s_tmax = p.s_tmax
         self.s_noise = p.s_noise
         self.s_min_uncond = p.s_min_uncond
+        self.skip_early_cond = p.skip_early_cond
         self.sampler_noise_scheduler_override = p.sampler_noise_scheduler_override
         self.prompt = self.prompt if not isinstance(self.prompt, list) else self.prompt[0]
         self.negative_prompt = self.negative_prompt if not isinstance(self.negative_prompt, list) else self.negative_prompt[0]

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -217,7 +217,7 @@ class CFGDenoiser(torch.nn.Module):
         uncond = denoiser_params.text_uncond
         skip_uncond = False
 
-        if skip_early_cond is not None and skip_early_cond > 0 and self.step / self.total_steps <= skip_early_cond:
+        if skip_early_cond is not None and skip_early_cond > 0 and (1.0 + self.step) / self.total_steps <= skip_early_cond:
             skip_uncond = True
             self.p.extra_generation_params["Skip Early CFG"] = skip_early_cond
         elif (self.step % 2 or shared.opts.s_min_uncond_all) and s_min_uncond > 0 and sigma[0] < s_min_uncond and not is_edit_model:

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -217,7 +217,6 @@ class CFGDenoiser(torch.nn.Module):
         uncond = denoiser_params.text_uncond
         skip_uncond = False
 
-        # if shared.opts.skip_early_cond != 0. and self.step / self.total_steps <= shared.opts.skip_early_cond:
         if skip_early_cond is not None and skip_early_cond > 0 and self.step / self.total_steps <= skip_early_cond:
             skip_uncond = True
             self.p.extra_generation_params["Skip Early CFG"] = skip_early_cond

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -237,6 +237,7 @@ class Sampler:
         self.config: SamplerData = None  # set by the function calling the constructor
         self.last_latent = None
         self.s_min_uncond = None
+        self.skip_early_cond = None
         self.s_churn = 0.0
         self.s_tmin = 0.0
         self.s_tmax = float('inf')
@@ -292,6 +293,7 @@ class Sampler:
         self.model_wrap_cfg.image_cfg_scale = getattr(p, 'image_cfg_scale', None)
         self.eta = p.eta if p.eta is not None else getattr(opts, self.eta_option_field, 0.0)
         self.s_min_uncond = getattr(p, 's_min_uncond', 0.0)
+        self.skip_early_cond = getattr(p, 'skip_early_cond', 0.0)
 
         k_diffusion.sampling.torch = TorchHijack(p)
 

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -178,7 +178,8 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
             'image_cond': image_conditioning,
             'uncond': unconditional_conditioning,
             'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            's_min_uncond': self.s_min_uncond,
+            'skip_early_cond': self.skip_early_cond
         }
 
         samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
@@ -224,7 +225,8 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
             'image_cond': image_conditioning,
             'uncond': unconditional_conditioning,
             'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            's_min_uncond': self.s_min_uncond,
+            'skip_early_cond': self.skip_early_cond
         }
 
         samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
@@ -232,5 +234,3 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         self.add_infotext(p)
 
         return samples
-
-

--- a/modules/sd_samplers_timesteps.py
+++ b/modules/sd_samplers_timesteps.py
@@ -129,7 +129,8 @@ class CompVisSampler(sd_samplers_common.Sampler):
             'image_cond': image_conditioning,
             'uncond': unconditional_conditioning,
             'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            's_min_uncond': self.s_min_uncond,
+            'skip_early_cond': self.skip_early_cond
         }
 
         samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
@@ -154,7 +155,8 @@ class CompVisSampler(sd_samplers_common.Sampler):
             'image_cond': image_conditioning,
             'uncond': unconditional_conditioning,
             'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            's_min_uncond': self.s_min_uncond,
+            'skip_early_cond': self.skip_early_cond
         }
         samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -251,6 +251,7 @@ axis_options = [
     AxisOptionImg2Img("Sampler", str, apply_field("sampler_name"), format_value=format_value, confirm=confirm_samplers, choices=lambda: [x.name for x in sd_samplers.samplers_for_img2img if x.name not in opts.hide_samplers]),
     AxisOption("Checkpoint name", str, apply_checkpoint, format_value=format_remove_path, confirm=confirm_checkpoints, cost=1.0, choices=lambda: sorted(sd_models.checkpoints_list, key=str.casefold)),
     AxisOption("Negative Guidance minimum sigma", float, apply_field("s_min_uncond")),
+    AxisOption("Skip CFG during early sampling", float, apply_field("skip_early_cond")),
     AxisOption("Sigma Churn", float, apply_field("s_churn")),
     AxisOption("Sigma min", float, apply_field("s_tmin")),
     AxisOption("Sigma max", float, apply_field("s_tmax")),


### PR DESCRIPTION
## Description

- Adds Skip CFG feature from #15607 to the XYZ_grid script
- Fixes progress calculation for `skip_early_cond` (the first step is zero so to have 1.0 at 100% progress we need to add one)

## Screenshots/videos:

![image](https://github.com/user-attachments/assets/36944126-1bd7-4f0b-affe-f1d3c329a556)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
