### PR TITLE
option: reduce connecting to huggingface

### DIFF
--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -14,6 +14,7 @@ def imports():
 
     import torch  # noqa: F401
     startup_timer.record("import torch")
+    from modules import patch_hf_hub_download  # noqa: F401
     import pytorch_lightning  # noqa: F401
     startup_timer.record("import torch")
     warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="pytorch_lightning")

--- a/modules/patch_hf_hub_download.py
+++ b/modules/patch_hf_hub_download.py
@@ -1,0 +1,41 @@
+from modules.patches import patch
+from modules.errors import report
+from inspect import signature
+from functools import wraps
+
+try:
+    from huggingface_hub.utils import LocalEntryNotFoundError
+    from huggingface_hub import file_download
+
+    def try_local_files_only(func):
+        if (param := signature(func).parameters.get('local_files_only', None)) and not param.kind == param.KEYWORD_ONLY:
+            raise ValueError(f'{func.__name__} does not have keyword-only parameter "local_files_only"')
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                from modules.shared import opts
+                try_offline_mode = not kwargs.get('local_files_only') and opts.hd_dl_local_first
+            except Exception:
+                report('Error in try_local_files_only - skip try_local_files_only', exc_info=True)
+                try_offline_mode = False
+
+            if try_offline_mode:
+                try:
+                    return func(*args, **{**kwargs, 'local_files_only': True})
+                except LocalEntryNotFoundError:
+                    pass
+                except Exception:
+                    report('Unexpected exception in try_local_files_only - retry without patch', exc_info=True)
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    try:
+        patch(__name__, file_download, 'hf_hub_download', try_local_files_only(file_download.hf_hub_download))
+    except RuntimeError:
+        pass  # already patched
+
+except Exception:
+    report('Error patching hf_hub_download', exc_info=True)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -128,6 +128,7 @@ options_templates.update(options_section(('system', "System", "system"), {
     "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
     "hide_ldm_prints": OptionInfo(True, "Prevent Stability-AI's ldm/sgm modules from printing noise to console."),
     "dump_stacks_on_signal": OptionInfo(False, "Print stack traces before exiting the program with ctrl+c."),
+    "hd_dl_local_first": OptionInfo(False, "Prevent connecting to huggingface for assets if cache is available").info('this will also prevent assets from being updated'),
 }))
 
 options_templates.update(options_section(('profiler', "Profiler", "system"), {


### PR DESCRIPTION
## Description
add option: reduce connecting to huggingface
for assets if local cache is available
note: enabling this with prevent the assets from being updated

option is disabled by default because it can prevent updates to those assets if updates are necessary

---

some user are not too happy with webui connecting to hugging face to fetch metadata for assets
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/16284


like when loading SD3Tokenizer
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/48239090f18d07acd8070a7af9da38b0021fdea3/modules/models/sd3/other_impls.py#L216-L221

the `.from_pretrained` internally calls `hf_hub_download()` whitch connects to hugging face (basically checking if there's any revisions to the files) and downloading the files if not locally available

one way for those sensitive users who really don't want it to connect to hugging face se to set the environment variable `TRANSFORMERS_OFFLINE` to `1` this would disabled connecting to hugging face
when `local_files_only=True` it basically it doesn't cause to hugging face checking for updates and just newest revision in the local 
if the cache isn't found then it raise `LocalEntryNotFoundError`

> note `TRANSFORMERS_OFFLINE=1` sets `local_files_only` to True

the problem with using `TRANSFORMERS_OFFLINE` is that if those files haven't been downloaded, it won't be able to download them at all, which makes this rather not user friendly

even sensitive users should understand that it will have to at least make the connection once in order to download the necessary files

for these users ideally hugging face hub should have an `only downloads once and don't check for updates` option
but since there isn't the easiest way to add this functionality is to patch `file_download` and let it first try with `local_files_only=True`
and if it raise `LocalEntryNotFoundError` error try again with `local_files_only=False`

---

to prevent crushing if there's updates to huggingface_hub
- this entire patch is wrapped inside a try block
- check if keyword-only arg `local_files_only` is a parameter of file_download.hf_hub_download

this should mean so as long as huggingface_hub did not completely modify how file_download.hf_hub_download the `local_files_only` arg works it should not break the patch should be disabled and shouldn't cause issues
if all safety checks failed and it raise an unexpected exception it would just try the function without patch again

---

not too happy with my description of this option
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/8574528e2b1e9948d76a6475767548850711662a/modules/shared_options.py#L131

---

normally I would prefer to introduce this type of thing as an extension
but this happens way too early during the even before preload
unless something to pre-initialize callback is added I don't think this is possible as an extension

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
