### PR TITLE
Fix Default system None filter logic

### DIFF
--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -176,7 +176,7 @@ class UiLoadsave:
             if new_value == old_value:
                 continue
 
-            if old_value is None and new_value == '' or new_value == []:
+            if old_value is None and (new_value == '' or new_value == []):
                 continue
 
             yield path, old_value, new_value


### PR DESCRIPTION
## Description

- Fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16307

I'm not totally sure why that None filter logic exist
I'm assuming that it's basically just to prevent writing equivalent values
to the files and bloating the default output

and if I'm understanding the logic correctly then the logic is incorrect
there should be a parenthesis around the new value or section

did some quick test and seem to function as intended

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
