### PR TITLE
Provide option to use bilinear filtering for resizing masks/grayscale images

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -24,7 +24,7 @@ from modules.paths_internal import roboto_ttf_file
 from modules.shared import opts
 
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
-
+BILINEAR = (Image.Resampling.BILINEAR if hasattr(Image, 'Resampling') else Image.BILINEAR)
 
 def get_font(fontsize: int):
     try:
@@ -268,7 +268,7 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
 
     def resize(im, w, h):
         if upscaler_name is None or upscaler_name == "None" or im.mode == 'L':
-            return im.resize((w, h), resample=LANCZOS)
+            return im.resize((w, h), resample=BILINEAR if im.mode == 'L' and opts.img2img_bilinear_grayscale_resize else LANCZOS)
 
         scale = max(w / im.width, h / im.height)
 
@@ -283,7 +283,7 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
             im = upscaler.scaler.upscale(im, scale, upscaler.data_path)
 
         if im.width != w or im.height != h:
-            im = im.resize((w, h), resample=LANCZOS)
+            im = im.resize((w, h), resample=BILINEAR if im.mode == 'L' and opts.img2img_bilinear_grayscale_resize else LANCZOS)
 
         return im
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -227,6 +227,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "img2img_bilinear_grayscale_resize": OptionInfo(False, "Use bilinear filtering for grayscale images (masks)").info("when resizing, grayscale images (which are almost always masks) will use bilinear filtering instead of Lanczos, which can introduce ringing artifacts"),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {


### PR DESCRIPTION
## Description

The fallback resizing option in `resize_image` is Lanczos, which is a good default in the majority of cases. However, when resizing grayscale images, in particular masks, it can introduce ringing artifacts. A better option in this case is bilinear filtering. You can see the difference in the filters in the provided image (which are outputs of the cropping masks used in img2img during ADetailer processing with mask blurring set to zero).

Both nearest and bicubic were considered, however:

1. Bicubic can "pinch" hard corners, which are extremely common for binary masks.
2. Nearest is optimal for binary masks, but inferior if the mask is blurred (which is true in almost all cases).
3. Therefore, bilinear provides the best compromise.

To this end, this commit introduces a new option in the img2img settings (disabled by default) that allows the use of bilinear filtering when resizing, if the incoming image is grayscale (PIL's mode 'L'). In all other cases, Lanczos is used as is the case currently.

I've made it a toggle because it does alter the shape of the mask enough to potentially affect current workflows. The effect is also very subtle (as evidenced by the image), but I would argue is more correct.

## Screenshots/videos:
![bilinear_vs_lanczos](https://github.com/user-attachments/assets/614e4d13-edac-40a9-8460-97b36a1cb9b1)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
