### PR TITLE
Add fast prescale option to upscaler settings (off by default)

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -105,6 +105,7 @@ options_templates.update(options_section(('upscaling', "Upscaling", "postprocess
     "DAT_tile_overlap": OptionInfo(8, "Tile overlap for DAT upscalers.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}).info("Low values = visible seam"),
     "upscaler_for_img2img": OptionInfo(None, "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}),
     "set_scale_by_when_changing_upscaler": OptionInfo(False, "Automatically set the Scale by factor based on the name of the selected Upscaler."),
+    "upscaler_fast_prescale_threshold": OptionInfo(1.0, "Maximum threshold for fast pre-scaling of very small images.", gr.Slider, {"minimum": 1, "maximum": 8, "step": 0.01}).info("The maximum scale difference for performing fast Lanczos pre-scaling before the first upscaling step. This can prevent expensive additional steps if the source image is very small. 1 = disabled; 1.25-3.0 recommended"),
 }))
 
 options_templates.update(options_section(('face-restoration', "Face restoration", "postprocessing"), {

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 import modules.shared
 from modules import modelloader, shared
+import math
 
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
 NEAREST = (Image.Resampling.NEAREST if hasattr(Image, 'Resampling') else Image.NEAREST)
@@ -55,6 +56,40 @@ class Upscaler:
         self.scale = scale
         dest_w = int((img.width * scale) // 8 * 8)
         dest_h = int((img.height * scale) // 8 * 8)
+
+        # Attempt a cheap resize of the source image, if it falls below the fixed scaling size of the upscaling model.
+        # We resize the image by the smallest amount necessary for the fixed scaling to meet the target dimensions.
+        
+        prescale_threshold = modules.shared.opts.upscaler_fast_prescale_threshold
+        if prescale_threshold > 1 and self.name and self.name not in ["Nearest", "Lanczos"]:
+            
+            # Get the matching upscaler
+            upscaler_data = next((x for x in self.scalers if x.data_path == selected_model), None)
+
+            if upscaler_data is not None:
+                upscaler_scale = upscaler_data.scale
+                if scale > upscaler_scale:
+
+                    # Calculate the minimum intermediate dimensions.
+                    min_intermediate_w = math.ceil(dest_w / upscaler_scale)
+                    min_intermediate_h = math.ceil(dest_h / upscaler_scale)
+
+                    # Preserve aspect ratio and make sure any adjustments don't drop us below the
+                    # minimum scaling needed.
+                    aspect_ratio = img.width / img.height
+
+                    intermediate_w = max(min_intermediate_w, int(math.ceil(min_intermediate_h * aspect_ratio)))
+                    intermediate_h = max(min_intermediate_h, int(math.ceil(min_intermediate_w / aspect_ratio)))
+
+                    if intermediate_w / aspect_ratio > intermediate_h:
+                        intermediate_w = int(math.ceil(intermediate_h * aspect_ratio))
+                    else:
+                        intermediate_h = int(math.ceil(intermediate_w / aspect_ratio))
+
+                    scale_diff = max(intermediate_w / img.width, intermediate_h / img.height)
+
+                    if scale_diff <= prescale_threshold:
+                        img = img.resize((intermediate_w, intermediate_h), resample=LANCZOS)
 
         for i in range(3):
             if img.width >= dest_w and img.height >= dest_h and (i > 0 or scale != 1):

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -59,10 +59,8 @@ class Upscaler:
 
         # Attempt a cheap resize of the source image, if it falls below the fixed scaling size of the upscaling model.
         # We resize the image by the smallest amount necessary for the fixed scaling to meet the target dimensions.
-        
         prescale_threshold = modules.shared.opts.upscaler_fast_prescale_threshold
         if prescale_threshold > 1 and self.name and self.name not in ["Nearest", "Lanczos"]:
-            
             # Get the matching upscaler
             upscaler_data = next((x for x in self.scalers if x.data_path == selected_model), None)
 


### PR DESCRIPTION
## Description

By default, upscaling will loop several times to upscale incoming images to the target dimensions. This is necessary, as upscaling models work in fixed increments (x4 is common). However, for very small images, such as those generated by ADetailer for inpainting, this can regularly result two upscaling steps. The second step is often expensive, far exceeding the target dimensions, and is particularly wasteful as it will be forcibly downsized by the final part of the `upscale` method anyway.

Examining the behaviour, it's often the case that a minor resize using Lanczos *before* the upscaling loop would guarantee a single upscaling step that hits or slightly exceeds the target dimensions.

This commit introduces an optional value to the upscaler settings allowing this minor resize, should the incoming image fall below a certain threshold compared to the fixed scaling value of the upscaling model. By default, this setting is set to 1.0, disabling it. Values of 1.25-3.0 are recommended.

## Screenshots/videos:
N/A

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
