### PR TITLE
Reduce server request

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -62,7 +62,9 @@ def reload_javascript():
 
         # remove preconnects
         res.body = re_preconnect.sub(b'', res.body)
-        
+        # replace iframeResizer with local version
+        res.body = res.body.replace(b'src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.6/iframeResizer.contentWindow.min.js"', b'src="webui-assets/js/iframe-resizer/4.3.6/iframeResizer.contentWindow.min.js"')
+
         res.body = res.body.replace(b'</head>', f'{js}<meta name="referrer" content="no-referrer"/></head>'.encode("utf8"))
         res.body = res.body.replace(b'</body>', f'{css}</body>'.encode("utf8"))
         res.init_headers()

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -1,4 +1,5 @@
 import os
+import re
 import gradio as gr
 
 from modules import localization, shared, scripts, util
@@ -49,12 +50,19 @@ def css_html():
     return head
 
 
+re_preconnect = re.compile(rb'<link\s+rel="preconnect"\s+href="([^"]+)"(?:\s+[^>]*)?/?>')
+
+
 def reload_javascript():
     js = javascript_html()
     css = css_html()
 
     def template_response(*args, **kwargs):
         res = shared.GradioTemplateResponseOriginal(*args, **kwargs)
+
+        # remove preconnects
+        res.body = re_preconnect.sub(b'', res.body)
+        
         res.body = res.body.replace(b'</head>', f'{js}<meta name="referrer" content="no-referrer"/></head>'.encode("utf8"))
         res.body = res.body.replace(b'</body>', f'{css}</body>'.encode("utf8"))
         res.init_headers()


### PR DESCRIPTION
### Reveiw but don't merge, this PR requires a merge to asset repo function

## Description
Reduce server request

- remove 
preconnets to `fonts.googleapis.com` `fonts.gstatic.com`

- serves [iframe-resizer v4.3.6](https://github.com/davidjbradshaw/iframe-resizer/blob/e9731cba97eaff5fb3e76560a312d73d709cf2c1/js/iframeResizer.contentWindow.min.js) locally from webUI assets
- - requires this https://github.com/AUTOMATIC1111/stable-diffusion-webui-assets/pull/2 to be merged
- - `ASSETS_COMMIT_HASH` needs to be updated accordingly after merge
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/launch_utils.py#L354
- - - to be honest I'm not sure what iframe-resizer is used for, webui seems to work without it

| befroe | after |
|--------|--------|
| ![2024-08-10 19_27_27_576 chrome](https://github.com/user-attachments/assets/5cdbcd37-a592-47d7-b5cf-7e67a785eeb2) | ![2024-08-10 19_26_40_073 chrome](https://github.com/user-attachments/assets/a5dbf811-90eb-44d5-baf5-51b883d24061) | 

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
