### PR TITLE
Fix postprocessing_enable_in_main_ui ScriptPostprocessing elem_id

### DIFF
--- a/extensions-builtin/postprocessing-for-training/scripts/postprocessing_autosized_crop.py
+++ b/extensions-builtin/postprocessing-for-training/scripts/postprocessing_autosized_crop.py
@@ -34,14 +34,14 @@ class ScriptPostprocessingAutosizedCrop(scripts_postprocessing.ScriptPostprocess
         with ui_components.InputAccordion(False, label="Auto-sized crop") as enable:
             gr.Markdown('Each image is center-cropped with an automatically chosen width and height.')
             with gr.Row():
-                mindim = gr.Slider(minimum=64, maximum=2048, step=8, label="Dimension lower bound", value=384, elem_id="postprocess_multicrop_mindim")
-                maxdim = gr.Slider(minimum=64, maximum=2048, step=8, label="Dimension upper bound", value=768, elem_id="postprocess_multicrop_maxdim")
+                mindim = gr.Slider(minimum=64, maximum=2048, step=8, label="Dimension lower bound", value=384, elem_id=self.elem_id_suffix("postprocess_multicrop_mindim"))
+                maxdim = gr.Slider(minimum=64, maximum=2048, step=8, label="Dimension upper bound", value=768, elem_id=self.elem_id_suffix("postprocess_multicrop_maxdim"))
             with gr.Row():
-                minarea = gr.Slider(minimum=64 * 64, maximum=2048 * 2048, step=1, label="Area lower bound", value=64 * 64, elem_id="postprocess_multicrop_minarea")
-                maxarea = gr.Slider(minimum=64 * 64, maximum=2048 * 2048, step=1, label="Area upper bound", value=640 * 640, elem_id="postprocess_multicrop_maxarea")
+                minarea = gr.Slider(minimum=64 * 64, maximum=2048 * 2048, step=1, label="Area lower bound", value=64 * 64, elem_id=self.elem_id_suffix("postprocess_multicrop_minarea"))
+                maxarea = gr.Slider(minimum=64 * 64, maximum=2048 * 2048, step=1, label="Area upper bound", value=640 * 640, elem_id=self.elem_id_suffix("postprocess_multicrop_maxarea"))
             with gr.Row():
-                objective = gr.Radio(["Maximize area", "Minimize error"], value="Maximize area", label="Resizing objective", elem_id="postprocess_multicrop_objective")
-                threshold = gr.Slider(minimum=0, maximum=1, step=0.01, label="Error threshold", value=0.1, elem_id="postprocess_multicrop_threshold")
+                objective = gr.Radio(["Maximize area", "Minimize error"], value="Maximize area", label="Resizing objective", elem_id=self.elem_id_suffix("postprocess_multicrop_objective"))
+                threshold = gr.Slider(minimum=0, maximum=1, step=0.01, label="Error threshold", value=0.1, elem_id=self.elem_id_suffix("postprocess_multicrop_threshold"))
 
         return {
             "enable": enable,

--- a/extensions-builtin/postprocessing-for-training/scripts/postprocessing_focal_crop.py
+++ b/extensions-builtin/postprocessing-for-training/scripts/postprocessing_focal_crop.py
@@ -11,10 +11,10 @@ class ScriptPostprocessingFocalCrop(scripts_postprocessing.ScriptPostprocessing)
 
     def ui(self):
         with ui_components.InputAccordion(False, label="Auto focal point crop") as enable:
-            face_weight = gr.Slider(label='Focal point face weight', value=0.9, minimum=0.0, maximum=1.0, step=0.05, elem_id="postprocess_focal_crop_face_weight")
-            entropy_weight = gr.Slider(label='Focal point entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id="postprocess_focal_crop_entropy_weight")
-            edges_weight = gr.Slider(label='Focal point edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="postprocess_focal_crop_edges_weight")
-            debug = gr.Checkbox(label='Create debug image', elem_id="train_process_focal_crop_debug")
+            face_weight = gr.Slider(label='Focal point face weight', value=0.9, minimum=0.0, maximum=1.0, step=0.05, elem_id=self.elem_id_suffix("postprocess_focal_crop_face_weight"))
+            entropy_weight = gr.Slider(label='Focal point entropy weight', value=0.15, minimum=0.0, maximum=1.0, step=0.05, elem_id=self.elem_id_suffix("postprocess_focal_crop_entropy_weight"))
+            edges_weight = gr.Slider(label='Focal point edges weight', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id=self.elem_id_suffix("postprocess_focal_crop_edges_weight"))
+            debug = gr.Checkbox(label='Create debug image', elem_id=self.elem_id_suffix("train_process_focal_crop_debug"))
 
         return {
             "enable": enable,

--- a/extensions-builtin/postprocessing-for-training/scripts/postprocessing_split_oversized.py
+++ b/extensions-builtin/postprocessing-for-training/scripts/postprocessing_split_oversized.py
@@ -35,8 +35,8 @@ class ScriptPostprocessingSplitOversized(scripts_postprocessing.ScriptPostproces
     def ui(self):
         with ui_components.InputAccordion(False, label="Split oversized images") as enable:
             with gr.Row():
-                split_threshold = gr.Slider(label='Threshold', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id="postprocess_split_threshold")
-                overlap_ratio = gr.Slider(label='Overlap ratio', value=0.2, minimum=0.0, maximum=0.9, step=0.05, elem_id="postprocess_overlap_ratio")
+                split_threshold = gr.Slider(label='Threshold', value=0.5, minimum=0.0, maximum=1.0, step=0.05, elem_id=self.elem_id_suffix("postprocess_split_threshold"))
+                overlap_ratio = gr.Slider(label='Overlap ratio', value=0.2, minimum=0.0, maximum=0.9, step=0.05, elem_id=self.elem_id_suffix("postprocess_overlap_ratio"))
 
         return {
             "enable": enable,

--- a/modules/scripts_auto_postprocessing.py
+++ b/modules/scripts_auto_postprocessing.py
@@ -13,6 +13,7 @@ class ScriptPostprocessingForMainUI(scripts.Script):
         return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
+        self.script.tab_name = '_img2img' if is_img2img else '_txt2img'
         self.postprocessing_controls = self.script.ui()
         return self.postprocessing_controls.values()
 

--- a/modules/scripts_postprocessing.py
+++ b/modules/scripts_postprocessing.py
@@ -1,3 +1,4 @@
+import re
 import dataclasses
 import os
 import gradio as gr
@@ -96,6 +97,31 @@ class ScriptPostprocessing:
 
     def image_changed(self):
         pass
+
+    tab_name = ''  # used by ScriptPostprocessingForMainUI
+    replace_pattern = re.compile(r'\s')
+    rm_pattern = re.compile(r'[^a-z_0-9]')
+
+    def elem_id(self, item_id):
+        """
+        Helper function to generate id for a HTML element
+        constructs final id out of script name and user-supplied item_id
+        'script_extras_{self.name.lower()}_{item_id}'
+        {tab_name} will append to the end of the id if set
+        tab_name will be set to '_img2img' or '_txt2img' if use by ScriptPostprocessingForMainUI
+
+        Extensions should use this function to generate element IDs
+        """
+        return self.elem_id_suffix(f'extras_{self.name.lower()}_{item_id}')
+
+    def elem_id_suffix(self, base_id):
+        """
+        Append tab_name to the base_id
+
+        Extensions that already have specific there element IDs and wish to keep their IDs the same when possible should use this function
+        """
+        base_id = self.rm_pattern.sub('', self.replace_pattern.sub('_', base_id))
+        return f'{base_id}{self.tab_name}'
 
 
 def wrap_call(func, filename, funcname, *args, default=None, **kwargs):

--- a/scripts/postprocessing_codeformer.py
+++ b/scripts/postprocessing_codeformer.py
@@ -12,8 +12,8 @@ class ScriptPostprocessingCodeFormer(scripts_postprocessing.ScriptPostprocessing
     def ui(self):
         with ui_components.InputAccordion(False, label="CodeFormer") as enable:
             with gr.Row():
-                codeformer_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id="extras_codeformer_visibility")
-                codeformer_weight = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Weight (0 = maximum effect, 1 = minimum effect)", value=0, elem_id="extras_codeformer_weight")
+                codeformer_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id=self.elem_id_suffix("extras_codeformer_visibility"))
+                codeformer_weight = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Weight (0 = maximum effect, 1 = minimum effect)", value=0, elem_id=self.elem_id_suffix("extras_codeformer_weight"))
 
         return {
             "enable": enable,

--- a/scripts/postprocessing_gfpgan.py
+++ b/scripts/postprocessing_gfpgan.py
@@ -11,7 +11,7 @@ class ScriptPostprocessingGfpGan(scripts_postprocessing.ScriptPostprocessing):
 
     def ui(self):
         with ui_components.InputAccordion(False, label="GFPGAN") as enable:
-            gfpgan_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id="extras_gfpgan_visibility")
+            gfpgan_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id=self.elem_id_suffix("extras_gfpgan_visibility"))
 
         return {
             "enable": enable,

--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -30,31 +30,31 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
     def ui(self):
         selected_tab = gr.Number(value=0, visible=False)
 
-        with InputAccordion(True, label="Upscale", elem_id="extras_upscale") as upscale_enabled:
+        with InputAccordion(True, label="Upscale", elem_id=self.elem_id_suffix("extras_upscale")) as upscale_enabled:
             with FormRow():
-                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
+                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id=self.elem_id_suffix("extras_upscaler_1"), choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
 
             with FormRow():
-                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
-                extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
+                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id=self.elem_id_suffix("extras_upscaler_2"), choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
+                extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id=self.elem_id_suffix("extras_upscaler_2_visibility"))
 
             with FormRow():
-                with gr.Tabs(elem_id="extras_resize_mode"):
-                    with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
+                with gr.Tabs(elem_id=self.elem_id_suffix("extras_resize_mode")):
+                    with gr.TabItem('Scale by', elem_id=self.elem_id_suffix("extras_scale_by_tab")) as tab_scale_by:
                         with gr.Row():
                             with gr.Column(scale=4):
-                                upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=4, elem_id="extras_upscaling_resize")
+                                upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=4, elem_id=self.elem_id_suffix("extras_upscaling_resize"))
                             with gr.Column(scale=1, min_width=160):
-                                max_side_length = gr.Number(label="Max side length", value=0, elem_id="extras_upscale_max_side_length", tooltip="If any of two sides of the image ends up larger than specified, will downscale it to fit. 0 = no limit.", min_width=160, step=8, minimum=0)
+                                max_side_length = gr.Number(label="Max side length", value=0, elem_id=self.elem_id_suffix("extras_upscale_max_side_length"), tooltip="If any of two sides of the image ends up larger than specified, will downscale it to fit. 0 = no limit.", min_width=160, step=8, minimum=0)
 
-                    with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                    with gr.TabItem('Scale to', elem_id=self.elem_id_suffix("extras_scale_to_tab")) as tab_scale_to:
                         with FormRow():
-                            with gr.Column(elem_id="upscaling_column_size", scale=4):
-                                upscaling_resize_w = gr.Slider(minimum=64, maximum=8192, step=8, label="Width", value=512, elem_id="extras_upscaling_resize_w")
-                                upscaling_resize_h = gr.Slider(minimum=64, maximum=8192, step=8, label="Height", value=512, elem_id="extras_upscaling_resize_h")
-                            with gr.Column(elem_id="upscaling_dimensions_row", scale=1, elem_classes="dimensions-tools"):
-                                upscaling_res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="upscaling_res_switch_btn", tooltip="Switch width/height")
-                                upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
+                            with gr.Column(elem_id=self.elem_id_suffix("upscaling_column_size"), scale=4):
+                                upscaling_resize_w = gr.Slider(minimum=64, maximum=8192, step=8, label="Width", value=512, elem_id=self.elem_id_suffix("extras_upscaling_resize_w"))
+                                upscaling_resize_h = gr.Slider(minimum=64, maximum=8192, step=8, label="Height", value=512, elem_id=self.elem_id_suffix("extras_upscaling_resize_h"))
+                            with gr.Column(elem_id=self.elem_id_suffix("upscaling_dimensions_row"), scale=1, elem_classes="dimensions-tools"):
+                                upscaling_res_switch_btn = ToolButton(value=switch_values_symbol, elem_id=self.elem_id_suffix("upscaling_res_switch_btn"), tooltip="Switch width/height")
+                                upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id=self.elem_id_suffix("extras_upscaling_crop"))
 
         def on_selected_upscale_method(upscale_method):
             if not shared.opts.set_scale_by_when_changing_upscaler:


### PR DESCRIPTION
## Description
Fix `postprocessing_enable_in_main_ui` `ScriptPostprocessing` duplicate `elem_id`

`ScriptPostprocessing` (`extras` tab) modules such as `Upscale` can be use as a processing add on in `txt2img` and `img2img` pipeline with the use of `ScriptPostprocessingForMainUI` / `opts.postprocessing_enable_in_main_ui`

this causes an issue, due to the way `ScriptPostprocessingForMainUI` creates the UI for the `ScriptPostprocessing` UI is the same as Extra tab, if an element has a fixed `elem_id` configured the element IDs will be duplicated

this has always been an issue since the beginning but this has become a serious issue  due to the switch to `InputAccordion` in `ScriptPostprocessing`
as `InputAccordion` relies on the id being unique (if manually set)

the issue can be reproduced by
1. `Setting > Postprocessing > Enable postprocessing operations in txt2img and img2img tabs` add `Upscale`
2. try to use `Upscale` on extras tab, you should find that the `InputAccordion` is not responsive
3. the `InputAccordion` on `txt2img` tab actually controls the `InputAccordion` on `extras` tab

> assuming that `txt2img` is created before extras tab

---

## Proposed solution

similer to `scripts.Script` `elem_id` should be generated with the `elem_id()` helper function
`tab_name` will be append to the end of the `elem_id`
on `extras` tab `tab_name` is blank
but before `ScriptPostprocessingForMainUI` creates the UI, `tab_name` of the script should be set to `_txt2img` or `_img2img`

issue with this approach any extension that wishes to make their `ScriptPostprocessing` should also be update to use `elem_id()` to create there `elem_id`
unfortunately I don't think there is a better solution that can be applied in automatic efficiently issue globally without change to extensions
reason being `elem_id` are mostly reference inside JavaScript, and there's really no unified method of modifying what function do they target within python

also additional inconvenience extension that wishes to use this function if they wish to maintain compatibility with old versions of web UI they need to test if this function exists

---

there are two variant of the create elem_id helper function `elem_id()` and `func elem_id_suffix()`
`elem_id()` is for new extentions, they can use this to creat there elem_id, this create the ID with `extras_` and `script name` prefix followed by the input string and `tab_name` suffix

`func elem_id_suffix()` on the other hand only adds the suffix without modifying the rest of the ID
the reason is that it is possible that some other things extensions are already utilizing set ID to Target the specific elements and it would be bad to multiply the ID

Note invalid characters are still removed in both functions


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
