### PR TITLE
extra_only / main_ui_only ScriptPostprocessing

### DIFF
--- a/modules/scripts_auto_postprocessing.py
+++ b/modules/scripts_auto_postprocessing.py
@@ -33,7 +33,7 @@ def create_auto_preprocessing_script_data():
 
     for name in shared.opts.postprocessing_enable_in_main_ui:
         script = next(iter([x for x in scripts.postprocessing_scripts_data if x.script_class.name == name]), None)
-        if script is None:
+        if script is None or script.script_class.extra_only:
             continue
 
         constructor = lambda s=script: ScriptPostprocessingForMainUI(s.script_class())

--- a/modules/scripts_postprocessing.py
+++ b/modules/scripts_postprocessing.py
@@ -119,10 +119,6 @@ class ScriptPostprocessingRunner:
         for script_data in scripts_data:
             script: ScriptPostprocessing = script_data.script_class()
             script.filename = script_data.path
-
-            if script.name == "Simple Upscale":
-                continue
-
             self.scripts.append(script)
 
     def create_script_ui(self, script, inputs):
@@ -144,6 +140,7 @@ class ScriptPostprocessingRunner:
 
         scripts_order = shared.opts.postprocessing_operation_order
         scripts_filter_out = set(shared.opts.postprocessing_disable_in_extras)
+        scripts_filter_out.add("Simple Upscale")
 
         def script_score(name):
             for i, possible_match in enumerate(scripts_order):

--- a/modules/scripts_postprocessing.py
+++ b/modules/scripts_postprocessing.py
@@ -59,6 +59,10 @@ class ScriptPostprocessing:
     args_from = None
     args_to = None
 
+    # define if the script should be used only in extras or main UI
+    extra_only = None
+    main_ui_only = None
+
     order = 1000
     """scripts will be ordred by this value in postprocessing UI"""
 
@@ -140,7 +144,6 @@ class ScriptPostprocessingRunner:
 
         scripts_order = shared.opts.postprocessing_operation_order
         scripts_filter_out = set(shared.opts.postprocessing_disable_in_extras)
-        scripts_filter_out.add("Simple Upscale")
 
         def script_score(name):
             for i, possible_match in enumerate(scripts_order):
@@ -149,7 +152,7 @@ class ScriptPostprocessingRunner:
 
             return len(self.scripts)
 
-        filtered_scripts = [script for script in self.scripts if script.name not in scripts_filter_out]
+        filtered_scripts = [script for script in self.scripts if script.name not in scripts_filter_out and not script.main_ui_only]
         script_scores = {script.name: (script_score(script.name), script.order, script.name, original_index) for original_index, script in enumerate(filtered_scripts)}
 
         return sorted(filtered_scripts, key=lambda x: script_scores[x.name])

--- a/modules/shared_items.py
+++ b/modules/shared_items.py
@@ -16,10 +16,12 @@ def dat_models_names():
     return [x.name for x in modules.dat_model.get_dat_models(None)]
 
 
-def postprocessing_scripts():
+def postprocessing_scripts(filter_out_extra_only=False, filter_out_main_ui_only=False):
     import modules.scripts
-
-    return modules.scripts.scripts_postproc.scripts
+    return list(filter(
+        lambda s: (not filter_out_extra_only or not s.extra_only) and (not filter_out_main_ui_only or not s.main_ui_only),
+        modules.scripts.scripts_postproc.scripts,
+    ))
 
 
 def sd_vae_items():

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -410,9 +410,9 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
 }))
 
 options_templates.update(options_section(('postprocessing', "Postprocessing", "postprocessing"), {
-    'postprocessing_enable_in_main_ui': OptionInfo([], "Enable postprocessing operations in txt2img and img2img tabs", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
-    'postprocessing_disable_in_extras': OptionInfo([], "Disable postprocessing operations in extras tab", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
-    'postprocessing_operation_order': OptionInfo([], "Postprocessing operation order", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
+    'postprocessing_enable_in_main_ui': OptionInfo([], "Enable postprocessing operations in txt2img and img2img tabs", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts(filter_out_extra_only=True)]}),
+    'postprocessing_disable_in_extras': OptionInfo([], "Disable postprocessing operations in extras tab", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts(filter_out_main_ui_only=True)]}),
+    'postprocessing_operation_order': OptionInfo([], "Postprocessing operation order", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts(filter_out_main_ui_only=True)]}),
     'upscaling_max_images_in_cache': OptionInfo(5, "Maximum number of images in upscaling cache", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
     'postprocessing_existing_caption_action': OptionInfo("Ignore", "Action for existing captions", gr.Radio, {"choices": ["Ignore", "Keep", "Prepend", "Append"]}).info("when generating captions using postprocessing; Ignore = use generated; Keep = use original; Prepend/Append = combine both"),
 }))

--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -169,6 +169,7 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
 class ScriptPostprocessingUpscaleSimple(ScriptPostprocessingUpscale):
     name = "Simple Upscale"
     order = 900
+    main_ui_only = True
 
     def ui(self):
         with FormRow():


### PR DESCRIPTION
## Description
fix `Simple Upscale` 

mentioned by @light-and-ray in Discord for whatever reason the the main UI only script `Simple Upscale` was hidden and not selectable

my guess is doing some refactoring some logical change and so it got lost

this PR as it back by changing how a ScriptPostprocessing` is filtered out
by adding 2 new attribute to `ScriptPostprocessing`, `ScriptPostprocessing.extra_only` and `ScriptPostprocessing.main_ui_only`
when set to `Ture`, the script will only show ther specified tab

example
[`Simple Upscale` now has the `.main_ui_only` set to true](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16374/files#diff-74a048a9b8cd45c850125f83f5b3e1b1e83640f35636a4c9e0d633d6fb43cde4R172)
and so will only work in main ui if added into `opts.postprocessing_enable_in_main_ui`

`shared_items.postprocessing_scripts(filter_out_extra_only=False, filter_out_main_ui_only=False)` now have filter options to filter out the two script types

the advantage of doing this way as opposed to adding a special case for `Simple Upscale` is that extensions if they so wish to can limit their use on specific tabs

## Screenshots/videos:
![image](https://github.com/user-attachments/assets/afab0797-b4ff-4572-ae85-63ba8076b9d2)
![image](https://github.com/user-attachments/assets/088ff1c4-0987-4b93-b421-bdabefa8fd56)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
