### PR TITLE
InputAccordion duplicate elem_id handling

### DIFF
--- a/modules/ui_components.py
+++ b/modules/ui_components.py
@@ -91,6 +91,7 @@ class InputAccordion(gr.Checkbox):
     Actually just a hidden checkbox, but creates an accordion that follows and is followed by the state of the checkbox.
     """
 
+    accordion_id_set = set()
     global_index = 0
 
     def __init__(self, value, **kwargs):
@@ -98,6 +99,18 @@ class InputAccordion(gr.Checkbox):
         if self.accordion_id is None:
             self.accordion_id = f"input-accordion-{InputAccordion.global_index}"
             InputAccordion.global_index += 1
+
+        if not InputAccordion.accordion_id_set:
+            from modules import script_callbacks
+            script_callbacks.on_script_unloaded(InputAccordion.reset)
+
+        if self.accordion_id in InputAccordion.accordion_id_set:
+            count = 1
+            while (unique_id := f'{self.accordion_id}-{count}') in InputAccordion.accordion_id_set:
+                count += 1
+            self.accordion_id = unique_id
+
+        InputAccordion.accordion_id_set.add(self.accordion_id)
 
         kwargs_checkbox = {
             **kwargs,
@@ -143,3 +156,7 @@ class InputAccordion(gr.Checkbox):
     def get_block_name(self):
         return "checkbox"
 
+    @classmethod
+    def reset(cls):
+        cls.global_index = 0
+        cls.accordion_id_set.clear()


### PR DESCRIPTION
## Description

this implements handling of duplicate element IDs for `InputAccordion`
- this PR is a supplement too https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16373

for more details about this issue read #16373

this PR makes  `InputAccordion` function correctly if the issue described in #16373 were to occur, this would also forcibly modify the element ID by app ending a number
if an extension actually relies on the element ID for a specific use case for example inside JavaScript then the JavaScript will still not function
so this is just a "increase compatibility" but not a fix

extension should not rely on this
the real fixed requires manual modification with the use of #16373

---

with this PR
InputAccordion now tracks all previously used InputAccordion elem_id and if if it input ID is found to be a duplicate then it append a number at the end of the input id

a on_script_unloaded callback is added to clear / reset the accordion_id_set and global_index
> the callback is registered here inside the init amd mpt oput side is becaluse ui_components, happens too early before callbacks can be registered
> well if I really want to I can register the call back some other place in the script
> but I feel like registering it somewhere else introduces more spaghetti in the code so I decided to put everything inside the class itself

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
