### PR TITLE
hires button, opt insert gallery

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -314,6 +314,7 @@ options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
     "sd_webui_modal_lightbox_toolbar_opacity": OptionInfo(0.9, "Full page image viewer: tool bar opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
     "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("can be any valid CSS value, for example 768px or 20em").needs_reload_ui(),
     "open_dir_button_choice": OptionInfo("Subdirectory", "What directory the [📂] button opens", gr.Radio, {"choices": ["Output Root", "Subdirectory", "Subdirectory (even temp dir)"]}),
+    "hires_button_gallery_inset": OptionInfo(False, "Insert [✨] hires button results to gallery").info("when False the original first pass image is replaced by the results"),
 }))
 
 options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -87,14 +87,18 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     new_gallery = []
     for i, image in enumerate(gallery):
         if i == gallery_index:
-            geninfo["infotexts"][gallery_index: gallery_index+1] = processed.infotexts
+            if shared.opts.hires_button_gallery_inset:
+                fake_image = Image.new(mode="RGB", size=(1, 1))
+                fake_image.already_saved_as = image["name"].rsplit('?', 1)[0]
+                new_gallery.append(fake_image)
+                geninfo["infotexts"][gallery_index+1: gallery_index+1] = processed.infotexts
+            else:
+                geninfo["infotexts"][gallery_index: gallery_index+1] = processed.infotexts
             new_gallery.extend(processed.images)
         else:
             fake_image = Image.new(mode="RGB", size=(1, 1))
             fake_image.already_saved_as = image["name"].rsplit('?', 1)[0]
             new_gallery.append(fake_image)
-
-    geninfo["infotexts"][gallery_index] = processed.info
 
     return new_gallery, json.dumps(geninfo), plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
 


### PR DESCRIPTION
## Description

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16404

add option to insert the resulting images into Gallery as opposed to replace original when using high button to perform upscale

`Setting > Gallery > Insert [✨] hires button results to gallery` default `False`

## Screenshots/videos:
![image](https://github.com/user-attachments/assets/4cf43f44-f009-4482-a08d-cad41ea0deba)

---

- as far as I can tell `geninfo["infotexts"][gallery_index: gallery_index+1] = processed.infotexts` was a line I forgot to when remove when I was working on https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/cfb90a938eff6d5d4cfa39f58ebc0ab32ffedfb3 luckily it wasn't causing any issues

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
