### PR TITLE
MIME type text/css

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -44,6 +44,9 @@ mimetypes.add_type('application/javascript', '.mjs')
 mimetypes.add_type('image/webp', '.webp')
 mimetypes.add_type('image/avif', '.avif')
 
+# override potentially incorrect mimetypes
+mimetypes.add_type('text/css', '.css')
+
 if not cmd_opts.share and not cmd_opts.listen:
     # fix gradio phoning home
     gradio.utils.version_check = lambda: None


### PR DESCRIPTION
## Description

I'm not sure how / why but apparently sometimes the MIME type of .css can be incorrectly set to `application/text`
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/16396#discussioncomment-10369771

so I think it's a good idea to override it internally to make sure it's `text/css`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
