### PR TITLE
Allow newline in Extra Network activation text

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -201,7 +201,7 @@ function setupExtraNetworks() {
     setupExtraNetworksForTab('img2img');
 }
 
-var re_extranet = /<([^:^>]+:[^:]+):[\d.]+>(.*)/;
+var re_extranet = /<([^:^>]+:[^:]+):[\d.]+>(.*)/s;
 var re_extranet_g = /<([^:^>]+:[^:]+):[\d.]+>/g;
 
 var re_extranet_neg = /\(([^:^>]+:[\d.]+)\)/;

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -177,10 +177,8 @@ def add_pages_to_demo(app):
     app.add_api_route("/sd_extra_networks/get-single-card", get_single_card, methods=["GET"])
 
 
-def quote_js(s):
-    s = s.replace('\\', '\\\\')
-    s = s.replace('"', '\\"')
-    return f'"{s}"'
+def quote_js(s: str):
+    return json.dumps(s, ensure_ascii=False)
 
 
 class ExtraNetworksPage:


### PR DESCRIPTION
## Description
Allow newline in Extra Network activation text

currently it is possible possible for the user to input newline into the activation text by `shift + enter` or copy and paste
when the activation contains new line, it breakes the javascript

## changes / fix
- use json.dumps for `quote_js` so special characters such as newline also properly escaped
- use 's' flag for `re_extranet` regex so that `.` it matches all characters
- - `re_extranet` will have a minor merge conflict with https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15530

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
