### PR TITLE
feat: Allows the XYZ plot to be sorted alphabetically

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -322,6 +322,7 @@ options_templates.update(options_section(('ui_alternatives', "UI alternatives", 
     "txt2img_settings_accordion": OptionInfo(False, "Settings in txt2img hidden under Accordion").needs_reload_ui(),
     "img2img_settings_accordion": OptionInfo(False, "Settings in img2img hidden under Accordion").needs_reload_ui(),
     "interrupt_after_current": OptionInfo(True, "Don't Interrupt in the middle").info("when using Interrupt button, if generating more than one image, stop after the generation of an image has finished, instead of immediately"),
+    "xyz_plot_sort_alphabetical": OptionInfo(True, "Sort XYZ plot options alphabetically").needs_reload_ui(),
 }))
 
 options_templates.update(options_section(('ui', "User interface", "ui"), {

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -419,7 +419,7 @@ class Script(scripts.Script):
     def ui(self, is_img2img):
         _axis_options = copy(axis_options)
         if opts.xyz_plot_sort_alphabetical:
-            _axis_options.sort(key=lambda x: (x.label != "Nothing", x.label)) # Sort by label, but keep "Nothing" first
+            _axis_options.sort(key=lambda x: (x.label != "Nothing", x.label.lower())) # Sort by label, but keep "Nothing" first
 
         self.current_axis_options = [x for x in _axis_options if type(x) == AxisOption or x.is_img2img == is_img2img]
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -417,7 +417,11 @@ class Script(scripts.Script):
         return "X/Y/Z plot"
 
     def ui(self, is_img2img):
-        self.current_axis_options = [x for x in axis_options if type(x) == AxisOption or x.is_img2img == is_img2img]
+        _axis_options = copy(axis_options)
+        if opts.xyz_plot_sort_alphabetical:
+            _axis_options.sort(key=lambda x: (x.label != "Nothing", x.label)) # Sort by label, but keep "Nothing" first
+
+        self.current_axis_options = [x for x in _axis_options if type(x) == AxisOption or x.is_img2img == is_img2img]
 
         with gr.Row():
             with gr.Column(scale=19):


### PR DESCRIPTION
## Description

The XYZ plot currently lists options in an order that seems random, likely reflecting their UI placement. This can make locating specific options challenging, particularly as extensions are adding items to the list.

In this PR:
- added a simple option to sort XYZ Plot options alphabetically
- created a copy of `axis_options` and applied sorting during the XYZ Plot UI rendering
- kept "Nothing" as the first option


## Screenshots/videos:
| Before | After |
|-|-|
| Options are organized by functionality, with related items like Sampler and Hires-Sampler placed together. | Options are sorted alphabetically.|
| ![Before Screenshot](https://github.com/user-attachments/assets/60ade860-adc8-40b2-ab96-2b29aa718c3e) | ![After Screenshot](https://github.com/user-attachments/assets/d24a73ac-069b-4609-8891-cd8720686fc8) |

Settings option:
<img width="460" alt="Screenshot 2024-08-31 at 16 51 56" src="https://github.com/user-attachments/assets/cdf26c8e-137b-4073-b9e0-726d66cd325f">



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
  - Unable to verify tests fully. My MacBook Pro M3pro on master without any changes does not pass all tests.
  - Changes in this PR are UI only. No changes to Python or other server-side code. It is unlikely that these changes will affect existing functionality.
  - Github test passes