### PR TITLE
reduce script extensions loading time using threadpoolexecutor

### DIFF
--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -3,7 +3,9 @@ import re
 import sys
 import inspect
 from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from threading import Lock
 
 import gradio as gr
 
@@ -492,9 +494,10 @@ def load_scripts():
 
     scripts_list = list_scripts("scripts", ".py") + list_scripts("modules/processing_scripts", ".py", include_extensions=False)
 
-    syspath = sys.path
+    lock = Lock()
+    syspath = sys.path[:]
 
-    def register_scripts_from_module(module):
+    def register_scripts_from_module(scriptfile, module):
         for script_class in module.__dict__.values():
             if not inspect.isclass(script_class):
                 continue
@@ -504,24 +507,43 @@ def load_scripts():
             elif issubclass(script_class, scripts_postprocessing.ScriptPostprocessing):
                 postprocessing_scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir, module))
 
-    # here the scripts_list is already ordered
-    # processing_script is not considered though
-    for scriptfile in scripts_list:
+    def load_module(scriptfile):
+        global current_basedir
         try:
-            if scriptfile.basedir != paths.script_path:
-                sys.path = [scriptfile.basedir] + sys.path
-            current_basedir = scriptfile.basedir
+            with lock:
+                if scriptfile.basedir != paths.script_path:
+                    sys.path[0] = scriptfile.basedir
+                current_basedir = scriptfile.basedir
 
-            script_module = script_loading.load_module(scriptfile.path)
-            register_scripts_from_module(script_module)
+                script_module = script_loading.load_module(scriptfile.path)
+            register_scripts_from_module(scriptfile, script_module)
 
         except Exception:
             errors.report(f"Error loading script: {scriptfile.filename}", exc_info=True)
 
         finally:
-            sys.path = syspath
-            current_basedir = paths.script_path
             timer.startup_timer.record(scriptfile.filename)
+
+    sys.path.insert(0, current_basedir)
+
+    # here the scripts_list is already ordered
+    # processing_script is not considered though
+    max_workers = shared.opts.data.get("script_loading_max_thread", 2)
+    if max_workers == 1:
+        for scriptfile in scripts_list:
+            load_module(scriptfile)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(load_module, scriptfile) for scriptfile in scripts_list]
+            completed = 0
+            for _ in as_completed(futures):
+                completed += 1
+
+            print(f"Total {completed} script files loaded")
+
+
+    sys.path = syspath
+    current_basedir = paths.script_path
 
     global scripts_txt2img, scripts_img2img, scripts_postproc
 

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -528,7 +528,7 @@ def load_scripts():
 
     # here the scripts_list is already ordered
     # processing_script is not considered though
-    max_workers = shared.opts.data.get("script_loading_max_thread", 2)
+    max_workers = shared.opts.data.get("script_loading_max_thread", 1)
     if max_workers == 1:
         for scriptfile in scripts_list:
             load_module(scriptfile)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -128,6 +128,7 @@ options_templates.update(options_section(('system', "System", "system"), {
     "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
     "hide_ldm_prints": OptionInfo(True, "Prevent Stability-AI's ldm/sgm modules from printing noise to console."),
     "dump_stacks_on_signal": OptionInfo(False, "Print stack traces before exiting the program with ctrl+c."),
+    "script_loading_max_thread": OptionInfo(2, "Maximum Thread number for for asynchronously loading script extensions", gr.Slider, {"minimum": 1, "maximum": 8, "step": 1}).info("1 = normal execution"),
 }))
 
 options_templates.update(options_section(('profiler', "Profiler", "system"), {

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -128,7 +128,7 @@ options_templates.update(options_section(('system', "System", "system"), {
     "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
     "hide_ldm_prints": OptionInfo(True, "Prevent Stability-AI's ldm/sgm modules from printing noise to console."),
     "dump_stacks_on_signal": OptionInfo(False, "Print stack traces before exiting the program with ctrl+c."),
-    "script_loading_max_thread": OptionInfo(2, "Maximum Thread number for for asynchronously loading script extensions", gr.Slider, {"minimum": 1, "maximum": 8, "step": 1}).info("1 = normal execution"),
+    "script_loading_max_thread": OptionInfo(1, "Maximum Thread number for for asynchronously loading script extensions", gr.Slider, {"minimum": 1, "maximum": 8, "step": 1}).info("1 = normal execution. ⚠ Enabling this feature may cause unintended issues with some extensions."),
 }))
 
 options_templates.update(options_section(('profiler', "Profiler", "system"), {


### PR DESCRIPTION
## Description

* [x] reduce script extensions loading time using ThreadPoolExecutor
  * at loading extension modules step, it could be parallelized.
* [x] add `script_loading_max_thread` "System" option. (set max thread =1 for normal loading)

Notes: Due to the fact that `sys.path` is required with `Lock()`, the effect of `max_thread>2` is not quite large.

## Results:
test condition:
- with all builtin extensions
- +controlnet + dynamic_prompt + supermerge + loractl + ...

without `ThreadPoolExecutor()` : `script_loading_max_thread=1`
~16.5 sec `load scripts` time.

![image](https://github.com/user-attachments/assets/db9fd9e0-d9e8-455c-b958-06498237d9ca)

with `ThreadPoolExecutor()`: `script_loading_max_thread=4`
~10 sec `load scripts` time.
![image](https://github.com/user-attachments/assets/09aeeb81-d9ac-4cc5-9b17-393ba87e709d)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
