### PR TITLE
suppress some chrome violation warnings

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -816,7 +816,7 @@ onUiLoaded(async() => {
                 // Increase or decrease brush size based on scroll direction
                 adjustBrushSize(elemId, e.deltaY);
             }
-        });
+        }, {passive: true});
 
         // Handle the move event for pan functionality. Updates the panX and panY variables and applies the new transform to the target element.
         function handleMoveKeyDown(e) {

--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -104,7 +104,7 @@ var contextMenuInit = function() {
                         e.preventDefault();
                     }
                 });
-            });
+            }, {passive: true});
         });
         eventListenerApplied = true;
 

--- a/javascript/resizeHandle.js
+++ b/javascript/resizeHandle.js
@@ -124,7 +124,7 @@
                 } else {
                     R.screenX = evt.changedTouches[0].screenX;
                 }
-            });
+            }, {passive: true});
         });
 
         resizeHandle.addEventListener('dblclick', onDoubleClick);


### PR DESCRIPTION
## Description

* [x] add `{passive: true}` option the `addEventListener()` to suppress chrome violation warnings.

See also: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
