### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ torchdiffeq
 torchsde
 transformers==4.30.2
 pillow-avif-plugin==1.4.3
+wheel


### PR DESCRIPTION
Add wheel to requirements because 'packaging' module is referred to and is not available unless you install 'wheel' in the environment.

## Description

When setting up A1111 or similar, the 'packaging' module is required.

In later versions of Python (3.10 isn't always available on some people's systems!) the setuptools and other packages that provide this aren't default-installed items.

As such, you have to install the 'wheel' package and its dependencies from PyPI to complete initial setup.

## Screenshots/videos/logs:

Logs showing the failure case to setup:

```
Installing clip
Installing open_clip
Installing xformers
Traceback (most recent call last):
  File "D:\StableDiffusion\A1111\launch.py", line 48, in <module>
    main()
  File "D:\StableDiffusion\A1111\launch.py", line 39, in main
    prepare_environment()
  File "D:\StableDiffusion\A1111\modules\launch_utils.py", line 421, in prepare_environment
    if not requirements_met(requirements_file):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\StableDiffusion\A1111\modules\launch_utils.py", line 289, in requirements_met
    import packaging.version
ModuleNotFoundError: No module named 'packaging'
Press any key to continue . . .
```

This doesn't happen when `wheel` is installed.


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
