### PR TITLE
image embedding data cache

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -291,6 +291,7 @@ options_templates.update(options_section(('extra_networks', "Extra Networks", "s
     "textual_inversion_print_at_load": OptionInfo(False, "Print a list of Textual Inversion embeddings when loading model"),
     "textual_inversion_add_hashes_to_infotext": OptionInfo(True, "Add Textual Inversion hashes to infotext"),
     "sd_hypernetwork": OptionInfo("None", "Add hypernetwork to prompt", gr.Dropdown, lambda: {"choices": ["None", *shared.hypernetworks]}, refresh=shared_items.reload_hypernetworks),
+    "textual_inversion_image_embedding_data_cache": OptionInfo(False, 'Cache the data of image embeddings').info('potentially increase TI load time at the cost some disk space'),
 }))
 
 options_templates.update(options_section(('ui_prompt_editing', "Prompt editing", "ui"), {


### PR DESCRIPTION
## Description

tldr
- reduce future unnecessary disk read for determining if an image is an image embedding or not
- if addition option is enabled potentially reduce embedding load time by cacheing the embedding data

---

in embedding dir webui will scan and load `image embedding`
> images that has textual inversion data embedded inside the image file

all `png` `webp` `jxl` `avif` in the dir will be considered as potential `image embedding` unless the image file name has a second suffix of `preview`
webui will attempt to read and extract the textual inversion data from the image file
this is a rather slow operation as it requires reading of the entire image from disk

---

if a user does not know about or forgot about image embedding (I don't think this is commonly used)
they may decide to sotre extra image files that alongside the embedding file, like previews but don't have the `.preview` 2nd suffix
if there are lots of images then they may found that loading embedded is taking exceedingly long
> this happened to me, when I decided to dump lots of PNGs files that doesn't have `.preview` 2nd suffix into the embedded dir, took me some time to realize what happened

to solve this I use the diskcache from cache models to caching the results of loading an image as embedding
this was able to drastically reduces the time that it takes to load the textual inversion

I implemented so that if an image is not an image embedding then the result is always cache, so next time it won't need to read from disk

if actual image embeddings won't be cached by default unless option `textual_inversion_image_embedding_data_cache : Cache the data of image embeddings` is enabled
the reason why is an option is because even though I believe this reduce load time for the "actual image embedding" it will also takes up extra disk space

---

### Notes:
I don't think I've done any changes that will cause things to break
but I don't have any actual image embedding so this PR tested not teste with real data
if someone that regularly use image embedding please verify this PR

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
