### PR TITLE
addEventListener {passive: false}

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -816,7 +816,7 @@ onUiLoaded(async() => {
                 // Increase or decrease brush size based on scroll direction
                 adjustBrushSize(elemId, e.deltaY);
             }
-        });
+        }, {passive: false});
 
         // Handle the move event for pan functionality. Updates the panX and panY variables and applies the new transform to the target element.
         function handleMoveKeyDown(e) {

--- a/javascript/contextMenus.js
+++ b/javascript/contextMenus.js
@@ -104,7 +104,7 @@ var contextMenuInit = function() {
                         e.preventDefault();
                     }
                 });
-            });
+            }, {passive: false});
         });
         eventListenerApplied = true;
 

--- a/javascript/resizeHandle.js
+++ b/javascript/resizeHandle.js
@@ -124,7 +124,7 @@
                 } else {
                     R.screenX = evt.changedTouches[0].screenX;
                 }
-            });
+            }, {passive: false});
         });
 
         resizeHandle.addEventListener('dblclick', onDoubleClick);


### PR DESCRIPTION
## Description
while passive: false by default there should be no need to specify it as so
and we do call .preventDefault() so it has to be non-passive
the Chrome browser shows vebros level suggestions which annoys some users see
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16547

by specify `passive : false` Chrome won't output suggestions

this PR is not necessary and serves almost no purpose
I don't care if this is merger, I just put this up so I could close the other PR

![image](https://github.com/user-attachments/assets/43925ada-a00a-473f-8f5f-458b4da0baea)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
