### PR TITLE
use empty_like to reduce model loading time

### DIFF
--- a/modules/sd_disable_initialization.py
+++ b/modules/sd_disable_initialization.py
@@ -188,7 +188,7 @@ class LoadStateDictOnMeta(ReplaceHelper):
 
                 if param.is_meta:
                     dtype = sd_param.dtype if sd_param is not None else param.dtype
-                    module._parameters[name] = torch.nn.parameter.Parameter(torch.zeros_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
+                    module._parameters[name] = torch.nn.parameter.Parameter(torch.empty_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
 
             for name in module._buffers:
                 key = prefix + name


### PR DESCRIPTION
use `empty_like()` instead of `zeros_like()` in the `LoadStateDictOnMeta()` we don't have to initialize params with zeros, It will be overwrittened by `param.copy_(input_param)`, (https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L2441 )

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)