### PR TITLE
Warn if WebUI is installed under a dot directory

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -45,6 +45,42 @@ def api_only():
     )
 
 
+def warning_if_invalid_install_dir():
+    """
+    Shows a warning if the webui is installed under a path that contains a leading dot in any of its parent directories.
+
+    Gradio '/file=' route will block access to files that have a leading dot in the path segments.
+    We use this route to serve files such as JavaScript and CSS to the webpage,
+    if those files are blocked, the webpage will not function properly.
+    See https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13292
+
+    This is a security feature was added to Gradio 3.32.0 and is removed in later versions,
+    this function replicates Gradio file access blocking logic.
+
+    This check should be removed when it's no longer applicable.
+    """
+    from pathlib import Path
+
+    def abspath(path):
+        """modified from Gradio 3.41.2 gradio.utils.abspath()"""
+        if path.is_absolute():
+            return path
+        is_symlink = path.is_symlink() or any(parent.is_symlink() for parent in path.parents)
+        if is_symlink or path == path.resolve():
+            return Path.cwd() / path
+        else:
+            return path.resolve()
+    webui_root = Path(__file__).parent
+    if any(part.startswith(".") for part in abspath(webui_root).parts):
+        print(f'''{"!"*25} Warning {"!"*25}
+WebUI is installed in a directory that has a leading dot (.) in one of its parent directories.
+This will prevent WebUI from functioning properly.
+Please move the installation to a different directory.
+Current path: "{webui_root}"
+For more information see: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13292
+{"!"*25} Warning {"!"*25}''')
+
+
 def webui():
     from modules.shared_cmd_options import cmd_opts
 
@@ -52,6 +88,8 @@ def webui():
     initialize.initialize()
 
     from modules import shared, ui_tempdir, script_callbacks, ui, progress, ui_extra_networks
+
+    warning_if_invalid_install_dir()
 
     while 1:
         if shared.opts.clean_temp_dir_at_start:

--- a/webui.py
+++ b/webui.py
@@ -59,20 +59,22 @@ def warning_if_invalid_install_dir():
 
     This check should be removed when it's no longer applicable.
     """
+    from packaging.version import parse
     from pathlib import Path
+    import gradio
 
-    def abspath(path):
-        """modified from Gradio 3.41.2 gradio.utils.abspath()"""
-        if path.is_absolute():
-            return path
-        is_symlink = path.is_symlink() or any(parent.is_symlink() for parent in path.parents)
-        if is_symlink or path == path.resolve():
-            return Path.cwd() / path
-        else:
-            return path.resolve()
-    webui_root = Path(__file__).parent
-    if any(part.startswith(".") for part in abspath(webui_root).parts):
-        print(f'''{"!"*25} Warning {"!"*25}
+    if parse('3.32.0') <= parse(gradio.__version__) < parse('4'):
+
+        def abspath(path):
+            """modified from Gradio 3.41.2 gradio.utils.abspath()"""
+            if path.is_absolute():
+                return path
+            is_symlink = path.is_symlink() or any(parent.is_symlink() for parent in path.parents)
+            return Path.cwd() / path if (is_symlink or path == path.resolve()) else path.resolve()
+
+        webui_root = Path(__file__).parent
+        if any(part.startswith(".") for part in abspath(webui_root).parts):
+            print(f'''{"!"*25} Warning {"!"*25}
 WebUI is installed in a directory that has a leading dot (.) in one of its parent directories.
 This will prevent WebUI from functioning properly.
 Please move the installation to a different directory.


### PR DESCRIPTION
## Description
detects and show a warning if WebUI is installed under a dot directory whitch will break the webpage as lots of files are blocked

this is a long-standing issue see
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13292

even though I have pind the issue on top of the issue page
I still see people faceing this issue from time to time

so better to add big a warning

- this issue should get resolve when https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14184 is merged
- - ~~no idea when that will happen~~
- this warning should be removed in the future when it's no longer necessary

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
