### PR TITLE
support loading libtcmalloc_minimal.dll for windows

### DIFF
--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -213,3 +213,21 @@ def configure_cors_middleware(app):
         cors_options["allow_origin_regex"] = cmd_opts.cors_allow_origins_regex
     app.add_middleware(CORSMiddleware, **cors_options)
 
+
+def preload_malloc():
+    if os.name == 'nt':
+        import ctypes
+        # under windows we can't use LD_PRELOAD method but still we can load the libtcmalloc_minimal.dll using ctypes.cdll
+        # https://github.com/gperftools/gperftools/ (only gperftools's tcmalloc works with windows)
+        # build libtcmalloc_minimal.dll patch module and copy it into the top dir of webui
+
+        dir_path = os.path.dirname(__file__)
+        tcmallocdll = os.path.join(dir_path, "..", "libtcmalloc_minimal.dll")
+
+        if os.path.exists(tcmallocdll):
+            # load libtcmalloc_minimal.dll if it exists.
+            _tcmalloc_dll = ctypes.cdll.LoadLibrary(tcmallocdll)
+
+            return 'tcmalloc'
+
+    return None

--- a/webui.py
+++ b/webui.py
@@ -10,6 +10,10 @@ from modules import initialize
 startup_timer = timer.startup_timer
 startup_timer.record("launcher")
 
+malloc = initialize_util.preload_malloc()
+if malloc is not None:
+    startup_timer.record(f"{malloc}")
+
 initialize.imports()
 
 initialize.check_versions()


### PR DESCRIPTION
## Description
The effectiveness of tcmalloc has been discussed in several other threads.
For Windows, `LD_PRELOAD` is not available, but the `tcmalloc_minimal` module supported by gperftool can be compiled with `patch` type to use with Windows and perform hot patching already loaded modules.

## How to compile/install `tcmalloc_minimal`

- git  checkout https://github.com/gperftools/gperftools/
- install visual c++ 2022 + open cmd.exe and `cd go_to_gperfoools`
- `cd gperftools\vsprojects\libtcmalloc_minimal`
- `msbuild /property:Configuration=Release-Patch`
- copy `x64\Release-Patch\libtcmalloc_minimal.dll` to the top dir of webui

## Notes
- some extensions will not work as expected with strange error msg. (e.g. Adetailer)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
