### PR TITLE
add "Forbid too small crop region" option

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -77,6 +77,44 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
     return x1, y1, x2, y2
 
 
+def expand_too_small_crop_region(crop_region, processing_width, processing_height, image_width, image_height):
+    """expands crop region to not have width and height smaller then processing_width and processing_height"""
+
+    x1, y1, x2, y2 = crop_region
+
+    desired_w = processing_width
+    diff_w = desired_w - (x2 - x1)
+    if diff_w > 0:
+        diff_w_l = diff_w // 2
+        diff_w_r = diff_w - diff_w_l
+        x1 -= diff_w_l
+        x2 += diff_w_r
+        if x1 < 0:
+            x2 -= x1
+            x1 -= x1
+        if x2 >= image_width:
+            x2 = image_width
+
+    desired_h = processing_height
+    diff_h = desired_h - (y2 - y1)
+    if diff_h > 0:
+        diff_h_u = diff_h // 2
+        diff_h_d = diff_h - diff_h_u
+        y1 -= diff_h_u
+        y2 += diff_h_d
+        if y1 < 0:
+            y2 -= y1
+            y1 -= y1
+        if y2 >= image_height:
+            y2 = image_height
+
+    if diff_h > 0 or diff_w > 0:
+        print("Crop region was smaller then resolution and has been corrected")
+
+    return x1, y1, x2, y2
+
+
+
 def fill(image, mask):
     """fills masked regions with colors from image using blur. Not extremely effective."""
 

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -89,6 +89,10 @@ def expand_too_small_crop_region(crop_region, processing_width, processing_heigh
         diff_w_r = diff_w - diff_w_l
         x1 -= diff_w_l
         x2 += diff_w_r
+        if x2 >= image_width:
+            diff = x2 - image_width
+            x2 -= diff
+            x1 -= diff
         if x1 < 0:
             x2 -= x1
             x1 -= x1
@@ -102,6 +106,10 @@ def expand_too_small_crop_region(crop_region, processing_width, processing_heigh
         diff_h_d = diff_h - diff_h_u
         y1 -= diff_h_u
         y2 += diff_h_d
+        if y2 >= image_height:
+            diff = y2 - image_height
+            y2 -= diff
+            y1 -= diff
         if y1 < 0:
             y2 -= y1
             y1 -= y1

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1639,6 +1639,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
                 if crop_region:
                     crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    if shared.opts.forbid_too_small_crop_region:
+                        crop_region = masking.expand_too_small_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -227,6 +227,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "forbid_too_small_crop_region": OptionInfo(False, "Forbid too small crop region").info("Correct inpaint padding for only masked to avoid crop region sides less then processing resolution"),
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {


### PR DESCRIPTION
## Description

Expands crop region if it is smaller then processing resolution. This can happen for example if was selected 60px mask, padding = 90, so crop region has 240px side. With this option it will be expanded to 512px to not lose "free" context which doesn't eat resolution. This behavior can be either desirable or not, so I've made an option

Copy of https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16260 but disconnected with my other patch

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
