### PR TITLE
Check for Extension Updates in Parallel

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -128,6 +128,7 @@ options_templates.update(options_section(('system', "System", "system"), {
     "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
     "hide_ldm_prints": OptionInfo(True, "Prevent Stability-AI's ldm/sgm modules from printing noise to console."),
     "dump_stacks_on_signal": OptionInfo(False, "Print stack traces before exiting the program with ctrl+c."),
+    "concurrent_git_fetch_limit": OptionInfo(16, "Number of simultaneous extension update checks ", gr.Slider, {"step": 1, "minimum": 1, "maximum": 100}).info("reduce extension update check time"),
 }))
 
 options_templates.update(options_section(('profiler', "Profiler", "system"), {

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -1,5 +1,6 @@
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 import threading
 import time
 from datetime import datetime, timezone
@@ -106,26 +107,24 @@ def check_updates(id_task, disable_list):
     exts = [ext for ext in extensions.extensions if ext.remote is not None and ext.name not in disabled]
     shared.state.job_count = len(exts)
 
-    def _check_update(ext):
-        shared.state.textinfo = ext.name
+    lock = threading.Lock()
 
+    def _check_update(ext):
         try:
             ext.check_updates()
         except FileNotFoundError as e:
             if 'FETCH_HEAD' not in str(e):
                 raise
         except Exception:
-            errors.report(f"Error checking updates for {ext.name}", exc_info=True)
+            with lock:
+                errors.report(f"Error checking updates for {ext.name}", exc_info=True)
+        with lock:
+            shared.state.textinfo = ext.name
+            shared.state.nextjob()
 
-    threads = []
-    for ext in exts:
-        thread = threading.Thread(target=_check_update, args=(ext,))
-        thread.start()
-        threads.append(thread)
-
-    for thread in threads:
-        thread.join()
-        shared.state.nextjob()
+    with ThreadPoolExecutor(max_workers=max(1, int(shared.opts.concurrent_git_fetch_limit))) as executor:
+        for ext in exts:
+            executor.submit(_check_update, ext)
 
     return extension_table(), ""
 

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -106,7 +106,7 @@ def check_updates(id_task, disable_list):
     exts = [ext for ext in extensions.extensions if ext.remote is not None and ext.name not in disabled]
     shared.state.job_count = len(exts)
 
-    for ext in exts:
+    def _check_update(ext):
         shared.state.textinfo = ext.name
 
         try:
@@ -117,6 +117,14 @@ def check_updates(id_task, disable_list):
         except Exception:
             errors.report(f"Error checking updates for {ext.name}", exc_info=True)
 
+    threads = []
+    for ext in exts:
+        thread = threading.Thread(target=_check_update, args=(ext,))
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
         shared.state.nextjob()
 
     return extension_table(), ""


### PR DESCRIPTION
## Description

- **a simple description of what you're trying to accomplish:**  Check the updates for all Extensions at once rather than one by one
    - On my system, checking updates for a dozen Extensions now only takes around 1 second, and after applying the updates, everything still works fine.
- **a summary of changes in code:** Make the `for ext in exts:` loop multi-threaded using the `threading` package

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

<hr>

Though, I'm not sure if the `shared.state` parts should be changed or not...
