### PR TITLE
Fix config for SDXL v-pred

### DIFF
--- a/configs/sd_xl_v.yaml
+++ b/configs/sd_xl_v.yaml
@@ -21,7 +21,7 @@ model:
       params:
         adm_in_channels: 2816
         num_classes: sequential
-        use_checkpoint: True
+        use_checkpoint: False
         in_channels: 4
         out_channels: 4
         model_channels: 320

--- a/configs/sd_xl_v.yaml
+++ b/configs/sd_xl_v.yaml
@@ -10,7 +10,7 @@ model:
         num_idx: 1000
 
         weighting_config:
-          target: sgm.modules.diffusionmodules.denoiser_weighting.EpsWeighting
+          target: sgm.modules.diffusionmodules.denoiser_weighting.VWeighting
         scaling_config:
           target: sgm.modules.diffusionmodules.denoiser_scaling.VScaling
         discretization_config:


### PR DESCRIPTION
## Description

Fixes a few small oversights I made. Weighting should be using v-prediction rather than epsilon. `use_checkpoint` is also not necessary (see https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15803).

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
