### PR TITLE
Change --nowebui default port to 7860

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -40,7 +40,7 @@ def api_only():
     print(f"Startup time: {startup_timer.summary()}.")
     api.launch(
         server_name=initialize_util.gradio_server_name(),
-        port=cmd_opts.port if cmd_opts.port else 7861,
+        port=cmd_opts.port if cmd_opts.port else 7860,
         root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else ""
     )
 


### PR DESCRIPTION
There doesn't seem to be any particular reason for this to be different. This way, it works consistently whether `--nowebui` is enabled or not.
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
