### PR TITLE
Canvas: Undo & Clear hotkey, brush scales by area, consistent max brush size

### DIFF
--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -483,7 +483,12 @@ onUiLoaded(async() => {
                         const currentRadius = parseFloat(input.value);
                         const currentArea = currentRadius ** 2;
                         const newArea = currentArea * brush_factor;
-                        const newValue = Math.sqrt(newArea);
+                        let delta = Math.sqrt(newArea) - currentRadius;
+                        // gradio seems to have a minimum brush size step of 1
+                        if (Math.abs(delta) < 1) {
+                            delta = delta > 0 ? 1 : -1;
+                        }
+                        const newValue = currentRadius + delta;
                         input.value = Math.min(Math.max(newValue, 0), maxValue);
                     }
                     input.dispatchEvent(new Event("change"));

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -470,11 +470,20 @@ onUiLoaded(async() => {
                 if (!withoutValue) {
                     const maxValue =
                         parseFloat(input.getAttribute("max")) || 100;
-                    const changeAmount = maxValue * (percentage / 100);
-                    const newValue =
-                        parseFloat(input.value) +
-                        (deltaY > 0 ? -changeAmount : changeAmount);
-                    input.value = Math.min(Math.max(newValue, 0), maxValue);
+                    if (opts.canvas_hotkey_brush_scale === "Radius") {
+                        const changeAmount = maxValue * (percentage / 100);
+                        const newValue =
+                            parseFloat(input.value) +
+                            (deltaY > 0 ? -changeAmount : changeAmount);
+                        input.value = Math.min(Math.max(newValue, 0), maxValue);
+                    } else {
+                        const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor
+                        const currentRadius = parseFloat(input.value);
+                        const currentArea = currentRadius ** 2;
+                        const newArea = currentArea * brush_factor;
+                        const newValue = Math.sqrt(newArea);
+                        input.value = Math.min(Math.max(newValue, 0), maxValue);
+                    }
                     input.dispatchEvent(new Event("change"));
                 }
             }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -227,6 +227,7 @@ onUiLoaded(async() => {
         canvas_auto_expand: true,
         canvas_blur_prompt: false,
         canvas_hotkey_undo: "KeyZ",
+        canvas_hotkey_clear: "KeyC",
     };
 
     const functionMap = {
@@ -323,6 +324,7 @@ onUiLoaded(async() => {
                     keySuffix: " + wheel"
                 },
                 {configKey: "canvas_hotkey_undo", action: "Undo brush stroke"},
+                {configKey: "canvas_hotkey_clear", action: "Clear canvas"},
                 {configKey: "canvas_hotkey_reset", action: "Reset zoom"},
                 {
                     configKey: "canvas_hotkey_fullscreen",
@@ -481,9 +483,7 @@ onUiLoaded(async() => {
                     } else {
                         const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor
                         const currentRadius = parseFloat(input.value);
-                        const currentArea = currentRadius ** 2;
-                        const newArea = currentArea * brush_factor;
-                        let delta = Math.sqrt(newArea) - currentRadius;
+                        let delta = Math.sqrt(currentRadius ** 2 * brush_factor) - currentRadius;
                         // gradio seems to have a minimum brush size step of 1
                         if (Math.abs(delta) < 1) {
                             delta = delta > 0 ? 1 : -1;
@@ -499,6 +499,10 @@ onUiLoaded(async() => {
         // Undo the last brush stroke by clicking the undo button
         function undoBrushStroke() {
             gradioApp().querySelector(`${elemId} button[aria-label='Undo']`).click();
+        }
+
+        function clearCanvas() {
+            gradioApp().querySelector(`${elemId} button[aria-label='Clear']`).click();
         }
 
         // Reset zoom when uploading a new image
@@ -721,7 +725,8 @@ onUiLoaded(async() => {
                 [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen,
                 [hotkeysConfig.canvas_hotkey_shrink_brush]: () => adjustBrushSize(elemId, 10),
                 [hotkeysConfig.canvas_hotkey_grow_brush]: () => adjustBrushSize(elemId, -10),
-                [hotkeysConfig.canvas_hotkey_undo]: undoBrushStroke
+                [hotkeysConfig.canvas_hotkey_undo]: undoBrushStroke,
+                [hotkeysConfig.canvas_hotkey_clear]: clearCanvas
             };
 
             const action = hotkeyActions[event.code];

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -482,8 +482,18 @@ onUiLoaded(async() => {
                     if (Math.abs(delta) < 1) {
                         delta = deltaY > 0 ? -1 : 1;
                     }
-                    let newValue = currentRadius + delta;
-                    input.value = Math.min(Math.max(newValue, 1), maxValue);
+                    const newValue = currentRadius + delta;
+                    // allow increasing the brush size beyond what's limited by gradio up to 1/2 diagonal of the image
+                    if (newValue > maxValue) {
+                        const canvasImg = gradioApp().querySelector(`${elemId} img`);
+                        if (canvasImg) {
+                            const maxDiameter = Math.sqrt(canvasImg.naturalWidth ** 2 + canvasImg.naturalHeight ** 2) / 2;
+                            if (newValue < maxDiameter) {
+                                input.setAttribute("max", newValue);
+                            }
+                        }
+                    }
+                    input.value = Math.max(newValue, 1);
                     input.dispatchEvent(new Event("change"));
                 }
             }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -476,7 +476,7 @@ onUiLoaded(async() => {
                 if (!withoutValue) {
                     const maxValue =
                         parseFloat(input.getAttribute("max")) || 100;
-                    if (opts.canvas_hotkey_brush_scale === "Radius") {
+                    if (opts.canvas_hotkey_brush_factor_mode === "Radius") {
                         const changeAmount = maxValue * (percentage / 100);
                         const newValue =
                             parseFloat(input.value) +

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -483,7 +483,7 @@ onUiLoaded(async() => {
                             (deltaY > 0 ? -changeAmount : changeAmount);
                         input.value = Math.min(Math.max(newValue, 0), maxValue);
                     } else {
-                        const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor
+                        const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor;
                         const currentRadius = parseFloat(input.value);
                         let delta = Math.sqrt(currentRadius ** 2 * brush_factor) - currentRadius;
                         // gradio seems to have a minimum brush size step of 1

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -238,7 +238,9 @@ onUiLoaded(async() => {
         "Moving canvas": "canvas_hotkey_move",
         "Fullscreen": "canvas_hotkey_fullscreen",
         "Reset Zoom": "canvas_hotkey_reset",
-        "Overlap": "canvas_hotkey_overlap"
+        "Overlap": "canvas_hotkey_overlap",
+        "Undo": "canvas_hotkey_undo",
+        "Clear": "canvas_hotkey_clear"
     };
 
     // Loading the configuration from opts

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -226,6 +226,7 @@ onUiLoaded(async() => {
         canvas_show_tooltip: true,
         canvas_auto_expand: true,
         canvas_blur_prompt: false,
+        canvas_hotkey_undo: "KeyZ",
     };
 
     const functionMap = {
@@ -321,6 +322,7 @@ onUiLoaded(async() => {
                     action: "Adjust brush size",
                     keySuffix: " + wheel"
                 },
+                {configKey: "canvas_hotkey_undo", action: "Undo brush stroke"},
                 {configKey: "canvas_hotkey_reset", action: "Reset zoom"},
                 {
                     configKey: "canvas_hotkey_fullscreen",
@@ -487,6 +489,11 @@ onUiLoaded(async() => {
                     input.dispatchEvent(new Event("change"));
                 }
             }
+        }
+
+        // Undo the last brush stroke by clicking the undo button
+        function undoBrushStroke() {
+            gradioApp().querySelector(`${elemId} button[aria-label='Undo']`).click();
         }
 
         // Reset zoom when uploading a new image
@@ -708,7 +715,8 @@ onUiLoaded(async() => {
                 [hotkeysConfig.canvas_hotkey_overlap]: toggleOverlap,
                 [hotkeysConfig.canvas_hotkey_fullscreen]: fitToScreen,
                 [hotkeysConfig.canvas_hotkey_shrink_brush]: () => adjustBrushSize(elemId, 10),
-                [hotkeysConfig.canvas_hotkey_grow_brush]: () => adjustBrushSize(elemId, -10)
+                [hotkeysConfig.canvas_hotkey_grow_brush]: () => adjustBrushSize(elemId, -10),
+                [hotkeysConfig.canvas_hotkey_undo]: undoBrushStroke
             };
 
             const action = hotkeyActions[event.code];

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -470,11 +470,18 @@ onUiLoaded(async() => {
                 gradioApp().querySelector(
                     `${elemId} button[aria-label="Use brush"]`
                 );
-
             if (input) {
                 input.click();
                 if (!withoutValue) {
                     const maxValue = parseFloat(input.getAttribute("max")) || 100;
+                    // allow brush size up to 1/2 diagonal of the image, beyond gradio's arbitrary limit
+                    const canvasImg = gradioApp().querySelector(`${elemId} img`);
+                    if (canvasImg) {
+                        const maxDiameter = Math.sqrt(canvasImg.naturalWidth ** 2 + canvasImg.naturalHeight ** 2) / 2;
+                        if (maxDiameter > maxValue) {
+                            input.setAttribute("max", maxDiameter);
+                        }
+                    }
                     const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor;
                     const currentRadius = parseFloat(input.value);
                     let delta = Math.sqrt(currentRadius ** 2 * brush_factor) - currentRadius;
@@ -483,16 +490,6 @@ onUiLoaded(async() => {
                         delta = deltaY > 0 ? -1 : 1;
                     }
                     const newValue = currentRadius + delta;
-                    // allow increasing the brush size beyond what's limited by gradio up to 1/2 diagonal of the image
-                    if (newValue > maxValue) {
-                        const canvasImg = gradioApp().querySelector(`${elemId} img`);
-                        if (canvasImg) {
-                            const maxDiameter = Math.sqrt(canvasImg.naturalWidth ** 2 + canvasImg.naturalHeight ** 2) / 2;
-                            if (newValue < maxDiameter) {
-                                input.setAttribute("max", newValue);
-                            }
-                        }
-                    }
                     input.value = Math.max(newValue, 1);
                     input.dispatchEvent(new Event("change"));
                 }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -474,25 +474,16 @@ onUiLoaded(async() => {
             if (input) {
                 input.click();
                 if (!withoutValue) {
-                    const maxValue =
-                        parseFloat(input.getAttribute("max")) || 100;
-                    if (opts.canvas_hotkey_brush_factor_mode === "Radius") {
-                        const changeAmount = maxValue * (percentage / 100);
-                        const newValue =
-                            parseFloat(input.value) +
-                            (deltaY > 0 ? -changeAmount : changeAmount);
-                        input.value = Math.min(Math.max(newValue, 0), maxValue);
-                    } else {
-                        const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor;
-                        const currentRadius = parseFloat(input.value);
-                        let delta = Math.sqrt(currentRadius ** 2 * brush_factor) - currentRadius;
-                        // gradio seems to have a minimum brush size step of 1
-                        if (Math.abs(delta) < 1) {
-                            delta = delta > 0 ? 1 : -1;
-                        }
-                        const newValue = currentRadius + delta;
-                        input.value = Math.min(Math.max(newValue, 0), maxValue);
+                    const maxValue = parseFloat(input.getAttribute("max")) || 100;
+                    const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor;
+                    const currentRadius = parseFloat(input.value);
+                    let delta = Math.sqrt(currentRadius ** 2 * brush_factor) - currentRadius;
+                    // minimum brush size step of 1
+                    if (Math.abs(delta) < 1) {
+                        delta = deltaY > 0 ? -1 : 1;
                     }
+                    let newValue = currentRadius + delta;
+                    input.value = Math.min(Math.max(newValue, 1), maxValue);
                     input.dispatchEvent(new Event("change"));
                 }
             }

--- a/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
+++ b/extensions-builtin/canvas-zoom-and-pan/javascript/zoom.js
@@ -474,12 +474,16 @@ onUiLoaded(async() => {
                 input.click();
                 if (!withoutValue) {
                     const maxValue = parseFloat(input.getAttribute("max")) || 100;
+                    const minValue = parseFloat(input.getAttribute("min")) || 1;
                     // allow brush size up to 1/2 diagonal of the image, beyond gradio's arbitrary limit
                     const canvasImg = gradioApp().querySelector(`${elemId} img`);
                     if (canvasImg) {
                         const maxDiameter = Math.sqrt(canvasImg.naturalWidth ** 2 + canvasImg.naturalHeight ** 2) / 2;
                         if (maxDiameter > maxValue) {
                             input.setAttribute("max", maxDiameter);
+                        }
+                        if (minValue > 1) {
+                            input.setAttribute("min", '1');
                         }
                     }
                     const brush_factor = deltaY > 0 ? 1 - opts.canvas_hotkey_brush_factor : 1 + opts.canvas_hotkey_brush_factor;

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -2,8 +2,8 @@ import gradio as gr
 from modules import shared
 
 shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas Hotkeys"), {
-    "canvas_hotkey_zoom": shared.OptionInfo("Alt", "Zoom canvas", gr.Radio, {"choices": ["Shift","Ctrl", "Alt"]}).info("If you choose 'Shift' you cannot scroll horizontally, 'Alt' can cause a little trouble in firefox"),
-    "canvas_hotkey_adjust": shared.OptionInfo("Ctrl", "Adjust brush size", gr.Radio, {"choices": ["Shift","Ctrl", "Alt"]}).info("If you choose 'Shift' you cannot scroll horizontally, 'Alt' can cause a little trouble in firefox"),
+    "canvas_hotkey_zoom": shared.OptionInfo("Alt", "Zoom canvas", gr.Radio, {"choices": ["Shift", "Ctrl", "Alt"]}).info("If you choose 'Shift' you cannot scroll horizontally, 'Alt' can cause a little trouble in firefox"),
+    "canvas_hotkey_adjust": shared.OptionInfo("Ctrl", "Adjust brush size", gr.Radio, {"choices": ["Shift", "Ctrl", "Alt"]}).info("If you choose 'Shift' you cannot scroll horizontally, 'Alt' can cause a little trouble in firefox"),
     "canvas_hotkey_shrink_brush": shared.OptionInfo("Q", "Shrink the brush size"),
     "canvas_hotkey_grow_brush": shared.OptionInfo("W", "Enlarge the brush size"),
     "canvas_hotkey_move": shared.OptionInfo("F", "Moving the canvas").info("To work correctly in firefox, turn off 'Automatically search the page text when typing' in the browser settings"),
@@ -13,5 +13,7 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_show_tooltip": shared.OptionInfo(True, "Enable tooltip on the canvas"),
     "canvas_auto_expand": shared.OptionInfo(True, "Automatically expands an image that does not fit completely in the canvas area, similar to manually pressing the S and R buttons"),
     "canvas_blur_prompt": shared.OptionInfo(False, "Take the focus off the prompt when working with a canvas"),
-    "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom","Adjust brush size","Hotkey enlarge brush","Hotkey shrink brush","Moving canvas","Fullscreen","Reset Zoom","Overlap"]}),
+    "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom", "Adjust brush size", "Hotkey enlarge brush", "Hotkey shrink brush", "Moving canvas", "Fullscreen", "Reset Zoom", "Overlap"]}),
+    "canvas_hotkey_brush_scale": shared.OptionInfo("Radius", "Brush scale", gr.Radio, {"choices": ["Radius", "Area"]}),
+    "canvas_hotkey_brush_factor": shared.OptionInfo(0.1, "Brush factor", gr.Slider, {"minimum": 0, "maximum": 2, "step": 0.01})
 }))

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -16,6 +16,6 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_auto_expand": shared.OptionInfo(True, "Automatically expands an image that does not fit completely in the canvas area, similar to manually pressing the S and R buttons"),
     "canvas_blur_prompt": shared.OptionInfo(False, "Take the focus off the prompt when working with a canvas"),
     "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom", "Adjust brush size", "Hotkey enlarge brush", "Hotkey shrink brush", "Undo", "Clear", "Moving canvas", "Fullscreen", "Reset Zoom", "Overlap"]}),
-    "canvas_hotkey_brush_scale": shared.OptionInfo("Radius", "Brush scale", gr.Radio, {"choices": ["Radius", "Area"]}),
+    "canvas_hotkey_brush_factor_mode": shared.OptionInfo("Area", "Brush size adjustment mode", gr.Radio, {"choices": ["Area", "Radius"]}),
     "canvas_hotkey_brush_factor": shared.OptionInfo(0.1, "Brush factor", gr.Slider, {"minimum": 0, "maximum": 2, "step": 0.01})
 }))

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -15,7 +15,7 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_show_tooltip": shared.OptionInfo(True, "Enable tooltip on the canvas"),
     "canvas_auto_expand": shared.OptionInfo(True, "Automatically expands an image that does not fit completely in the canvas area, similar to manually pressing the S and R buttons"),
     "canvas_blur_prompt": shared.OptionInfo(False, "Take the focus off the prompt when working with a canvas"),
-    "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom", "Adjust brush size", "Hotkey enlarge brush", "Hotkey shrink brush", "Moving canvas", "Fullscreen", "Reset Zoom", "Overlap"]}),
+    "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom", "Adjust brush size", "Hotkey enlarge brush", "Hotkey shrink brush", "Undo", "Clear", "Moving canvas", "Fullscreen", "Reset Zoom", "Overlap"]}),
     "canvas_hotkey_brush_scale": shared.OptionInfo("Radius", "Brush scale", gr.Radio, {"choices": ["Radius", "Area"]}),
     "canvas_hotkey_brush_factor": shared.OptionInfo(0.1, "Brush factor", gr.Slider, {"minimum": 0, "maximum": 2, "step": 0.01})
 }))

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -7,6 +7,7 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_hotkey_shrink_brush": shared.OptionInfo("Q", "Shrink the brush size"),
     "canvas_hotkey_grow_brush": shared.OptionInfo("W", "Enlarge the brush size"),
     "canvas_hotkey_move": shared.OptionInfo("F", "Moving the canvas").info("To work correctly in firefox, turn off 'Automatically search the page text when typing' in the browser settings"),
+    "canvas_hotkey_undo": shared.OptionInfo("Z", "Undo brush stroke"),
     "canvas_hotkey_fullscreen": shared.OptionInfo("S", "Fullscreen Mode, maximizes the picture so that it fits into the screen and stretches it to its full width "),
     "canvas_hotkey_reset": shared.OptionInfo("R", "Reset zoom and canvas position"),
     "canvas_hotkey_overlap": shared.OptionInfo("O", "Toggle overlap").info("Technical button, needed for testing"),

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -8,6 +8,7 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_hotkey_grow_brush": shared.OptionInfo("W", "Enlarge the brush size"),
     "canvas_hotkey_move": shared.OptionInfo("F", "Moving the canvas").info("To work correctly in firefox, turn off 'Automatically search the page text when typing' in the browser settings"),
     "canvas_hotkey_undo": shared.OptionInfo("Z", "Undo brush stroke"),
+    "canvas_hotkey_clear": shared.OptionInfo("C", "Clear canvas"),
     "canvas_hotkey_fullscreen": shared.OptionInfo("S", "Fullscreen Mode, maximizes the picture so that it fits into the screen and stretches it to its full width "),
     "canvas_hotkey_reset": shared.OptionInfo("R", "Reset zoom and canvas position"),
     "canvas_hotkey_overlap": shared.OptionInfo("O", "Toggle overlap").info("Technical button, needed for testing"),

--- a/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
+++ b/extensions-builtin/canvas-zoom-and-pan/scripts/hotkey_config.py
@@ -16,6 +16,5 @@ shared.options_templates.update(shared.options_section(('canvas_hotkey', "Canvas
     "canvas_auto_expand": shared.OptionInfo(True, "Automatically expands an image that does not fit completely in the canvas area, similar to manually pressing the S and R buttons"),
     "canvas_blur_prompt": shared.OptionInfo(False, "Take the focus off the prompt when working with a canvas"),
     "canvas_disabled_functions": shared.OptionInfo(["Overlap"], "Disable function that you don't use", gr.CheckboxGroup, {"choices": ["Zoom", "Adjust brush size", "Hotkey enlarge brush", "Hotkey shrink brush", "Undo", "Clear", "Moving canvas", "Fullscreen", "Reset Zoom", "Overlap"]}),
-    "canvas_hotkey_brush_factor_mode": shared.OptionInfo("Area", "Brush size adjustment mode", gr.Radio, {"choices": ["Area", "Radius"]}),
-    "canvas_hotkey_brush_factor": shared.OptionInfo(0.1, "Brush factor", gr.Slider, {"minimum": 0, "maximum": 2, "step": 0.01})
+    "canvas_hotkey_brush_factor": shared.OptionInfo(0.1, "Brush size change rate", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}).info('controls how much the brush size is changed when using hotkeys or scroll wheel'),
 }))


### PR DESCRIPTION
## Description

- add Undo hotkey to canvas
- - default `Z` key
- add Clear hotkey to canvas
- - default `C` key

https://github.com/user-attachments/assets/226e44d9-bfcd-4430-a1b5-d92c6e85ec22

---

- Brush size adjustment mode, `Area` ~~and `Radius`~~ (new commit removed `Radius` mode)
- - currently the brush size increase or decrease by 5% (hardcoded) of the maximum allowed `Radius` of the brush
- - - > I'm not sure how gradio determines the maximum brush size
- - - this poses some usability issues especially when dealing with small brush sizes
- - to solve this issue I implemented a new scaling method based on the `Area`
- - - with the Area method the brush size is increase or decrease by 10% (configurable) in Area allowing for finer adjustment

in my opinion `Area` mode it's much more usable than `Radius` mode
as such I have made the `Area` mode the `Default` **changing old behavior**
users who prefer the old method can configure it in settings
>  I have been testing with Area mode for a while locally and it feels quite natural

Radius

https://github.com/user-attachments/assets/70047e5e-0640-4962-9b19-d5bb79bd7abe

Area

https://github.com/user-attachments/assets/625b7df1-6840-4c87-883c-dc215fdbcb21

notice that the Area mode brush size step is much more smoother then Radius

---

Brush size is set to 1/2 diagonal image, beyond the gradio default after the usere uses either the hotkeys or scroll wheel to change the brush size
- see comment below https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16668#issuecomment-2492759100

---

Considering there's no timeline for Gradio 4 or 5 
I think implement this relatively trivial function is worth it

---

future potential improvements / discussion

- add hotkey for removeing the image?
- - what key should it use

- in the PR only the factor / step for `Area` mode is configurable, while the `5%` step in Radius model is hardcoded
- should it be made configurable, if so should it share the same setting key as the factor used for `Area` mode
- - if so it's going to be hard to set a default value
- - or should it use a different setting key


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
