### PR TITLE
fix prompt-bracket-checker miscounting of literal tokens

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -5,7 +5,7 @@
 
 function checkBrackets(textArea, counterElt) {
     var counts = {};
-    (textArea.value.match(/[(){}[\]]/g) || []).forEach(bracket => {
+    (textArea.value.match(/(?<!\\)[(){}[\]]/g) || []).forEach(bracket => {
         counts[bracket] = (counts[bracket] || 0) + 1;
     });
     var errors = [];


### PR DESCRIPTION
## Description

Current the `prompt-bracket-checker.js` treats literal tokens as normal tokens 
> brackets and parentheses proceeded with a slash `\(` `\)` are literal

this is wrong

this can easily be fixed by modifying the regex to so it does not count tokens proceeded by a `\`

internal prompt parser for reference 
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/prompt_parser.py#L370-L382

> this is not too big of an issue most of the time as if you have a literal opening token in prompts, you would almost alwase have a literal closing token

> the internal prompt parser dose handles miss match `(()`or strangely ordered `)(` brackets 

## Screenshots/videos:

Current
![image](https://github.com/user-attachments/assets/531b5308-9ac3-4243-81a3-aa10d8793b54)
![image](https://github.com/user-attachments/assets/53be1370-c448-49cb-94c3-1278edc5d487)

Fixed
![image](https://github.com/user-attachments/assets/b10b024b-3d9c-4840-b32a-528b65d7fa50)
![image](https://github.com/user-attachments/assets/8a592c7c-b669-4652-a1d1-a987e0f51cb1)


test sample text

should error
```
Current prompt-bracket-checker.js treats \( literal brackets and parentheses )
\(parentheses proceeded with a slash\) are treated as normal brackets
this is wrong, this SHOUD error
the literal parentheses on the 1st line shoud NOT be counted
resulting an extra closeing parentheses on 1st line
```

should not error
```
while this \( should NOT error
as the parentheses on the first line is literal
```

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
