### PR TITLE
fix passing of literal backslash

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -4,11 +4,11 @@
 // If there's a mismatch, the keyword counter turns red and if you hover on it, a tooltip tells you what's wrong.
 
 function checkBrackets(textArea, counterElt) {
-    var counts = {};
-    (textArea.value.match(/(?<!\\)[(){}[\]]/g) || []).forEach(bracket => {
-        counts[bracket] = (counts[bracket] || 0) + 1;
+    const counts = {};
+    textArea.value.matchAll(/(?<!\\)(?:\\\\)*?([(){}[\]])/g).forEach(bracket => {
+        counts[bracket[1]] = (counts[bracket[1]] || 0) + 1;
     });
-    var errors = [];
+    const errors = [];
 
     function checkPair(open, close, kind) {
         if (counts[open] !== counts[close]) {


### PR DESCRIPTION
## Description

- follow up to #16669

in that PR I forgot to account for literal escape character `\\` (double backslash)
`\\` or even number of `\\` like `\\\\` is literal `\` and not be treated as escape character

https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/prompt_parser.py#L381

## Screenshots/videos:

current after #16669
notice that it dose not cycle between error and pass  as `\` is added

https://github.com/user-attachments/assets/ca3fa8d3-1df7-4feb-b215-3f094158bfc5

this PR
correctly psychos between error and pass as `\` is added

https://github.com/user-attachments/assets/746da735-f8e6-4b8c-837a-401fde6acdd9

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
