### PR TITLE
Fix sd hijack infotext cased by conda cache

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -508,7 +508,7 @@ class StableDiffusionProcessing:
             try:
                 func(self.extra_generation_params)
             except Exception:
-                errors.report(f"Failed to apply hijack generation params state", exc_info=True)
+                errors.report('Failed to apply hijack generation params state', exc_info=True)
         self.hijack_generation_params_state_list.clear()
 
     def setup_conds(self):

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -6,6 +6,7 @@ from modules import devices, sd_hijack_optimizations, shared, script_callbacks, 
 from modules.hypernetworks import hypernetwork
 from modules.shared import cmd_opts
 from modules import sd_hijack_clip, sd_hijack_open_clip, sd_hijack_unet, sd_hijack_xlmr, xlmr, xlmr_m18
+from modules.util import GenerationParamsState
 
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
@@ -320,6 +321,13 @@ class StableDiffusionModelHijack:
     def clear_comments(self):
         self.comments = []
         self.extra_generation_params = {}
+
+    def capture_generation_params_state(self):
+        state = []
+        for key in list(self.extra_generation_params):
+            if isinstance(self.extra_generation_params[key], GenerationParamsState):
+                state.append(self.extra_generation_params.pop(key))
+        return state
 
     def get_prompt_lengths(self, text):
         if self.clip is None:

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 import torch
 
-from modules import prompt_parser, devices, sd_hijack, sd_emphasis
+from modules import prompt_parser, devices, sd_hijack, sd_emphasis, util
 from modules.shared import opts
 from modules.util import GenerationParamsState
 
@@ -37,7 +37,7 @@ class EmbeddingHashes(GenerationParamsState):
         unique_hashes = dict.fromkeys(self.hashes)
         if existing_ti_hashes := extra_generation_params.get('TI hashes'):
             unique_hashes.update(dict.fromkeys(existing_ti_hashes.split(', ')))
-        extra_generation_params['TI hashes'] = ', '.join(unique_hashes)
+        extra_generation_params['TI hashes'] = ', '.join(sorted(unique_hashes, key=util.natural_sort_key))
 
 
 class EmphasisMode(GenerationParamsState):

--- a/modules/util.py
+++ b/modules/util.py
@@ -288,3 +288,18 @@ def compare_sha256(file_path: str, hash_prefix: str) -> bool:
         for chunk in iter(lambda: f.read(blksize), b""):
             hash_sha256.update(chunk)
     return hash_sha256.hexdigest().startswith(hash_prefix.strip().lower())
+
+
+class GenerationParamsState:
+    """A custom class used in StableDiffusionModelHijack for assigning extra_generation_params
+    generation_params assigned using this class will work properly with StableDiffusionProcessing.get_conds_with_caching()
+        if assigned directly the generation_params will not be populated if conda cache is used
+
+    Generation_params of this class will be captured (see StableDiffusionModelHijack.capture_generation_params_state) and stored with conda cache, and will be extracted in StableDiffusionProcessing.apply_hijack_generation_params()
+
+    To use this class, create a subclass with a __call__ method that takes extra_generation_params: dict as input
+
+    Example usage: sd_hijack_clip.EmbeddingHashes, sd_hijack_clip.EmphasisMode
+    """
+    def __call__(self, extra_generation_params: dict):
+        raise NotImplementedError


### PR DESCRIPTION
## Description

fix: missing infotext cased by conda cache
some generation params such as TI hashes or Emphasis is added in sd_hijack / sd_hijack_clip
if conda are fetche from cache sd_hijack_clip will not be executed and it won't have a chance to to add generation params

fix: generation params will also be missing if webui is in non low-vram mode because the hijack.extra_generation_params was never read after calculate_hr_conds

> simply put if you generate multiple images with the exact same prompt and embedding, only the first image will have TI hashes in infotext
> same when your are using non `Original` emphasis modes, only the first image will have the correct info

---

in order to fix this the generation parameters from sd_hijack will also has to be cahched along with conda cache
unfortunately caching generation parameters is not straightforward as sd_hijack could be called multiple times and in some cases
later calles will modify or add to existing generation parameters (TI hashes are combined from positive and negative prompts)
essentially you can't really cash the results but if we turn the results into actions (function) then we can cache the function object that will be use do add the necessary parameters
then after conda is calculated call all those actions to populate the generation parameters

in order to implement this was maintaining backwards compatibility
I created a custom class `util.GenerationParamsState`, when self.hijack.extra_generation_params is assigned with the value of this class, webui will store these with conda cache then execute them after conda is calculated

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
