### PR TITLE
fix missing infotext cased by conds cache

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -2,7 +2,7 @@ import torch
 from torch.nn.functional import silu
 from types import MethodType
 
-from modules import devices, sd_hijack_optimizations, shared, script_callbacks, errors, sd_unet, patches
+from modules import devices, sd_hijack_optimizations, shared, script_callbacks, errors, sd_unet, patches, util
 from modules.hypernetworks import hypernetwork
 from modules.shared import cmd_opts
 from modules import sd_hijack_clip, sd_hijack_open_clip, sd_hijack_unet, sd_hijack_xlmr, xlmr, xlmr_m18
@@ -320,6 +320,14 @@ class StableDiffusionModelHijack:
     def clear_comments(self):
         self.comments = []
         self.extra_generation_params = {}
+
+    def extract_generation_params_states(self):
+        """Extracts GenerationParametersList so that they can be cached and restored later"""
+        states = {}
+        for key in list(self.extra_generation_params):
+            if isinstance(self.extra_generation_params[key], util.GenerationParametersList):
+                states[key] = self.extra_generation_params.pop(key)
+        return states
 
     def get_prompt_lengths(self, text):
         if self.clip is None:

--- a/modules/util.py
+++ b/modules/util.py
@@ -308,8 +308,16 @@ class GenerationParametersList(list):
     if return str, the value will be written to infotext, if return None will be ignored.
     """
 
+    def __init__(self, *args, to_be_clear_before_batch=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._to_be_clear_before_batch = to_be_clear_before_batch
+
     def __call__(self, *args, **kwargs):
         return ', '.join(sorted(set(self), key=natural_sort_key))
+
+    @property
+    def to_be_clear_before_batch(self):
+        return self._to_be_clear_before_batch
 
     def __add__(self, other):
         if isinstance(other, GenerationParametersList):


### PR DESCRIPTION
## Description

fix: missing infotext cased by conds cache
some generation params such as TI hashes or Emphasis is added in sd_hijack / sd_hijack_clip
if conds are fetche from cache sd_hijack_clip will not be executed and it won't have a chance to to add generation params

fix: generation params will also be missing if webui is in non low-vram mode because the hijack.extra_generation_params was never read after calculate_hr_conds

> simply put if you generate multiple images with the exact same prompt and embedding, only the first image will have TI hashes in infotext
> same when your are using non `Original` emphasis modes, only the first image will have the correct info

---

in order to fix this the generation parameters from sd_hijack will also has to be cahched along with conds cache
unfortunately caching generation parameters is not straightforward as sd_hijack could be called multiple times and in some cases
later calles will modify or add to existing generation parameters essentially you can't really cache the resules as the rules are mixed (TI hashes are combined from positive and negative prompts)

but if we change the way the info is writternm by using callable, we can cache the callable for later use

in order to achive I implement a new class GenerationParametersList
when a infotext needs to be created in sd_hijack / sd_hijack_clip, instead of directly writing `to sd_hijack.extra_generation parameters create a GenerationParametersList or a custom
this class extracted and cached after cond is calcated and apply to StableDiffusionProcessing..extra_generation parameters when the cached is retrived

the should be minimum compatible issues
the only potential risk is if an extention would interact with extra_generation_params['TI hashes'] or extra_generation_params['Emphasis'], which is unlikey and I was not able to find any extenton that do so
in the enven that dose happen, in most case the worst case it it will just fallback to what it was like before, I implement interaction with the new GenerationParametersList with str types 

---

another implementation but decide to no go with it
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16673

---

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
