### PR TITLE
Prevent Redundant Live-Preview

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -115,7 +115,11 @@ def images_tensor_to_samples(image, approximation=None, model=None):
 def store_latent(decoded):
     state.current_latent = decoded
 
-    if opts.live_previews_enable and opts.show_progress_every_n_steps > 0 and shared.state.sampling_step % opts.show_progress_every_n_steps == 0:
+    if (
+        (opts.live_previews_enable and opts.show_progress_every_n_steps > 0) and
+        (shared.state.sampling_steps - shared.state.sampling_step > opts.show_progress_every_n_steps) and
+        (shared.state.sampling_step % opts.show_progress_every_n_steps == 0)
+    ):
         if not shared.parallel_processing_allowed:
             shared.state.assign_current_image(sample_to_image(decoded))
 

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -139,7 +139,11 @@ class State:
         if not shared.parallel_processing_allowed:
             return
 
-        if self.sampling_step - self.current_image_sampling_step >= shared.opts.show_progress_every_n_steps and shared.opts.live_previews_enable and shared.opts.show_progress_every_n_steps != -1:
+        if (
+            (shared.opts.live_previews_enable and shared.opts.show_progress_every_n_steps != -1) and
+            (self.sampling_steps - self.sampling_step > shared.opts.show_progress_every_n_steps) and
+            (self.sampling_step - self.current_image_sampling_step >= shared.opts.show_progress_every_n_steps)
+        ):
             self.do_set_current_image()
 
     def do_set_current_image(self):


### PR DESCRIPTION
## Description

- **Simple Description:** Currently, the condition of whether to generate a preview is solely based on the current step count. Depending on the settings *(**ie.** `show_progress_every_n_steps` and `live_preview_refresh_period`)* and parameters *(**ie.** `steps`)*, you may waste resources generating an extra preview that you would never be able to see anyway.

  > **eg.** Generate a total of `30` steps, with `show_progress_every_n_steps` set to `4`. At step `28`, you only have `2` steps left to see the preview. If your system is fast enough, you won't see the preview; even if you do see the preview, there's rather little point in interrupting with only `2` steps left anyway...

- **Summary of Changes:** Add a new condition to check if the remaining steps is larger than `show_progress_every_n_steps` still

## Checklist

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
