### PR TITLE
[Bracket Checker] Also check for the order of brackets

### DIFF
--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -1,42 +1,89 @@
-// Stable Diffusion WebUI - Bracket checker
-// By Hingashi no Florin/Bwin4L & @akx
+// Stable Diffusion WebUI - Bracket Checker
+// By @Bwin4L, @akx, @w-e-w, @Haoming02
 // Counts open and closed brackets (round, square, curly) in the prompt and negative prompt text boxes in the txt2img and img2img tabs.
-// If there's a mismatch, the keyword counter turns red and if you hover on it, a tooltip tells you what's wrong.
+// If there's a mismatch, the keyword counter turns red, and if you hover on it, a tooltip tells you what's wrong.
 
-function checkBrackets(textArea, counterElt) {
-    const counts = {};
-    textArea.value.matchAll(/(?<!\\)(?:\\\\)*?([(){}[\]])/g).forEach(bracket => {
-        counts[bracket[1]] = (counts[bracket[1]] || 0) + 1;
-    });
-    const errors = [];
+(function() {
+    const pairs = [
+        ['(', ')', 'round brackets'],
+        ['[', ']', 'square brackets'],
+        ['{', '}', 'curly brackets']
+    ];
 
-    function checkPair(open, close, kind) {
-        if (counts[open] !== counts[close]) {
-            errors.push(
-                `${open}...${close} - Detected ${counts[open] || 0} opening and ${counts[close] || 0} closing ${kind}.`
-            );
+    function checkBrackets(textArea, counterElem) {
+        const counts = {};
+        const errors = new Set();
+        let i = 0;
+
+        while (i < textArea.value.length) {
+            let char = textArea.value[i];
+            let escaped = false;
+            while (char === '\\' && i + 1 < textArea.value.length) {
+                escaped = !escaped;
+                i++;
+                char = textArea.value[i];
+            }
+
+            for (const [open, close, label] of pairs) {
+                const lb = escaped ? `escaped ${label}` : label;
+
+                if (char === open) {
+                    counts[lb] = (counts[lb] || 0) + 1;
+                } else if (char === close) {
+                    counts[lb] = (counts[lb] || 0) - 1;
+                    if (counts[lb] < 0) {
+                        errors.add(`Incorrect order of ${lb}.`);
+                    }
+                }
+            }
+
+            i++;
+        }
+
+        for (const [open, close, label] of pairs) {
+            if (counts[label] == undefined) {
+                continue;
+            }
+
+            if (counts[label] > 0) {
+                errors.add(`${open} ... ${close} - Detected ${counts[label]} more opening than closing ${label}.`);
+            } else if (counts[label] < 0) {
+                errors.add(`${open} ... ${close} - Detected ${-counts[label]} more closing than opening ${label}.`);
+            }
+        }
+
+        for (const [open, close, label] of pairs) {
+            const lb = `escaped ${label}`;
+            if (counts[lb] == undefined) {
+                continue;
+            }
+
+            const op = `\\${open}`;
+            const cl = `\\${close}`;
+            if (counts[lb] > 0) {
+                errors.add(`${op} ... ${cl} - Detected ${counts[lb]} more opening than closing ${lb}.`);
+            } else if (counts[lb] < 0) {
+                errors.add(`${op} ... ${cl} - Detected ${-counts[lb]} more closing than opening ${lb}.`);
+            }
+        }
+
+        counterElem.title = [...errors].join('\n');
+        counterElem.classList.toggle('error', errors.size !== 0);
+    }
+
+    function setupBracketChecking(id_prompt, id_counter) {
+        const textarea = gradioApp().querySelector(`#${id_prompt} > label > textarea`);
+        const counter = gradioApp().getElementById(id_counter);
+
+        if (textarea && counter) {
+            onEdit(`${id_prompt}_BracketChecking`, textarea, 400, () => checkBrackets(textarea, counter));
         }
     }
 
-    checkPair('(', ')', 'round brackets');
-    checkPair('[', ']', 'square brackets');
-    checkPair('{', '}', 'curly brackets');
-    counterElt.title = errors.join('\n');
-    counterElt.classList.toggle('error', errors.length !== 0);
-}
-
-function setupBracketChecking(id_prompt, id_counter) {
-    var textarea = gradioApp().querySelector("#" + id_prompt + " > label > textarea");
-    var counter = gradioApp().getElementById(id_counter);
-
-    if (textarea && counter) {
-        textarea.addEventListener("input", () => checkBrackets(textarea, counter));
-    }
-}
-
-onUiLoaded(function() {
-    setupBracketChecking('txt2img_prompt', 'txt2img_token_counter');
-    setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter');
-    setupBracketChecking('img2img_prompt', 'img2img_token_counter');
-    setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter');
-});
+    onUiLoaded(function() {
+        setupBracketChecking('txt2img_prompt', 'txt2img_token_counter');
+        setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter');
+        setupBracketChecking('img2img_prompt', 'img2img_token_counter');
+        setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter');
+    });
+})();

--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -24,15 +24,18 @@
                 char = textArea.value[i];
             }
 
-            for (const [open, close, label] of pairs) {
-                const lb = escaped ? `escaped ${label}` : label;
+            if (escaped) {
+                i++;
+                continue;
+            }
 
+            for (const [open, close, label] of pairs) {
                 if (char === open) {
-                    counts[lb] = (counts[lb] || 0) + 1;
+                    counts[label] = (counts[label] || 0) + 1;
                 } else if (char === close) {
-                    counts[lb] = (counts[lb] || 0) - 1;
-                    if (counts[lb] < 0) {
-                        errors.add(`Incorrect order of ${lb}.`);
+                    counts[label] = (counts[label] || 0) - 1;
+                    if (counts[label] < 0) {
+                        errors.add(`Incorrect order of ${label}.`);
                     }
                 }
             }
@@ -49,21 +52,6 @@
                 errors.add(`${open} ... ${close} - Detected ${counts[label]} more opening than closing ${label}.`);
             } else if (counts[label] < 0) {
                 errors.add(`${open} ... ${close} - Detected ${-counts[label]} more closing than opening ${label}.`);
-            }
-        }
-
-        for (const [open, close, label] of pairs) {
-            const lb = `escaped ${label}`;
-            if (counts[lb] == undefined) {
-                continue;
-            }
-
-            const op = `\\${open}`;
-            const cl = `\\${close}`;
-            if (counts[lb] > 0) {
-                errors.add(`${op} ... ${cl} - Detected ${counts[lb]} more opening than closing ${lb}.`);
-            } else if (counts[lb] < 0) {
-                errors.add(`${op} ... ${cl} - Detected ${-counts[lb]} more closing than opening ${lb}.`);
             }
         }
 

--- a/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
+++ b/extensions-builtin/prompt-bracket-checker/javascript/prompt-bracket-checker.js
@@ -3,75 +3,73 @@
 // Counts open and closed brackets (round, square, curly) in the prompt and negative prompt text boxes in the txt2img and img2img tabs.
 // If there's a mismatch, the keyword counter turns red, and if you hover on it, a tooltip tells you what's wrong.
 
-(function() {
+function checkBrackets(textArea, counterElem) {
     const pairs = [
         ['(', ')', 'round brackets'],
         ['[', ']', 'square brackets'],
         ['{', '}', 'curly brackets']
     ];
 
-    function checkBrackets(textArea, counterElem) {
-        const counts = {};
-        const errors = new Set();
-        let i = 0;
+    const counts = {};
+    const errors = new Set();
+    let i = 0;
 
-        while (i < textArea.value.length) {
-            let char = textArea.value[i];
-            let escaped = false;
-            while (char === '\\' && i + 1 < textArea.value.length) {
-                escaped = !escaped;
-                i++;
-                char = textArea.value[i];
-            }
-
-            if (escaped) {
-                i++;
-                continue;
-            }
-
-            for (const [open, close, label] of pairs) {
-                if (char === open) {
-                    counts[label] = (counts[label] || 0) + 1;
-                } else if (char === close) {
-                    counts[label] = (counts[label] || 0) - 1;
-                    if (counts[label] < 0) {
-                        errors.add(`Incorrect order of ${label}.`);
-                    }
-                }
-            }
-
+    while (i < textArea.value.length) {
+        let char = textArea.value[i];
+        let escaped = false;
+        while (char === '\\' && i + 1 < textArea.value.length) {
+            escaped = !escaped;
             i++;
+            char = textArea.value[i];
+        }
+
+        if (escaped) {
+            i++;
+            continue;
         }
 
         for (const [open, close, label] of pairs) {
-            if (counts[label] == undefined) {
-                continue;
-            }
-
-            if (counts[label] > 0) {
-                errors.add(`${open} ... ${close} - Detected ${counts[label]} more opening than closing ${label}.`);
-            } else if (counts[label] < 0) {
-                errors.add(`${open} ... ${close} - Detected ${-counts[label]} more closing than opening ${label}.`);
+            if (char === open) {
+                counts[label] = (counts[label] || 0) + 1;
+            } else if (char === close) {
+                counts[label] = (counts[label] || 0) - 1;
+                if (counts[label] < 0) {
+                    errors.add(`Incorrect order of ${label}.`);
+                }
             }
         }
 
-        counterElem.title = [...errors].join('\n');
-        counterElem.classList.toggle('error', errors.size !== 0);
+        i++;
     }
 
-    function setupBracketChecking(id_prompt, id_counter) {
-        const textarea = gradioApp().querySelector(`#${id_prompt} > label > textarea`);
-        const counter = gradioApp().getElementById(id_counter);
+    for (const [open, close, label] of pairs) {
+        if (counts[label] == undefined) {
+            continue;
+        }
 
-        if (textarea && counter) {
-            onEdit(`${id_prompt}_BracketChecking`, textarea, 400, () => checkBrackets(textarea, counter));
+        if (counts[label] > 0) {
+            errors.add(`${open} ... ${close} - Detected ${counts[label]} more opening than closing ${label}.`);
+        } else if (counts[label] < 0) {
+            errors.add(`${open} ... ${close} - Detected ${-counts[label]} more closing than opening ${label}.`);
         }
     }
 
-    onUiLoaded(function() {
-        setupBracketChecking('txt2img_prompt', 'txt2img_token_counter');
-        setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter');
-        setupBracketChecking('img2img_prompt', 'img2img_token_counter');
-        setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter');
-    });
-})();
+    counterElem.title = [...errors].join('\n');
+    counterElem.classList.toggle('error', errors.size !== 0);
+}
+
+function setupBracketChecking(id_prompt, id_counter) {
+    const textarea = gradioApp().querySelector(`#${id_prompt} > label > textarea`);
+    const counter = gradioApp().getElementById(id_counter);
+
+    if (textarea && counter) {
+        onEdit(`${id_prompt}_BracketChecking`, textarea, 400, () => checkBrackets(textarea, counter));
+    }
+}
+
+onUiLoaded(function() {
+    setupBracketChecking('txt2img_prompt', 'txt2img_token_counter');
+    setupBracketChecking('txt2img_neg_prompt', 'txt2img_negative_token_counter');
+    setupBracketChecking('img2img_prompt', 'img2img_token_counter');
+    setupBracketChecking('img2img_neg_prompt', 'img2img_negative_token_counter');
+});


### PR DESCRIPTION
## Simple Description

- Currently, this script only checks if the number of opening and closing brackets are the same. So if you have mistyped something like `)...(` in the prompts, the checker would not detect it as error.

- The current regular expression is frankly... difficult to read
    - Also, [regexr](https://regexr.com/) gave a warning that "negative lookbehind" *(`(?<!`)* may not be supported on all browsers; though when I looked it up, it seems to be supported on all modern browsers.

## List of Changes

- Manually loop through the text to check for the order of brackets
- ~~Now also checks for pairing of escaped brackets~~
- Use the [built-in](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/v1.10.1/javascript/ui.js#L425) `onEdit` function to detect user inputs 
    - The delay is set to `400 ms`, half of [token-counter](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/v1.10.1/javascript/token-counters.js#L58) 
- Converted to use the [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) pattern
    - To revert this, also move the `const pairs = [ ... ]` inside `checkBrackets() { ... }`

<br>

- Edited the credits - The only mention of "Hingashi no Florin" I can ever find online is this line, which is probably the original author of this script, <ins>Bwin4L</ins>'s nickname? Do we keep it?

## Checklist

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

<hr>

**Performance:** Checking a textbox filled to ~150 tokens took `0.2 ms`
