### PR TITLE
add API server-reload-ui and server-reload-script-bodies

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -249,6 +249,7 @@ class Api:
             self.add_api_route("/sdapi/v1/server-kill", self.kill_webui, methods=["POST"])
             self.add_api_route("/sdapi/v1/server-restart", self.restart_webui, methods=["POST"])
             self.add_api_route("/sdapi/v1/server-stop", self.stop_webui, methods=["POST"])
+            self.add_api_route("/sdapi/v1/server-reload-ui", self.reload_webui, methods=["POST"])
 
         self.default_script_arg_txt2img = []
         self.default_script_arg_img2img = []
@@ -926,3 +927,6 @@ class Api:
         shared.state.server_command = "stop"
         return Response("Stopping.")
 
+    def reload_webui(self):
+        shared.state.request_restart()
+        return Response("Reloading.")

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -250,6 +250,7 @@ class Api:
             self.add_api_route("/sdapi/v1/server-restart", self.restart_webui, methods=["POST"])
             self.add_api_route("/sdapi/v1/server-stop", self.stop_webui, methods=["POST"])
             self.add_api_route("/sdapi/v1/server-reload-ui", self.reload_webui, methods=["POST"])
+            self.add_api_route("/sdapi/v1/server-reload-script-bodies", self.reload_script_bodies, methods=["POST"])
 
         self.default_script_arg_txt2img = []
         self.default_script_arg_img2img = []
@@ -930,3 +931,7 @@ class Api:
     def reload_webui(self):
         shared.state.request_restart()
         return Response("Reloading.")
+
+    def reload_script_bodies(self):
+        scripts.reload_script_body_only()
+        return Response("Reload script bodies.")


### PR DESCRIPTION
## Description

Add 2 api route
`/sdapi/v1/server-reload-ui`
`/sdapi/v1/server-reload-script-bodies`
same function as these `Reload UI` and `Reload custom script bodies (No ui updates, No restart)` buttons
![image](https://github.com/user-attachments/assets/a279a750-8f47-41ef-984f-5c7a14b534fa)

similer to the existing api rounts 
`/sdapi/v1/server-stop` `/sdapi/v1/server-restart` `/sdapi/v1/server-restart`
> note only available if  `--api` and `--api-server-stop` is used

![image](https://github.com/user-attachments/assets/157a60af-335b-4cd6-85c1-cee120a69b2e)

---

context 

some settings needs `reload ui` to apply, but it only does is update the UI visually and so does not really impact API use
but there are some settings that goes deeper such as `control_net_unit_count`, this setting dose need `reload ui` as it will correctly corresponding inputs for the API, and some reloading in these cases are important

it is possible to just Restart UI, but this is slower then just reloading the UI, (also sometimes restarting is not available)
so I see no reason why we shouldn't add `/sdapi/v1/server-reload-ui` for those cases that actually do need it

`/sdapi/v1/server-reload-script-bodies` it's just something I decide to also Implement because why not (I'm not sure how useful is this one)

- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/16742

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
