### PR TITLE
fix sd_vae_explanation

### DIFF
--- a/modules/shared_items.py
+++ b/modules/shared_items.py
@@ -125,7 +125,7 @@ def ui_reorder_categories():
 
 def callbacks_order_settings():
     options = {
-        "sd_vae_explanation": OptionHTML("""
+        "callbacks_order_explanation": OptionHTML("""
     For categories below, callbacks added to dropdowns happen before others, in order listed.
     """),
 


### PR DESCRIPTION
## Description
`sd_vae_explanation` was not showing
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/fc0952abb9592b69f2311e4ede1b82492d312a64/modules/shared_options.py#L200-L207

cause auto must have forgotten to rename the key of `OptionHTML` for `callbacks_order_settings` from `sd_vae_explanation` to something else when implementing it, causing a duplicate entry overriding the `sd_vae_explanation`

## Screenshots/videos:
![image](https://github.com/user-attachments/assets/1958eba4-7a20-4ddc-a1cb-b29cdfc97260)

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
