### PR TITLE
Fix  Codeformer and gfpgan extension , Inconsistent overlay layer types when visibility value is less than 1

### DIFF
--- a/scripts/postprocessing_codeformer.py
+++ b/scripts/postprocessing_codeformer.py
@@ -29,14 +29,10 @@ class ScriptPostprocessingCodeFormer(scripts_postprocessing.ScriptPostprocessing
         res = Image.fromarray(restored_img)
 
         if codeformer_visibility < 1.0:
-            # Ensure consistent size
             if pp.image.size != res.size:
                 res = res.resize(pp.image.size)
-                
-            # Ensure consistent mode
             if pp.image.mode != res.mode:
                 res = res.convert(pp.image.mode)
-                
             res = Image.blend(pp.image, res, codeformer_visibility)
 
         pp.image = res

--- a/scripts/postprocessing_codeformer.py
+++ b/scripts/postprocessing_codeformer.py
@@ -29,6 +29,14 @@ class ScriptPostprocessingCodeFormer(scripts_postprocessing.ScriptPostprocessing
         res = Image.fromarray(restored_img)
 
         if codeformer_visibility < 1.0:
+            # Ensure consistent size
+            if pp.image.size != res.size:
+                res = res.resize(pp.image.size)
+                
+            # Ensure consistent mode
+            if pp.image.mode != res.mode:
+                res = res.convert(pp.image.mode)
+                
             res = Image.blend(pp.image, res, codeformer_visibility)
 
         pp.image = res

--- a/scripts/postprocessing_gfpgan.py
+++ b/scripts/postprocessing_gfpgan.py
@@ -26,6 +26,15 @@ class ScriptPostprocessingGfpGan(scripts_postprocessing.ScriptPostprocessing):
         res = Image.fromarray(restored_img)
 
         if gfpgan_visibility < 1.0:
+            
+            # Ensure consistent size
+            if pp.image.size != res.size:
+                res = res.resize(pp.image.size)
+                
+            # Ensure consistent mode
+            if pp.image.mode != res.mode:
+                res = res.convert(pp.image.mode)
+                
             res = Image.blend(pp.image, res, gfpgan_visibility)
 
         pp.image = res

--- a/scripts/postprocessing_gfpgan.py
+++ b/scripts/postprocessing_gfpgan.py
@@ -26,15 +26,10 @@ class ScriptPostprocessingGfpGan(scripts_postprocessing.ScriptPostprocessing):
         res = Image.fromarray(restored_img)
 
         if gfpgan_visibility < 1.0:
-            
-            # Ensure consistent size
             if pp.image.size != res.size:
                 res = res.resize(pp.image.size)
-                
-            # Ensure consistent mode
             if pp.image.mode != res.mode:
                 res = res.convert(pp.image.mode)
-                
             res = Image.blend(pp.image, res, gfpgan_visibility)
 
         pp.image = res


### PR DESCRIPTION
## Description

Fix  Codeformer and gfpgan extension , Inconsistent overlay layer types when visibility value is less than 1

## Screenshots/videos:

![Snipaste_2024-12-26_02-23-35](https://github.com/user-attachments/assets/fbf6507b-80c4-4cb7-9f94-887b0a8b73b7)


![Snipaste_2024-12-26_02-24-29](https://github.com/user-attachments/assets/b9433263-26bf-4711-bc43-e5fa6ac44a09)



