### PR TITLE
ruff <path> is deprecated. Use ruff check <path>

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Ruff
         run: pip install ruff==0.3.3
       - name: Run Ruff
-        run: ruff .
+        run: ruff check .
   lint-js:
     name: eslint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

get rid of a minor annoyance in the ruff workflow
```shell
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```

Current
https://github.com/AUTOMATIC1111/stable-diffusion-webui/actions/runs/12496694101/job/34868649002
![image](https://github.com/user-attachments/assets/9fcf34c2-f3b3-4868-b7d4-5bfcd66457d4)

PR
https://github.com/AUTOMATIC1111/stable-diffusion-webui/actions/runs/12509973467/job/34900142548
![image](https://github.com/user-attachments/assets/0b054967-3218-423b-99cd-5bafd09ad8b3)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
