### PR TITLE
Authenticated Sysinfo

### DIFF
--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -69,3 +69,39 @@ onOptionsChanged(function() {
     });
 });
 
+function downloadSysinfo() {
+    const pad = (n) => String(n).padStart(2, '0');
+    const now = new Date();
+    const YY = now.getFullYear();
+    const MM = pad(now.getMonth() + 1);
+    const DD = pad(now.getDate());
+    const HH = pad(now.getHours());
+    const mm = pad(now.getMinutes());
+    const link = document.createElement('a');
+    link.download = `sysinfo-${YY}-${MM}-${DD}-${HH}-${mm}.json`;
+    const sysinfo_textbox = gradioApp().querySelector('#internal-sysinfo-textbox textarea');
+    const content = sysinfo_textbox.value;
+    if (content.startsWith('file=')) {
+        link.href = content;
+    } else {
+        const blob = new Blob([content], {type: 'application/json'});
+        link.href = URL.createObjectURL(blob);
+    }
+    link.click();
+    sysinfo_textbox.value = '';
+    updateInput(sysinfo_textbox);
+}
+
+function openTabSysinfo() {
+    const sysinfo_textbox = gradioApp().querySelector('#internal-sysinfo-textbox textarea');
+    const content = sysinfo_textbox.value;
+    if (content.startsWith('file=')) {
+        window.open(content, '_blank');
+    } else {
+        const blob = new Blob([content], {type: 'application/json'});
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+    }
+    sysinfo_textbox.value = '';
+    updateInput(sysinfo_textbox);
+}

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -17,7 +17,7 @@ from fastapi.encoders import jsonable_encoder
 from secrets import compare_digest
 
 import modules.shared as shared
-from modules import sd_samplers, deepbooru, sd_hijack, images, scripts, ui, postprocessing, errors, restart, shared_items, script_callbacks, infotext_utils, sd_models, sd_schedulers
+from modules import sd_samplers, deepbooru, sd_hijack, images, scripts, ui, postprocessing, errors, restart, shared_items, script_callbacks, infotext_utils, sd_models, sd_schedulers, sysinfo
 from modules.api import models
 from modules.shared import opts
 from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img, process_images
@@ -32,6 +32,7 @@ import piexif
 import piexif.helper
 from contextlib import closing
 from modules.progress import create_task_id, add_task_to_queue, start_task, finish_task, current_task
+
 
 def script_name_to_index(name, scripts):
     try:
@@ -244,6 +245,8 @@ class Api:
         self.add_api_route("/sdapi/v1/scripts", self.get_scripts_list, methods=["GET"], response_model=models.ScriptsList)
         self.add_api_route("/sdapi/v1/script-info", self.get_script_info, methods=["GET"], response_model=list[models.ScriptInfo])
         self.add_api_route("/sdapi/v1/extensions", self.get_extensions_list, methods=["GET"], response_model=list[models.ExtensionItem])
+        self.add_api_route("/internal/sysinfo", sysinfo.download_sysinfo, methods=["GET"])
+        self.add_api_route("/internal/sysinfo-download", lambda: sysinfo.download_sysinfo(attachment=True), methods=["GET"])
 
         if shared.cmd_opts.api_server_stop:
             self.add_api_route("/sdapi/v1/server-kill", self.kill_webui, methods=["POST"])

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -213,3 +213,13 @@ def get_config():
                 return json.load(f)
         except Exception as e:
             return str(e)
+
+
+def download_sysinfo(attachment=False):
+    from fastapi.responses import PlainTextResponse
+    from datetime import datetime
+
+    text = get()
+    filename = f"sysinfo-{datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
+
+    return PlainTextResponse(text, headers={'Content-Disposition': f'{"attachment" if attachment else "inline"}; filename="{filename}"'})

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1,4 +1,3 @@
-import datetime
 import mimetypes
 import os
 import sys
@@ -10,10 +9,10 @@ import gradio as gr
 import gradio.utils
 import numpy as np
 from PIL import Image, PngImagePlugin  # noqa: F401
-from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, wrap_gradio_call, wrap_gradio_call_no_job # noqa: F401
+from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, wrap_gradio_call, wrap_gradio_call_no_job  # noqa: F401
 
 from modules import gradio_extensons, sd_schedulers  # noqa: F401
-from modules import sd_hijack, sd_models, script_callbacks, ui_extensions, deepbooru, extra_networks, ui_common, ui_postprocessing, progress, ui_loadsave, shared_items, ui_settings, timer, sysinfo, ui_checkpoint_merger, scripts, sd_samplers, processing, ui_extra_networks, ui_toprow, launch_utils
+from modules import sd_hijack, sd_models, script_callbacks, ui_extensions, deepbooru, extra_networks, ui_common, ui_postprocessing, progress, ui_loadsave, shared_items, ui_settings, timer, ui_checkpoint_merger, scripts, sd_samplers, processing, ui_extra_networks, ui_toprow, launch_utils
 from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML, InputAccordion, ResizeHandleRow
 from modules.paths import script_path
 from modules.ui_common import create_refresh_button
@@ -1222,17 +1221,6 @@ def setup_ui_api(app):
     app.add_api_route("/internal/ping", lambda: {}, methods=["GET"])
 
     app.add_api_route("/internal/profile-startup", lambda: timer.startup_record, methods=["GET"])
-
-    def download_sysinfo(attachment=False):
-        from fastapi.responses import PlainTextResponse
-
-        text = sysinfo.get()
-        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
-
-        return PlainTextResponse(text, headers={'Content-Disposition': f'{"attachment" if attachment else "inline"}; filename="{filename}"'})
-
-    app.add_api_route("/internal/sysinfo", download_sysinfo, methods=["GET"])
-    app.add_api_route("/internal/sysinfo-download", lambda: download_sysinfo(attachment=True), methods=["GET"])
 
     import fastapi.staticfiles
     app.mount("/webui-assets", fastapi.staticfiles.StaticFiles(directory=launch_utils.repo_dir('stable-diffusion-webui-assets')), name="webui-assets")

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -335,7 +335,7 @@ class UiSettings:
 
             for method in methods:
                 method(
-                    fn=lambda value, k=k: self.run_settings_single(value, key=k),
+                    fn=lambda value, key=k: self.run_settings_single(value, key=key),
                     inputs=[component],
                     outputs=[component, self.text_settings],
                     show_progress=info.refresh is not None,


### PR DESCRIPTION
## Description

- [Authenticated Sysinfo](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16755/commits/fc5483350590510368a2886168c4848e8880bfc6)

currently previously the the internal `/internal/sysinfo` `/internal/sysinfo-download` routes are not authenticated
> I think AUTO's intention was that so the same API can be reused

but this has lead to a security issue in the past and could lead to more in the future if not already
so to be safe it's better that these routes require authenticated

this PR changes how sysinfo tabs downloads sysinfo, using javascript button clicks and gradio calls
(as opposed to browser to API calls)
and as an extra benefit there's now a progress effect on the HTML while retrieving sysinfo

the Sysinfo tab no longer no longer relies on the API
instead it's gradio button click event that generates sysinfo to a hidden text box
followed by JavaScript to download as file or open this info in new taba hidden textarea

> this is overkill
> > normally the sysinfo should be in the realms of kilobytes so it should be totally fine to store it in textarea
> > > I have tested that it works for even text size of 256MB
> > but as it is technically possible for the size to be extremely large (maybe there are lots of exceptions or something)
> > I implemented a logic that if the file is greater than 1MB, it would writes to `tmp/sysinfo.json` and then use `file=` route to retrieve it

for backwards compatibility the existing `/internal/sysinfo` `/internal/sysinfo-download` are moved to models.api 
the behavior is unchanged except that it now would respect `--api-auth` and would only be created if `--api` is enabled

tested to work in Chrome and Firefox

---

additional change
- [fix shadows name 'k' from outer scope](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16755/commits/dc34c0041c41654998111fd3e0ab2abcc426aec1)

this line of code triggers a false error in pycharms inspector
I decided to add in because I'm already working on this file



## Screenshots/videos:

https://github.com/user-attachments/assets/c2c4b995-cf82-4d16-b23c-c577c8b60354

> firefox

![2024-12-27 22_16_04_744 pycharm64](https://github.com/user-attachments/assets/685df097-0a02-408e-bc98-800d3c133b69)
> false error

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)


