### PR TITLE
Allow add middleware after app has started

### DIFF
--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -50,6 +50,7 @@ def check_versions():
 
 def initialize():
     from modules import initialize_util
+    initialize_util.allow_add_middleware_after_start()
     initialize_util.fix_torch_version()
     initialize_util.fix_pytorch_lightning()
     initialize_util.fix_asyncio_event_loop_policy()


### PR DESCRIPTION
allow add middleware after app has started

this should completely fix RuntimeError("Cannot add middleware after an application has started")
which can occur due to a race condition


## explanation of  race condition

By design `Starlette / FastAPI` middleware can only be added before the the server has started, technically it can still be added until the server receive a first request, at which point it builds the `app.middleware_stack`
after this point you normally cannot add middleware 

BUT we do add and remove middlewares after the app is launched
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/webui.py#L79
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/webui.py#L104-L112
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/initialize_util.py#L192-L198
in this section of code we first remove the gradio default `CORSMiddleware` then added our own `CORSMiddleware` with different config along with `GZipMiddleware`

and after this if `--api` is enabled we also add some more middlewares
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/api/api.py#L135-L196

we are able to add new middlewares because in `setup_middleware()` we set `app.middleware_stack` to `None`, which would make `Starlette / FastAPI` rebuild the `app.middleware_stack` on the next recived request

In most cases this works fine, but if one is unlucky enough it is totally possible for the server to receive a request after we set `app.middleware_stack` to `None` and between the last middleware is added
if this were to happen it will trigger a runtime error which would then crash the server

---

## reproducing the race condition
### key point
if ther is a request between `app.middleware_stack = None` but and `add_middleware()` then the issue will be trigger

For testing purposes this issue can be manually triggered by placeing a breakpoin in `setup_middleware()` after `app.middleware_stack = None` but before any `app.add_middleware`
for example on
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/82a973c04367123ae98bd9abdf80d9eda9b910e2/modules/initialize_util.py#L196

When the breakpoint is hit, make a request the server (visit the webui webpage or make any request on any endpoint
or perform any request on any API route)
after request continued execution

you should see `RuntimeError("Cannot add middleware after an application has started")` been trigger

this is because even though we have set `app.middleware_stack = None` if a request has been made to the server it will rebuild `middleware_stack`, makeing `middleware_stack` no longer None, triggeing the error


## Is this an issue that needs addressing?
Yes
well this doesn't happen often, it does happen frequent enough that we have seen multiple report of this issue
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7939
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7759
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/7749

also remember seeing some reports of the server dying soon after launch, this may be the cause of those issues,
when runtime error is triggered the server only shutsdown after the model is loaded, resulting in a delay between the runtime error and the actual shutdown
> depending on the storage speed it is totally probable to have enough time to open the webpage as if everything is normal only to have the server shutdown soon after causing confusion

browser auto launch after app start, would significantly increase the chance of this happening
as it essentially is sending lots of requests to the serve at around the same time as we add new middleare
> I suspect this would cause this issue to be triggered more often on slower systems

---

## The Fix

the fix I came up with is to patch `Starlette.add_middleware`, adding some logic that ensures the `middleware_stack` is `None` when we add new middlewares

the resulting of this is that I believe it is now impossible for it to trigger a RuntimeError due to this issue
this even makes it possible to add new middleware at any time
> I made a test extention to test adding of middleware after an application has started
> https://gist.github.com/w-e-w/3b98e4fe30b3bf75c1f632bdb1ec704e

## Remarks

while setting `middleware_stack` to `None` makeing it rebuild the stack is a but unorthodox so could be considered dangerous and could break in the future
BUT, but considering we have been doing this operation for a long time and it has worked I think it's good enough
The only difference that this PR does is add better logic in performing this operation

> maybe it will cause trouble when we upgrade gradio, but I don't know if that would ever come

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
