### PR TITLE
Update webui.sh for non-nightly Torch builds

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -153,7 +153,7 @@ case "$gpu_info" in
     *"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
     ;;
     *"Navi 3"*) [[ -z "${TORCH_COMMAND}" ]] && \
-         export TORCH_COMMAND="pip install torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm5.7"
+         export TORCH_COMMAND="pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm5.7"
     ;;
     *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
         printf "\n%s\n" "${delimiter}"


### PR DESCRIPTION
## Description

A simple `git clone` + `./webui.sh` produces the following error on an Arch machine with an AMD Navi 3 (7900XT):
```
Installing torch and torchvision
Looking in indexes: https://download.pytorch.org/whl/nightly/rocm5.7
Collecting torch
  ERROR: HTTP error 403 while getting https://download.pytorch.org/whl/nightly/rocm5.7/torch-2.2.0.dev20231010%2Brocm5.7-cp310-cp310-linux_x86_64.whl (from https://download.pytorch.org/whl/nightly/rocm5.7/torch/)
ERROR: Could not install requirement torch
```

I think Torch moved the url for their Nightly builds or something, I don't know. Regardless, this fixes the error on my machine and allows the installation to proceed. 


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
