### PR TITLE
Update sd_samplers_cfg_denoiser.py

### DIFF
--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -160,7 +160,10 @@ class CFGDenoiser(torch.nn.Module):
         if sd_samplers_common.apply_refiner(self, sigma):
             cond = self.sampler.sampler_extra_args['cond']
             uncond = self.sampler.sampler_extra_args['uncond']
-
+               
+        # Ensures the scheduler respects the requested step count and halts excess iterations
+        if self.step >= self.total_steps:            
+            raise sd_samplers_common.InterruptedException
         # at self.image_cfg_scale == 1.0 produced results for edit model are the same as with normal sampling,
         # so is_edit_model is set to False to support AND composition.
         is_edit_model = shared.sd_model.cond_stage_key == "edit" and self.image_cfg_scale is not None and self.image_cfg_scale != 1.0


### PR DESCRIPTION
This commit introduces a safeguard to ensure that schedulers and samplers strictly adhere to the requested step count during iterative processing. The change prevents the system from exceeding the total number of steps, avoiding potential errors, inconsistencies, or unexpected behavior caused by unintended step overflows.

A check is added to verify that the current step (self.step) does not exceed or equal the total allowed steps (self.total_steps). If the condition is met, an InterruptedException is raised, gracefully halting further processing.

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
