### PR TITLE
Randomize prompt iterations during Batch - img2img.py

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -104,7 +104,10 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
             except Exception:
                 parsed_parameters = {}
 
-            p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "")
+            # p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "")
+            from modules.scripts import process_prompt
+            p.prompt = process_prompt(prompt)
+            
             p.negative_prompt = negative_prompt + (" " + parsed_parameters["Negative prompt"] if "Negative prompt" in parsed_parameters else "")
             p.seed = int(parsed_parameters.get("Seed", seed))
             p.cfg_scale = float(parsed_parameters.get("CFG scale", cfg_scale))


### PR DESCRIPTION
Randomize prompt iterations during Batch, for dynamic prompts.

When using img2img in batch mode, any dynamic promps are no longer dynamic. It randomly picks one and then its stuck for the entire batch process.
The code forces to read the prompt on each generation
Now the img2img recreated images can use dynamic prompts to give a random variety if required.

