### PR TITLE
Added optional argument to store model hashes

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -126,3 +126,4 @@ parser.add_argument("--skip-load-model-at-start", action='store_true', help="if 
 parser.add_argument("--unix-filenames-sanitization", action='store_true', help="allow any symbols except '/' in filenames. May conflict with your browser and file system")
 parser.add_argument("--filenames-max-length", type=int, default=128, help='maximal length of filenames of saved images. If you override it, it can conflict with your file system')
 parser.add_argument("--no-prompt-history", action='store_true', help="disable read prompt from last generation feature; settings this argument will not create '--data_path/params.txt' file")
+parser.add_argument("--local-hash-path", type=str, help="path to store full models hashes; It will generate hashes at first launch and will load it on next startups; Useless on local storage but significally reduces startup time when using remote models storage", default=None)

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -308,32 +308,6 @@ def get_state_dict_from_checkpoint(pl_sd):
 
     return pl_sd
 
-def save_metadata_from_safetensors(filename):
-    import json
-
-    with open(filename, mode="rb") as file:
-        metadata_len = file.read(8)
-        metadata_len = int.from_bytes(metadata_len, "little")
-        json_start = file.read(2)
-
-        assert metadata_len > 2 and json_start in (b'{"', b"{'"), f"{filename} is not a safetensors file"
-
-        res = {}
-
-        try:
-            json_data = json_start + file.read(metadata_len-2)
-            json_obj = json.loads(json_data)
-            for k, v in json_obj.get("__metadata__", {}).items():
-                res[k] = v
-                if isinstance(v, str) and v[0:1] == '{':
-                    try:
-                        res[k] = json.loads(v)
-                    except Exception:
-                        pass
-        except Exception:
-             errors.report(f"Error reading metadata from file: {filename}", exc_info=True)
-
-        return res
 
 def read_metadata_from_safetensors(filename):
     import json

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -311,7 +311,6 @@ def get_state_dict_from_checkpoint(pl_sd):
 
 def read_metadata_from_safetensors(filename):
     import json
-    print(f"Reading metadata from {filename}...")
     with open(filename, mode="rb") as file:
         metadata_len = file.read(8)
         metadata_len = int.from_bytes(metadata_len, "little")


### PR DESCRIPTION
## Description

### What this PR do?
This PR add support for local hashes storing. It is very usable when using remote models storage, such as S3 mounted through s3fs or using very large models storages. Significantly reduces startup speed but needs to "compile" hashes on first launch.   
It is not happens until you provide "--local-hash-path" argument.  
In my configuration with local s3 storage on 10Gb\sec network reduces "list SD models" time on startup **from 617.0s to 0.4s.**  

### Why it is needed?
When using remote model storages stable-diffusion-webui models files will be fully downloaded on the local system to generate hash. When using large local model storages it will read every model file to generate hash.  
Due to this specific behavior, startup time can increase significantly when using remote storage, or just a HUGE local storage, where large amount of big files must be readen to generate hash. This PR reduces startup speed with optional storing models hashes. Also potentially it can preserve model spoof attacks too: hashes generated earlier safer than hashes that updates every launch.

### This PR changes:   
modules/cmd_args.py: 
- appending new argument `--local-hash-path `

modules/sd_models.py:  
- added variable `models_hash_path` to store path from commandline 
- appending new function `model_hash_generate` that generates and reads hash files with given path 
- changing behaviour of `model_hash` function to check property models_hash_path is defined and choose what to do: generate now or use stored hashes.

### Final behaviour:
When launching with `--local-hash-path`: on every call of `model_hash` it will check existing of hash file and given directory. If it is exists - just reads hash. If not - creating dir (if not exists) and file, generating hash and writing it.  

Without `--local-hash-path`: behaviour not changing at all.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
