### PR TITLE
Old hash form cache

### DIFF
--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -32,7 +32,7 @@ def sha256_from_cache(filename, title, use_addnet_hash=False):
     cached_sha256 = hashes[title].get("sha256", None)
     cached_mtime = hashes[title].get("mtime", 0)
 
-    if ondisk_mtime > cached_mtime or cached_sha256 is None:
+    if ondisk_mtime != cached_mtime or cached_sha256 is None:
         return None
 
     return cached_sha256


### PR DESCRIPTION
## Description

- re-implemented of PR https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16829 using the existing caching system

currently every time when the SD models scanned (on webui start up, model refresh)
it re-calculate the old partial hash (which we don't use) this massive waste
I see no reason not to cache it like we do for `hahses.sha256()`

## additional change

[use not equal when comparing mtime](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16830/commits/dce4a4cd3b98788bbafec52480a6c5ff46e20891)
I can't think of reason why the mtime check for sha256 is `>` and not `!=`, so I change it to `!=`

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
