### PR TITLE
Fix missing Emphasis infotext

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -763,6 +763,9 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
     prompt_text = p.main_prompt if use_main_prompt else all_prompts[index]
     negative_prompt = p.main_negative_prompt if use_main_prompt else all_negative_prompts[index]
 
+    if any(x for x in [prompt_text, negative_prompt] if "(" in x or "[" in x):
+        p.extra_generation_params["Emphasis"] = opts.emphasis
+
     uses_ensd = opts.eta_noise_seed_delta != 0
     if uses_ensd:
         uses_ensd = sd_samplers_common.is_sampler_using_eta_noise_seed_delta(p)

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -202,7 +202,7 @@ class TextConditionalModel(torch.nn.Module):
         Returns a tensor with shape of (B, T, C), where B is length of the array; T is length, in tokens, of texts (including padding) - T will
         be a multiple of 77; and C is dimensionality of each token - for SD1 it's 768, for SD2 it's 1024, and for SDXL it's 1280.
         An example shape returned by this function can be: (2, 77, 768).
-        For SDXL, instead of returning one tensor avobe, it returns a tuple with two: the other one with shape (B, 1280) with pooled values.
+        For SDXL, instead of returning one tensor above, it returns a tuple with two: the other one with shape (B, 1280) with pooled values.
         Webui usually sends just one text at a time through this function - the only time when texts is an array with more than one element
         is when you do prompt editing: "a picture of a [cat:dog:0.4] eating ice cream"
         """
@@ -241,9 +241,6 @@ class TextConditionalModel(torch.nn.Module):
                 if self.hijack.extra_generation_params.get("TI hashes"):
                     hashes.append(self.hijack.extra_generation_params.get("TI hashes"))
                 self.hijack.extra_generation_params["TI hashes"] = ", ".join(hashes)
-
-        if any(x for x in texts if "(" in x or "[" in x) and opts.emphasis != "Original":
-            self.hijack.extra_generation_params["Emphasis"] = opts.emphasis
 
         if self.return_pooled:
             return torch.hstack(zs), zs[0].pooled


### PR DESCRIPTION
## Description

- **Simple Description:** Currently, in certain situations *(see **Repro**)*, the `Emphasis` parameter would be missing from the infotext
- **Summary of Changes:** Moved the code that adds this parameter into `create_infotext` function

## Repro

0. Enable `Persistent cond cache` in settings
1. Generate an image that contains emphasis
    - notice the `Emphasis: ...` in infotext
2. Generate again with the exact same parameters *(`Seed` can vary)*
    - notice the `Emphasis: ...` is now missing
3. Reload UI
4. Click the `Read generation parameters` button (↙️)
5. See the `Override settings` now shows up as a result

- **TL;DR:** Currently, the `Emphasis` parameter is added during `CLIP` processing. So if you enable the `Persistent cond cache`, the `CLIP` no longer gets called in subsequent generations, thus missing the parameter.

## Checklist

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)