### PR TITLE
DowngradeVersion

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,4 +1,4 @@
-setuptools==69.5.1  # temp fix for compatibility with some old packages
+setuptools==60.10.0  # Downgrade setuptools as a temporary fix for compatibility with some old packages
 GitPython==3.1.32
 Pillow==9.5.0
 accelerate==0.21.0


### PR DESCRIPTION
## Issue Description

- Setuptools version 61.0.0+ introduces stricter configuration validation that breaks installation of filterpy due to an invalid configuration key in setup.cfg.

## Detailed Problem:

1. Current setuptools versions raise an error for the description-file key in setup.cfg.
2. This prevents installation of filterpy, which is a dependency for facexlib.
3. This error occurs with setuptools versions 61.0.0


## Temporary Workaround:

- Downgrade setuptools to version 60.10.0:

pip install setuptools==60.10.0

## Recommended Long Term Solution:
Update filterpy packages's setup.cfg to use correct configurtion key:

- Change `description-file = README.rst` to `description_file = README.rst`