### PR TITLE
Add random number generator source to filename

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -409,6 +409,7 @@ class FilenameGenerator:
         'generation_number': lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT if (self.p.n_iter == 1 and self.p.batch_size == 1) or self.zip else self.p.iteration * self.p.batch_size + self.p.batch_index + 1,
         'hasprompt': lambda self, *args: self.hasprompt(*args),  # accepts formats:[hasprompt<prompt1|default><prompt2>..]
         'clip_skip': lambda self: opts.data["CLIP_stop_at_last_layers"],
+        'randn_source': lambda self: opts.data["randn_source"],
         'denoising': lambda self: self.p.denoising_strength if self.p and self.p.denoising_strength else NOTHING_AND_SKIP_PREVIOUS_TEXT,
         'user': lambda self: self.p.user,
         'vae_filename': lambda self: self.get_vae_filename(),


### PR DESCRIPTION
Adds option for random number generator source for filename generator.

## Description

Add option to include random number generator source in filename.

Code changes TLDR:
  Pipes random number generator source from Options.data.

This addresses #16901

## Screenshots/videos:
With this setting:
![screenshot2](https://github.com/user-attachments/assets/975da864-da21-4db0-a8bf-69804be91767)
filenames like this are generated:
![screenshot](https://github.com/user-attachments/assets/196b6016-d304-4073-afb5-07a57e23d03b)


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)


