### PR TITLE
Fix issue with modal image viewer with low live_preview_refresh_period

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
         // imageviewer.js
         modalPrevImage: "readonly",
         modalNextImage: "readonly",
+        updateModalImageIfVisible: "readonly",
         // localStorage.js
         localSet: "readonly",
         localGet: "readonly",

--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -54,6 +54,7 @@ function updateOnBackgroundChange() {
         updateModalImage();
     }
 }
+const updateModalImageIfVisible = updateOnBackgroundChange;
 
 function modalImageSwitch(offset) {
     var galleryButtons = all_gallery_buttons();

--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -165,6 +165,7 @@ function modalLivePreviewToggle(event) {
     const modalToggleLivePreview = gradioApp().getElementById("modal_toggle_live_preview");
     opts.js_live_preview_in_modal_lightbox = !opts.js_live_preview_in_modal_lightbox;
     modalToggleLivePreview.innerHTML = opts.js_live_preview_in_modal_lightbox ? "&#x1F5C7;" : "&#x1F5C6;";
+    updateModalImageIfVisible();
     event.stopPropagation();
 }
 

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -190,7 +190,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
                         livePreview.className = 'livePreview';
                         gallery.insertBefore(livePreview, gallery.firstElementChild);
                     }
-
+                    updateModalImageIfVisible();
                     livePreview.appendChild(img);
                     if (livePreview.childElementCount > 2) {
                         livePreview.removeChild(livePreview.firstElementChild);

--- a/style.css
+++ b/style.css
@@ -602,6 +602,7 @@ table.popup-table .link{
     background: var(--background-fill-primary);
     width: 100%;
     height: 100%;
+    pointer-events: none;
 }
 
 .livePreview img{


### PR DESCRIPTION
## Description
fix issues with `modal image viewer` (aka the `full screen image viewer`) when `Progressbar and preview update period` aka `opts.live_preview_refresh_period` is set to a low value say 10 ms

1. unable to enter `modal image viewer` while live with `live preview`
2. `live preview` in `modal image viewer` dose not update

I'm not sure what has changed but I remember it working even with low values
my guess is that some subtle browser behavior has changed (testing on Chrome)

casue of (2) is because `scheduleAfterUiUpdateCallbacks` effectively sets a 200ms limit on how fast it can be caled
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ebbc56b4ec1bca6438e83753adb24faaeb1730b0/script.js#L111-L116

Fix
- adding css rule `pointer-events: none` to `livePreview` class fixes this issue<br>
this effectively lets the user to click the element underneath `livePreview` class allowing the use to enter `modal image viewer`

- explicitly trigger updateing of livepreveiw image in `modal image viewer` when a live preview is recived
- additionally I also added also trigger and update when the user toggle live preview

other changes of note
I created an ailes `updateModalImageIfVisible()` for `updateOnBackgroundChange()` as I belive the functon name `updateOnBackgroundChange` is too generic

## Video

### issue demo

https://github.com/user-attachments/assets/7a2bdfb4-ea74-40ec-89ed-83883f572418

> with `live_preview_refresh_period` set to 10 ms I am not able to enter `modal image viewer` while during image generation
> and in `modal image viewer` dose not update
> then shows the works when `live_preview_refresh_period` set to 1000 ms 


### fix demo

https://github.com/user-attachments/assets/6c40a63c-0e92-4990-b183-8ed706b7e9f6

> can enter `modal image viewer` even with `live_preview_refresh_period` set to 10 ms 
> live preview in `modal image viewer` also updates as intended

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
