### PR TITLE
CUDA Compute Capability change for RTX 5000 series

### DIFF
--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -54,7 +54,7 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
+        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (12, 0))
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward


### PR DESCRIPTION
The CUDA Compute Capability threshold that enables xformers in sd_hijack_optimizations.py is set to 9, 

which only covers up to the RTX 4000 series (Ada Lovelace: 8.9).

On RTX 5000 series cards (Blackwell: Compute Capability 10.0~12.0), xformers may show as enabled but it isn’t actually applied and doesn’t appear in the Cross-Attention optimizations list.
