### PR TITLE
docs(readme): correct yay installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sudo dnf install wget git python3 gperftools-libs libglvnd-glx
 # openSUSE-based:
 sudo zypper install wget git python3 libtcmalloc4 libglvnd
 # Arch-based:
-sudo pacman -S wget git python3
+sudo pacman -S --needed wget git python3 base-devel
 ```
 If your system is very new, you need to install python3.11 or python3.10:
 ```bash
@@ -136,7 +136,10 @@ sudo apt update
 sudo apt install python3.11
 
 # Manjaro/Arch
-sudo pacman -S yay
+git clone https://aur.archlinux.org/yay.git
+cd yay
+makepkg -si
+cd ..
 yay -S python311 # do not confuse with python3.11 package
 
 # Only for 3.11


### PR DESCRIPTION
Reason: 'yay' is not in official Arch Linux repositories, so `sudo pacman -S yay` will fail.

Changes:
- Remove sudo pacman -S yay
- Add proper AUR installation steps
- Add base-devel to pacman command, since it's required for AUR builds
- Add --needed flag to avoid reinstalling existing packages

Tested it on my system and it works.

## Description

Fix incorrect yay installation instructions for Arch Linux

The current documentation suggests `sudo pacman -S yay`,
which fails because yay is not in the official Arch repositories (it's only available in AUR).

Changes:
- Removed incorrect `sudo pacman -S yay` line
- Added proper AUR installation: `git clone` + `makepkg`
- Added `base-devel` to system dependencies (required for AUR builds)
- Added `--needed` flag to avoid reinstalling existing packages

Tested successfully on my Arch Linux system.

## Screenshots/videos:

Terminal output verifying the corrected installation steps work:
<img width="1071" height="1480" alt="result" src="https://github.com/user-attachments/assets/f57bb881-8804-4347-a994-a61ca09cf12c" />

## Checklist:

- [✔️ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ✔️] I have performed a self-review of my own code
- [ ✔️] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ✔️] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
