### PR TITLE
use cu126 for 10 series and older GPUs

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -347,8 +347,21 @@ def early_access_blackwell_wheels():
         return f'pip install {ea_whl.get(sys.version_info.minor)}'
 
 
+def get_default_torch_index_url():
+    """Choose default torch index url based on GPU CUDA Compute Capability (CC)
+    Use cu126 for CC <= 7.2, cu128 for CC > 7.2
+    PyTorch have dropped support for older GPUs on their cu128 and above wheels,
+    For Nvidia 10 series and older GPUs (CC < 7.0) should use cu126 wheels
+    Since GPUs with CC <= 7.2 are considered legacy by Nvidia
+        ref 2025-11-07 https://developer.nvidia.com/cuda-legacy-gpus
+    """
+    if get_cuda_comp_cap() <= 7.2:
+        return "https://download.pytorch.org/whl/cu126"
+    return "https://download.pytorch.org/whl/cu128"
+
+
 def prepare_environment():
-    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu128")
+    torch_index_url = os.environ.get('TORCH_INDEX_URL', get_default_torch_index_url())
     torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.7.0 torchvision==0.22.0 --extra-index-url {torch_index_url}")
     if args.use_ipex:
         if platform.system() == "Windows":


### PR DESCRIPTION
alternate PR for
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/17163
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/17171

apparently 10 series and older gpus don't work with `cu128`
10 series gpu have CUDA Compatibility of 7
and since GPU with Compatibility 7.2 is considered legacy by Nvidia
I belive everything under 7.2 should use cu126

ref
https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/support-matrix.html
https://developer.nvidia.com/cuda-gpus
https://download.pytorch.org/whl/cu128
https://en.wikipedia.org/wiki/CUDA
https://discuss.pytorch.org/t/uninstall-pytorch-completely-to-install-older-version/223551
https://dev-discuss.pytorch.org/t/cuda-toolkit-version-and-architecture-support-update-maxwell-and-pascal-architecture-support-removed-in-cuda-12-8-and-12-9-builds/3128

I don't fully understand the situation with older gpus
from the information I can find it seems that they only deleted support on pytorch 2.8
and since we use 2.7 I'm not quite sure why it doesn't work with cu128

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
