### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -11,8 +11,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.11
           # NB: there's no cache: pip here since we're not installing anything
@@ -29,9 +29,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
       - run: npm i --ci

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,9 +11,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.10.6
           cache: pip
@@ -22,7 +22,7 @@ jobs:
             launch.py
       - name: Cache models
         id: cache-models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: models
           key: "2023-12-30"
@@ -68,13 +68,13 @@ jobs:
           python -m coverage report -i
           python -m coverage html -i
       - name: Upload main app output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: output
           path: output.txt
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: htmlcov


### PR DESCRIPTION
## Description  
- Updated GitHub Actions versions to v6 where applicable  
- Updated `actions/checkout` (v4 → v6) in `.github/workflows/run_tests.yaml`  
- Updated `actions/setup-node` (v4 → v6) in `.github/workflows/on_pull_request.yaml`  
- Updated `actions/cache` (v4 → v5) in `.github/workflows/run_tests.yaml`  
- Updated `actions/upload-artifact` (v4 → v6) in `.github/workflows/run_tests.yaml`  
- Updated `actions/setup-python` (v5 → v6) in `.github/workflows/on_pull_request.yaml`  

## Checklist:  
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)  
- [x] I have performed a self-review of my own code  
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)  
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)