### PR TITLE
Fix CLIP installation failures

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -422,8 +422,24 @@ def prepare_environment():
         )
     startup_timer.record("torch GPU test")
 
+    # Ensure build dependencies are installed before any package that might need them
+    def ensure_build_dependencies():
+        """Ensure essential build tools are available"""
+        if not is_installed("wheel"):
+            run_pip("install wheel", "wheel")
+        # Check setuptools version compatibility
+        try:
+            setuptools_version = run(f'"{python}" -c "import setuptools; print(setuptools.__version__)"', None, None).strip()
+            if setuptools_version >= "70":
+                run_pip("install 'setuptools<70'", "setuptools")
+        except Exception:
+            # If setuptools check fails, install compatible version
+            run_pip("install 'setuptools<70'", "setuptools")
+    # Install build dependencies early
+    ensure_build_dependencies()
+
     if not is_installed("clip"):
-        run_pip(f"install {clip_package}", "clip")
+        run_pip(f"install --no-build-isolation {clip_package}", "clip")
         startup_timer.record("install clip")
 
     if not is_installed("open_clip"):


### PR DESCRIPTION
## Description

### Summary
This PR fixes multiple CLIP installation issues that prevent Stable Diffusion WebUI from completing its initial setup. The core problem is that CLIP uses a pyproject.toml build system which requires proper build dependencies (wheel and setuptools) to be available during installation.

### Technical Changes
- Added a dedicated `ensure_build_dependencies()` function that checks and installs essential build tools before CLIP installation
- Implemented setuptools version compatibility checking to prevent issues with setuptools >= 70
- Modified CLIP installation to use `--no-build-isolation` flag to avoid build environment isolation issues
- Consolidated build dependency management in the runtime logic rather than relying solely on requirements_versions.txt

### Issues Fixed
This PR resolves the following reported issues:
- #17201 : ```Cannot import 'setuptools.build_meta'```
- #17284 : ```ModuleNotFoundError: No module named 'pkg_resources'```
- #17287 : ```ModuleNotFoundError: No module named 'pkg_resources'```
- Related Discussions: #17283, #17275

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
