### PR TITLE
Fix the issue of `pip install 'setuptools<70'` failing in cmd

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -431,10 +431,10 @@ def prepare_environment():
         try:
             setuptools_version = run(f'"{python}" -c "import setuptools; print(setuptools.__version__)"', None, None).strip()
             if setuptools_version >= "70":
-                run_pip("install 'setuptools<70'", "setuptools")
+                run_pip("install setuptools==69.5.1", "setuptools")
         except Exception:
             # If setuptools check fails, install compatible version
-            run_pip("install 'setuptools<70'", "setuptools")
+            run_pip("install setuptools==69.5.1", "setuptools")
     # Install build dependencies early
     ensure_build_dependencies()
 


### PR DESCRIPTION
## Description

### Summary

Use fixed setuptools version 69.5.1 instead of version range '<70'

The original constraint uses single quotes which causes issues in Windows Command Prompt, where '<' is interpreted as a redirection operator. This issue wasn't caught earlier because PowerShell handles single quotes correctly, masking the problem during initial testing. Using a fixed version avoids this shell compatibility issue entirely and aligns with requirements_versions.txt.

### Changes

Replace version constraint 'setuptools<70' with fixed version setuptools==69.5.1

### Issues Fixed

This issue originates from the previous PR #17293.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
