### PR TITLE
set a timeout on launch utils HTTP calls

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -211,7 +211,7 @@ def git_pull_recursive(dir):
 def version_check(commit):
     try:
         import requests
-        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
+        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master', timeout=10.0).json()
         if commit != "<none>" and commits['commit']['sha'] != commit:
             print("--------------------------------------------------------")
             print("| You are not up to date with the most recent release. |")

--- a/modules/textual_inversion/autocrop.py
+++ b/modules/textual_inversion/autocrop.py
@@ -311,7 +311,7 @@ def download_and_cache_models():
     if not os.path.exists(model_file_path):
         os.makedirs(model_dir_opencv, exist_ok=True)
         print(f"downloading face detection model from '{model_url}' to '{model_file_path}'")
-        response = requests.get(model_url)
+        response = requests.get(model_url, timeout=10.0)
         with open(model_file_path, "wb") as f:
             f.write(response.content)
     return model_file_path


### PR DESCRIPTION
Upon reviewing modules/launch_utils.py, I noticed an opportunity for improvement. Set a timeout on launch utils HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.