### PR TITLE
fix: restore model_hijack.clip after LDSR upscale

### DIFF
--- a/extensions-builtin/LDSR/ldsr_model_arch.py
+++ b/extensions-builtin/LDSR/ldsr_model_arch.py
@@ -104,6 +104,7 @@ class LDSR:
         return logs
 
     def super_resolution(self, image, steps=100, target_scale=2, half_attention=False):
+        previous_clip = sd_hijack.model_hijack.clip
         model = self.load_model_from_config(half_attention)
 
         # Run settings
@@ -150,6 +151,8 @@ class LDSR:
         del model
         gc.collect()
         devices.torch_gc()
+
+        sd_hijack.model_hijack.clip = previous_clip
 
         return a
 


### PR DESCRIPTION
## What

Fixes #12942 - LDSR upscaler breaks prompt token counters after use.

## Root Cause

`load_model_from_config()` calls `sd_hijack.model_hijack.hijack(model)` on the LDSR diffusion model (line 46). This sets `model_hijack.clip = model.cond_stage_model`, but the LDSR model's `cond_stage_model` is a VQ-VAE autoencoder, not a CLIP encoder.

After `super_resolution()` completes and the LDSR model is garbage collected, `model_hijack.clip` remains set to this wrong object. Any subsequent call to `model_hijack.get_prompt_lengths()` then fails because the object has no `process_texts` method:

```
AttributeError: 'Identity' object has no attribute 'process_texts'
```

## Fix

Save `model_hijack.clip` before loading the LDSR model and restore it after upscaling is complete. The LDSR run itself does not depend on `model_hijack.clip` - it receives the model directly via the `run()` call.

## Changes

- `extensions-builtin/LDSR/ldsr_model_arch.py`: save/restore `model_hijack.clip` in `super_resolution()`