### PR TITLE
fix various bugs and robustness issues across core modules

### DIFF
--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -140,7 +140,7 @@ def restore_webui_config(config):
         webui_repo.git.reset(webui_commit_hash, hard=True)
         print(f"* Restored webui to commit {webui_commit_hash}.")
     except Exception:
-        errors.report(f"Error restoring webui to commit{webui_commit_hash}")
+        errors.report(f"Error restoring webui to commit {webui_commit_hash}", exc_info=True)
 
 
 def restore_extension_config(config):

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -97,7 +97,7 @@ def run(code, task):
     try:
         code()
     except Exception as e:
-        display(task, e)
+        display(e, task)
 
 
 def check_versions():

--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -776,7 +776,7 @@ def save_hypernetwork(hypernetwork, checkpoint, hypernetwork_name, filename):
         hypernetwork.sd_checkpoint_name = checkpoint.model_name
         hypernetwork.name = hypernetwork_name
         hypernetwork.save(filename)
-    except:
+    except Exception:
         hypernetwork.sd_checkpoint = old_sd_checkpoint
         hypernetwork.sd_checkpoint_name = old_sd_checkpoint_name
         hypernetwork.name = old_hypernetwork_name

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -15,7 +15,7 @@ def imports():
     import torch  # noqa: F401
     startup_timer.record("import torch")
     import pytorch_lightning  # noqa: F401
-    startup_timer.record("import torch")
+    startup_timer.record("import pytorch_lightning")
     warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="pytorch_lightning")
     warnings.filterwarnings(action="ignore", category=UserWarning, module="torchvision")
 

--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -22,7 +22,9 @@ def fix_torch_version():
     # Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
     if ".dev" in torch.__version__ or "+git" in torch.__version__:
         torch.__long_version__ = torch.__version__
-        torch.__version__ = re.search(r'[\d.]+[\d]', torch.__version__).group(0)
+        match = re.search(r'[\d.]+[\d]', torch.__version__)
+        if match:
+            torch.__version__ = match.group(0)
 
 def fix_pytorch_lightning():
     # Checks if pytorch_lightning.utilities.distributed already exists in the sys.modules cache

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -38,9 +38,9 @@ def check_python_version():
     micro = sys.version_info.micro
 
     if is_windows:
-        supported_minors = [10]
+        supported_minors = [10, 11, 12]
     else:
-        supported_minors = [7, 8, 9, 10, 11]
+        supported_minors = [7, 8, 9, 10, 11, 12]
 
     if not (major == 3 and minor in supported_minors):
         import modules.errors
@@ -54,7 +54,7 @@ or any other error regarding unsuccessful package (library) installation,
 please downgrade (or upgrade) to the latest version of 3.10 Python
 and delete current Python and "venv" folder in WebUI's directory.
 
-You can download 3.10 Python from here: https://www.python.org/downloads/release/python-3106/
+You can download the latest 3.10 Python from here: https://www.python.org/downloads/release/python-31016/
 
 {"Alternatively, use a binary release of WebUI: https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/tag/v1.0.0-pre" if is_windows else ""}
 
@@ -195,23 +195,24 @@ def git_clone(url, dir, name, commithash=None):
         raise
 
     if commithash is not None:
-        run(f'"{git}" -C "{dir}" checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
+        run(f'"{git}" -C "{dir}" checkout {commithash}', None, f"Couldn't checkout {name}'s hash: {commithash}")
 
 
 def git_pull_recursive(dir):
     for subdir, _, _ in os.walk(dir):
         if os.path.exists(os.path.join(subdir, '.git')):
             try:
-                output = subprocess.check_output([git, '-C', subdir, 'pull', '--autostash'])
-                print(f"Pulled changes for repository in '{subdir}':\n{output.decode('utf-8').strip()}\n")
+                output = subprocess.check_output([git, '-C', subdir, 'pull', '--autostash'], encoding='utf8', errors='replace')
+                print(f"Pulled changes for repository in '{subdir}':\n{output.strip()}\n")
             except subprocess.CalledProcessError as e:
-                print(f"Couldn't perform 'git pull' on repository in '{subdir}':\n{e.output.decode('utf-8').strip()}\n")
+                output = e.output.decode('utf-8', errors='replace') if isinstance(e.output, bytes) else (e.output or '')
+                print(f"Couldn't perform 'git pull' on repository in '{subdir}':\n{output.strip()}\n")
 
 
 def version_check(commit):
     try:
         import requests
-        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
+        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master', timeout=10).json()
         if commit != "<none>" and commits['commit']['sha'] != commit:
             print("--------------------------------------------------------")
             print("| You are not up to date with the most recent release. |")
@@ -222,7 +223,7 @@ def version_check(commit):
         else:
             print("Not a git clone, can't perform version check.")
     except Exception as e:
-        print("version check failed", e)
+        print(f"version check failed: {e}")
 
 
 def run_extension_installer(extension_dir):
@@ -251,6 +252,7 @@ def list_extensions(settings_file):
         pass
     except Exception:
         errors.report(f'\nCould not load settings\nThe config file "{settings_file}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+        os.makedirs(os.path.join(script_path, "tmp"), exist_ok=True)
         os.replace(settings_file, os.path.join(script_path, "tmp", "config.json"))
 
     disabled_extensions = set(settings.get('disabled_extensions', []))
@@ -277,7 +279,7 @@ def run_extensions_installers(settings_file):
                 startup_timer.record(dirname_extension)
 
 
-re_requirement = re.compile(r"\s*([-_a-zA-Z0-9]+)\s*(?:==\s*([-+_.a-zA-Z0-9]+))?\s*")
+re_requirement = re.compile(r"\s*([-_a-zA-Z0-9]+)\s*(?:==\s*([-+_.a-zA-Z0-9]+))?[^#]*")
 
 
 def requirements_met(requirements_file):
@@ -414,7 +416,7 @@ def prepare_environment():
     git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
     git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
 
-    startup_timer.record("clone repositores")
+    startup_timer.record("clone repositories")
 
     if not os.path.isfile(requirements_file):
         requirements_file = os.path.join(script_path, requirements_file)

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 import torch
 
-from modules import shared
+from modules import shared, errors
 from modules.upscaler import Upscaler, UpscalerLanczos, UpscalerNearest, UpscalerNone
 
 if TYPE_CHECKING:
@@ -85,7 +85,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
                 output.append(model_url)
 
     except Exception:
-        pass
+        errors.report("Error scanning model paths", exc_info=True)
 
     return output
 

--- a/modules/options.py
+++ b/modules/options.py
@@ -202,6 +202,7 @@ class Options:
             self.data = {}
         except Exception:
             errors.report(f'\nCould not load settings\nThe config file "{filename}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+            os.makedirs(os.path.join(script_path, "tmp"), exist_ok=True)
             os.replace(filename, os.path.join(script_path, "tmp", "config.json"))
             self.data = {}
         # 1.6.0 VAE defaults

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -170,7 +170,7 @@ def list_models():
 
         shared.opts.data['sd_model_checkpoint'] = checkpoint_info.title
     elif cmd_ckpt is not None and cmd_ckpt != shared.default_sd_model_file:
-        print(f"Checkpoint in --ckpt argument not found (Possible it was moved to {model_path}: {cmd_ckpt}", file=sys.stderr)
+        print(f"Checkpoint in --ckpt argument not found (possible it was moved to {model_path}): {cmd_ckpt}", file=sys.stderr)
 
     for filename in model_list:
         checkpoint_info = CheckpointInfo(filename)
@@ -317,7 +317,8 @@ def read_state_dict(checkpoint_file, print_global_state=False, map_location=None
         if not shared.opts.disable_mmap_load_safetensors:
             pl_sd = safetensors.torch.load_file(checkpoint_file, device=device)
         else:
-            pl_sd = safetensors.torch.load(open(checkpoint_file, 'rb').read())
+            with open(checkpoint_file, 'rb') as f:
+                pl_sd = safetensors.torch.load(f.read())
             pl_sd = {k: v.to(device) for k, v in pl_sd.items()}
     else:
         pl_sd = torch.load(checkpoint_file, map_location=map_location or shared.weight_load_location)

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -701,7 +701,7 @@ def save_embedding(embedding, optimizer, checkpoint, embedding_name, filename, r
         embedding.name = embedding_name
         embedding.optimizer_state_dict = optimizer.state_dict()
         embedding.save(filename)
-    except:
+    except Exception:
         embedding.sd_checkpoint = old_sd_checkpoint
         embedding.sd_checkpoint_name = old_sd_checkpoint_name
         embedding.name = old_embedding_name


### PR DESCRIPTION
- errors.py: fix inverted args in errors.run() (display(task,e) -> display(e,task))
- initialize_util.py: guard re.search() result before .group(0) to prevent startup crash
- initialize.py: fix duplicate startup_timer label for pytorch_lightning import
- launch_utils.py: add f-prefix to error string in git_clone so {name}/{commithash} interpolate
- launch_utils.py: add Python 3.11/3.12 to supported versions on all platforms
- launch_utils.py: update stale Python 3.10.6 download URL to 3.10.16
- launch_utils.py: add timeout=10 to version_check requests.get call
- launch_utils.py: fix requirements regex to allow inline comments
- launch_utils.py: ensure tmp/ dir exists before os.replace() on corrupted config
- launch_utils.py: fix git_pull_recursive to use encoding param, avoiding UnicodeDecodeError
- launch_utils.py: fix typo "clone repositores" -> "clone repositories"
- modelloader.py: replace bare except:pass with errors.report() so scan failures are visible
- options.py: ensure tmp/ dir exists before os.replace() on corrupted config
- sd_models.py: fix unclosed file handle when loading safetensors with disable_mmap
- sd_models.py: fix unclosed parenthesis in --ckpt not found error message
- config_states.py: fix missing space + add exc_info=True on restore failure
- hypernetworks/hypernetwork.py: replace bare except: with except Exception: in rollback
- textual_inversion/textual_inversion.py: replace bare except: with except Exception: in rollback

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
