### PR TITLE
fix(launch): add --no-build-isolation to open_clip and requirements installs

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -443,7 +443,7 @@ def prepare_environment():
         startup_timer.record("install clip")
 
     if not is_installed("open_clip"):
-        run_pip(f"install {openclip_package}", "open_clip")
+        run_pip(f"install --no-build-isolation {openclip_package}", "open_clip")
         startup_timer.record("install open_clip")
 
     if (not is_installed("xformers") or args.reinstall_xformers) and args.xformers:
@@ -468,14 +468,14 @@ def prepare_environment():
         requirements_file = os.path.join(script_path, requirements_file)
 
     if not requirements_met(requirements_file):
-        run_pip(f"install -r \"{requirements_file}\"", "requirements")
+        run_pip(f"install --no-build-isolation -r \"{requirements_file}\"", "requirements")
         startup_timer.record("install requirements")
 
     if not os.path.isfile(requirements_file_for_npu):
         requirements_file_for_npu = os.path.join(script_path, requirements_file_for_npu)
 
     if "torch_npu" in torch_command and not requirements_met(requirements_file_for_npu):
-        run_pip(f"install -r \"{requirements_file_for_npu}\"", "requirements_for_npu")
+        run_pip(f"install --no-build-isolation -r \"{requirements_file_for_npu}\"", "requirements_for_npu")
         startup_timer.record("install requirements_for_npu")
 
     if not args.skip_install:


### PR DESCRIPTION
## What was changed?

Added `--no-build-isolation` to the `open_clip` and `requirements` pip install calls in `prepare_environment()`, mirroring the existing flag already applied to `clip`.

## Why?

Commit 76759a18 fixed CLIP installation failures (#17201, #17284, #17287) by adding `--no-build-isolation` to the `clip` install. The same flag was missing from two other install calls in the same block:

- `open_clip` — installed from a GitHub ZIP (source distribution)
- `requirements_versions.txt` — contains `jsonmerge==1.8.0` (source distribution, no binary wheel)

With **pip 26+**, the isolated build environment fails to import `setuptools.build_meta` for source distributions:

```
BackendUnavailable: Cannot import 'setuptools.build_meta'
RuntimeError: Couldn't install open_clip.
RuntimeError: Couldn't install requirements.
```

This causes a complete startup failure on portable/embedded Python 3.10.6 environments (e.g. the sd.webui one-click package) after pip auto-updates to 26+.

Using `--no-build-isolation` lets pip use the already-installed `setuptools==69.5.1` (pinned as line 1 of `requirements_versions.txt`) directly, avoiding the broken isolated build environment.

## How to reproduce

1. Use the sd.webui one-click portable package (embedded Python 3.10.6)
2. Let pip update to 26+ (happens automatically via `get-pip.py`)
3. Run `run.bat` — startup fails with `BackendUnavailable: Cannot import 'setuptools.build_meta'`

## How to test

Run `run.bat` on a portable sd.webui installation with pip 26+ — startup completes successfully.

## Checklist

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)