### PR TITLE
used to run in a 5090

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -346,13 +346,13 @@ def prepare_environment():
     openclip_package = os.environ.get('OPENCLIP_PACKAGE', "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip")
 
     assets_repo = os.environ.get('ASSETS_REPO', "https://github.com/AUTOMATIC1111/stable-diffusion-webui-assets.git")
-    stable_diffusion_repo = os.environ.get('STABLE_DIFFUSION_REPO', "https://github.com/Stability-AI/stablediffusion.git")
+    stable_diffusion_repo = os.environ.get('STABLE_DIFFUSION_REPO', "https://github.com/CompVis/stable-diffusion.git")
     stable_diffusion_xl_repo = os.environ.get('STABLE_DIFFUSION_XL_REPO', "https://github.com/Stability-AI/generative-models.git")
     k_diffusion_repo = os.environ.get('K_DIFFUSION_REPO', 'https://github.com/crowsonkb/k-diffusion.git')
     blip_repo = os.environ.get('BLIP_REPO', 'https://github.com/salesforce/BLIP.git')
 
     assets_commit_hash = os.environ.get('ASSETS_COMMIT_HASH', "6f7db241d2f8ba7457bac5ca9753331f0c266917")
-    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf")
+    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "21f890f9da3cfbeaba8e2ac3c425ee9e998d5229")
     stable_diffusion_xl_commit_hash = os.environ.get('STABLE_DIFFUSION_XL_COMMIT_HASH', "45c443b316737a4ab6e40413d7794a7f5657c19f")
     k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "ab527a9a6d347f364e3d185ba6d714e22d80cb3c")
     blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -40,6 +40,7 @@ path_dirs = [
     (os.path.join(sd_path, '../generative-models'), 'sgm', 'Stable Diffusion XL', ["sgm"]),
     (os.path.join(sd_path, '../BLIP'), 'models/blip.py', 'BLIP', []),
     (os.path.join(sd_path, '../k-diffusion'), 'k_diffusion/sampling.py', 'k_diffusion', ["atstart"]),
+    (os.path.join(sd_path, '../taming-transformers'), 'taming', 'Taming Transformers', ["atstart"]),
 ]
 
 paths = {}

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -239,7 +239,7 @@ class StableDiffusionModelHijack:
             model_embeddings.token_embedding = EmbeddingsWithFixes(model_embeddings.token_embedding, self)
             m.cond_stage_model = sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords(m.cond_stage_model, self)
 
-        elif type(m.cond_stage_model) == ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder:
+        elif type(m.cond_stage_model) == getattr(ldm.modules.encoders.modules, "FrozenOpenCLIPEmbedder", type(None)):
             m.cond_stage_model.model.token_embedding = EmbeddingsWithFixes(m.cond_stage_model.model.token_embedding, self)
             m.cond_stage_model = sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(m.cond_stage_model, self)
 

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -1,8 +1,10 @@
 @echo off
 
-set PYTHON=
+set PYTHON=C:\Users\nicol\AppData\Local\Programs\Python\Python310\python.exe
 set GIT=
 set VENV_DIR=
-set COMMANDLINE_ARGS=
+set COMMANDLINE_ARGS=--api
+set STABLE_DIFFUSION_REPO=https://github.com/CompVis/stable-diffusion.git
+set STABLE_DIFFUSION_COMMIT_HASH=21f890f9da3cfbeaba8e2ac3c425ee9e998d5229
 
 call webui.bat


### PR DESCRIPTION
## Description

This PR restores compatibility with the legacy Stable Diffusion repository layout required by some setups (including my RTX 5090 environment), and prevents startup/import issues caused by missing taming-transformers path registration.

* a simple description of what you're trying to accomplish

Switched default STABLE_DIFFUSION_REPO from Stability-AI/stablediffusion back to CompVis/stable-diffusion in modules/launch_utils.py.

Updated default STABLE_DIFFUSION_COMMIT_HASH to 21f890f9da3cfbeaba8e2ac3c425ee9e998d5229 in modules/launch_utils.py.

Added taming-transformers path registration in modules/paths.py to ensure taming imports are found at startup.

Made OpenCLIP type check more defensive in modules/sd_hijack.py using getattr(..., "FrozenOpenCLIPEmbedder", type(None)) to avoid hard failures when symbol resolution differs.

Updated local webui-user.bat defaults for my environment (PYTHON, --api, SD repo/hash) for reproducible launch behavior.

* a summary of changes in code
* which issues it fixes, if any

Fixes startup/import errors in environments expecting the CompVis + taming-transformers structure.

Fixes a fragile class comparison path in OpenCLIP hijack logic.

## Screenshots/videos:

N/A

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
