### PR TITLE
Fix typo in README: 'mix' should be 'min'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A web interface for Stable Diffusion, implemented using Gradio library.
 - Settings page
 - Running arbitrary python code from UI (must run with `--allow-code` to enable)
 - Mouseover hints for most UI elements
-- Possible to change defaults/mix/max/step values for UI elements via text config
+- Possible to change defaults/min/max/step values for UI elements via text config
 - Tiling support, a checkbox to create images that can be tiled like textures
 - Progress bar and live image generation preview
     - Can use a separate neural network to produce previews with almost none VRAM or compute requirement


### PR DESCRIPTION
Fixes a typo in the README feature list: `defaults/mix/max/step` should be `defaults/min/max/step`. The word 'mix' is clearly a typo for 'min' (minimum), as the context describes UI element value ranges (min/max/step).