### PR TITLE
Fix Scale by 1x not running upscaler on Extras tab

### DIFF
--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -56,8 +56,8 @@ class Upscaler:
         dest_w = int((img.width * scale) // 8 * 8)
         dest_h = int((img.height * scale) // 8 * 8)
 
-        for i in range(3):
-            if img.width >= dest_w and img.height >= dest_h and (i > 0 or scale != 1):
+        for _ in range(3):
+            if img.width > dest_w and img.height > dest_h:
                 break
 
             if shared.state.interrupted:
@@ -68,6 +68,9 @@ class Upscaler:
             img = self.do_upscale(img, selected_model)
 
             if shape == (img.width, img.height):
+                break
+
+            if img.width >= dest_w and img.height >= dest_h:
                 break
 
         if img.width != dest_w or img.height != dest_h:


### PR DESCRIPTION
## Description
Fixes #14738.

Root cause: a previous commit moved the upscale loop's break guard before do_upscale. For scale=1, img.width >= dest_w was true on the first iteration, breaking before the upscaler ever ran.

Fix: restructured with two guards — a > guard before do_upscale (only breaks when image strictly larger than target, preventing wasted work for downscales), and a >= guard after do_upscale (normal completion check).
## Screenshots/videos:
N/A — no visual changes
## Checklist:
- [x] Tested locally