### PR TITLE
Fix missing scrollbar on extra networks directory listing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1240,6 +1240,11 @@ body.resizing .resize-handle {
 .extra-network-dirs-hidden .resize-handle { display: none; }
 .extra-network-dirs-hidden .resize-handle-row { display: flex !important; }
 
+.extra-network-pane .extra-network-dirs {
+    max-height: 33%;
+    overflow: clip auto;
+}
+
 .extra-network-pane .extra-network-tree {
     flex: 1;
     font-size: 1rem;
@@ -1264,26 +1269,30 @@ body.resizing .resize-handle {
 
 
 .extra-network-pane .extra-network-cards::-webkit-scrollbar,
-.extra-network-pane .extra-network-tree::-webkit-scrollbar {
+.extra-network-pane .extra-network-tree::-webkit-scrollbar,
+.extra-network-pane .extra-network-dirs::-webkit-scrollbar {
     background-color: transparent;
     width: 16px;
 }
 
 .extra-network-pane .extra-network-cards::-webkit-scrollbar-track,
-.extra-network-pane .extra-network-tree::-webkit-scrollbar-track {
+.extra-network-pane .extra-network-tree::-webkit-scrollbar-track,
+.extra-network-pane .extra-network-dirs::-webkit-scrollbar-track {
     background-color: transparent;
     background-clip: content-box;
 }
 
 .extra-network-pane .extra-network-cards::-webkit-scrollbar-thumb,
-.extra-network-pane .extra-network-tree::-webkit-scrollbar-thumb {
+.extra-network-pane .extra-network-tree::-webkit-scrollbar-thumb,
+.extra-network-pane .extra-network-dirs::-webkit-scrollbar-thumb {
     background-color: var(--border-color-primary);
     border-radius: 16px;
     border: 4px solid var(--background-fill-primary);
 }
 
 .extra-network-pane .extra-network-cards::-webkit-scrollbar-button,
-.extra-network-pane .extra-network-tree::-webkit-scrollbar-button {
+.extra-network-pane .extra-network-tree::-webkit-scrollbar-button,
+.extra-network-pane .extra-network-dirs::-webkit-scrollbar-button {
     display: none;
 }
 


### PR DESCRIPTION
## Description
Fixes #15518.

Added max-height and overflow to .extra-network-dirs to match the existing scroll behavior of .extra-network-tree and .extra-network-cards.
## Screenshots/videos:
N/A — no visual changes
## Checklist:
- [x] Tested locally