### PR TITLE
docs: fix missing article 'the' before Gradio library in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Stable Diffusion web UI
-A web interface for Stable Diffusion, implemented using Gradio library.
+A web interface for Stable Diffusion, implemented using the Gradio library.
 
 ![](screenshot.png)
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 2).

## Problem

Missing article "the" before "Gradio library". The sentence reads "implemented using Gradio library" which is grammatically incomplete.

The problematic text:

```markdown
implemented using Gradio library
```

## Fix

Replaced with:

```markdown
implemented using the Gradio library
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text