### PR TITLE
docs: fix capitalization of 'Python' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A web interface for Stable Diffusion, implemented using Gradio library.
 ## Features
 [Detailed feature showcase with images](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features):
 - Original txt2img and img2img modes
-- One click install and run script (but you still must install python and git)
+- One click install and run script (but you still must install Python and git)
 - Outpainting
 - Inpainting
 - Color Sketch


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 9).

## Problem

"python" should be capitalized as "Python" (proper noun). This is inconsistent with line 114 which correctly uses "Python 3.10.6".

The problematic text:

```markdown
but you still must install python and git
```

## Fix

Replaced with:

```markdown
but you still must install Python and git
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text