### PR TITLE
docs: fix 'a MacOS' to 'macOS' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A web interface for Stable Diffusion, implemented using Gradio library.
 - Attention, specify parts of text that the model should pay more attention to
     - a man in a `((tuxedo))` - will pay more attention to tuxedo
     - a man in a `(tuxedo:1.21)` - alternative syntax
-    - select text and press `Ctrl+Up` or `Ctrl+Down` (or `Command+Up` or `Command+Down` if you're on a MacOS) to automatically adjust attention to selected text (code contributed by anonymous user)
+    - select text and press `Ctrl+Up` or `Ctrl+Down` (or `Command+Up` or `Command+Down` if you're on macOS) to automatically adjust attention to selected text (code contributed by anonymous user)
 - Loopback, run img2img processing multiple times
 - X/Y/Z plot, a way to draw a 3 dimensional plot of images with different parameters
 - Textual Inversion


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 18).

## Problem

Incorrect article "a" before "MacOS" and wrong capitalization. "macOS" is a proper noun that does not take an indefinite article.

The problematic text:

```markdown
if you're on a MacOS
```

## Fix

Replaced with:

```markdown
if you're on macOS
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text