### PR TITLE
Fix X/Y/Z grid annotations with Pillow 10+

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -168,9 +168,11 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
         for line in lines:
             fnt = initial_fnt
             fontsize = initial_fontsize
-            while drawing.multiline_textsize(line.text, font=fnt)[0] > line.allowed_width and fontsize > 0:
+            bbox = drawing.multiline_textbbox((0, 0), line.text, font=fnt)
+            while bbox[2] - bbox[0] > line.allowed_width and fontsize > 0:
                 fontsize -= 1
                 fnt = get_font(fontsize)
+                bbox = drawing.multiline_textbbox((0, 0), line.text, font=fnt)
             drawing.multiline_text((draw_x, draw_y + line.size[1] / 2), line.text, font=fnt, fill=color_active if line.is_active else color_inactive, anchor="mm", align="center")
 
             if not line.is_active:

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -1,0 +1,21 @@
+import pytest
+from PIL import Image, ImageDraw
+
+
+@pytest.mark.usefixtures("initialize")
+def test_draw_grid_annotations_without_multiline_textsize(monkeypatch):
+    from modules.images import GridAnnotation, draw_grid_annotations
+
+    monkeypatch.delattr(ImageDraw.ImageDraw, "multiline_textsize", raising=False)
+
+    image = Image.new("RGB", (64, 64), "white")
+    result = draw_grid_annotations(
+        image,
+        64,
+        64,
+        [[GridAnnotation("a long grid annotation")]],
+        [[GridAnnotation("")]],
+    )
+
+    assert result.width == image.width
+    assert result.height > image.height


### PR DESCRIPTION
## Description

- Replace the removed `ImageDraw.multiline_textsize` call with `multiline_textbbox` width calculation while preserving the existing font-shrinking behavior.
- Add a regression test that removes the legacy method from Pillow 9.5 to exercise the Pillow 10+ API surface.

Fixes #17054.

## Screenshots/videos:

N/A; this fixes an exception raised while rendering X/Y/Z grid labels.

## Test plan

- `python -m pytest -vv --verify-base-url test` (34 passed with Pillow 9.5.0)
- Focused regression passed with Pillow 12.3.0
- `ruff check .` (Ruff 0.3.3)

## Checklist:

- [x] I have read the contributing wiki page
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines
- [x] My code passes tests