### PR TITLE
fix(scheduler): clamp beta_dist_alpha/beta at point of use to avoid NaN

### DIFF
--- a/modules/sd_schedulers.py
+++ b/modules/sd_schedulers.py
@@ -118,8 +118,15 @@ def ddim_scheduler(n, sigma_min, sigma_max, inner_model, device):
 
 def beta_scheduler(n, sigma_min, sigma_max, inner_model, device):
     # From "Beta Sampling is All You Need" [arXiv:2407.12173] (Lee et. al, 2024)
-    alpha = shared.opts.beta_dist_alpha
-    beta = shared.opts.beta_dist_beta
+    # stats.beta.ppf requires both shape parameters to be strictly positive --
+    # 0 (or negative) produces NaN. Commit 94275b11 raised the options UI
+    # slider's minimum to 0.01 to stop new 0 values from being set, but a
+    # value saved before that change, or set directly through the
+    # /sdapi/v1/options API (which the slider's minimum doesn't constrain),
+    # can still reach here as 0. Clamp at the point of use so every path
+    # is covered.
+    alpha = max(shared.opts.beta_dist_alpha, 0.01)
+    beta = max(shared.opts.beta_dist_beta, 0.01)
     curve = [stats.beta.ppf(x, alpha, beta) for x in np.linspace(1, 0, n)]
 
     start = inner_model.sigma_to_t(torch.tensor(sigma_max))


### PR DESCRIPTION
## Description

Follow-up to 94275b11, which raised the Beta scheduler's `beta_dist_alpha` / `beta_dist_beta` options-UI slider minimum from `0.0` to `0.01` to avoid `NaN`.

That guard is UI-only, and two paths around it are both still open:

1. **Old persisted settings.** A `config.json` saved with `beta_dist_alpha`/`beta_dist_beta` already at `0.0` from before 94275b11 loads unchanged — the slider's new minimum only stops a *new* value being set through the UI, it doesn't touch what's already on disk.
2. **`/sdapi/v1/options`.** This API endpoint can set either option straight to `0.0`; it isn't routed through the Gradio slider's `minimum` at all.

Either path reaches `beta_scheduler()` in `modules/sd_schedulers.py`, which reads `shared.opts.beta_dist_alpha`/`beta_dist_beta` directly with no validation and passes them to `stats.beta.ppf()`. `scipy`'s Beta distribution requires both shape parameters to be strictly positive — at `0` (or negative) `ppf()` returns `NaN` for every timestep, confirmed against the real, installed `scipy`:

```
Case 1: shared.opts.beta_dist_alpha = 0.0 (an old persisted config.json,
        or a direct POST to /sdapi/v1/options -- neither goes through the UI slider)
  sigmas: [nan nan nan nan nan nan nan nan nan nan  0.]
  any NaN: True
```

## Fix

Clamp at the point of use in `beta_scheduler()` instead of only at the UI edge, so every path (UI, persisted config, direct API) is covered by the same guard:

```python
alpha = max(shared.opts.beta_dist_alpha, 0.01)
beta = max(shared.opts.beta_dist_beta, 0.01)
```

`0.01` matches the slider's own minimum from 94275b11, so a value that would already be accepted through the UI is completely unaffected — the clamp only changes behavior for values the UI itself now considers invalid.

## Testing

Ran `ruff check` (the same linter + version this repo's CI uses) on the changed file — clean:

```
$ pip install ruff==0.3.3
$ ruff check modules/sd_schedulers.py
All checks passed!
```

The full test suite (`run_tests.yaml`) spins up the actual webui server against downloaded models, which isn't practical to reproduce locally — I'm relying on this PR's own CI run for that. What I verified locally, against the real code (not a reimplementation):

- Stubbed the heavy/irrelevant imports (`torch`, `k_diffusion`, `modules.shared`) and imported the *actual* `modules/sd_schedulers.py` file, then called the real `beta_scheduler()` directly with `shared.opts.beta_dist_alpha = 0.0`:

```
Calling the REAL beta_scheduler() imported from modules/sd_schedulers.py

Case 1: shared.opts.beta_dist_alpha = 0.0 (an old persisted config.json,
        or a direct POST to /sdapi/v1/options -- neither goes through the UI slider)
  sigmas: [1.         0.10001791 0.1        0.1        0.1        0.1
 0.1        0.1        0.1        0.1        0.        ]
  any NaN: False

Case 2: shared.opts.beta_dist_alpha = 0.6 (the normal default -- unaffected by the guard)
  sigmas: [1.         0.95761736 0.86895901 0.75212804 0.61914271 0.48085729
 0.34787196 0.23104099 0.14238264 0.1        0.        ]
  any NaN: False
```

- Confirmed the fix is what's making the difference, not a mock artifact: temporarily reverted the clamp in that same imported file and reran Case 1 — it reproduced the `NaN` (`any NaN: True`), then restored the fix and confirmed both cases pass again.
- Confirmed the default (`0.6`/`0.6`) path produces byte-identical output whether clamped or not, so normal usage is unaffected.

![verification run](https://raw.githubusercontent.com/kapil971390/stable-diffusion-webui/assets/beta-scheduler-nan-guard-verify.png)

## Out of scope

This doesn't add server-side validation to `/sdapi/v1/options` itself, or migrate old `config.json` values on load — clamping at `beta_scheduler()`'s point of use covers the actual failure mode (a `NaN` in the sampling output) regardless of how an out-of-range value got there, without needing to catch every possible entry point separately.

## Note on branch

Targeted at `dev` per the contributing guide. `beta_scheduler()`'s surrounding sigma computation already differs between `master` and `dev` (an unrelated change reworked it to go through `inner_model.sigma_to_t`/`t_to_sigma`), but the vulnerable lines this PR touches (`alpha = shared.opts.beta_dist_alpha` / `beta = shared.opts.beta_dist_beta`, with no validation) are identical on both branches, and this fix is written and verified against `dev`'s current version of the file.

## Checklist

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style) (`ruff check` clean)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests) (verified the specific function directly, per the Testing section above; the full server-based suite runs via this PR's own CI)
