### PR TITLE
Add pre-commit configuration and fix linting issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+repos:
+  # Python linting with Ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        exclude: |
+          (?x)^(
+            extensions/|
+            extensions-builtin/|
+            models/|
+            embeddings/|
+            localizations/
+          )
+      - id: ruff-format
+        exclude: |
+          (?x)^(
+            extensions/|
+            extensions-builtin/|
+            models/|
+            embeddings/|
+            localizations/
+          )
+
+  # JavaScript/TypeScript linting with ESLint (v8 for .eslintrc.js compatibility)
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        args: [--fix]
+        types: [javascript]
+        exclude: |
+          (?x)^(
+            extensions/|
+            extensions-builtin/|
+            models/|
+            embeddings/|
+            localizations/|
+            node_modules/
+          )
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * Add filename pattern: `[basename]` ([#15978](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15978))
 * Add option to enable clip skip for clip L on SDXL ([#15992](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15992))
 * Option to prevent screen sleep during generation ([#16001](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16001))
-* ToggleLivePriview button in image viewer ([#16065](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16065))
+* ToggleLivePreview button in image viewer ([#16065](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16065))
 * Remove ui flashing on reloading and fast scrollong ([#16153](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16153))
 * option to disable save button log.csv ([#16242](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16242))
 
@@ -60,7 +60,7 @@
 * Fix Hypertile xyz ([#15831](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15831))
 * XYZ CSV skipinitialspace ([#15832](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15832))
 * fix soft inpainting on mps and xpu, torch_utils.float64 ([#15815](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15815))
-* fix extention update when not on main branch ([#15797](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15797))
+* fix extension update when not on main branch ([#15797](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15797))
 * update pickle safe filenames
 * use relative path for webui-assets css ([#15757](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15757))
 * When creating a virtual environment, upgrade pip in webui.bat/webui.sh ([#15750](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15750))
@@ -78,7 +78,7 @@
 * Possible fix of wrong scale in weight decomposition ([#16151](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16151))
 * Ensure use of python from venv on Mac and Linux ([#16116](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16116))
 * Prioritize python3.10 over python3 if both are available on Linux and Mac (with fallback) ([#16092](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16092))
-* stoping generation extras ([#16085](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16085))
+* stopping generation extras ([#16085](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16085))
 * Fix SD2 loading ([#16078](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16078), [#16079](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16079))
 * fix infotext Lora hashes for hires fix different lora ([#16062](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16062))
 * Fix sampler scheduler autocorrection warning ([#16054](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16054))
@@ -146,7 +146,7 @@
 * fix: remove_callbacks_for_function should also remove from the ordered map ([#15533](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15533))
 * fix x1 upscalers ([#15555](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15555))
 * Fix cls.__module__ value in extension script ([#15532](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15532))
-* fix typo in function call (eror -> error) ([#15531](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15531))
+* fix typo in function call (error -> error) ([#15531](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15531))
 
 ### Other:
 * Hide 'No Image data blocks found.' message ([#15567](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15567))
@@ -186,7 +186,7 @@
 * add an option to hide postprocessing options in Extras tab
 
 ### Extensions and API:
-* ResizeHandleRow - allow overriden column scale parametr ([#15004](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15004))
+* ResizeHandleRow - allow overridden column scale parameter ([#15004](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15004))
 * call script_callbacks.ui_settings_callback earlier; fix extra-options-section built-in extension killing the ui if using a setting that doesn't exist
 * make it possible to use zoom.js outside webui context ([#15286](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15286), [#15288](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15288))
 * allow variants for extension name in metadata.ini ([#15290](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15290))
@@ -202,10 +202,10 @@
 
 ### Bug Fixes:
 * prevent escape button causing an interrupt when no generation has been made yet
-* [bug] avoid doble upscaling in inpaint ([#14966](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14966))
+* [bug] avoid double upscaling in inpaint ([#14966](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14966))
 * possible fix for reload button not appearing in some cases for extra networks.
 * fix: the `split_threshold` parameter does not work when running Split oversized images ([#15006](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15006))
-* Fix resize-handle visability for vertical layout (mobile) ([#15010](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15010))
+* Fix resize-handle visibility for vertical layout (mobile) ([#15010](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15010))
 * register_tmp_file also for mtime ([#15012](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15012))
 * Protect alphas_cumprod during refiner switchover ([#14979](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14979))
 * Fix EXIF orientation in API image loading ([#15062](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15062))
@@ -545,7 +545,7 @@
 * update dragdrop.js ([#13372](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13372))
 * use orderdict as lru cache:opt/bug ([#13313](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13313))
 * XYZ if not include sub grids do not save sub grid ([#13282](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13282))
-* initialize state.time_start befroe state.job_count ([#13229](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13229))
+* initialize state.time_start before state.job_count ([#13229](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13229))
 * fix fieldname regex ([#13458](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13458))
 * change denoising_strength default to None. ([#13466](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13466))
 * fix regression ([#13475](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/13475))
@@ -681,7 +681,7 @@
  * fix api only Lora not working ([#12387](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12387))
  * fix options in main UI misbehaving when there's just one element
  * make it possible to use a sampler from infotext even if it's hidden in the dropdown
- * fix styles missing from the prompt in infotext when making a grid of batch of multiplie images
+ * fix styles missing from the prompt in infotext when making a grid of batch of multiply images
  * prevent bogus progress output in console when calculating hires fix dimensions
  * fix --use-textbox-seed
  * fix broken `Lora/Networks: use old method` option ([#12466](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12466))

--- a/configs/sd_xl_inpaint.yaml
+++ b/configs/sd_xl_inpaint.yaml
@@ -61,19 +61,19 @@ model:
           # vector cond
           - is_trainable: False
             input_key: original_size_as_tuple
-            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderND
+            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderAND
             params:
               outdim: 256  # multiplied by two
           # vector cond
           - is_trainable: False
             input_key: crop_coords_top_left
-            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderND
+            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderAND
             params:
               outdim: 256  # multiplied by two
           # vector cond
           - is_trainable: False
             input_key: target_size_as_tuple
-            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderND
+            target: sgm.modules.encoders.modules.ConcatTimestepEmbedderAND
             params:
               outdim: 256  # multiplied by two
 

--- a/extensions-builtin/postprocessing-for-training/scripts/postprocessing_split_oversized.py
+++ b/extensions-builtin/postprocessing-for-training/scripts/postprocessing_split_oversized.py
@@ -22,10 +22,10 @@ def split_pic(image, inverse_xy, width, height, overlap_ratio):
     for i in range(split_count):
         y = int(y_step * i)
         if inverse_xy:
-            splitted = image.crop((y, 0, y + to_h, to_w))
+            split = image.crop((y, 0, y + to_h, to_w))
         else:
-            splitted = image.crop((0, y, to_w, y + to_h))
-        yield splitted
+            split = image.crop((0, y, to_w, y + to_h))
+        yield split
 
 
 class ScriptPostprocessingSplitOversized(scripts_postprocessing.ScriptPostprocessing):

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -17,11 +17,33 @@ from fastapi.encoders import jsonable_encoder
 from secrets import compare_digest
 
 import modules.shared as shared
-from modules import sd_samplers, deepbooru, sd_hijack, images, scripts, ui, postprocessing, errors, restart, shared_items, script_callbacks, infotext_utils, sd_models, sd_schedulers
+from modules import (
+    sd_samplers,
+    deepbooru,
+    sd_hijack,
+    images,
+    scripts,
+    ui,
+    postprocessing,
+    errors,
+    restart,
+    shared_items,
+    script_callbacks,
+    infotext_utils,
+    sd_models,
+    sd_schedulers,
+)
 from modules.api import models
 from modules.shared import opts
-from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img, process_images
-from modules.textual_inversion.textual_inversion import create_embedding, train_embedding
+from modules.processing import (
+    StableDiffusionProcessingTxt2Img,
+    StableDiffusionProcessingImg2Img,
+    process_images,
+)
+from modules.textual_inversion.textual_inversion import (
+    create_embedding,
+    train_embedding,
+)
 from modules.hypernetworks.hypernetwork import create_hypernetwork, train_hypernetwork
 from PIL import PngImagePlugin
 from modules.sd_models_config import find_checkpoint_config_near_filename
@@ -31,7 +53,14 @@ from typing import Any
 import piexif
 import piexif.helper
 from contextlib import closing
-from modules.progress import create_task_id, add_task_to_queue, start_task, finish_task, current_task
+from modules.progress import (
+    create_task_id,
+    add_task_to_queue,
+    start_task,
+    finish_task,
+    current_task,
+)
+
 
 def script_name_to_index(name, scripts):
     try:
@@ -50,8 +79,8 @@ def validate_sampler_name(name):
 
 def setUpscalers(req: dict):
     reqDict = vars(req)
-    reqDict['extras_upscaler_1'] = reqDict.pop('upscaler_1', None)
-    reqDict['extras_upscaler_2'] = reqDict.pop('upscaler_2', None)
+    reqDict["extras_upscaler_1"] = reqDict.pop("upscaler_1", None)
+    reqDict["extras_upscaler_2"] = reqDict.pop("upscaler_2", None)
     return reqDict
 
 
@@ -60,6 +89,7 @@ def verify_url(url):
 
     import socket
     from urllib.parse import urlparse
+
     try:
         parsed_url = urlparse(url)
         domain_name = parsed_url.netloc
@@ -80,9 +110,11 @@ def decode_base64_to_image(encoding):
             raise HTTPException(status_code=500, detail="Requests not allowed")
 
         if opts.api_forbid_local_requests and not verify_url(encoding):
-            raise HTTPException(status_code=500, detail="Request to local resource not allowed")
+            raise HTTPException(
+                status_code=500, detail="Request to local resource not allowed"
+            )
 
-        headers = {'user-agent': opts.api_useragent} if opts.api_useragent else {}
+        headers = {"user-agent": opts.api_useragent} if opts.api_useragent else {}
         response = requests.get(encoding, timeout=30, headers=headers)
         try:
             image = images.read(BytesIO(response.content))
@@ -103,26 +135,47 @@ def encode_pil_to_base64(image):
     with io.BytesIO() as output_bytes:
         if isinstance(image, str):
             return image
-        if opts.samples_format.lower() == 'png':
+        if opts.samples_format.lower() == "png":
             use_metadata = False
             metadata = PngImagePlugin.PngInfo()
             for key, value in image.info.items():
                 if isinstance(key, str) and isinstance(value, str):
                     metadata.add_text(key, value)
                     use_metadata = True
-            image.save(output_bytes, format="PNG", pnginfo=(metadata if use_metadata else None), quality=opts.jpeg_quality)
+            image.save(
+                output_bytes,
+                format="PNG",
+                pnginfo=(metadata if use_metadata else None),
+                quality=opts.jpeg_quality,
+            )
 
         elif opts.samples_format.lower() in ("jpg", "jpeg", "webp"):
             if image.mode in ("RGBA", "P"):
                 image = image.convert("RGB")
-            parameters = image.info.get('parameters', None)
-            exif_bytes = piexif.dump({
-                "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(parameters or "", encoding="unicode") }
-            })
+            parameters = image.info.get("parameters", None)
+            exif_bytes = piexif.dump(
+                {
+                    "Exif": {
+                        piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(
+                            parameters or "", encoding="unicode"
+                        )
+                    }
+                }
+            )
             if opts.samples_format.lower() in ("jpg", "jpeg"):
-                image.save(output_bytes, format="JPEG", exif = exif_bytes, quality=opts.jpeg_quality)
+                image.save(
+                    output_bytes,
+                    format="JPEG",
+                    exif=exif_bytes,
+                    quality=opts.jpeg_quality,
+                )
             else:
-                image.save(output_bytes, format="WEBP", exif = exif_bytes, quality=opts.jpeg_quality)
+                image.save(
+                    output_bytes,
+                    format="WEBP",
+                    exif=exif_bytes,
+                    quality=opts.jpeg_quality,
+                )
 
         else:
             raise HTTPException(status_code=500, detail="Invalid image format")
@@ -135,10 +188,11 @@ def encode_pil_to_base64(image):
 def api_middleware(app: FastAPI):
     rich_available = False
     try:
-        if os.environ.get('WEBUI_RICH_EXCEPTIONS', None) is not None:
+        if os.environ.get("WEBUI_RICH_EXCEPTIONS", None) is not None:
             import anyio  # importing just so it can be placed on silent list
             import starlette  # importing just so it can be placed on silent list
             from rich.console import Console
+
             console = Console()
             rich_available = True
     except Exception:
@@ -150,35 +204,48 @@ def api_middleware(app: FastAPI):
         res: Response = await call_next(req)
         duration = str(round(time.time() - ts, 4))
         res.headers["X-Process-Time"] = duration
-        endpoint = req.scope.get('path', 'err')
-        if shared.cmd_opts.api_log and endpoint.startswith('/sdapi'):
-            print('API {t} {code} {prot}/{ver} {method} {endpoint} {cli} {duration}'.format(
-                t=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                code=res.status_code,
-                ver=req.scope.get('http_version', '0.0'),
-                cli=req.scope.get('client', ('0:0.0.0', 0))[0],
-                prot=req.scope.get('scheme', 'err'),
-                method=req.scope.get('method', 'err'),
-                endpoint=endpoint,
-                duration=duration,
-            ))
+        endpoint = req.scope.get("path", "err")
+        if shared.cmd_opts.api_log and endpoint.startswith("/sdapi"):
+            print(
+                "API {t} {code} {prot}/{ver} {method} {endpoint} {cli} {duration}".format(
+                    t=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    code=res.status_code,
+                    ver=req.scope.get("http_version", "0.0"),
+                    cli=req.scope.get("client", ("0:0.0.0", 0))[0],
+                    prot=req.scope.get("scheme", "err"),
+                    method=req.scope.get("method", "err"),
+                    endpoint=endpoint,
+                    duration=duration,
+                )
+            )
         return res
 
     def handle_exception(request: Request, e: Exception):
         err = {
             "error": type(e).__name__,
-            "detail": vars(e).get('detail', ''),
-            "body": vars(e).get('body', ''),
+            "detail": vars(e).get("detail", ""),
+            "body": vars(e).get("body", ""),
             "errors": str(e),
         }
-        if not isinstance(e, HTTPException):  # do not print backtrace on known httpexceptions
+        if not isinstance(
+            e, HTTPException
+        ):  # do not print backtrace on known httpexceptions
             message = f"API error: {request.method}: {request.url} {err}"
             if rich_available:
                 print(message)
-                console.print_exception(show_locals=True, max_frames=2, extra_lines=1, suppress=[anyio, starlette], word_wrap=False, width=min([console.width, 200]))
+                console.print_exception(
+                    show_locals=True,
+                    max_frames=2,
+                    extra_lines=1,
+                    suppress=[anyio, starlette],
+                    word_wrap=False,
+                    width=min([console.width, 200]),
+                )
             else:
                 errors.report(message, exc_info=True)
-        return JSONResponse(status_code=vars(e).get('status_code', 500), content=jsonable_encoder(err))
+        return JSONResponse(
+            status_code=vars(e).get("status_code", 500), content=jsonable_encoder(err)
+        )
 
     @app.middleware("http")
     async def exception_handling(request: Request, call_next):
@@ -208,47 +275,198 @@ class Api:
         self.app = app
         self.queue_lock = queue_lock
         api_middleware(self.app)
-        self.add_api_route("/sdapi/v1/txt2img", self.text2imgapi, methods=["POST"], response_model=models.TextToImageResponse)
-        self.add_api_route("/sdapi/v1/img2img", self.img2imgapi, methods=["POST"], response_model=models.ImageToImageResponse)
-        self.add_api_route("/sdapi/v1/extra-single-image", self.extras_single_image_api, methods=["POST"], response_model=models.ExtrasSingleImageResponse)
-        self.add_api_route("/sdapi/v1/extra-batch-images", self.extras_batch_images_api, methods=["POST"], response_model=models.ExtrasBatchImagesResponse)
-        self.add_api_route("/sdapi/v1/png-info", self.pnginfoapi, methods=["POST"], response_model=models.PNGInfoResponse)
-        self.add_api_route("/sdapi/v1/progress", self.progressapi, methods=["GET"], response_model=models.ProgressResponse)
-        self.add_api_route("/sdapi/v1/interrogate", self.interrogateapi, methods=["POST"])
+        self.add_api_route(
+            "/sdapi/v1/txt2img",
+            self.text2imgapi,
+            methods=["POST"],
+            response_model=models.TextToImageResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/img2img",
+            self.img2imgapi,
+            methods=["POST"],
+            response_model=models.ImageToImageResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/extra-single-image",
+            self.extras_single_image_api,
+            methods=["POST"],
+            response_model=models.ExtrasSingleImageResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/extra-batch-images",
+            self.extras_batch_images_api,
+            methods=["POST"],
+            response_model=models.ExtrasBatchImagesResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/png-info",
+            self.pnginfoapi,
+            methods=["POST"],
+            response_model=models.PNGInfoResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/progress",
+            self.progressapi,
+            methods=["GET"],
+            response_model=models.ProgressResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/interrogate", self.interrogateapi, methods=["POST"]
+        )
         self.add_api_route("/sdapi/v1/interrupt", self.interruptapi, methods=["POST"])
         self.add_api_route("/sdapi/v1/skip", self.skip, methods=["POST"])
-        self.add_api_route("/sdapi/v1/options", self.get_config, methods=["GET"], response_model=models.OptionsModel)
+        self.add_api_route(
+            "/sdapi/v1/options",
+            self.get_config,
+            methods=["GET"],
+            response_model=models.OptionsModel,
+        )
         self.add_api_route("/sdapi/v1/options", self.set_config, methods=["POST"])
-        self.add_api_route("/sdapi/v1/cmd-flags", self.get_cmd_flags, methods=["GET"], response_model=models.FlagsModel)
-        self.add_api_route("/sdapi/v1/samplers", self.get_samplers, methods=["GET"], response_model=list[models.SamplerItem])
-        self.add_api_route("/sdapi/v1/schedulers", self.get_schedulers, methods=["GET"], response_model=list[models.SchedulerItem])
-        self.add_api_route("/sdapi/v1/upscalers", self.get_upscalers, methods=["GET"], response_model=list[models.UpscalerItem])
-        self.add_api_route("/sdapi/v1/latent-upscale-modes", self.get_latent_upscale_modes, methods=["GET"], response_model=list[models.LatentUpscalerModeItem])
-        self.add_api_route("/sdapi/v1/sd-models", self.get_sd_models, methods=["GET"], response_model=list[models.SDModelItem])
-        self.add_api_route("/sdapi/v1/sd-vae", self.get_sd_vaes, methods=["GET"], response_model=list[models.SDVaeItem])
-        self.add_api_route("/sdapi/v1/hypernetworks", self.get_hypernetworks, methods=["GET"], response_model=list[models.HypernetworkItem])
-        self.add_api_route("/sdapi/v1/face-restorers", self.get_face_restorers, methods=["GET"], response_model=list[models.FaceRestorerItem])
-        self.add_api_route("/sdapi/v1/realesrgan-models", self.get_realesrgan_models, methods=["GET"], response_model=list[models.RealesrganItem])
-        self.add_api_route("/sdapi/v1/prompt-styles", self.get_prompt_styles, methods=["GET"], response_model=list[models.PromptStyleItem])
-        self.add_api_route("/sdapi/v1/embeddings", self.get_embeddings, methods=["GET"], response_model=models.EmbeddingsResponse)
-        self.add_api_route("/sdapi/v1/refresh-embeddings", self.refresh_embeddings, methods=["POST"])
-        self.add_api_route("/sdapi/v1/refresh-checkpoints", self.refresh_checkpoints, methods=["POST"])
+        self.add_api_route(
+            "/sdapi/v1/cmd-flags",
+            self.get_cmd_flags,
+            methods=["GET"],
+            response_model=models.FlagsModel,
+        )
+        self.add_api_route(
+            "/sdapi/v1/samplers",
+            self.get_samplers,
+            methods=["GET"],
+            response_model=list[models.SamplerItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/schedulers",
+            self.get_schedulers,
+            methods=["GET"],
+            response_model=list[models.SchedulerItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/upscalers",
+            self.get_upscalers,
+            methods=["GET"],
+            response_model=list[models.UpscalerItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/latent-upscale-modes",
+            self.get_latent_upscale_modes,
+            methods=["GET"],
+            response_model=list[models.LatentUpscalerModeItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/sd-models",
+            self.get_sd_models,
+            methods=["GET"],
+            response_model=list[models.SDModelItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/sd-vae",
+            self.get_sd_vaes,
+            methods=["GET"],
+            response_model=list[models.SDVaeItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/hypernetworks",
+            self.get_hypernetworks,
+            methods=["GET"],
+            response_model=list[models.HypernetworkItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/face-restorers",
+            self.get_face_restorers,
+            methods=["GET"],
+            response_model=list[models.FaceRestorerItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/realesrgan-models",
+            self.get_realesrgan_models,
+            methods=["GET"],
+            response_model=list[models.RealesrganItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/prompt-styles",
+            self.get_prompt_styles,
+            methods=["GET"],
+            response_model=list[models.PromptStyleItem],
+        )
+        self.add_api_route(
+            "/sdapi/v1/embeddings",
+            self.get_embeddings,
+            methods=["GET"],
+            response_model=models.EmbeddingsResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/refresh-embeddings", self.refresh_embeddings, methods=["POST"]
+        )
+        self.add_api_route(
+            "/sdapi/v1/refresh-checkpoints", self.refresh_checkpoints, methods=["POST"]
+        )
         self.add_api_route("/sdapi/v1/refresh-vae", self.refresh_vae, methods=["POST"])
-        self.add_api_route("/sdapi/v1/create/embedding", self.create_embedding, methods=["POST"], response_model=models.CreateResponse)
-        self.add_api_route("/sdapi/v1/create/hypernetwork", self.create_hypernetwork, methods=["POST"], response_model=models.CreateResponse)
-        self.add_api_route("/sdapi/v1/train/embedding", self.train_embedding, methods=["POST"], response_model=models.TrainResponse)
-        self.add_api_route("/sdapi/v1/train/hypernetwork", self.train_hypernetwork, methods=["POST"], response_model=models.TrainResponse)
-        self.add_api_route("/sdapi/v1/memory", self.get_memory, methods=["GET"], response_model=models.MemoryResponse)
-        self.add_api_route("/sdapi/v1/unload-checkpoint", self.unloadapi, methods=["POST"])
-        self.add_api_route("/sdapi/v1/reload-checkpoint", self.reloadapi, methods=["POST"])
-        self.add_api_route("/sdapi/v1/scripts", self.get_scripts_list, methods=["GET"], response_model=models.ScriptsList)
-        self.add_api_route("/sdapi/v1/script-info", self.get_script_info, methods=["GET"], response_model=list[models.ScriptInfo])
-        self.add_api_route("/sdapi/v1/extensions", self.get_extensions_list, methods=["GET"], response_model=list[models.ExtensionItem])
+        self.add_api_route(
+            "/sdapi/v1/create/embedding",
+            self.create_embedding,
+            methods=["POST"],
+            response_model=models.CreateResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/create/hypernetwork",
+            self.create_hypernetwork,
+            methods=["POST"],
+            response_model=models.CreateResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/train/embedding",
+            self.train_embedding,
+            methods=["POST"],
+            response_model=models.TrainResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/train/hypernetwork",
+            self.train_hypernetwork,
+            methods=["POST"],
+            response_model=models.TrainResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/memory",
+            self.get_memory,
+            methods=["GET"],
+            response_model=models.MemoryResponse,
+        )
+        self.add_api_route(
+            "/sdapi/v1/unload-checkpoint", self.unloadapi, methods=["POST"]
+        )
+        self.add_api_route(
+            "/sdapi/v1/reload-checkpoint", self.reloadapi, methods=["POST"]
+        )
+        self.add_api_route(
+            "/sdapi/v1/scripts",
+            self.get_scripts_list,
+            methods=["GET"],
+            response_model=models.ScriptsList,
+        )
+        self.add_api_route(
+            "/sdapi/v1/script-info",
+            self.get_script_info,
+            methods=["GET"],
+            response_model=list[models.ScriptInfo],
+        )
+        self.add_api_route(
+            "/sdapi/v1/extensions",
+            self.get_extensions_list,
+            methods=["GET"],
+            response_model=list[models.ExtensionItem],
+        )
 
         if shared.cmd_opts.api_server_stop:
-            self.add_api_route("/sdapi/v1/server-kill", self.kill_webui, methods=["POST"])
-            self.add_api_route("/sdapi/v1/server-restart", self.restart_webui, methods=["POST"])
-            self.add_api_route("/sdapi/v1/server-stop", self.stop_webui, methods=["POST"])
+            self.add_api_route(
+                "/sdapi/v1/server-kill", self.kill_webui, methods=["POST"]
+            )
+            self.add_api_route(
+                "/sdapi/v1/server-restart", self.restart_webui, methods=["POST"]
+            )
+            self.add_api_route(
+                "/sdapi/v1/server-stop", self.stop_webui, methods=["POST"]
+            )
 
         self.default_script_arg_txt2img = []
         self.default_script_arg_img2img = []
@@ -262,26 +480,36 @@ class Api:
         if not txt2img_script_runner.scripts:
             txt2img_script_runner.initialize_scripts(False)
         if not self.default_script_arg_txt2img:
-            self.default_script_arg_txt2img = self.init_default_script_args(txt2img_script_runner)
+            self.default_script_arg_txt2img = self.init_default_script_args(
+                txt2img_script_runner
+            )
 
         if not img2img_script_runner.scripts:
             img2img_script_runner.initialize_scripts(True)
         if not self.default_script_arg_img2img:
-            self.default_script_arg_img2img = self.init_default_script_args(img2img_script_runner)
-
-
+            self.default_script_arg_img2img = self.init_default_script_args(
+                img2img_script_runner
+            )
 
     def add_api_route(self, path: str, endpoint, **kwargs):
         if shared.cmd_opts.api_auth:
-            return self.app.add_api_route(path, endpoint, dependencies=[Depends(self.auth)], **kwargs)
+            return self.app.add_api_route(
+                path, endpoint, dependencies=[Depends(self.auth)], **kwargs
+            )
         return self.app.add_api_route(path, endpoint, **kwargs)
 
     def auth(self, credentials: HTTPBasicCredentials = Depends(HTTPBasic())):
         if credentials.username in self.credentials:
-            if compare_digest(credentials.password, self.credentials[credentials.username]):
+            if compare_digest(
+                credentials.password, self.credentials[credentials.username]
+            ):
                 return True
 
-        raise HTTPException(status_code=401, detail="Incorrect username or password", headers={"WWW-Authenticate": "Basic"})
+        raise HTTPException(
+            status_code=401,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Basic"},
+        )
 
     def get_selectable_script(self, script_name, script_runner):
         if script_name is None or script_name == "":
@@ -292,16 +520,29 @@ class Api:
         return script, script_idx
 
     def get_scripts_list(self):
-        t2ilist = [script.name for script in scripts.scripts_txt2img.scripts if script.name is not None]
-        i2ilist = [script.name for script in scripts.scripts_img2img.scripts if script.name is not None]
+        t2ilist = [
+            script.name
+            for script in scripts.scripts_txt2img.scripts
+            if script.name is not None
+        ]
+        i2ilist = [
+            script.name
+            for script in scripts.scripts_img2img.scripts
+            if script.name is not None
+        ]
 
         return models.ScriptsList(txt2img=t2ilist, img2img=i2ilist)
 
     def get_script_info(self):
         res = []
 
-        for script_list in [scripts.scripts_txt2img.scripts, scripts.scripts_img2img.scripts]:
-            res += [script.api_info for script in script_list if script.api_info is not None]
+        for script_list in [
+            scripts.scripts_txt2img.scripts,
+            scripts.scripts_img2img.scripts,
+        ]:
+            res += [
+                script.api_info for script in script_list if script.api_info is not None
+            ]
 
         return res
 
@@ -313,26 +554,35 @@ class Api:
         return script_runner.scripts[script_idx]
 
     def init_default_script_args(self, script_runner):
-        #find max idx from the scripts in runner and generate a none array to init script_args
+        # find max idx from the scripts in runner and generate a none array to init script_args
         last_arg_index = 1
         for script in script_runner.scripts:
             if last_arg_index < script.args_to:
                 last_arg_index = script.args_to
         # None everywhere except position 0 to initialize script args
-        script_args = [None]*last_arg_index
+        script_args = [None] * last_arg_index
         script_args[0] = 0
 
         # get default values
-        with gr.Blocks(): # will throw errors calling ui function without this
+        with gr.Blocks():  # will throw errors calling ui function without this
             for script in script_runner.scripts:
                 if script.ui(script.is_img2img):
                     ui_default_values = []
                     for elem in script.ui(script.is_img2img):
                         ui_default_values.append(elem.value)
-                    script_args[script.args_from:script.args_to] = ui_default_values
+                    script_args[script.args_from : script.args_to] = ui_default_values
         return script_args
 
-    def init_script_args(self, request, default_script_args, selectable_scripts, selectable_idx, script_runner, *, input_script_args=None):
+    def init_script_args(
+        self,
+        request,
+        default_script_args,
+        selectable_scripts,
+        selectable_idx,
+        script_runner,
+        *,
+        input_script_args=None,
+    ):
         script_args = default_script_args.copy()
 
         if input_script_args is not None:
@@ -341,7 +591,9 @@ class Api:
 
         # position 0 in script_arg is the idx+1 of the selectable script that is going to be run when using scripts.scripts_*2img.run()
         if selectable_scripts:
-            script_args[selectable_scripts.args_from:selectable_scripts.args_to] = request.script_args
+            script_args[selectable_scripts.args_from : selectable_scripts.args_to] = (
+                request.script_args
+            )
             script_args[0] = selectable_idx + 1
 
         # Now check for always on scripts
@@ -349,18 +601,34 @@ class Api:
             for alwayson_script_name in request.alwayson_scripts.keys():
                 alwayson_script = self.get_script(alwayson_script_name, script_runner)
                 if alwayson_script is None:
-                    raise HTTPException(status_code=422, detail=f"always on script {alwayson_script_name} not found")
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"always on script {alwayson_script_name} not found",
+                    )
                 # Selectable script in always on script param check
                 if alwayson_script.alwayson is False:
-                    raise HTTPException(status_code=422, detail="Cannot have a selectable script in the always on scripts params")
+                    raise HTTPException(
+                        status_code=422,
+                        detail="Cannot have a selectable script in the always on scripts params",
+                    )
                 # always on script with no arg should always run so you don't really need to add them to the requests
                 if "args" in request.alwayson_scripts[alwayson_script_name]:
                     # min between arg length in scriptrunner and arg length in the request
-                    for idx in range(0, min((alwayson_script.args_to - alwayson_script.args_from), len(request.alwayson_scripts[alwayson_script_name]["args"]))):
-                        script_args[alwayson_script.args_from + idx] = request.alwayson_scripts[alwayson_script_name]["args"][idx]
+                    for idx in range(
+                        0,
+                        min(
+                            (alwayson_script.args_to - alwayson_script.args_from),
+                            len(request.alwayson_scripts[alwayson_script_name]["args"]),
+                        ),
+                    ):
+                        script_args[alwayson_script.args_from + idx] = (
+                            request.alwayson_scripts[alwayson_script_name]["args"][idx]
+                        )
         return script_args
 
-    def apply_infotext(self, request, tabname, *, script_runner=None, mentioned_script_args=None):
+    def apply_infotext(
+        self, request, tabname, *, script_runner=None, mentioned_script_args=None
+    ):
         """Processes `infotext` field from the `request`, and sets other fields of the `request` according to what's in infotext.
 
         If request already has a field set, and that field is encountered in infotext too, the value from infotext is ignored.
@@ -372,11 +640,17 @@ class Api:
             return {}
 
         possible_fields = infotext_utils.paste_fields[tabname]["fields"]
-        set_fields = request.model_dump(exclude_unset=True) if hasattr(request, "request") else request.dict(exclude_unset=True)  # pydantic v1/v2 have different names for this
+        set_fields = (
+            request.model_dump(exclude_unset=True)
+            if hasattr(request, "request")
+            else request.dict(exclude_unset=True)
+        )  # pydantic v1/v2 have different names for this
         params = infotext_utils.parse_generation_parameters(request.infotext)
 
         def get_field_value(field, params):
-            value = field.function(params) if field.function else params.get(field.label)
+            value = (
+                field.function(params) if field.function else params.get(field.label)
+            )
             if value is None:
                 return None
 
@@ -388,8 +662,10 @@ class Api:
             if target_type == type(None):
                 return None
 
-            if isinstance(value, dict) and value.get('__type__') == 'generic_update':  # this is a gradio.update rather than a value
-                value = value.get('value')
+            if (
+                isinstance(value, dict) and value.get("__type__") == "generic_update"
+            ):  # this is a gradio.update rather than a value
+                value = value.get("value")
 
             if value is not None and not isinstance(value, target_type):
                 value = target_type(value)
@@ -417,7 +693,11 @@ class Api:
 
         if script_runner is not None and mentioned_script_args is not None:
             indexes = {v: i for i, v in enumerate(script_runner.inputs)}
-            script_fields = ((field, indexes[field.component]) for field in possible_fields if field.component in indexes)
+            script_fields = (
+                (field, indexes[field.component])
+                for field in possible_fields
+                if field.component in indexes
+            )
 
             for field, index in script_fields:
                 value = get_field_value(field, params)
@@ -435,16 +715,27 @@ class Api:
         script_runner = scripts.scripts_txt2img
 
         infotext_script_args = {}
-        self.apply_infotext(txt2imgreq, "txt2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
+        self.apply_infotext(
+            txt2imgreq,
+            "txt2img",
+            script_runner=script_runner,
+            mentioned_script_args=infotext_script_args,
+        )
 
-        selectable_scripts, selectable_script_idx = self.get_selectable_script(txt2imgreq.script_name, script_runner)
-        sampler, scheduler = sd_samplers.get_sampler_and_scheduler(txt2imgreq.sampler_name or txt2imgreq.sampler_index, txt2imgreq.scheduler)
+        selectable_scripts, selectable_script_idx = self.get_selectable_script(
+            txt2imgreq.script_name, script_runner
+        )
+        sampler, scheduler = sd_samplers.get_sampler_and_scheduler(
+            txt2imgreq.sampler_name or txt2imgreq.sampler_index, txt2imgreq.scheduler
+        )
 
-        populate = txt2imgreq.copy(update={  # Override __init__ params
-            "sampler_name": validate_sampler_name(sampler),
-            "do_not_save_samples": not txt2imgreq.save_images,
-            "do_not_save_grid": not txt2imgreq.save_images,
-        })
+        populate = txt2imgreq.copy(
+            update={  # Override __init__ params
+                "sampler_name": validate_sampler_name(sampler),
+                "do_not_save_samples": not txt2imgreq.save_images,
+                "do_not_save_grid": not txt2imgreq.save_images,
+            }
+        )
         if populate.sampler_name:
             populate.sampler_index = None  # prevent a warning later on
 
@@ -452,20 +743,31 @@ class Api:
             populate.scheduler = scheduler
 
         args = vars(populate)
-        args.pop('script_name', None)
-        args.pop('script_args', None) # will refeed them to the pipeline directly after initializing them
-        args.pop('alwayson_scripts', None)
-        args.pop('infotext', None)
+        args.pop("script_name", None)
+        args.pop(
+            "script_args", None
+        )  # will refeed them to the pipeline directly after initializing them
+        args.pop("alwayson_scripts", None)
+        args.pop("infotext", None)
 
-        script_args = self.init_script_args(txt2imgreq, self.default_script_arg_txt2img, selectable_scripts, selectable_script_idx, script_runner, input_script_args=infotext_script_args)
+        script_args = self.init_script_args(
+            txt2imgreq,
+            self.default_script_arg_txt2img,
+            selectable_scripts,
+            selectable_script_idx,
+            script_runner,
+            input_script_args=infotext_script_args,
+        )
 
-        send_images = args.pop('send_images', True)
-        args.pop('save_images', None)
+        send_images = args.pop("send_images", True)
+        args.pop("save_images", None)
 
         add_task_to_queue(task_id)
 
         with self.queue_lock:
-            with closing(StableDiffusionProcessingTxt2Img(sd_model=shared.sd_model, **args)) as p:
+            with closing(
+                StableDiffusionProcessingTxt2Img(sd_model=shared.sd_model, **args)
+            ) as p:
                 p.is_api = True
                 p.scripts = script_runner
                 p.outpath_grids = opts.outdir_txt2img_grids
@@ -476,18 +778,26 @@ class Api:
                     start_task(task_id)
                     if selectable_scripts is not None:
                         p.script_args = script_args
-                        processed = scripts.scripts_txt2img.run(p, *p.script_args) # Need to pass args as list here
+                        processed = scripts.scripts_txt2img.run(
+                            p, *p.script_args
+                        )  # Need to pass args as list here
                     else:
-                        p.script_args = tuple(script_args) # Need to pass args as tuple here
+                        p.script_args = tuple(
+                            script_args
+                        )  # Need to pass args as tuple here
                         processed = process_images(p)
                     finish_task(task_id)
                 finally:
                     shared.state.end()
                     shared.total_tqdm.clear()
 
-        b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        b64images = (
+            list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        )
 
-        return models.TextToImageResponse(images=b64images, parameters=vars(txt2imgreq), info=processed.js())
+        return models.TextToImageResponse(
+            images=b64images, parameters=vars(txt2imgreq), info=processed.js()
+        )
 
     def img2imgapi(self, img2imgreq: models.StableDiffusionImg2ImgProcessingAPI):
         task_id = img2imgreq.force_task_id or create_task_id("img2img")
@@ -503,17 +813,28 @@ class Api:
         script_runner = scripts.scripts_img2img
 
         infotext_script_args = {}
-        self.apply_infotext(img2imgreq, "img2img", script_runner=script_runner, mentioned_script_args=infotext_script_args)
+        self.apply_infotext(
+            img2imgreq,
+            "img2img",
+            script_runner=script_runner,
+            mentioned_script_args=infotext_script_args,
+        )
 
-        selectable_scripts, selectable_script_idx = self.get_selectable_script(img2imgreq.script_name, script_runner)
-        sampler, scheduler = sd_samplers.get_sampler_and_scheduler(img2imgreq.sampler_name or img2imgreq.sampler_index, img2imgreq.scheduler)
+        selectable_scripts, selectable_script_idx = self.get_selectable_script(
+            img2imgreq.script_name, script_runner
+        )
+        sampler, scheduler = sd_samplers.get_sampler_and_scheduler(
+            img2imgreq.sampler_name or img2imgreq.sampler_index, img2imgreq.scheduler
+        )
 
-        populate = img2imgreq.copy(update={  # Override __init__ params
-            "sampler_name": validate_sampler_name(sampler),
-            "do_not_save_samples": not img2imgreq.save_images,
-            "do_not_save_grid": not img2imgreq.save_images,
-            "mask": mask,
-        })
+        populate = img2imgreq.copy(
+            update={  # Override __init__ params
+                "sampler_name": validate_sampler_name(sampler),
+                "do_not_save_samples": not img2imgreq.save_images,
+                "do_not_save_grid": not img2imgreq.save_images,
+                "mask": mask,
+            }
+        )
         if populate.sampler_name:
             populate.sampler_index = None  # prevent a warning later on
 
@@ -521,21 +842,34 @@ class Api:
             populate.scheduler = scheduler
 
         args = vars(populate)
-        args.pop('include_init_images', None)  # this is meant to be done by "exclude": True in model, but it's for a reason that I cannot determine.
-        args.pop('script_name', None)
-        args.pop('script_args', None)  # will refeed them to the pipeline directly after initializing them
-        args.pop('alwayson_scripts', None)
-        args.pop('infotext', None)
+        args.pop(
+            "include_init_images", None
+        )  # this is meant to be done by "exclude": True in model, but it's for a reason that I cannot determine.
+        args.pop("script_name", None)
+        args.pop(
+            "script_args", None
+        )  # will refeed them to the pipeline directly after initializing them
+        args.pop("alwayson_scripts", None)
+        args.pop("infotext", None)
 
-        script_args = self.init_script_args(img2imgreq, self.default_script_arg_img2img, selectable_scripts, selectable_script_idx, script_runner, input_script_args=infotext_script_args)
+        script_args = self.init_script_args(
+            img2imgreq,
+            self.default_script_arg_img2img,
+            selectable_scripts,
+            selectable_script_idx,
+            script_runner,
+            input_script_args=infotext_script_args,
+        )
 
-        send_images = args.pop('send_images', True)
-        args.pop('save_images', None)
+        send_images = args.pop("send_images", True)
+        args.pop("save_images", None)
 
         add_task_to_queue(task_id)
 
         with self.queue_lock:
-            with closing(StableDiffusionProcessingImg2Img(sd_model=shared.sd_model, **args)) as p:
+            with closing(
+                StableDiffusionProcessingImg2Img(sd_model=shared.sd_model, **args)
+            ) as p:
                 p.init_images = [decode_base64_to_image(x) for x in init_images]
                 p.is_api = True
                 p.scripts = script_runner
@@ -547,43 +881,70 @@ class Api:
                     start_task(task_id)
                     if selectable_scripts is not None:
                         p.script_args = script_args
-                        processed = scripts.scripts_img2img.run(p, *p.script_args) # Need to pass args as list here
+                        processed = scripts.scripts_img2img.run(
+                            p, *p.script_args
+                        )  # Need to pass args as list here
                     else:
-                        p.script_args = tuple(script_args) # Need to pass args as tuple here
+                        p.script_args = tuple(
+                            script_args
+                        )  # Need to pass args as tuple here
                         processed = process_images(p)
                     finish_task(task_id)
                 finally:
                     shared.state.end()
                     shared.total_tqdm.clear()
 
-        b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        b64images = (
+            list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        )
 
         if not img2imgreq.include_init_images:
             img2imgreq.init_images = None
             img2imgreq.mask = None
 
-        return models.ImageToImageResponse(images=b64images, parameters=vars(img2imgreq), info=processed.js())
+        return models.ImageToImageResponse(
+            images=b64images, parameters=vars(img2imgreq), info=processed.js()
+        )
 
     def extras_single_image_api(self, req: models.ExtrasSingleImageRequest):
         reqDict = setUpscalers(req)
 
-        reqDict['image'] = decode_base64_to_image(reqDict['image'])
+        reqDict["image"] = decode_base64_to_image(reqDict["image"])
 
         with self.queue_lock:
-            result = postprocessing.run_extras(extras_mode=0, image_folder="", input_dir="", output_dir="", save_output=False, **reqDict)
+            result = postprocessing.run_extras(
+                extras_mode=0,
+                image_folder="",
+                input_dir="",
+                output_dir="",
+                save_output=False,
+                **reqDict,
+            )
 
-        return models.ExtrasSingleImageResponse(image=encode_pil_to_base64(result[0][0]), html_info=result[1])
+        return models.ExtrasSingleImageResponse(
+            image=encode_pil_to_base64(result[0][0]), html_info=result[1]
+        )
 
     def extras_batch_images_api(self, req: models.ExtrasBatchImagesRequest):
         reqDict = setUpscalers(req)
 
-        image_list = reqDict.pop('imageList', [])
+        image_list = reqDict.pop("imageList", [])
         image_folder = [decode_base64_to_image(x.data) for x in image_list]
 
         with self.queue_lock:
-            result = postprocessing.run_extras(extras_mode=1, image_folder=image_folder, image="", input_dir="", output_dir="", save_output=False, **reqDict)
+            result = postprocessing.run_extras(
+                extras_mode=1,
+                image_folder=image_folder,
+                image="",
+                input_dir="",
+                output_dir="",
+                save_output=False,
+                **reqDict,
+            )
 
-        return models.ExtrasBatchImagesResponse(images=list(map(encode_pil_to_base64, result[0])), html_info=result[1])
+        return models.ExtrasBatchImagesResponse(
+            images=list(map(encode_pil_to_base64, result[0])), html_info=result[1]
+        )
 
     def pnginfoapi(self, req: models.PNGInfoRequest):
         image = decode_base64_to_image(req.image.strip())
@@ -603,7 +964,12 @@ class Api:
         # copy from check_progress_call of ui.py
 
         if shared.state.job_count == 0:
-            return models.ProgressResponse(progress=0, eta_relative=0, state=shared.state.dict(), textinfo=shared.state.textinfo)
+            return models.ProgressResponse(
+                progress=0,
+                eta_relative=0,
+                state=shared.state.dict(),
+                textinfo=shared.state.textinfo,
+            )
 
         # avoid dividing zero
         progress = 0.01
@@ -611,11 +977,16 @@ class Api:
         if shared.state.job_count > 0:
             progress += shared.state.job_no / shared.state.job_count
         if shared.state.sampling_steps > 0:
-            progress += 1 / shared.state.job_count * shared.state.sampling_step / shared.state.sampling_steps
+            progress += (
+                1
+                / shared.state.job_count
+                * shared.state.sampling_step
+                / shared.state.sampling_steps
+            )
 
         time_since_start = time.time() - shared.state.time_start
-        eta = (time_since_start/progress)
-        eta_relative = eta-time_since_start
+        eta = time_since_start / progress
+        eta_relative = eta - time_since_start
 
         progress = min(progress, 1)
 
@@ -625,7 +996,14 @@ class Api:
         if shared.state.current_image and not req.skip_current_image:
             current_image = encode_pil_to_base64(shared.state.current_image)
 
-        return models.ProgressResponse(progress=progress, eta_relative=eta_relative, state=shared.state.dict(), current_image=current_image, textinfo=shared.state.textinfo, current_task=current_task)
+        return models.ProgressResponse(
+            progress=progress,
+            eta_relative=eta_relative,
+            state=shared.state.dict(),
+            current_image=current_image,
+            textinfo=shared.state.textinfo,
+            current_task=current_task,
+        )
 
     def interrogateapi(self, interrogatereq: models.InterrogateRequest):
         image_b64 = interrogatereq.image
@@ -633,7 +1011,7 @@ class Api:
             raise HTTPException(status_code=404, detail="Image not found")
 
         img = decode_base64_to_image(image_b64)
-        img = img.convert('RGB')
+        img = img.convert("RGB")
 
         # Override object param
         with self.queue_lock:
@@ -668,8 +1046,14 @@ class Api:
         options = {}
         for key in shared.opts.data.keys():
             metadata = shared.opts.data_labels.get(key)
-            if(metadata is not None):
-                options.update({key: shared.opts.data.get(key, shared.opts.data_labels.get(key).default)})
+            if metadata is not None:
+                options.update(
+                    {
+                        key: shared.opts.data.get(
+                            key, shared.opts.data_labels.get(key).default
+                        )
+                    }
+                )
             else:
                 options.update({key: shared.opts.data.get(key, None)})
 
@@ -677,7 +1061,10 @@ class Api:
 
     def set_config(self, req: dict[str, Any]):
         checkpoint_name = req.get("sd_model_checkpoint", None)
-        if checkpoint_name is not None and checkpoint_name not in sd_models.checkpoint_aliases:
+        if (
+            checkpoint_name is not None
+            and checkpoint_name not in sd_models.checkpoint_aliases
+        ):
             raise RuntimeError(f"model {checkpoint_name!r} not found")
 
         for k, v in req.items():
@@ -690,7 +1077,10 @@ class Api:
         return vars(shared.cmd_opts)
 
     def get_samplers(self):
-        return [{"name": sampler[0], "aliases":sampler[2], "options":sampler[3]} for sampler in sd_samplers.all_samplers]
+        return [
+            {"name": sampler[0], "aliases": sampler[2], "options": sampler[3]}
+            for sampler in sd_samplers.all_samplers
+        ]
 
     def get_schedulers(self):
         return [
@@ -701,7 +1091,8 @@ class Api:
                 "default_rho": scheduler.default_rho,
                 "need_inner_model": scheduler.need_inner_model,
             }
-            for scheduler in sd_schedulers.schedulers]
+            for scheduler in sd_schedulers.schedulers
+        ]
 
     def get_upscalers(self):
         return [
@@ -725,26 +1116,52 @@ class Api:
 
     def get_sd_models(self):
         import modules.sd_models as sd_models
-        return [{"title": x.title, "model_name": x.model_name, "hash": x.shorthash, "sha256": x.sha256, "filename": x.filename, "config": find_checkpoint_config_near_filename(x)} for x in sd_models.checkpoints_list.values()]
+
+        return [
+            {
+                "title": x.title,
+                "model_name": x.model_name,
+                "hash": x.shorthash,
+                "sha256": x.sha256,
+                "filename": x.filename,
+                "config": find_checkpoint_config_near_filename(x),
+            }
+            for x in sd_models.checkpoints_list.values()
+        ]
 
     def get_sd_vaes(self):
         import modules.sd_vae as sd_vae
-        return [{"model_name": x, "filename": sd_vae.vae_dict[x]} for x in sd_vae.vae_dict.keys()]
+
+        return [
+            {"model_name": x, "filename": sd_vae.vae_dict[x]}
+            for x in sd_vae.vae_dict.keys()
+        ]
 
     def get_hypernetworks(self):
-        return [{"name": name, "path": shared.hypernetworks[name]} for name in shared.hypernetworks]
+        return [
+            {"name": name, "path": shared.hypernetworks[name]}
+            for name in shared.hypernetworks
+        ]
 
     def get_face_restorers(self):
-        return [{"name":x.name(), "cmd_dir": getattr(x, "cmd_dir", None)} for x in shared.face_restorers]
+        return [
+            {"name": x.name(), "cmd_dir": getattr(x, "cmd_dir", None)}
+            for x in shared.face_restorers
+        ]
 
     def get_realesrgan_models(self):
-        return [{"name":x.name,"path":x.data_path, "scale":x.scale} for x in get_realesrgan_models(None)]
+        return [
+            {"name": x.name, "path": x.data_path, "scale": x.scale}
+            for x in get_realesrgan_models(None)
+        ]
 
     def get_prompt_styles(self):
         styleList = []
         for k in shared.prompt_styles.styles:
             style = shared.prompt_styles.styles[k]
-            styleList.append({"name":style[0], "prompt": style[1], "negative_prompt": style[2]})
+            styleList.append(
+                {"name": style[0], "prompt": style[1], "negative_prompt": style[2]}
+            )
 
         return styleList
 
@@ -761,7 +1178,10 @@ class Api:
             }
 
         def convert_embeddings(embeddings):
-            return {embedding.name: convert_embedding(embedding) for embedding in embeddings.values()}
+            return {
+                embedding.name: convert_embedding(embedding)
+                for embedding in embeddings.values()
+            }
 
         return {
             "loaded": convert_embeddings(db.word_embeddings),
@@ -770,7 +1190,9 @@ class Api:
 
     def refresh_embeddings(self):
         with self.queue_lock:
-            sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)
+            sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(
+                force_reload=True
+            )
 
     def refresh_checkpoints(self):
         with self.queue_lock:
@@ -783,20 +1205,21 @@ class Api:
     def create_embedding(self, args: dict):
         try:
             shared.state.begin(job="create_embedding")
-            filename = create_embedding(**args) # create empty embedding
-            sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings() # reload embeddings so new one can be immediately used
+            filename = create_embedding(**args)  # create empty embedding
+            sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings()  # reload embeddings so new one can be immediately used
             return models.CreateResponse(info=f"create embedding filename: {filename}")
         except AssertionError as e:
             return models.TrainResponse(info=f"create embedding error: {e}")
         finally:
             shared.state.end()
 
-
     def create_hypernetwork(self, args: dict):
         try:
             shared.state.begin(job="create_hypernetwork")
-            filename = create_hypernetwork(**args) # create empty embedding
-            return models.CreateResponse(info=f"create hypernetwork filename: {filename}")
+            filename = create_hypernetwork(**args)  # create empty embedding
+            return models.CreateResponse(
+                info=f"create hypernetwork filename: {filename}"
+            )
         except AssertionError as e:
             return models.TrainResponse(info=f"create hypernetwork error: {e}")
         finally:
@@ -807,17 +1230,21 @@ class Api:
             shared.state.begin(job="train_embedding")
             apply_optimizations = shared.opts.training_xattention_optimizations
             error = None
-            filename = ''
+            filename = ""
             if not apply_optimizations:
                 sd_hijack.undo_optimizations()
             try:
-                embedding, filename = train_embedding(**args) # can take a long time to complete
+                embedding, filename = train_embedding(
+                    **args
+                )  # can take a long time to complete
             except Exception as e:
                 error = e
             finally:
                 if not apply_optimizations:
                     sd_hijack.apply_optimizations()
-            return models.TrainResponse(info=f"train embedding complete: filename: {filename} error: {error}")
+            return models.TrainResponse(
+                info=f"train embedding complete: filename: {filename} error: {error}"
+            )
         except Exception as msg:
             return models.TrainResponse(info=f"train embedding error: {msg}")
         finally:
@@ -829,7 +1256,7 @@ class Api:
             shared.loaded_hypernetworks = []
             apply_optimizations = shared.opts.training_xattention_optimizations
             error = None
-            filename = ''
+            filename = ""
             if not apply_optimizations:
                 sd_hijack.undo_optimizations()
             try:
@@ -842,7 +1269,9 @@ class Api:
                 if not apply_optimizations:
                     sd_hijack.apply_optimizations()
                 shared.state.end()
-            return models.TrainResponse(info=f"train embedding complete: filename: {filename} error: {error}")
+            return models.TrainResponse(
+                info=f"train embedding complete: filename: {filename} error: {error}"
+            )
         except Exception as exc:
             return models.TrainResponse(info=f"train embedding error: {exc}")
         finally:
@@ -852,54 +1281,75 @@ class Api:
         try:
             import os
             import psutil
+
             process = psutil.Process(os.getpid())
-            res = process.memory_info() # only rss is cross-platform guaranteed so we dont rely on other values
-            ram_total = 100 * res.rss / process.memory_percent() # and total memory is calculated as actual value is not cross-platform safe
-            ram = { 'free': ram_total - res.rss, 'used': res.rss, 'total': ram_total }
+            res = (
+                process.memory_info()
+            )  # only rss is cross-platform guaranteed so we dont rely on other values
+            ram_total = (
+                100 * res.rss / process.memory_percent()
+            )  # and total memory is calculated as actual value is not cross-platform safe
+            ram = {"free": ram_total - res.rss, "used": res.rss, "total": ram_total}
         except Exception as err:
-            ram = { 'error': f'{err}' }
+            ram = {"error": f"{err}"}
         try:
             import torch
+
             if torch.cuda.is_available():
                 s = torch.cuda.mem_get_info()
-                system = { 'free': s[0], 'used': s[1] - s[0], 'total': s[1] }
+                system = {"free": s[0], "used": s[1] - s[0], "total": s[1]}
                 s = dict(torch.cuda.memory_stats(shared.device))
-                allocated = { 'current': s['allocated_bytes.all.current'], 'peak': s['allocated_bytes.all.peak'] }
-                reserved = { 'current': s['reserved_bytes.all.current'], 'peak': s['reserved_bytes.all.peak'] }
-                active = { 'current': s['active_bytes.all.current'], 'peak': s['active_bytes.all.peak'] }
-                inactive = { 'current': s['inactive_split_bytes.all.current'], 'peak': s['inactive_split_bytes.all.peak'] }
-                warnings = { 'retries': s['num_alloc_retries'], 'oom': s['num_ooms'] }
+                allocated = {
+                    "current": s["allocated_bytes.all.current"],
+                    "peak": s["allocated_bytes.all.peak"],
+                }
+                reserved = {
+                    "current": s["reserved_bytes.all.current"],
+                    "peak": s["reserved_bytes.all.peak"],
+                }
+                active = {
+                    "current": s["active_bytes.all.current"],
+                    "peak": s["active_bytes.all.peak"],
+                }
+                inactive = {
+                    "current": s["inactive_split_bytes.all.current"],
+                    "peak": s["inactive_split_bytes.all.peak"],
+                }
+                warnings = {"retries": s["num_alloc_retries"], "oom": s["num_ooms"]}
                 cuda = {
-                    'system': system,
-                    'active': active,
-                    'allocated': allocated,
-                    'reserved': reserved,
-                    'inactive': inactive,
-                    'events': warnings,
+                    "system": system,
+                    "active": active,
+                    "allocated": allocated,
+                    "reserved": reserved,
+                    "inactive": inactive,
+                    "events": warnings,
                 }
             else:
-                cuda = {'error': 'unavailable'}
+                cuda = {"error": "unavailable"}
         except Exception as err:
-            cuda = {'error': f'{err}'}
+            cuda = {"error": f"{err}"}
         return models.MemoryResponse(ram=ram, cuda=cuda)
 
     def get_extensions_list(self):
         from modules import extensions
+
         extensions.list_extensions()
         ext_list = []
         for ext in extensions.extensions:
             ext: extensions.Extension
             ext.read_info_from_repo()
             if ext.remote is not None:
-                ext_list.append({
-                    "name": ext.name,
-                    "remote": ext.remote,
-                    "branch": ext.branch,
-                    "commit_hash":ext.commit_hash,
-                    "commit_date":ext.commit_date,
-                    "version":ext.version,
-                    "enabled":ext.enabled
-                })
+                ext_list.append(
+                    {
+                        "name": ext.name,
+                        "remote": ext.remote,
+                        "branch": ext.branch,
+                        "commit_hash": ext.commit_hash,
+                        "commit_date": ext.commit_date,
+                        "version": ext.version,
+                        "enabled": ext.enabled,
+                    }
+                )
         return ext_list
 
     def launch(self, server_name, port, root_path):
@@ -911,7 +1361,7 @@ class Api:
             timeout_keep_alive=shared.cmd_opts.timeout_keep_alive,
             root_path=root_path,
             ssl_keyfile=shared.cmd_opts.tls_keyfile,
-            ssl_certfile=shared.cmd_opts.tls_certfile
+            ssl_certfile=shared.cmd_opts.tls_certfile,
         )
 
     def kill_webui(self):
@@ -925,4 +1375,3 @@ class Api:
     def stop_webui(request):
         shared.state.server_command = "stop"
         return Response("Stopping.")
-

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -766,9 +766,7 @@ class Api:
         add_task_to_queue(task_id)
 
         with self.queue_lock:
-            with closing(
-                StableDiffusionProcessingTxt2Img(sd_model=shared.sd_model, **args)
-            ) as p:
+            with closing(StableDiffusionProcessingTxt2Img(**args)) as p:
                 p.is_api = True
                 p.scripts = script_runner
                 p.outpath_grids = opts.outdir_txt2img_grids
@@ -864,13 +862,15 @@ class Api:
 
         send_images = args.pop("send_images", True)
         args.pop("save_images", None)
+        mask_blur = args.pop("mask_blur", None)
+        if mask_blur is not None:
+            args["mask_blur_x"] = mask_blur
+            args["mask_blur_y"] = mask_blur
 
         add_task_to_queue(task_id)
 
         with self.queue_lock:
-            with closing(
-                StableDiffusionProcessingImg2Img(sd_model=shared.sd_model, **args)
-            ) as p:
+            with closing(StableDiffusionProcessingImg2Img(**args)) as p:
                 p.init_images = [decode_base64_to_image(x) for x in init_images]
                 p.is_api = True
                 p.scripts = script_runner

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -3,7 +3,10 @@ import inspect
 from pydantic import BaseModel, Field, create_model
 from typing import Any, Optional, Literal
 from inflection import underscore
-from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img
+from modules.processing import (
+    StableDiffusionProcessingTxt2Img,
+    StableDiffusionProcessingImg2Img,
+)
 from modules.shared import sd_upscalers, opts, parser
 
 API_NOT_ALLOWED = [
@@ -21,8 +24,9 @@ API_NOT_ALLOWED = [
     "seed_enable_extras",
     "prompt_for_display",
     "sampler_noise_scheduler_override",
-    "ddim_discretize"
+    "ddim_discretize",
 ]
+
 
 class ModelDef(BaseModel):
     """Assistance Class for Pydantic Dynamic Model Generation"""
@@ -44,23 +48,28 @@ class PydanticModelGenerator:
     def __init__(
         self,
         model_name: str = None,
-        class_instance = None,
-        additional_fields = None,
+        class_instance=None,
+        additional_fields=None,
     ):
         def field_type_generator(k, v):
             field_type = v.annotation
 
-            if field_type == 'Image':
+            if field_type == "Image":
                 # images are sent as base64 strings via API
-                field_type = 'str'
+                field_type = "str"
 
             return Optional[field_type]
 
         def merge_class_params(class_):
-            all_classes = list(filter(lambda x: x is not object, inspect.getmro(class_)))
+            all_classes = list(
+                filter(lambda x: x is not object, inspect.getmro(class_))
+            )
             parameters = {}
             for classes in all_classes:
-                parameters = {**parameters, **inspect.signature(classes.__init__).parameters}
+                parameters = {
+                    **parameters,
+                    **inspect.signature(classes.__init__).parameters,
+                }
             return parameters
 
         self._model_name = model_name
@@ -71,18 +80,22 @@ class PydanticModelGenerator:
                 field=underscore(k),
                 field_alias=k,
                 field_type=field_type_generator(k, v),
-                field_value=None if isinstance(v.default, property) else v.default
+                field_value=None if isinstance(v.default, property) else v.default,
             )
-            for (k,v) in self._class_data.items() if k not in API_NOT_ALLOWED
+            for (k, v) in self._class_data.items()
+            if k not in API_NOT_ALLOWED
         ]
 
         for fields in additional_fields:
-            self._model_def.append(ModelDef(
-                field=underscore(fields["key"]),
-                field_alias=fields["key"],
-                field_type=fields["type"],
-                field_value=fields["default"],
-                field_exclude=fields["exclude"] if "exclude" in fields else False))
+            self._model_def.append(
+                ModelDef(
+                    field=underscore(fields["key"]),
+                    field_alias=fields["key"],
+                    field_type=fields["type"],
+                    field_value=fields["default"],
+                    field_exclude=fields["exclude"] if "exclude" in fields else False,
+                )
+            )
 
     def generate_model(self):
         """
@@ -90,12 +103,19 @@ class PydanticModelGenerator:
         from the json and overrides provided at initialization
         """
         fields = {
-            d.field: (d.field_type, Field(default=d.field_value, alias=d.field_alias, exclude=d.field_exclude)) for d in self._model_def
+            d.field: (
+                d.field_type,
+                Field(
+                    default=d.field_value, alias=d.field_alias, exclude=d.field_exclude
+                ),
+            )
+            for d in self._model_def
         }
         DynamicModel = create_model(self._model_name, **fields)
         DynamicModel.__config__.allow_population_by_field_name = True
         DynamicModel.__config__.allow_mutation = True
         return DynamicModel
+
 
 StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
     "StableDiffusionProcessingTxt2Img",
@@ -109,7 +129,7 @@ StableDiffusionTxt2ImgProcessingAPI = PydanticModelGenerator(
         {"key": "alwayson_scripts", "type": dict, "default": {}},
         {"key": "force_task_id", "type": str, "default": None},
         {"key": "infotext", "type": str, "default": None},
-    ]
+    ],
 ).generate_model()
 
 StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
@@ -120,7 +140,7 @@ StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
         {"key": "init_images", "type": list, "default": None},
         {"key": "denoising_strength", "type": float, "default": 0.75},
         {"key": "mask", "type": str, "default": None},
-        {"key": "include_init_images", "type": bool, "default": False, "exclude" : True},
+        {"key": "include_init_images", "type": bool, "default": False, "exclude": True},
         {"key": "script_name", "type": str, "default": None},
         {"key": "script_args", "type": list, "default": []},
         {"key": "send_images", "type": bool, "default": True},
@@ -128,112 +148,268 @@ StableDiffusionImg2ImgProcessingAPI = PydanticModelGenerator(
         {"key": "alwayson_scripts", "type": dict, "default": {}},
         {"key": "force_task_id", "type": str, "default": None},
         {"key": "infotext", "type": str, "default": None},
-    ]
+    ],
 ).generate_model()
 
+
 class TextToImageResponse(BaseModel):
-    images: list[str] = Field(default=None, title="Image", description="The generated image in base64 format.")
+    images: list[str] = Field(
+        default=None, title="Image", description="The generated image in base64 format."
+    )
     parameters: dict
     info: str
+
 
 class ImageToImageResponse(BaseModel):
-    images: list[str] = Field(default=None, title="Image", description="The generated image in base64 format.")
+    images: list[str] = Field(
+        default=None, title="Image", description="The generated image in base64 format."
+    )
     parameters: dict
     info: str
 
+
 class ExtrasBaseRequest(BaseModel):
-    resize_mode: Literal[0, 1] = Field(default=0, title="Resize Mode", description="Sets the resize mode: 0 to upscale by upscaling_resize amount, 1 to upscale up to upscaling_resize_h x upscaling_resize_w.")
-    show_extras_results: bool = Field(default=True, title="Show results", description="Should the backend return the generated image?")
-    gfpgan_visibility: float = Field(default=0, title="GFPGAN Visibility", ge=0, le=1, allow_inf_nan=False, description="Sets the visibility of GFPGAN, values should be between 0 and 1.")
-    codeformer_visibility: float = Field(default=0, title="CodeFormer Visibility", ge=0, le=1, allow_inf_nan=False, description="Sets the visibility of CodeFormer, values should be between 0 and 1.")
-    codeformer_weight: float = Field(default=0, title="CodeFormer Weight", ge=0, le=1, allow_inf_nan=False, description="Sets the weight of CodeFormer, values should be between 0 and 1.")
-    upscaling_resize: float = Field(default=2, title="Upscaling Factor", gt=0, description="By how much to upscale the image, only used when resize_mode=0.")
-    upscaling_resize_w: int = Field(default=512, title="Target Width", ge=1, description="Target width for the upscaler to hit. Only used when resize_mode=1.")
-    upscaling_resize_h: int = Field(default=512, title="Target Height", ge=1, description="Target height for the upscaler to hit. Only used when resize_mode=1.")
-    upscaling_crop: bool = Field(default=True, title="Crop to fit", description="Should the upscaler crop the image to fit in the chosen size?")
-    upscaler_1: str = Field(default="None", title="Main upscaler", description=f"The name of the main upscaler to use, it has to be one of this list: {' , '.join([x.name for x in sd_upscalers])}")
-    upscaler_2: str = Field(default="None", title="Secondary upscaler", description=f"The name of the secondary upscaler to use, it has to be one of this list: {' , '.join([x.name for x in sd_upscalers])}")
-    extras_upscaler_2_visibility: float = Field(default=0, title="Secondary upscaler visibility", ge=0, le=1, allow_inf_nan=False, description="Sets the visibility of secondary upscaler, values should be between 0 and 1.")
-    upscale_first: bool = Field(default=False, title="Upscale first", description="Should the upscaler run before restoring faces?")
+    resize_mode: Literal[0, 1] = Field(
+        default=0,
+        title="Resize Mode",
+        description="Sets the resize mode: 0 to upscale by upscaling_resize amount, 1 to upscale up to upscaling_resize_h x upscaling_resize_w.",
+    )
+    show_extras_results: bool = Field(
+        default=True,
+        title="Show results",
+        description="Should the backend return the generated image?",
+    )
+    gfpgan_visibility: float = Field(
+        default=0,
+        title="GFPGAN Visibility",
+        ge=0,
+        le=1,
+        allow_inf_nan=False,
+        description="Sets the visibility of GFPGAN, values should be between 0 and 1.",
+    )
+    codeformer_visibility: float = Field(
+        default=0,
+        title="CodeFormer Visibility",
+        ge=0,
+        le=1,
+        allow_inf_nan=False,
+        description="Sets the visibility of CodeFormer, values should be between 0 and 1.",
+    )
+    codeformer_weight: float = Field(
+        default=0,
+        title="CodeFormer Weight",
+        ge=0,
+        le=1,
+        allow_inf_nan=False,
+        description="Sets the weight of CodeFormer, values should be between 0 and 1.",
+    )
+    upscaling_resize: float = Field(
+        default=2,
+        title="Upscaling Factor",
+        gt=0,
+        description="By how much to upscale the image, only used when resize_mode=0.",
+    )
+    upscaling_resize_w: int = Field(
+        default=512,
+        title="Target Width",
+        ge=1,
+        description="Target width for the upscaler to hit. Only used when resize_mode=1.",
+    )
+    upscaling_resize_h: int = Field(
+        default=512,
+        title="Target Height",
+        ge=1,
+        description="Target height for the upscaler to hit. Only used when resize_mode=1.",
+    )
+    upscaling_crop: bool = Field(
+        default=True,
+        title="Crop to fit",
+        description="Should the upscaler crop the image to fit in the chosen size?",
+    )
+    upscaler_1: str = Field(
+        default="None",
+        title="Main upscaler",
+        description=f"The name of the main upscaler to use, it has to be one of this list: {' , '.join([x.name for x in sd_upscalers])}",
+    )
+    upscaler_2: str = Field(
+        default="None",
+        title="Secondary upscaler",
+        description=f"The name of the secondary upscaler to use, it has to be one of this list: {' , '.join([x.name for x in sd_upscalers])}",
+    )
+    extras_upscaler_2_visibility: float = Field(
+        default=0,
+        title="Secondary upscaler visibility",
+        ge=0,
+        le=1,
+        allow_inf_nan=False,
+        description="Sets the visibility of secondary upscaler, values should be between 0 and 1.",
+    )
+    upscale_first: bool = Field(
+        default=False,
+        title="Upscale first",
+        description="Should the upscaler run before restoring faces?",
+    )
+
 
 class ExtraBaseResponse(BaseModel):
-    html_info: str = Field(title="HTML info", description="A series of HTML tags containing the process info.")
+    html_info: str = Field(
+        title="HTML info",
+        description="A series of HTML tags containing the process info.",
+    )
+
 
 class ExtrasSingleImageRequest(ExtrasBaseRequest):
-    image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")
+    image: str = Field(
+        default="",
+        title="Image",
+        description="Image to work on, must be a Base64 string containing the image's data.",
+    )
+
 
 class ExtrasSingleImageResponse(ExtraBaseResponse):
-    image: str = Field(default=None, title="Image", description="The generated image in base64 format.")
+    image: str = Field(
+        default=None, title="Image", description="The generated image in base64 format."
+    )
+
 
 class FileData(BaseModel):
-    data: str = Field(title="File data", description="Base64 representation of the file")
+    data: str = Field(
+        title="File data", description="Base64 representation of the file"
+    )
     name: str = Field(title="File name")
 
+
 class ExtrasBatchImagesRequest(ExtrasBaseRequest):
-    imageList: list[FileData] = Field(title="Images", description="List of images to work on. Must be Base64 strings")
+    imageList: list[FileData] = Field(
+        title="Images", description="List of images to work on. Must be Base64 strings"
+    )
+
 
 class ExtrasBatchImagesResponse(ExtraBaseResponse):
-    images: list[str] = Field(title="Images", description="The generated images in base64 format.")
+    images: list[str] = Field(
+        title="Images", description="The generated images in base64 format."
+    )
+
 
 class PNGInfoRequest(BaseModel):
     image: str = Field(title="Image", description="The base64 encoded PNG image")
 
+
 class PNGInfoResponse(BaseModel):
-    info: str = Field(title="Image info", description="A string with the parameters used to generate the image")
-    items: dict = Field(title="Items", description="A dictionary containing all the other fields the image had")
-    parameters: dict = Field(title="Parameters", description="A dictionary with parsed generation info fields")
+    info: str = Field(
+        title="Image info",
+        description="A string with the parameters used to generate the image",
+    )
+    items: dict = Field(
+        title="Items",
+        description="A dictionary containing all the other fields the image had",
+    )
+    parameters: dict = Field(
+        title="Parameters",
+        description="A dictionary with parsed generation info fields",
+    )
+
 
 class ProgressRequest(BaseModel):
-    skip_current_image: bool = Field(default=False, title="Skip current image", description="Skip current image serialization")
+    skip_current_image: bool = Field(
+        default=False,
+        title="Skip current image",
+        description="Skip current image serialization",
+    )
+
 
 class ProgressResponse(BaseModel):
-    progress: float = Field(title="Progress", description="The progress with a range of 0 to 1")
+    progress: float = Field(
+        title="Progress", description="The progress with a range of 0 to 1"
+    )
     eta_relative: float = Field(title="ETA in secs")
     state: dict = Field(title="State", description="The current state snapshot")
-    current_image: str = Field(default=None, title="Current image", description="The current image in base64 format. opts.show_progress_every_n_steps is required for this to work.")
-    textinfo: str = Field(default=None, title="Info text", description="Info text used by WebUI.")
+    current_image: str = Field(
+        default=None,
+        title="Current image",
+        description="The current image in base64 format. opts.show_progress_every_n_steps is required for this to work.",
+    )
+    textinfo: str = Field(
+        default=None, title="Info text", description="Info text used by WebUI."
+    )
+
 
 class InterrogateRequest(BaseModel):
-    image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")
-    model: str = Field(default="clip", title="Model", description="The interrogate model used.")
+    image: str = Field(
+        default="",
+        title="Image",
+        description="Image to work on, must be a Base64 string containing the image's data.",
+    )
+    model: str = Field(
+        default="clip", title="Model", description="The interrogate model used."
+    )
+
 
 class InterrogateResponse(BaseModel):
-    caption: str = Field(default=None, title="Caption", description="The generated caption for the image.")
+    caption: str = Field(
+        default=None,
+        title="Caption",
+        description="The generated caption for the image.",
+    )
+
 
 class TrainResponse(BaseModel):
-    info: str = Field(title="Train info", description="Response string from train embedding or hypernetwork task.")
+    info: str = Field(
+        title="Train info",
+        description="Response string from train embedding or hypernetwork task.",
+    )
+
 
 class CreateResponse(BaseModel):
-    info: str = Field(title="Create info", description="Response string from create embedding or hypernetwork task.")
+    info: str = Field(
+        title="Create info",
+        description="Response string from create embedding or hypernetwork task.",
+    )
+
 
 fields = {}
 for key, metadata in opts.data_labels.items():
     value = opts.data.get(key)
-    optType = opts.typemap.get(type(metadata.default), type(metadata.default)) if metadata.default else Any
+    optType = (
+        opts.typemap.get(type(metadata.default), type(metadata.default))
+        if metadata.default
+        else Any
+    )
 
     if metadata is not None:
-        fields.update({key: (Optional[optType], Field(default=metadata.default, description=metadata.label))})
+        fields.update(
+            {
+                key: (
+                    Optional[optType],
+                    Field(default=metadata.default, description=metadata.label),
+                )
+            }
+        )
     else:
         fields.update({key: (Optional[optType], Field())})
 
 OptionsModel = create_model("Options", **fields)
 
 flags = {}
-_options = vars(parser)['_option_string_actions']
+_options = vars(parser)["_option_string_actions"]
 for key in _options:
-    if(_options[key].dest != 'help'):
+    if _options[key].dest != "help":
         flag = _options[key]
         _type = str
         if _options[key].default is not None:
             _type = type(_options[key].default)
-        flags.update({flag.dest: (_type, Field(default=flag.default, description=flag.help))})
+        flags.update(
+            {flag.dest: (_type, Field(default=flag.default, description=flag.help))}
+        )
 
 FlagsModel = create_model("Flags", **flags)
+
 
 class SamplerItem(BaseModel):
     name: str = Field(title="Name")
     aliases: list[str] = Field(title="Aliases")
     options: dict[str, str] = Field(title="Options")
+
 
 class SchedulerItem(BaseModel):
     name: str = Field(title="Name")
@@ -242,6 +418,7 @@ class SchedulerItem(BaseModel):
     default_rho: Optional[float] = Field(title="Default Rho")
     need_inner_model: Optional[bool] = Field(title="Needs Inner Model")
 
+
 class UpscalerItem(BaseModel):
     name: str = Field(title="Name")
     model_name: Optional[str] = Field(title="Model Name")
@@ -249,8 +426,10 @@ class UpscalerItem(BaseModel):
     model_url: Optional[str] = Field(title="URL")
     scale: Optional[float] = Field(title="Scale")
 
+
 class LatentUpscalerModeItem(BaseModel):
     name: str = Field(title="Name")
+
 
 class SDModelItem(BaseModel):
     title: str = Field(title="Title")
@@ -260,22 +439,27 @@ class SDModelItem(BaseModel):
     filename: str = Field(title="Filename")
     config: Optional[str] = Field(title="Config file")
 
+
 class SDVaeItem(BaseModel):
     model_name: str = Field(title="Model Name")
     filename: str = Field(title="Filename")
+
 
 class HypernetworkItem(BaseModel):
     name: str = Field(title="Name")
     path: Optional[str] = Field(title="Path")
 
+
 class FaceRestorerItem(BaseModel):
     name: str = Field(title="Name")
     cmd_dir: Optional[str] = Field(title="Path")
+
 
 class RealesrganItem(BaseModel):
     name: str = Field(title="Name")
     path: Optional[str] = Field(title="Path")
     scale: Optional[int] = Field(title="Scale")
+
 
 class PromptStyleItem(BaseModel):
     name: str = Field(title="Name")
@@ -284,15 +468,36 @@ class PromptStyleItem(BaseModel):
 
 
 class EmbeddingItem(BaseModel):
-    step: Optional[int] = Field(title="Step", description="The number of steps that were used to train this embedding, if available")
-    sd_checkpoint: Optional[str] = Field(title="SD Checkpoint", description="The hash of the checkpoint this embedding was trained on, if available")
-    sd_checkpoint_name: Optional[str] = Field(title="SD Checkpoint Name", description="The name of the checkpoint this embedding was trained on, if available. Note that this is the name that was used by the trainer; for a stable identifier, use `sd_checkpoint` instead")
-    shape: int = Field(title="Shape", description="The length of each individual vector in the embedding")
-    vectors: int = Field(title="Vectors", description="The number of vectors in the embedding")
+    step: Optional[int] = Field(
+        title="Step",
+        description="The number of steps that were used to train this embedding, if available",
+    )
+    sd_checkpoint: Optional[str] = Field(
+        title="SD Checkpoint",
+        description="The hash of the checkpoint this embedding was trained on, if available",
+    )
+    sd_checkpoint_name: Optional[str] = Field(
+        title="SD Checkpoint Name",
+        description="The name of the checkpoint this embedding was trained on, if available. Note that this is the name that was used by the trainer; for a stable identifier, use `sd_checkpoint` instead",
+    )
+    shape: int = Field(
+        title="Shape",
+        description="The length of each individual vector in the embedding",
+    )
+    vectors: int = Field(
+        title="Vectors", description="The number of vectors in the embedding"
+    )
+
 
 class EmbeddingsResponse(BaseModel):
-    loaded: dict[str, EmbeddingItem] = Field(title="Loaded", description="Embeddings loaded for the current model")
-    skipped: dict[str, EmbeddingItem] = Field(title="Skipped", description="Embeddings skipped for the current model (likely due to architecture incompatibility)")
+    loaded: dict[str, EmbeddingItem] = Field(
+        title="Loaded", description="Embeddings loaded for the current model"
+    )
+    skipped: dict[str, EmbeddingItem] = Field(
+        title="Skipped",
+        description="Embeddings skipped for the current model (likely due to architecture incompatibility)",
+    )
+
 
 class MemoryResponse(BaseModel):
     ram: dict = Field(title="RAM", description="System memory stats")
@@ -300,30 +505,69 @@ class MemoryResponse(BaseModel):
 
 
 class ScriptsList(BaseModel):
-    txt2img: list = Field(default=None, title="Txt2img", description="Titles of scripts (txt2img)")
-    img2img: list = Field(default=None, title="Img2img", description="Titles of scripts (img2img)")
+    txt2img: list = Field(
+        default=None, title="Txt2img", description="Titles of scripts (txt2img)"
+    )
+    img2img: list = Field(
+        default=None, title="Img2img", description="Titles of scripts (img2img)"
+    )
 
 
 class ScriptArg(BaseModel):
-    label: str = Field(default=None, title="Label", description="Name of the argument in UI")
-    value: Optional[Any] = Field(default=None, title="Value", description="Default value of the argument")
-    minimum: Optional[Any] = Field(default=None, title="Minimum", description="Minimum allowed value for the argumentin UI")
-    maximum: Optional[Any] = Field(default=None, title="Minimum", description="Maximum allowed value for the argumentin UI")
-    step: Optional[Any] = Field(default=None, title="Minimum", description="Step for changing value of the argumentin UI")
-    choices: Optional[list[str]] = Field(default=None, title="Choices", description="Possible values for the argument")
+    label: str = Field(
+        default=None, title="Label", description="Name of the argument in UI"
+    )
+    value: Optional[Any] = Field(
+        default=None, title="Value", description="Default value of the argument"
+    )
+    minimum: Optional[Any] = Field(
+        default=None,
+        title="Minimum",
+        description="Minimum allowed value for the argumentin UI",
+    )
+    maximum: Optional[Any] = Field(
+        default=None,
+        title="Minimum",
+        description="Maximum allowed value for the argumentin UI",
+    )
+    step: Optional[Any] = Field(
+        default=None,
+        title="Minimum",
+        description="Step for changing value of the argumentin UI",
+    )
+    choices: Optional[list[str]] = Field(
+        default=None, title="Choices", description="Possible values for the argument"
+    )
 
 
 class ScriptInfo(BaseModel):
     name: str = Field(default=None, title="Name", description="Script name")
-    is_alwayson: bool = Field(default=None, title="IsAlwayson", description="Flag specifying whether this script is an alwayson script")
-    is_img2img: bool = Field(default=None, title="IsImg2img", description="Flag specifying whether this script is an img2img script")
-    args: list[ScriptArg] = Field(title="Arguments", description="List of script's arguments")
+    is_alwayson: bool = Field(
+        default=None,
+        title="IsAlwayson",
+        description="Flag specifying whether this script is an alwayson script",
+    )
+    is_img2img: bool = Field(
+        default=None,
+        title="IsImg2img",
+        description="Flag specifying whether this script is an img2img script",
+    )
+    args: list[ScriptArg] = Field(
+        title="Arguments", description="List of script's arguments"
+    )
+
 
 class ExtensionItem(BaseModel):
     name: str = Field(title="Name", description="Extension name")
     remote: str = Field(title="Remote", description="Extension Repository URL")
     branch: str = Field(title="Branch", description="Extension Repository Branch")
-    commit_hash: str = Field(title="Commit Hash", description="Extension Repository Commit Hash")
+    commit_hash: str = Field(
+        title="Commit Hash", description="Extension Repository Commit Hash"
+    )
     version: str = Field(title="Version", description="Extension Version")
-    commit_date: str = Field(title="Commit Date", description="Extension Repository Commit Date")
-    enabled: bool = Field(title="Enabled", description="Flag specifying whether this extension is enabled")
+    commit_date: str = Field(
+        title="Commit Date", description="Extension Repository Commit Date"
+    )
+    enabled: bool = Field(
+        title="Enabled", description="Flag specifying whether this extension is enabled"
+    )

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -8,8 +8,10 @@ import tqdm
 
 from modules.paths import data_path, script_path
 
-cache_filename = os.environ.get('SD_WEBUI_CACHE_FILE', os.path.join(data_path, "cache.json"))
-cache_dir = os.environ.get('SD_WEBUI_CACHE_DIR', os.path.join(data_path, "cache"))
+cache_filename = os.environ.get(
+    "SD_WEBUI_CACHE_FILE", os.path.join(data_path, "cache.json")
+)
+cache_dir = os.environ.get("SD_WEBUI_CACHE_DIR", os.path.join(data_path, "cache"))
 caches = {}
 cache_lock = threading.Lock()
 
@@ -36,7 +38,9 @@ def convert_old_cached_data():
         return
     except Exception:
         os.replace(cache_filename, os.path.join(script_path, "tmp", "cache.json"))
-        print('[ERROR] issue occurred while trying to read cache.json; old cache has been moved to tmp/cache.json')
+        print(
+            "[ERROR] issue occurred while trying to read cache.json; old cache has been moved to tmp/cache.json"
+        )
         return
 
     total_count = sum(len(keyvalues) for keyvalues in data.values())
@@ -110,14 +114,14 @@ def cached_data_for_file(subsection, title, filename, func):
         if ondisk_mtime > cached_mtime:
             entry = None
 
-    if not entry or 'value' not in entry:
+    if not entry or "value" not in entry:
         value = func()
         if value is None:
             return None
 
-        entry = {'mtime': ondisk_mtime, 'value': value}
+        entry = {"mtime": ondisk_mtime, "value": value}
         existing_cache[title] = entry
 
         dump_cache()
 
-    return entry['value']
+    return entry["value"]

--- a/modules/call_queue.py
+++ b/modules/call_queue.py
@@ -21,9 +21,13 @@ def wrap_queued_call(func):
 def wrap_gradio_gpu_call(func, extra_outputs=None):
     @wraps(func)
     def f(*args, **kwargs):
-
         # if the first argument is a string that says "task(...)", it is treated as a job id
-        if args and type(args[0]) == str and args[0].startswith("task(") and args[0].endswith(")"):
+        if (
+            args
+            and type(args[0]) == str
+            and args[0].startswith("task(")
+            and args[0].endswith(")")
+        ):
             id_task = args[0]
             progress.add_task_to_queue(id_task)
         else:
@@ -65,7 +69,11 @@ def wrap_gradio_call(func, extra_outputs=None, add_stats=False):
 def wrap_gradio_call_no_job(func, extra_outputs=None, add_stats=False):
     @wraps(func)
     def f(*args, extra_outputs_array=extra_outputs, **kwargs):
-        run_memmon = shared.opts.memmon_poll_rate > 0 and not shared.mem_mon.disabled and add_stats
+        run_memmon = (
+            shared.opts.memmon_poll_rate > 0
+            and not shared.mem_mon.disabled
+            and add_stats
+        )
         if run_memmon:
             shared.mem_mon.monitor()
         t = time.perf_counter()
@@ -83,10 +91,12 @@ def wrap_gradio_call_no_job(func, extra_outputs=None, add_stats=False):
             errors.report(f"{message}\n{arg_str}", exc_info=True)
 
             if extra_outputs_array is None:
-                extra_outputs_array = [None, '']
+                extra_outputs_array = [None, ""]
 
-            error_message = f'{type(e).__name__}: {e}'
-            res = extra_outputs_array + [f"<div class='error'>{html.escape(error_message)}</div>"]
+            error_message = f"{type(e).__name__}: {e}"
+            res = extra_outputs_array + [
+                f"<div class='error'>{html.escape(error_message)}</div>"
+            ]
 
         devices.torch_gc()
 
@@ -98,18 +108,22 @@ def wrap_gradio_call_no_job(func, extra_outputs=None, add_stats=False):
         elapsed_s = elapsed % 60
         elapsed_text = f"{elapsed_s:.1f} sec."
         if elapsed_m > 0:
-            elapsed_text = f"{elapsed_m} min. "+elapsed_text
+            elapsed_text = f"{elapsed_m} min. " + elapsed_text
 
         if run_memmon:
-            mem_stats = {k: -(v//-(1024*1024)) for k, v in shared.mem_mon.stop().items()}
-            active_peak = mem_stats['active_peak']
-            reserved_peak = mem_stats['reserved_peak']
-            sys_peak = mem_stats['system_peak']
-            sys_total = mem_stats['total']
-            sys_pct = sys_peak/max(sys_total, 1) * 100
+            mem_stats = {
+                k: -(v // -(1024 * 1024)) for k, v in shared.mem_mon.stop().items()
+            }
+            active_peak = mem_stats["active_peak"]
+            reserved_peak = mem_stats["reserved_peak"]
+            sys_peak = mem_stats["system_peak"]
+            sys_total = mem_stats["total"]
+            sys_pct = sys_peak / max(sys_total, 1) * 100
 
             toltip_a = "Active: peak amount of video memory used during generation (excluding cached data)"
-            toltip_r = "Reserved: total amount of video memory allocated by the Torch library "
+            toltip_r = (
+                "Reserved: total amount of video memory allocated by the Torch library "
+            )
             toltip_sys = "System: peak amount of video memory allocated by all running programs, out of total capacity"
 
             text_a = f"<abbr title='{toltip_a}'>A</abbr>: <span class='measurement'>{active_peak/1024:.2f} GB</span>"
@@ -118,17 +132,20 @@ def wrap_gradio_call_no_job(func, extra_outputs=None, add_stats=False):
 
             vram_html = f"<p class='vram'>{text_a}, <wbr>{text_r}, <wbr>{text_sys}</p>"
         else:
-            vram_html = ''
+            vram_html = ""
 
-        if shared.opts.profiling_enable and os.path.exists(shared.opts.profiling_filename):
+        if shared.opts.profiling_enable and os.path.exists(
+            shared.opts.profiling_filename
+        ):
             profiling_html = f"<p class='profile'> [ <a href='{profiling.webpath()}' download>Profile</a> ] </p>"
         else:
-            profiling_html = ''
+            profiling_html = ""
 
         # last item is always HTML
-        res[-1] += f"<div class='performance'><p class='time'>Time taken: <wbr><span class='measurement'>{elapsed_text}</span></p>{vram_html}{profiling_html}</div>"
+        res[-1] += (
+            f"<div class='performance'><p class='time'>Time taken: <wbr><span class='measurement'>{elapsed_text}</span></p>{vram_html}{profiling_html}</div>"
+        )
 
         return tuple(res)
 
     return f
-

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -1,128 +1,636 @@
 import argparse
 import json
 import os
-from modules.paths_internal import normalized_filepath, models_path, script_path, data_path, extensions_dir, extensions_builtin_dir, sd_default_config, sd_model_file  # noqa: F401
+from modules.paths_internal import (
+    normalized_filepath,
+    models_path,
+    script_path,
+    data_path,
+    sd_default_config,
+    sd_model_file,
+)  # noqa: F401
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("-f", action='store_true', help=argparse.SUPPRESS)  # allows running as root; implemented outside of webui
-parser.add_argument("--update-all-extensions", action='store_true', help="launch.py argument: download updates for all extensions when starting the program")
-parser.add_argument("--skip-python-version-check", action='store_true', help="launch.py argument: do not check python version")
-parser.add_argument("--skip-torch-cuda-test", action='store_true', help="launch.py argument: do not check if CUDA is able to work properly")
-parser.add_argument("--reinstall-xformers", action='store_true', help="launch.py argument: install the appropriate version of xformers even if you have some version already installed")
-parser.add_argument("--reinstall-torch", action='store_true', help="launch.py argument: install the appropriate version of torch even if you have some version already installed")
-parser.add_argument("--update-check", action='store_true', help="launch.py argument: check for updates at startup")
-parser.add_argument("--test-server", action='store_true', help="launch.py argument: configure server for testing")
-parser.add_argument("--log-startup", action='store_true', help="launch.py argument: print a detailed log of what's happening at startup")
-parser.add_argument("--skip-prepare-environment", action='store_true', help="launch.py argument: skip all environment preparation")
-parser.add_argument("--skip-install", action='store_true', help="launch.py argument: skip installation of packages")
-parser.add_argument("--dump-sysinfo", action='store_true', help="launch.py argument: dump limited sysinfo file (without information about extensions, options) to disk and quit")
-parser.add_argument("--loglevel", type=str, help="log level; one of: CRITICAL, ERROR, WARNING, INFO, DEBUG", default=None)
-parser.add_argument("--do-not-download-clip", action='store_true', help="do not download CLIP model even if it's not included in the checkpoint")
-parser.add_argument("--data-dir", type=normalized_filepath, default=os.path.dirname(os.path.dirname(os.path.realpath(__file__))), help="base path where all user data is stored")
-parser.add_argument("--models-dir", type=normalized_filepath, default=None, help="base path where models are stored; overrides --data-dir")
-parser.add_argument("--config", type=normalized_filepath, default=sd_default_config, help="path to config which constructs model",)
-parser.add_argument("--ckpt", type=normalized_filepath, default=sd_model_file, help="path to checkpoint of stable diffusion model; if specified, this checkpoint will be added to the list of checkpoints and loaded",)
-parser.add_argument("--ckpt-dir", type=normalized_filepath, default=None, help="Path to directory with stable diffusion checkpoints")
-parser.add_argument("--vae-dir", type=normalized_filepath, default=None, help="Path to directory with VAE files")
-parser.add_argument("--gfpgan-dir", type=normalized_filepath, help="GFPGAN directory", default=('./src/gfpgan' if os.path.exists('./src/gfpgan') else './GFPGAN'))
-parser.add_argument("--gfpgan-model", type=normalized_filepath, help="GFPGAN model file name", default=None)
-parser.add_argument("--no-half", action='store_true', help="do not switch the model to 16-bit floats")
-parser.add_argument("--no-half-vae", action='store_true', help="do not switch the VAE model to 16-bit floats")
-parser.add_argument("--no-progressbar-hiding", action='store_true', help="do not hide progressbar in gradio UI (we hide it because it slows down ML if you have hardware acceleration in browser)")
-parser.add_argument("--max-batch-count", type=int, default=16, help="does not do anything")
-parser.add_argument("--embeddings-dir", type=normalized_filepath, default=os.path.join(data_path, 'embeddings'), help="embeddings directory for textual inversion (default: embeddings)")
-parser.add_argument("--textual-inversion-templates-dir", type=normalized_filepath, default=os.path.join(script_path, 'textual_inversion_templates'), help="directory with textual inversion templates")
-parser.add_argument("--hypernetwork-dir", type=normalized_filepath, default=os.path.join(models_path, 'hypernetworks'), help="hypernetwork directory")
-parser.add_argument("--localizations-dir", type=normalized_filepath, default=os.path.join(script_path, 'localizations'), help="localizations directory")
-parser.add_argument("--allow-code", action='store_true', help="allow custom script execution from webui")
-parser.add_argument("--medvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a little speed for low VRM usage")
-parser.add_argument("--medvram-sdxl", action='store_true', help="enable --medvram optimization just for SDXL models")
-parser.add_argument("--lowvram", action='store_true', help="enable stable diffusion model optimizations for sacrificing a lot of speed for very low VRM usage")
-parser.add_argument("--lowram", action='store_true', help="load stable diffusion checkpoint weights to VRAM instead of RAM")
-parser.add_argument("--always-batch-cond-uncond", action='store_true', help="does not do anything")
-parser.add_argument("--unload-gfpgan", action='store_true', help="does not do anything.")
-parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["full", "half", "autocast"], default="autocast")
-parser.add_argument("--upcast-sampling", action='store_true', help="upcast sampling. No effect with --no-half. Usually produces similar results to --no-half with better performance while using less memory.")
-parser.add_argument("--share", action='store_true', help="use share=True for gradio and make the UI accessible through their site")
-parser.add_argument("--ngrok", type=str, help="ngrok authtoken, alternative to gradio --share", default=None)
-parser.add_argument("--ngrok-region", type=str, help="does not do anything.", default="")
-parser.add_argument("--ngrok-options", type=json.loads, help='The options to pass to ngrok in JSON format, e.g.: \'{"authtoken_from_env":true, "basic_auth":"user:password", "oauth_provider":"google", "oauth_allow_emails":"user@asdf.com"}\'', default=dict())
-parser.add_argument("--enable-insecure-extension-access", action='store_true', help="enable extensions tab regardless of other options")
-parser.add_argument("--codeformer-models-path", type=normalized_filepath, help="Path to directory with codeformer model file(s).", default=os.path.join(models_path, 'Codeformer'))
-parser.add_argument("--gfpgan-models-path", type=normalized_filepath, help="Path to directory with GFPGAN model file(s).", default=os.path.join(models_path, 'GFPGAN'))
-parser.add_argument("--esrgan-models-path", type=normalized_filepath, help="Path to directory with ESRGAN model file(s).", default=os.path.join(models_path, 'ESRGAN'))
-parser.add_argument("--bsrgan-models-path", type=normalized_filepath, help="Path to directory with BSRGAN model file(s).", default=os.path.join(models_path, 'BSRGAN'))
-parser.add_argument("--realesrgan-models-path", type=normalized_filepath, help="Path to directory with RealESRGAN model file(s).", default=os.path.join(models_path, 'RealESRGAN'))
-parser.add_argument("--dat-models-path", type=normalized_filepath, help="Path to directory with DAT model file(s).", default=os.path.join(models_path, 'DAT'))
-parser.add_argument("--clip-models-path", type=normalized_filepath, help="Path to directory with CLIP model file(s).", default=None)
-parser.add_argument("--xformers", action='store_true', help="enable xformers for cross attention layers")
-parser.add_argument("--force-enable-xformers", action='store_true', help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work")
-parser.add_argument("--xformers-flash-attention", action='store_true', help="enable xformers with Flash Attention to improve reproducibility (supported for SD2.x or variant only)")
-parser.add_argument("--deepdanbooru", action='store_true', help="does not do anything")
-parser.add_argument("--opt-split-attention", action='store_true', help="prefer Doggettx's cross-attention layer optimization for automatic choice of optimization")
-parser.add_argument("--opt-sub-quad-attention", action='store_true', help="prefer memory efficient sub-quadratic cross-attention layer optimization for automatic choice of optimization")
-parser.add_argument("--sub-quad-q-chunk-size", type=int, help="query chunk size for the sub-quadratic cross-attention layer optimization to use", default=1024)
-parser.add_argument("--sub-quad-kv-chunk-size", type=int, help="kv chunk size for the sub-quadratic cross-attention layer optimization to use", default=None)
-parser.add_argument("--sub-quad-chunk-threshold", type=int, help="the percentage of VRAM threshold for the sub-quadratic cross-attention layer optimization to use chunking", default=None)
-parser.add_argument("--opt-split-attention-invokeai", action='store_true', help="prefer InvokeAI's cross-attention layer optimization for automatic choice of optimization")
-parser.add_argument("--opt-split-attention-v1", action='store_true', help="prefer older version of split attention optimization for automatic choice of optimization")
-parser.add_argument("--opt-sdp-attention", action='store_true', help="prefer scaled dot product cross-attention layer optimization for automatic choice of optimization; requires PyTorch 2.*")
-parser.add_argument("--opt-sdp-no-mem-attention", action='store_true', help="prefer scaled dot product cross-attention layer optimization without memory efficient attention for automatic choice of optimization, makes image generation deterministic; requires PyTorch 2.*")
-parser.add_argument("--disable-opt-split-attention", action='store_true', help="prefer no cross-attention layer optimization for automatic choice of optimization")
-parser.add_argument("--disable-nan-check", action='store_true', help="do not check if produced images/latent spaces have nans; useful for running without a checkpoint in CI")
-parser.add_argument("--use-cpu", nargs='+', help="use CPU as torch device for specified modules", default=[], type=str.lower)
-parser.add_argument("--use-ipex", action="store_true", help="use Intel XPU as torch device")
-parser.add_argument("--disable-model-loading-ram-optimization", action='store_true', help="disable an optimization that reduces RAM use when loading a model")
-parser.add_argument("--listen", action='store_true', help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests")
-parser.add_argument("--port", type=int, help="launch gradio with given server port, you need root/admin rights for ports < 1024, defaults to 7860 if available", default=None)
-parser.add_argument("--show-negative-prompt", action='store_true', help="does not do anything", default=False)
-parser.add_argument("--ui-config-file", type=str, help="filename to use for ui configuration", default=os.path.join(data_path, 'ui-config.json'))
-parser.add_argument("--hide-ui-dir-config", action='store_true', help="hide directory configuration from webui", default=False)
-parser.add_argument("--freeze-settings", action='store_true', help="disable editing of all settings globally", default=False)
-parser.add_argument("--freeze-settings-in-sections", type=str, help='disable editing settings in specific sections of the settings page by specifying a comma-delimited list such like "saving-images,upscaling". The list of setting names can be found in the modules/shared_options.py file', default=None)
-parser.add_argument("--freeze-specific-settings", type=str, help='disable editing of individual settings by specifying a comma-delimited list like "samples_save,samples_format". The list of setting names can be found in the config.json file', default=None)
-parser.add_argument("--ui-settings-file", type=str, help="filename to use for ui settings", default=os.path.join(data_path, 'config.json'))
-parser.add_argument("--gradio-debug",  action='store_true', help="launch gradio with --debug option")
-parser.add_argument("--gradio-auth", type=str, help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
-parser.add_argument("--gradio-auth-path", type=normalized_filepath, help='set gradio authentication file path ex. "/path/to/auth/file" same auth format as --gradio-auth', default=None)
-parser.add_argument("--gradio-img2img-tool", type=str, help='does not do anything')
+parser.add_argument(
+    "-f", action="store_true", help=argparse.SUPPRESS
+)  # allows running as root; implemented outside of webui
+parser.add_argument(
+    "--update-all-extensions",
+    action="store_true",
+    help="launch.py argument: download updates for all extensions when starting the program",
+)
+parser.add_argument(
+    "--skip-python-version-check",
+    action="store_true",
+    help="launch.py argument: do not check python version",
+)
+parser.add_argument(
+    "--skip-torch-cuda-test",
+    action="store_true",
+    help="launch.py argument: do not check if CUDA is able to work properly",
+)
+parser.add_argument(
+    "--reinstall-xformers",
+    action="store_true",
+    help="launch.py argument: install the appropriate version of xformers even if you have some version already installed",
+)
+parser.add_argument(
+    "--reinstall-torch",
+    action="store_true",
+    help="launch.py argument: install the appropriate version of torch even if you have some version already installed",
+)
+parser.add_argument(
+    "--update-check",
+    action="store_true",
+    help="launch.py argument: check for updates at startup",
+)
+parser.add_argument(
+    "--test-server",
+    action="store_true",
+    help="launch.py argument: configure server for testing",
+)
+parser.add_argument(
+    "--log-startup",
+    action="store_true",
+    help="launch.py argument: print a detailed log of what's happening at startup",
+)
+parser.add_argument(
+    "--skip-prepare-environment",
+    action="store_true",
+    help="launch.py argument: skip all environment preparation",
+)
+parser.add_argument(
+    "--skip-install",
+    action="store_true",
+    help="launch.py argument: skip installation of packages",
+)
+parser.add_argument(
+    "--dump-sysinfo",
+    action="store_true",
+    help="launch.py argument: dump limited sysinfo file (without information about extensions, options) to disk and quit",
+)
+parser.add_argument(
+    "--loglevel",
+    type=str,
+    help="log level; one of: CRITICAL, ERROR, WARNING, INFO, DEBUG",
+    default=None,
+)
+parser.add_argument(
+    "--do-not-download-clip",
+    action="store_true",
+    help="do not download CLIP model even if it's not included in the checkpoint",
+)
+parser.add_argument(
+    "--data-dir",
+    type=normalized_filepath,
+    default=os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    help="base path where all user data is stored",
+)
+parser.add_argument(
+    "--models-dir",
+    type=normalized_filepath,
+    default=None,
+    help="base path where models are stored; overrides --data-dir",
+)
+parser.add_argument(
+    "--config",
+    type=normalized_filepath,
+    default=sd_default_config,
+    help="path to config which constructs model",
+)
+parser.add_argument(
+    "--ckpt",
+    type=normalized_filepath,
+    default=sd_model_file,
+    help="path to checkpoint of stable diffusion model; if specified, this checkpoint will be added to the list of checkpoints and loaded",
+)
+parser.add_argument(
+    "--ckpt-dir",
+    type=normalized_filepath,
+    default=None,
+    help="Path to directory with stable diffusion checkpoints",
+)
+parser.add_argument(
+    "--vae-dir",
+    type=normalized_filepath,
+    default=None,
+    help="Path to directory with VAE files",
+)
+parser.add_argument(
+    "--gfpgan-dir",
+    type=normalized_filepath,
+    help="GFPGAN directory",
+    default=("./src/gfpgan" if os.path.exists("./src/gfpgan") else "./GFPGAN"),
+)
+parser.add_argument(
+    "--gfpgan-model",
+    type=normalized_filepath,
+    help="GFPGAN model file name",
+    default=None,
+)
+parser.add_argument(
+    "--no-half", action="store_true", help="do not switch the model to 16-bit floats"
+)
+parser.add_argument(
+    "--no-half-vae",
+    action="store_true",
+    help="do not switch the VAE model to 16-bit floats",
+)
+parser.add_argument(
+    "--no-progressbar-hiding",
+    action="store_true",
+    help="do not hide progressbar in gradio UI (we hide it because it slows down ML if you have hardware acceleration in browser)",
+)
+parser.add_argument(
+    "--max-batch-count", type=int, default=16, help="does not do anything"
+)
+parser.add_argument(
+    "--embeddings-dir",
+    type=normalized_filepath,
+    default=os.path.join(data_path, "embeddings"),
+    help="embeddings directory for textual inversion (default: embeddings)",
+)
+parser.add_argument(
+    "--textual-inversion-templates-dir",
+    type=normalized_filepath,
+    default=os.path.join(script_path, "textual_inversion_templates"),
+    help="directory with textual inversion templates",
+)
+parser.add_argument(
+    "--hypernetwork-dir",
+    type=normalized_filepath,
+    default=os.path.join(models_path, "hypernetworks"),
+    help="hypernetwork directory",
+)
+parser.add_argument(
+    "--localizations-dir",
+    type=normalized_filepath,
+    default=os.path.join(script_path, "localizations"),
+    help="localizations directory",
+)
+parser.add_argument(
+    "--allow-code", action="store_true", help="allow custom script execution from webui"
+)
+parser.add_argument(
+    "--medvram",
+    action="store_true",
+    help="enable stable diffusion model optimizations for sacrificing a little speed for low VRM usage",
+)
+parser.add_argument(
+    "--medvram-sdxl",
+    action="store_true",
+    help="enable --medvram optimization just for SDXL models",
+)
+parser.add_argument(
+    "--lowvram",
+    action="store_true",
+    help="enable stable diffusion model optimizations for sacrificing a lot of speed for very low VRM usage",
+)
+parser.add_argument(
+    "--lowram",
+    action="store_true",
+    help="load stable diffusion checkpoint weights to VRAM instead of RAM",
+)
+parser.add_argument(
+    "--always-batch-cond-uncond", action="store_true", help="does not do anything"
+)
+parser.add_argument(
+    "--unload-gfpgan", action="store_true", help="does not do anything."
+)
+parser.add_argument(
+    "--precision",
+    type=str,
+    help="evaluate at this precision",
+    choices=["full", "half", "autocast"],
+    default="autocast",
+)
+parser.add_argument(
+    "--upcast-sampling",
+    action="store_true",
+    help="upcast sampling. No effect with --no-half. Usually produces similar results to --no-half with better performance while using less memory.",
+)
+parser.add_argument(
+    "--share",
+    action="store_true",
+    help="use share=True for gradio and make the UI accessible through their site",
+)
+parser.add_argument(
+    "--ngrok",
+    type=str,
+    help="ngrok authtoken, alternative to gradio --share",
+    default=None,
+)
+parser.add_argument(
+    "--ngrok-region", type=str, help="does not do anything.", default=""
+)
+parser.add_argument(
+    "--ngrok-options",
+    type=json.loads,
+    help='The options to pass to ngrok in JSON format, e.g.: \'{"authtoken_from_env":true, "basic_auth":"user:password", "oauth_provider":"google", "oauth_allow_emails":"user@asdf.com"}\'',
+    default=dict(),
+)
+parser.add_argument(
+    "--enable-insecure-extension-access",
+    action="store_true",
+    help="enable extensions tab regardless of other options",
+)
+parser.add_argument(
+    "--codeformer-models-path",
+    type=normalized_filepath,
+    help="Path to directory with codeformer model file(s).",
+    default=os.path.join(models_path, "Codeformer"),
+)
+parser.add_argument(
+    "--gfpgan-models-path",
+    type=normalized_filepath,
+    help="Path to directory with GFPGAN model file(s).",
+    default=os.path.join(models_path, "GFPGAN"),
+)
+parser.add_argument(
+    "--esrgan-models-path",
+    type=normalized_filepath,
+    help="Path to directory with ESRGAN model file(s).",
+    default=os.path.join(models_path, "ESRGAN"),
+)
+parser.add_argument(
+    "--bsrgan-models-path",
+    type=normalized_filepath,
+    help="Path to directory with BSRGAN model file(s).",
+    default=os.path.join(models_path, "BSRGAN"),
+)
+parser.add_argument(
+    "--realesrgan-models-path",
+    type=normalized_filepath,
+    help="Path to directory with RealESRGAN model file(s).",
+    default=os.path.join(models_path, "RealESRGAN"),
+)
+parser.add_argument(
+    "--dat-models-path",
+    type=normalized_filepath,
+    help="Path to directory with DAT model file(s).",
+    default=os.path.join(models_path, "DAT"),
+)
+parser.add_argument(
+    "--clip-models-path",
+    type=normalized_filepath,
+    help="Path to directory with CLIP model file(s).",
+    default=None,
+)
+parser.add_argument(
+    "--xformers", action="store_true", help="enable xformers for cross attention layers"
+)
+parser.add_argument(
+    "--force-enable-xformers",
+    action="store_true",
+    help="enable xformers for cross attention layers regardless of whether the checking code thinks you can run it; do not make bug reports if this fails to work",
+)
+parser.add_argument(
+    "--xformers-flash-attention",
+    action="store_true",
+    help="enable xformers with Flash Attention to improve reproducibility (supported for SD2.x or variant only)",
+)
+parser.add_argument("--deepdanbooru", action="store_true", help="does not do anything")
+parser.add_argument(
+    "--opt-split-attention",
+    action="store_true",
+    help="prefer Doggettx's cross-attention layer optimization for automatic choice of optimization",
+)
+parser.add_argument(
+    "--opt-sub-quad-attention",
+    action="store_true",
+    help="prefer memory efficient sub-quadratic cross-attention layer optimization for automatic choice of optimization",
+)
+parser.add_argument(
+    "--sub-quad-q-chunk-size",
+    type=int,
+    help="query chunk size for the sub-quadratic cross-attention layer optimization to use",
+    default=1024,
+)
+parser.add_argument(
+    "--sub-quad-kv-chunk-size",
+    type=int,
+    help="kv chunk size for the sub-quadratic cross-attention layer optimization to use",
+    default=None,
+)
+parser.add_argument(
+    "--sub-quad-chunk-threshold",
+    type=int,
+    help="the percentage of VRAM threshold for the sub-quadratic cross-attention layer optimization to use chunking",
+    default=None,
+)
+parser.add_argument(
+    "--opt-split-attention-invokeai",
+    action="store_true",
+    help="prefer InvokeAI's cross-attention layer optimization for automatic choice of optimization",
+)
+parser.add_argument(
+    "--opt-split-attention-v1",
+    action="store_true",
+    help="prefer older version of split attention optimization for automatic choice of optimization",
+)
+parser.add_argument(
+    "--opt-sdp-attention",
+    action="store_true",
+    help="prefer scaled dot product cross-attention layer optimization for automatic choice of optimization; requires PyTorch 2.*",
+)
+parser.add_argument(
+    "--opt-sdp-no-mem-attention",
+    action="store_true",
+    help="prefer scaled dot product cross-attention layer optimization without memory efficient attention for automatic choice of optimization, makes image generation deterministic; requires PyTorch 2.*",
+)
+parser.add_argument(
+    "--disable-opt-split-attention",
+    action="store_true",
+    help="prefer no cross-attention layer optimization for automatic choice of optimization",
+)
+parser.add_argument(
+    "--disable-nan-check",
+    action="store_true",
+    help="do not check if produced images/latent spaces have nans; useful for running without a checkpoint in CI",
+)
+parser.add_argument(
+    "--use-cpu",
+    nargs="+",
+    help="use CPU as torch device for specified modules",
+    default=[],
+    type=str.lower,
+)
+parser.add_argument(
+    "--use-ipex", action="store_true", help="use Intel XPU as torch device"
+)
+parser.add_argument(
+    "--disable-model-loading-ram-optimization",
+    action="store_true",
+    help="disable an optimization that reduces RAM use when loading a model",
+)
+parser.add_argument(
+    "--listen",
+    action="store_true",
+    help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests",
+)
+parser.add_argument(
+    "--port",
+    type=int,
+    help="launch gradio with given server port, you need root/admin rights for ports < 1024, defaults to 7860 if available",
+    default=None,
+)
+parser.add_argument(
+    "--show-negative-prompt",
+    action="store_true",
+    help="does not do anything",
+    default=False,
+)
+parser.add_argument(
+    "--ui-config-file",
+    type=str,
+    help="filename to use for ui configuration",
+    default=os.path.join(data_path, "ui-config.json"),
+)
+parser.add_argument(
+    "--hide-ui-dir-config",
+    action="store_true",
+    help="hide directory configuration from webui",
+    default=False,
+)
+parser.add_argument(
+    "--freeze-settings",
+    action="store_true",
+    help="disable editing of all settings globally",
+    default=False,
+)
+parser.add_argument(
+    "--freeze-settings-in-sections",
+    type=str,
+    help='disable editing settings in specific sections of the settings page by specifying a comma-delimited list such like "saving-images,upscaling". The list of setting names can be found in the modules/shared_options.py file',
+    default=None,
+)
+parser.add_argument(
+    "--freeze-specific-settings",
+    type=str,
+    help='disable editing of individual settings by specifying a comma-delimited list like "samples_save,samples_format". The list of setting names can be found in the config.json file',
+    default=None,
+)
+parser.add_argument(
+    "--ui-settings-file",
+    type=str,
+    help="filename to use for ui settings",
+    default=os.path.join(data_path, "config.json"),
+)
+parser.add_argument(
+    "--gradio-debug", action="store_true", help="launch gradio with --debug option"
+)
+parser.add_argument(
+    "--gradio-auth",
+    type=str,
+    help='set gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"',
+    default=None,
+)
+parser.add_argument(
+    "--gradio-auth-path",
+    type=normalized_filepath,
+    help='set gradio authentication file path ex. "/path/to/auth/file" same auth format as --gradio-auth',
+    default=None,
+)
+parser.add_argument("--gradio-img2img-tool", type=str, help="does not do anything")
 parser.add_argument("--gradio-inpaint-tool", type=str, help="does not do anything")
-parser.add_argument("--gradio-allowed-path", action='append', help="add path to gradio's allowed_paths, make it possible to serve files from it", default=[data_path])
-parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
-parser.add_argument("--styles-file", type=str, action='append', help="path or wildcard path of styles files, allow multiple entries.", default=[])
-parser.add_argument("--autolaunch", action='store_true', help="open the webui URL in the system's default browser upon launch", default=False)
-parser.add_argument("--theme", type=str, help="launches the UI with light or dark theme", default=None)
-parser.add_argument("--use-textbox-seed", action='store_true', help="use textbox for seeds in UI (no up/down, but possible to input long seeds)", default=False)
-parser.add_argument("--disable-console-progressbars", action='store_true', help="do not output progressbars to console", default=False)
-parser.add_argument("--enable-console-prompts", action='store_true', help="does not do anything", default=False)  # Legacy compatibility, use as default value shared.opts.enable_console_prompts
-parser.add_argument('--vae-path', type=normalized_filepath, help='Checkpoint to use as VAE; setting this argument disables all settings related to VAE', default=None)
-parser.add_argument("--disable-safe-unpickle", action='store_true', help="disable checking pytorch models for malicious code", default=False)
-parser.add_argument("--api", action='store_true', help="use api=True to launch the API together with the webui (use --nowebui instead for only the API)")
-parser.add_argument("--api-auth", type=str, help='Set authentication for API like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
-parser.add_argument("--api-log", action='store_true', help="use api-log=True to enable logging of all API requests")
-parser.add_argument("--nowebui", action='store_true', help="use api=True to launch the API instead of the webui")
-parser.add_argument("--ui-debug-mode", action='store_true', help="Don't load model to quickly launch UI")
-parser.add_argument("--device-id", type=str, help="Select the default CUDA device to use (export CUDA_VISIBLE_DEVICES=0,1,etc might be needed before)", default=None)
-parser.add_argument("--administrator", action='store_true', help="Administrator rights", default=False)
-parser.add_argument("--cors-allow-origins", type=str, help="Allowed CORS origin(s) in the form of a comma-separated list (no spaces)", default=None)
-parser.add_argument("--cors-allow-origins-regex", type=str, help="Allowed CORS origin(s) in the form of a single regular expression", default=None)
-parser.add_argument("--tls-keyfile", type=str, help="Partially enables TLS, requires --tls-certfile to fully function", default=None)
-parser.add_argument("--tls-certfile", type=str, help="Partially enables TLS, requires --tls-keyfile to fully function", default=None)
-parser.add_argument("--disable-tls-verify", action="store_false", help="When passed, enables the use of self-signed certificates.", default=None)
-parser.add_argument("--server-name", type=str, help="Sets hostname of server", default=None)
-parser.add_argument("--gradio-queue", action='store_true', help="does not do anything", default=True)
-parser.add_argument("--no-gradio-queue", action='store_true', help="Disables gradio queue; causes the webpage to use http requests instead of websockets; was the default in earlier versions")
-parser.add_argument("--skip-version-check", action='store_true', help="Do not check versions of torch and xformers")
-parser.add_argument("--no-hashing", action='store_true', help="disable sha256 hashing of checkpoints to help loading performance", default=False)
-parser.add_argument("--no-download-sd-model", action='store_true', help="don't download SD1.5 model even if no model is found in --ckpt-dir", default=False)
-parser.add_argument('--subpath', type=str, help='customize the subpath for gradio, use with reverse proxy')
-parser.add_argument('--add-stop-route', action='store_true', help='does not do anything')
-parser.add_argument('--api-server-stop', action='store_true', help='enable server stop/restart/kill via api')
-parser.add_argument('--timeout-keep-alive', type=int, default=30, help='set timeout_keep_alive for uvicorn')
-parser.add_argument("--disable-all-extensions", action='store_true', help="prevent all extensions from running regardless of any other settings", default=False)
-parser.add_argument("--disable-extra-extensions", action='store_true', help="prevent all extensions except built-in from running regardless of any other settings", default=False)
-parser.add_argument("--skip-load-model-at-start", action='store_true', help="if load a model at web start, only take effect when --nowebui")
-parser.add_argument("--unix-filenames-sanitization", action='store_true', help="allow any symbols except '/' in filenames. May conflict with your browser and file system")
-parser.add_argument("--filenames-max-length", type=int, default=128, help='maximal length of filenames of saved images. If you override it, it can conflict with your file system')
-parser.add_argument("--no-prompt-history", action='store_true', help="disable read prompt from last generation feature; settings this argument will not create '--data_path/params.txt' file")
+parser.add_argument(
+    "--gradio-allowed-path",
+    action="append",
+    help="add path to gradio's allowed_paths, make it possible to serve files from it",
+    default=[data_path],
+)
+parser.add_argument(
+    "--opt-channelslast",
+    action="store_true",
+    help="change memory type for stable diffusion to channels last",
+)
+parser.add_argument(
+    "--styles-file",
+    type=str,
+    action="append",
+    help="path or wildcard path of styles files, allow multiple entries.",
+    default=[],
+)
+parser.add_argument(
+    "--autolaunch",
+    action="store_true",
+    help="open the webui URL in the system's default browser upon launch",
+    default=False,
+)
+parser.add_argument(
+    "--theme", type=str, help="launches the UI with light or dark theme", default=None
+)
+parser.add_argument(
+    "--use-textbox-seed",
+    action="store_true",
+    help="use textbox for seeds in UI (no up/down, but possible to input long seeds)",
+    default=False,
+)
+parser.add_argument(
+    "--disable-console-progressbars",
+    action="store_true",
+    help="do not output progressbars to console",
+    default=False,
+)
+parser.add_argument(
+    "--enable-console-prompts",
+    action="store_true",
+    help="does not do anything",
+    default=False,
+)  # Legacy compatibility, use as default value shared.opts.enable_console_prompts
+parser.add_argument(
+    "--vae-path",
+    type=normalized_filepath,
+    help="Checkpoint to use as VAE; setting this argument disables all settings related to VAE",
+    default=None,
+)
+parser.add_argument(
+    "--disable-safe-unpickle",
+    action="store_true",
+    help="disable checking pytorch models for malicious code",
+    default=False,
+)
+parser.add_argument(
+    "--api",
+    action="store_true",
+    help="use api=True to launch the API together with the webui (use --nowebui instead for only the API)",
+)
+parser.add_argument(
+    "--api-auth",
+    type=str,
+    help='Set authentication for API like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"',
+    default=None,
+)
+parser.add_argument(
+    "--api-log",
+    action="store_true",
+    help="use api-log=True to enable logging of all API requests",
+)
+parser.add_argument(
+    "--nowebui",
+    action="store_true",
+    help="use api=True to launch the API instead of the webui",
+)
+parser.add_argument(
+    "--ui-debug-mode", action="store_true", help="Don't load model to quickly launch UI"
+)
+parser.add_argument(
+    "--device-id",
+    type=str,
+    help="Select the default CUDA device to use (export CUDA_VISIBLE_DEVICES=0,1,etc might be needed before)",
+    default=None,
+)
+parser.add_argument(
+    "--administrator", action="store_true", help="Administrator rights", default=False
+)
+parser.add_argument(
+    "--cors-allow-origins",
+    type=str,
+    help="Allowed CORS origin(s) in the form of a comma-separated list (no spaces)",
+    default=None,
+)
+parser.add_argument(
+    "--cors-allow-origins-regex",
+    type=str,
+    help="Allowed CORS origin(s) in the form of a single regular expression",
+    default=None,
+)
+parser.add_argument(
+    "--tls-keyfile",
+    type=str,
+    help="Partially enables TLS, requires --tls-certfile to fully function",
+    default=None,
+)
+parser.add_argument(
+    "--tls-certfile",
+    type=str,
+    help="Partially enables TLS, requires --tls-keyfile to fully function",
+    default=None,
+)
+parser.add_argument(
+    "--disable-tls-verify",
+    action="store_false",
+    help="When passed, enables the use of self-signed certificates.",
+    default=None,
+)
+parser.add_argument(
+    "--server-name", type=str, help="Sets hostname of server", default=None
+)
+parser.add_argument(
+    "--gradio-queue", action="store_true", help="does not do anything", default=True
+)
+parser.add_argument(
+    "--no-gradio-queue",
+    action="store_true",
+    help="Disables gradio queue; causes the webpage to use http requests instead of websockets; was the default in earlier versions",
+)
+parser.add_argument(
+    "--skip-version-check",
+    action="store_true",
+    help="Do not check versions of torch and xformers",
+)
+parser.add_argument(
+    "--no-hashing",
+    action="store_true",
+    help="disable sha256 hashing of checkpoints to help loading performance",
+    default=False,
+)
+parser.add_argument(
+    "--no-download-sd-model",
+    action="store_true",
+    help="don't download SD1.5 model even if no model is found in --ckpt-dir",
+    default=False,
+)
+parser.add_argument(
+    "--subpath",
+    type=str,
+    help="customize the subpath for gradio, use with reverse proxy",
+)
+parser.add_argument(
+    "--add-stop-route", action="store_true", help="does not do anything"
+)
+parser.add_argument(
+    "--api-server-stop",
+    action="store_true",
+    help="enable server stop/restart/kill via api",
+)
+parser.add_argument(
+    "--timeout-keep-alive",
+    type=int,
+    default=30,
+    help="set timeout_keep_alive for uvicorn",
+)
+parser.add_argument(
+    "--disable-all-extensions",
+    action="store_true",
+    help="prevent all extensions from running regardless of any other settings",
+    default=False,
+)
+parser.add_argument(
+    "--disable-extra-extensions",
+    action="store_true",
+    help="prevent all extensions except built-in from running regardless of any other settings",
+    default=False,
+)
+parser.add_argument(
+    "--skip-load-model-at-start",
+    action="store_true",
+    help="if load a model at web start, only take effect when --nowebui",
+)
+parser.add_argument(
+    "--unix-filenames-sanitization",
+    action="store_true",
+    help="allow any symbols except '/' in filenames. May conflict with your browser and file system",
+)
+parser.add_argument(
+    "--filenames-max-length",
+    type=int,
+    default=128,
+    help="maximal length of filenames of saved images. If you override it, it can conflict with your file system",
+)
+parser.add_argument(
+    "--no-prompt-history",
+    action="store_true",
+    help="disable read prompt from last generation feature; settings this argument will not create '--data_path/params.txt' file",
+)

--- a/modules/codeformer_model.py
+++ b/modules/codeformer_model.py
@@ -15,8 +15,10 @@ from modules import (
 
 logger = logging.getLogger(__name__)
 
-model_url = 'https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth'
-model_download_name = 'codeformer-v0.1.0.pth'
+model_url = (
+    "https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth"
+)
+model_download_name = "codeformer-v0.1.0.pth"
 
 # used by e.g. postprocessing_codeformer.py
 codeformer: face_restoration.FaceRestoration | None = None
@@ -32,12 +34,12 @@ class FaceRestorerCodeFormer(face_restoration_utils.CommonFaceRestoration):
             model_url=model_url,
             command_path=self.model_path,
             download_name=model_download_name,
-            ext_filter=['.pth'],
+            ext_filter=[".pth"],
         ):
             return modelloader.load_spandrel_model(
                 model_path,
                 device=devices.device_codeformer,
-                expected_architecture='CodeFormer',
+                expected_architecture="CodeFormer",
             ).model
         raise ValueError("No codeformer model found")
 

--- a/modules/config_states.py
+++ b/modules/config_states.py
@@ -32,12 +32,14 @@ def list_config_states():
                     j["filepath"] = path
                     config_states.append(j)
             except Exception as e:
-                print(f'[ERROR]: Config states {path}, {e}')
+                print(f"[ERROR]: Config states {path}, {e}")
 
     config_states = sorted(config_states, key=lambda cs: cs["created_at"], reverse=True)
 
     for cs in config_states:
-        timestamp = datetime.fromtimestamp(cs["created_at"]).strftime('%Y-%m-%d %H:%M:%S')
+        timestamp = datetime.fromtimestamp(cs["created_at"]).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
         name = cs.get("name", "Config")
         full_name = f"{name}: {timestamp}"
         all_config_states[full_name] = cs
@@ -92,7 +94,7 @@ def get_extension_config():
             "commit_hash": ext.commit_hash,
             "commit_date": ext.commit_date,
             "branch": ext.branch,
-            "have_info_from_repo": ext.have_info_from_repo
+            "have_info_from_repo": ext.have_info_from_repo,
         }
 
         ext_config[ext.name] = entry
@@ -108,7 +110,7 @@ def get_config():
     return {
         "created_at": creation_time,
         "webui": webui_config,
-        "extensions": ext_config
+        "extensions": ext_config,
     }
 
 
@@ -165,7 +167,14 @@ def restore_extension_config(config):
         if ext.name not in ext_config:
             ext.disabled = True
             disabled.append(ext.name)
-            results.append((ext, current_commit[:8], False, "Saved extension state not found in config, marking as disabled"))
+            results.append(
+                (
+                    ext,
+                    current_commit[:8],
+                    False,
+                    "Saved extension state not found in config, marking as disabled",
+                )
+            )
             continue
 
         entry = ext_config[ext.name]
@@ -175,11 +184,15 @@ def restore_extension_config(config):
                 ext.fetch_and_reset_hard(entry["commit_hash"])
                 ext.read_info_from_repo()
                 if current_commit != entry["commit_hash"]:
-                    results.append((ext, current_commit[:8], True, entry["commit_hash"][:8]))
+                    results.append(
+                        (ext, current_commit[:8], True, entry["commit_hash"][:8])
+                    )
             except Exception as ex:
                 results.append((ext, current_commit[:8], False, ex))
         else:
-            results.append((ext, current_commit[:8], False, "No commit hash found in config"))
+            results.append(
+                (ext, current_commit[:8], False, "No commit hash found in config")
+            )
 
         if not entry.get("enabled", False):
             ext.disabled = True

--- a/modules/dat_model.py
+++ b/modules/dat_model.py
@@ -51,7 +51,9 @@ class UpscalerDAT(Upscaler):
                         model_dir=self.model_download_path,
                     )
                 if not os.path.exists(scaler.local_data_path):
-                    raise FileNotFoundError(f"DAT data missing: {scaler.local_data_path}")
+                    raise FileNotFoundError(
+                        f"DAT data missing: {scaler.local_data_path}"
+                    )
                 return scaler
         raise ValueError(f"Unable to find model info: {path}")
 

--- a/modules/deepbooru.py
+++ b/modules/deepbooru.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from modules import modelloader, paths, deepbooru_model, devices, images, shared
 
-re_special = re.compile(r'([\\()])')
+re_special = re.compile(r"([\\()])")
 
 
 class DeepDanbooru:
@@ -19,9 +19,9 @@ class DeepDanbooru:
 
         files = modelloader.load_models(
             model_path=os.path.join(paths.models_path, "torch_deepdanbooru"),
-            model_url='https://github.com/AUTOMATIC1111/TorchDeepDanbooru/releases/download/v1/model-resnet_custom_v3.pt',
+            model_url="https://github.com/AUTOMATIC1111/TorchDeepDanbooru/releases/download/v1/model-resnet_custom_v3.pt",
             ext_filter=[".pt"],
-            download_name='model-resnet_custom_v3.pt',
+            download_name="model-resnet_custom_v3.pt",
         )
 
         self.model = deepbooru_model.DeepDanbooruModel()
@@ -74,19 +74,24 @@ class DeepDanbooru:
         if alpha_sort:
             tags = sorted(probability_dict)
         else:
-            tags = [tag for tag, _ in sorted(probability_dict.items(), key=lambda x: -x[1])]
+            tags = [
+                tag for tag, _ in sorted(probability_dict.items(), key=lambda x: -x[1])
+            ]
 
         res = []
 
-        filtertags = {x.strip().replace(' ', '_') for x in shared.opts.deepbooru_filter_tags.split(",")}
+        filtertags = {
+            x.strip().replace(" ", "_")
+            for x in shared.opts.deepbooru_filter_tags.split(",")
+        }
 
         for tag in [x for x in tags if x not in filtertags]:
             probability = probability_dict[tag]
             tag_outformat = tag
             if use_spaces:
-                tag_outformat = tag_outformat.replace('_', ' ')
+                tag_outformat = tag_outformat.replace("_", " ")
             if use_escape:
-                tag_outformat = re.sub(re_special, r'\\\1', tag_outformat)
+                tag_outformat = re.sub(re_special, r"\\\1", tag_outformat)
             if include_ranks:
                 tag_outformat = f"({tag_outformat}:{probability:.3f})"
 

--- a/modules/deepbooru_model.py
+++ b/modules/deepbooru_model.py
@@ -13,7 +13,9 @@ class DeepDanbooruModel(nn.Module):
 
         self.tags = []
 
-        self.n_Conv_0 = nn.Conv2d(kernel_size=(7, 7), in_channels=3, out_channels=64, stride=(2, 2))
+        self.n_Conv_0 = nn.Conv2d(
+            kernel_size=(7, 7), in_channels=3, out_channels=64, stride=(2, 2)
+        )
         self.n_MaxPool_0 = nn.MaxPool2d(kernel_size=(3, 3), stride=(2, 2))
         self.n_Conv_1 = nn.Conv2d(kernel_size=(1, 1), in_channels=64, out_channels=256)
         self.n_Conv_2 = nn.Conv2d(kernel_size=(1, 1), in_channels=64, out_channels=64)
@@ -25,182 +27,522 @@ class DeepDanbooruModel(nn.Module):
         self.n_Conv_8 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=64)
         self.n_Conv_9 = nn.Conv2d(kernel_size=(3, 3), in_channels=64, out_channels=64)
         self.n_Conv_10 = nn.Conv2d(kernel_size=(1, 1), in_channels=64, out_channels=256)
-        self.n_Conv_11 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=512, stride=(2, 2))
-        self.n_Conv_12 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=128)
-        self.n_Conv_13 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128, stride=(2, 2))
-        self.n_Conv_14 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_15 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_16 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_17 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_18 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_19 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_20 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_21 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_22 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_23 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_24 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_25 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_26 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_27 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_28 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_29 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_30 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_31 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_32 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_33 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=128)
-        self.n_Conv_34 = nn.Conv2d(kernel_size=(3, 3), in_channels=128, out_channels=128)
-        self.n_Conv_35 = nn.Conv2d(kernel_size=(1, 1), in_channels=128, out_channels=512)
-        self.n_Conv_36 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=1024, stride=(2, 2))
-        self.n_Conv_37 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=256)
-        self.n_Conv_38 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256, stride=(2, 2))
-        self.n_Conv_39 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_40 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_41 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_42 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_43 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_44 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_45 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_46 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_47 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_48 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_49 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_50 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_51 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_52 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_53 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_54 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_55 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_56 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_57 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_58 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_59 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_60 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_61 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_62 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_63 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_64 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_65 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_66 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_67 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_68 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_69 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_70 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_71 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_72 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_73 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_74 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_75 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_76 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_77 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_78 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_79 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_80 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_81 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_82 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_83 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_84 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_85 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_86 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_87 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_88 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_89 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_90 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_91 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_92 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_93 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_94 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_95 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_96 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_97 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_98 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256, stride=(2, 2))
-        self.n_Conv_99 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_100 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=1024, stride=(2, 2))
-        self.n_Conv_101 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_102 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_103 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_104 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_105 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_106 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_107 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_108 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_109 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_110 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_111 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_112 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_113 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_114 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_115 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_116 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_117 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_118 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_119 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_120 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_121 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_122 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_123 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_124 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_125 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_126 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_127 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_128 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_129 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_130 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_131 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_132 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_133 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_134 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_135 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_136 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_137 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_138 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_139 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_140 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_141 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_142 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_143 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_144 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_145 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_146 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_147 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_148 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_149 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_150 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_151 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_152 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_153 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_154 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_155 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=256)
-        self.n_Conv_156 = nn.Conv2d(kernel_size=(3, 3), in_channels=256, out_channels=256)
-        self.n_Conv_157 = nn.Conv2d(kernel_size=(1, 1), in_channels=256, out_channels=1024)
-        self.n_Conv_158 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=2048, stride=(2, 2))
-        self.n_Conv_159 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=512)
-        self.n_Conv_160 = nn.Conv2d(kernel_size=(3, 3), in_channels=512, out_channels=512, stride=(2, 2))
-        self.n_Conv_161 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=2048)
-        self.n_Conv_162 = nn.Conv2d(kernel_size=(1, 1), in_channels=2048, out_channels=512)
-        self.n_Conv_163 = nn.Conv2d(kernel_size=(3, 3), in_channels=512, out_channels=512)
-        self.n_Conv_164 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=2048)
-        self.n_Conv_165 = nn.Conv2d(kernel_size=(1, 1), in_channels=2048, out_channels=512)
-        self.n_Conv_166 = nn.Conv2d(kernel_size=(3, 3), in_channels=512, out_channels=512)
-        self.n_Conv_167 = nn.Conv2d(kernel_size=(1, 1), in_channels=512, out_channels=2048)
-        self.n_Conv_168 = nn.Conv2d(kernel_size=(1, 1), in_channels=2048, out_channels=4096, stride=(2, 2))
-        self.n_Conv_169 = nn.Conv2d(kernel_size=(1, 1), in_channels=2048, out_channels=1024)
-        self.n_Conv_170 = nn.Conv2d(kernel_size=(3, 3), in_channels=1024, out_channels=1024, stride=(2, 2))
-        self.n_Conv_171 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=4096)
-        self.n_Conv_172 = nn.Conv2d(kernel_size=(1, 1), in_channels=4096, out_channels=1024)
-        self.n_Conv_173 = nn.Conv2d(kernel_size=(3, 3), in_channels=1024, out_channels=1024)
-        self.n_Conv_174 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=4096)
-        self.n_Conv_175 = nn.Conv2d(kernel_size=(1, 1), in_channels=4096, out_channels=1024)
-        self.n_Conv_176 = nn.Conv2d(kernel_size=(3, 3), in_channels=1024, out_channels=1024)
-        self.n_Conv_177 = nn.Conv2d(kernel_size=(1, 1), in_channels=1024, out_channels=4096)
-        self.n_Conv_178 = nn.Conv2d(kernel_size=(1, 1), in_channels=4096, out_channels=9176, bias=False)
+        self.n_Conv_11 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=512, stride=(2, 2)
+        )
+        self.n_Conv_12 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=128
+        )
+        self.n_Conv_13 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128, stride=(2, 2)
+        )
+        self.n_Conv_14 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_15 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_16 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_17 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_18 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_19 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_20 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_21 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_22 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_23 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_24 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_25 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_26 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_27 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_28 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_29 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_30 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_31 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_32 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_33 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=128
+        )
+        self.n_Conv_34 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=128, out_channels=128
+        )
+        self.n_Conv_35 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=128, out_channels=512
+        )
+        self.n_Conv_36 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=1024, stride=(2, 2)
+        )
+        self.n_Conv_37 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=256
+        )
+        self.n_Conv_38 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256, stride=(2, 2)
+        )
+        self.n_Conv_39 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_40 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_41 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_42 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_43 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_44 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_45 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_46 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_47 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_48 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_49 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_50 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_51 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_52 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_53 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_54 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_55 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_56 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_57 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_58 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_59 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_60 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_61 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_62 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_63 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_64 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_65 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_66 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_67 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_68 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_69 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_70 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_71 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_72 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_73 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_74 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_75 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_76 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_77 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_78 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_79 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_80 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_81 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_82 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_83 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_84 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_85 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_86 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_87 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_88 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_89 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_90 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_91 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_92 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_93 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_94 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_95 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_96 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_97 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_98 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256, stride=(2, 2)
+        )
+        self.n_Conv_99 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_100 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=1024, stride=(2, 2)
+        )
+        self.n_Conv_101 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_102 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_103 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_104 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_105 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_106 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_107 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_108 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_109 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_110 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_111 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_112 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_113 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_114 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_115 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_116 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_117 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_118 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_119 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_120 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_121 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_122 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_123 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_124 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_125 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_126 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_127 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_128 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_129 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_130 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_131 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_132 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_133 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_134 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_135 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_136 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_137 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_138 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_139 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_140 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_141 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_142 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_143 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_144 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_145 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_146 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_147 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_148 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_149 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_150 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_151 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_152 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_153 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_154 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_155 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=256
+        )
+        self.n_Conv_156 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=256, out_channels=256
+        )
+        self.n_Conv_157 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=256, out_channels=1024
+        )
+        self.n_Conv_158 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=2048, stride=(2, 2)
+        )
+        self.n_Conv_159 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=512
+        )
+        self.n_Conv_160 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=512, out_channels=512, stride=(2, 2)
+        )
+        self.n_Conv_161 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=2048
+        )
+        self.n_Conv_162 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=2048, out_channels=512
+        )
+        self.n_Conv_163 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=512, out_channels=512
+        )
+        self.n_Conv_164 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=2048
+        )
+        self.n_Conv_165 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=2048, out_channels=512
+        )
+        self.n_Conv_166 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=512, out_channels=512
+        )
+        self.n_Conv_167 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=512, out_channels=2048
+        )
+        self.n_Conv_168 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=2048, out_channels=4096, stride=(2, 2)
+        )
+        self.n_Conv_169 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=2048, out_channels=1024
+        )
+        self.n_Conv_170 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=1024, out_channels=1024, stride=(2, 2)
+        )
+        self.n_Conv_171 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=4096
+        )
+        self.n_Conv_172 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=4096, out_channels=1024
+        )
+        self.n_Conv_173 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=1024, out_channels=1024
+        )
+        self.n_Conv_174 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=4096
+        )
+        self.n_Conv_175 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=4096, out_channels=1024
+        )
+        self.n_Conv_176 = nn.Conv2d(
+            kernel_size=(3, 3), in_channels=1024, out_channels=1024
+        )
+        self.n_Conv_177 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=1024, out_channels=4096
+        )
+        self.n_Conv_178 = nn.Conv2d(
+            kernel_size=(1, 1), in_channels=4096, out_channels=9176, bias=False
+        )
 
     def forward(self, *inputs):
-        t_358, = inputs
+        (t_358,) = inputs
         t_359 = t_358.permute(*[0, 3, 1, 2])
         t_359_padded = F.pad(t_359, [2, 3, 2, 3], value=0)
-        t_360 = self.n_Conv_0(t_359_padded.to(self.n_Conv_0.bias.dtype) if devices.unet_needs_upcast else t_359_padded)
+        t_360 = self.n_Conv_0(
+            t_359_padded.to(self.n_Conv_0.bias.dtype)
+            if devices.unet_needs_upcast
+            else t_359_padded
+        )
         t_361 = F.relu(t_360)
-        t_361 = F.pad(t_361, [0, 1, 0, 1], value=float('-inf'))
+        t_361 = F.pad(t_361, [0, 1, 0, 1], value=float("-inf"))
         t_362 = self.n_MaxPool_0(t_361)
         t_363 = self.n_Conv_1(t_362)
         t_364 = self.n_Conv_2(t_362)
@@ -672,7 +1014,8 @@ class DeepDanbooruModel(nn.Module):
         return t_771
 
     def load_state_dict(self, state_dict, **kwargs):
-        self.tags = state_dict.get('tags', [])
+        self.tags = state_dict.get("tags", [])
 
-        super(DeepDanbooruModel, self).load_state_dict({k: v for k, v in state_dict.items() if k != 'tags'})
-
+        super(DeepDanbooruModel, self).load_state_dict(
+            {k: v for k, v in state_dict.items() if k != "tags"}
+        )

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -26,10 +26,10 @@ def has_mps() -> bool:
 def cuda_no_autocast(device_id=None) -> bool:
     if device_id is None:
         device_id = get_cuda_device_id()
-    return (
-        torch.cuda.get_device_capability(device_id) == (7, 5)
-        and torch.cuda.get_device_name(device_id).startswith("NVIDIA GeForce GTX 16")
-    )
+    return torch.cuda.get_device_capability(device_id) == (
+        7,
+        5,
+    ) and torch.cuda.get_device_name(device_id).startswith("NVIDIA GeForce GTX 16")
 
 
 def get_cuda_device_id():
@@ -75,7 +75,6 @@ def get_device_for(task):
 
 
 def torch_gc():
-
     if torch.cuda.is_available():
         with torch.cuda.device(get_cuda_device_string()):
             torch.cuda.empty_cache()
@@ -100,7 +99,6 @@ def torch_npu_set_device():
 
 def enable_tf32():
     if torch.cuda.is_available():
-
         # enabling benchmark option seems to enable a range of cards to do fp16 when they otherwise can't
         # see https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4407
         if cuda_no_autocast():
@@ -152,11 +150,16 @@ patch_module_list = [
 def manual_cast_forward(target_dtype):
     def forward_wrapper(self, *args, **kwargs):
         if any(
-            isinstance(arg, torch.Tensor) and arg.dtype != target_dtype
-            for arg in args
+            isinstance(arg, torch.Tensor) and arg.dtype != target_dtype for arg in args
         ):
-            args = [arg.to(target_dtype) if isinstance(arg, torch.Tensor) else arg for arg in args]
-            kwargs = {k: v.to(target_dtype) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
+            args = [
+                arg.to(target_dtype) if isinstance(arg, torch.Tensor) else arg
+                for arg in args
+            ]
+            kwargs = {
+                k: v.to(target_dtype) if isinstance(v, torch.Tensor) else v
+                for k, v in kwargs.items()
+            }
 
         org_dtype = target_dtype
         for param in self.parameters():
@@ -173,14 +176,13 @@ def manual_cast_forward(target_dtype):
         if target_dtype != dtype_inference:
             if isinstance(result, tuple):
                 result = tuple(
-                    i.to(dtype_inference)
-                    if isinstance(i, torch.Tensor)
-                    else i
+                    i.to(dtype_inference) if isinstance(i, torch.Tensor) else i
                     for i in result
                 )
             elif isinstance(result, torch.Tensor):
                 result = result.to(dtype_inference)
         return result
+
     return forward_wrapper
 
 
@@ -216,7 +218,7 @@ def autocast(disable=False):
         # All tensor dtype conversion happens before inference.
         return contextlib.nullcontext()
 
-    if fp8 and device==cpu:
+    if fp8 and device == cpu:
         return torch.autocast("cpu", dtype=torch.bfloat16, enabled=True)
 
     if fp8 and dtype_inference == torch.float32:
@@ -232,7 +234,11 @@ def autocast(disable=False):
 
 
 def without_autocast(disable=False):
-    return torch.autocast("cuda", enabled=False) if torch.is_autocast_enabled() and not disable else contextlib.nullcontext()
+    return (
+        torch.autocast("cuda", enabled=False)
+        if torch.is_autocast_enabled() and not disable
+        else contextlib.nullcontext()
+    )
 
 
 class NansException(Exception):
@@ -243,14 +249,14 @@ def test_for_nans(x, where):
     if shared.cmd_opts.disable_nan_check:
         return
 
-    if not torch.isnan(x[(0, ) * len(x.shape)]):
+    if not torch.isnan(x[(0,) * len(x.shape)]):
         return
 
     if where == "unet":
         message = "A tensor with NaNs was produced in Unet."
 
         if not shared.cmd_opts.no_half:
-            message += " This could be either because there's not enough precision to represent the picture, or because your video card does not support half type. Try setting the \"Upcast cross attention layer to float32\" option in Settings > Stable Diffusion or using the --no-half commandline argument to fix this."
+            message += ' This could be either because there\'s not enough precision to represent the picture, or because your video card does not support half type. Try setting the "Upcast cross attention layer to float32" option in Settings > Stable Diffusion or using the --no-half commandline argument to fix this.'
 
     elif where == "vae":
         message = "A tensor with NaNs was produced in VAE."
@@ -290,6 +296,9 @@ def force_model_fp16():
     assert force_fp16
     import sgm.modules.diffusionmodules.util as sgm_util
     import ldm.modules.diffusionmodules.util as ldm_util
+
     sgm_util.GroupNorm32 = torch.nn.GroupNorm
     ldm_util.GroupNorm32 = torch.nn.GroupNorm
-    print("ldm/sgm GroupNorm32 replaced with normal torch.nn.GroupNorm due to `--precision half`.")
+    print(
+        "ldm/sgm GroupNorm32 replaced with normal torch.nn.GroupNorm due to `--precision half`."
+    )

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -7,7 +7,10 @@ exception_records = []
 
 
 def format_traceback(tb):
-    return [[f"{x.filename}, line {x.lineno}, {x.name}", x.line] for x in traceback.extract_tb(tb)]
+    return [
+        [f"{x.filename}, line {x.lineno}, {x.name}", x.line]
+        for x in traceback.extract_tb(tb)
+    ]
 
 
 def format_exception(e, tb):
@@ -55,10 +58,10 @@ def print_error_explanation(message):
     lines = message.strip().split("\n")
     max_len = max([len(x) for x in lines])
 
-    print('=' * max_len, file=sys.stderr)
+    print("=" * max_len, file=sys.stderr)
     for line in lines:
         print(line, file=sys.stderr)
-    print('=' * max_len, file=sys.stderr)
+    print("=" * max_len, file=sys.stderr)
 
 
 def display(e: Exception, task, *, full_traceback=False):
@@ -72,7 +75,10 @@ def display(e: Exception, task, *, full_traceback=False):
     print(*te.format(), sep="", file=sys.stderr)
 
     message = str(e)
-    if "copying a param with shape torch.Size([640, 1024]) from checkpoint, the shape in current model is torch.Size([640, 768])" in message:
+    if (
+        "copying a param with shape torch.Size([640, 1024]) from checkpoint, the shape in current model is torch.Size([640, 768])"
+        in message
+    ):
         print_error_explanation("""
 The most likely cause of this is you are trying to load Stable Diffusion 2.0 model without specifying its config file.
 See https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#stable-diffusion-20 for how to solve this.
@@ -112,7 +118,8 @@ def check_versions():
     expected_gradio_version = "3.41.2"
 
     if version.parse(torch.__version__) < version.parse(expected_torch_version):
-        print_error_explanation(f"""
+        print_error_explanation(
+            f"""
 You are running torch {torch.__version__}.
 The program is tested to work with torch {expected_torch_version}.
 To reinstall the desired version, run with commandline flag --reinstall-torch.
@@ -120,22 +127,28 @@ Beware that this will cause a lot of large files to be downloaded, as well as
 there are reports of issues with training tab on the latest version.
 
 Use --skip-version-check commandline argument to disable this check.
-        """.strip())
+        """.strip()
+        )
 
     if shared.xformers_available:
         import xformers
 
-        if version.parse(xformers.__version__) < version.parse(expected_xformers_version):
-            print_error_explanation(f"""
+        if version.parse(xformers.__version__) < version.parse(
+            expected_xformers_version
+        ):
+            print_error_explanation(
+                f"""
 You are running xformers {xformers.__version__}.
 The program is tested to work with xformers {expected_xformers_version}.
 To reinstall the desired version, run with commandline flag --reinstall-xformers.
 
 Use --skip-version-check commandline argument to disable this check.
-            """.strip())
+            """.strip()
+            )
 
     if gradio.__version__ != expected_gradio_version:
-        print_error_explanation(f"""
+        print_error_explanation(
+            f"""
 You are running gradio {gradio.__version__}.
 The program is designed to work with gradio {expected_gradio_version}.
 Using a different version of gradio is extremely likely to break the program.
@@ -146,5 +159,5 @@ Reasons why you have the mismatched gradio version can be:
   - an extension installs the incompatible gradio version.
 
 Use --skip-version-check commandline argument to disable this check.
-        """.strip())
-
+        """.strip()
+        )

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -7,7 +7,9 @@ from modules.upscaler_utils import upscale_with_model
 class UpscalerESRGAN(Upscaler):
     def __init__(self, dirname):
         self.name = "ESRGAN"
-        self.model_url = "https://github.com/cszn/KAIR/releases/download/v1.0/ESRGAN.pth"
+        self.model_url = (
+            "https://github.com/cszn/KAIR/releases/download/v1.0/ESRGAN.pth"
+        )
         self.model_name = "ESRGAN_4x"
         self.scalers = []
         self.user_path = dirname
@@ -30,7 +32,9 @@ class UpscalerESRGAN(Upscaler):
         try:
             model = self.load_model(selected_model)
         except Exception:
-            errors.report(f"Unable to load ESRGAN model {selected_model}", exc_info=True)
+            errors.report(
+                f"Unable to load ESRGAN model {selected_model}", exc_info=True
+            )
             return img
         model.to(devices.device_esrgan)
         return esrgan_upscale(model, img)
@@ -48,8 +52,8 @@ class UpscalerESRGAN(Upscaler):
 
         return modelloader.load_spandrel_model(
             filename,
-            device=('cpu' if devices.device_esrgan.type == 'mps' else None),
-            expected_architecture='ESRGAN',
+            device=("cpu" if devices.device_esrgan.type == "mps" else None),
+            expected_architecture="ESRGAN",
         )
 
 

--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -19,9 +19,15 @@ os.makedirs(extensions_dir, exist_ok=True)
 
 
 def active():
-    if shared.cmd_opts.disable_all_extensions or shared.opts.disable_all_extensions == "all":
+    if (
+        shared.cmd_opts.disable_all_extensions
+        or shared.opts.disable_all_extensions == "all"
+    ):
         return []
-    elif shared.cmd_opts.disable_extra_extensions or shared.opts.disable_all_extensions == "extra":
+    elif (
+        shared.cmd_opts.disable_extra_extensions
+        or shared.opts.disable_all_extensions == "extra"
+    ):
         return [x for x in extensions if x.enabled and x.is_builtin]
     else:
         return [x for x in extensions if x.enabled]
@@ -49,9 +55,14 @@ class ExtensionMetadata:
         try:
             self.config.read(filepath)
         except Exception:
-            errors.report(f"Error reading {self.filename} for extension {canonical_name}.", exc_info=True)
+            errors.report(
+                f"Error reading {self.filename} for extension {canonical_name}.",
+                exc_info=True,
+            )
 
-        self.canonical_name = self.config.get("Extension", "Name", fallback=canonical_name)
+        self.canonical_name = self.config.get(
+            "Extension", "Name", fallback=canonical_name
+        )
         self.canonical_name = canonical_name.lower().strip()
 
         self.requires = None
@@ -61,16 +72,18 @@ class ExtensionMetadata:
         like Requires or Before, and section is the name of the [section] in the ini file; additionally,
         reads more requirements from [extra_section] if specified."""
 
-        x = self.config.get(section, field, fallback='')
+        x = self.config.get(section, field, fallback="")
 
         if extra_section:
-            x = x + ', ' + self.config.get(extra_section, field, fallback='')
+            x = x + ", " + self.config.get(extra_section, field, fallback="")
 
         listed_requirements = self.parse_list(x.lower())
         res = []
 
         for requirement in listed_requirements:
-            loaded_requirements = (x for x in requirement.split("|") if x in loaded_extensions)
+            loaded_requirements = (
+                x for x in requirement.split("|") if x in loaded_extensions
+            )
             relevant_requirement = next(loaded_requirements, requirement)
             res.append(relevant_requirement)
 
@@ -93,34 +106,38 @@ class ExtensionMetadata:
             callback_name = section[10:]
 
             if not callback_name.startswith(self.canonical_name):
-                errors.report(f"Callback order section for extension {self.canonical_name} is referencing the wrong extension: {section}")
+                errors.report(
+                    f"Callback order section for extension {self.canonical_name} is referencing the wrong extension: {section}"
+                )
                 continue
 
-            before = self.parse_list(self.config.get(section, 'Before', fallback=''))
-            after = self.parse_list(self.config.get(section, 'After', fallback=''))
+            before = self.parse_list(self.config.get(section, "Before", fallback=""))
+            after = self.parse_list(self.config.get(section, "After", fallback=""))
 
             yield CallbackOrderInfo(callback_name, before, after)
 
 
 class Extension:
     lock = threading.Lock()
-    cached_fields = ['remote', 'commit_date', 'branch', 'commit_hash', 'version']
+    cached_fields = ["remote", "commit_date", "branch", "commit_hash", "version"]
     metadata: ExtensionMetadata
 
     def __init__(self, name, path, enabled=True, is_builtin=False, metadata=None):
         self.name = name
         self.path = path
         self.enabled = enabled
-        self.status = ''
+        self.status = ""
         self.can_update = False
         self.is_builtin = is_builtin
-        self.commit_hash = ''
+        self.commit_hash = ""
         self.commit_date = None
-        self.version = ''
+        self.version = ""
         self.branch = None
         self.remote = None
         self.have_info_from_repo = False
-        self.metadata = metadata if metadata else ExtensionMetadata(self.path, name.lower())
+        self.metadata = (
+            metadata if metadata else ExtensionMetadata(self.path, name.lower())
+        )
         self.canonical_name = metadata.canonical_name
 
     def to_dict(self):
@@ -144,11 +161,16 @@ class Extension:
                 return self.to_dict()
 
         try:
-            d = cache.cached_data_for_file('extensions-git', self.name, os.path.join(self.path, ".git"), read_from_repo)
+            d = cache.cached_data_for_file(
+                "extensions-git",
+                self.name,
+                os.path.join(self.path, ".git"),
+                read_from_repo,
+            )
             self.from_dict(d)
         except FileNotFoundError:
             pass
-        self.status = 'unknown' if self.status == '' else self.status
+        self.status = "unknown" if self.status == "" else self.status
 
     def do_read_info_from_repo(self):
         repo = None
@@ -156,7 +178,9 @@ class Extension:
             if os.path.exists(os.path.join(self.path, ".git")):
                 repo = Repo(self.path)
         except Exception:
-            errors.report(f"Error reading github repository info from {self.path}", exc_info=True)
+            errors.report(
+                f"Error reading github repository info from {self.path}", exc_info=True
+            )
 
         if repo is None or repo.bare:
             self.remote = None
@@ -171,7 +195,10 @@ class Extension:
                 self.version = self.commit_hash[:8]
 
             except Exception:
-                errors.report(f"Failed reading extension data from Git repository ({self.name})", exc_info=True)
+                errors.report(
+                    f"Failed reading extension data from Git repository ({self.name})",
+                    exc_info=True,
+                )
                 self.remote = None
 
         self.have_info_from_repo = True
@@ -183,15 +210,22 @@ class Extension:
 
         res = []
         for filename in sorted(os.listdir(dirpath)):
-            res.append(scripts.ScriptFile(self.path, filename, os.path.join(dirpath, filename)))
+            res.append(
+                scripts.ScriptFile(self.path, filename, os.path.join(dirpath, filename))
+            )
 
-        res = [x for x in res if os.path.splitext(x.path)[1].lower() == extension and os.path.isfile(x.path)]
+        res = [
+            x
+            for x in res
+            if os.path.splitext(x.path)[1].lower() == extension
+            and os.path.isfile(x.path)
+        ]
 
         return res
 
     def check_updates(self):
         repo = Repo(self.path)
-        branch_name = f'{repo.remote().name}/{self.branch}'
+        branch_name = f"{repo.remote().name}/{self.branch}"
         for fetch in repo.remote().fetch(dry_run=True):
             if self.branch and fetch.name != branch_name:
                 continue
@@ -217,7 +251,7 @@ class Extension:
     def fetch_and_reset_hard(self, commit=None):
         repo = Repo(self.path)
         if commit is None:
-            commit = f'{repo.remote().name}/{self.branch}'
+            commit = f"{repo.remote().name}/{self.branch}"
         # Fix: `error: Your local changes to the following files would be overwritten by merge`,
         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
         repo.git.fetch(all=True)
@@ -231,14 +265,21 @@ def list_extensions():
     loaded_extensions.clear()
 
     if shared.cmd_opts.disable_all_extensions:
-        print("*** \"--disable-all-extensions\" arg was used, will not load any extensions ***")
+        print(
+            '*** "--disable-all-extensions" arg was used, will not load any extensions ***'
+        )
     elif shared.opts.disable_all_extensions == "all":
-        print("*** \"Disable all extensions\" option was set, will not load any extensions ***")
+        print(
+            '*** "Disable all extensions" option was set, will not load any extensions ***'
+        )
     elif shared.cmd_opts.disable_extra_extensions:
-        print("*** \"--disable-extra-extensions\" arg was used, will only load built-in extensions ***")
+        print(
+            '*** "--disable-extra-extensions" arg was used, will only load built-in extensions ***'
+        )
     elif shared.opts.disable_all_extensions == "extra":
-        print("*** \"Disable all extensions\" option was set, will only load built-in extensions ***")
-
+        print(
+            '*** "Disable all extensions" option was set, will only load built-in extensions ***'
+        )
 
     # scan through extensions directory and load metadata
     for dirname in [extensions_builtin_dir, extensions_dir]:
@@ -256,17 +297,28 @@ def list_extensions():
             # check for duplicated canonical names
             already_loaded_extension = loaded_extensions.get(metadata.canonical_name)
             if already_loaded_extension is not None:
-                errors.report(f'Duplicate canonical name "{canonical_name}" found in extensions "{extension_dirname}" and "{already_loaded_extension.name}". Former will be discarded.', exc_info=False)
+                errors.report(
+                    f'Duplicate canonical name "{canonical_name}" found in extensions "{extension_dirname}" and "{already_loaded_extension.name}". Former will be discarded.',
+                    exc_info=False,
+                )
                 continue
 
             is_builtin = dirname == extensions_builtin_dir
-            extension = Extension(name=extension_dirname, path=path, enabled=extension_dirname not in shared.opts.disabled_extensions, is_builtin=is_builtin, metadata=metadata)
+            extension = Extension(
+                name=extension_dirname,
+                path=path,
+                enabled=extension_dirname not in shared.opts.disabled_extensions,
+                is_builtin=is_builtin,
+                metadata=metadata,
+            )
             extensions.append(extension)
             extension_paths[extension.path] = extension
             loaded_extensions[canonical_name] = extension
 
     for extension in extensions:
-        extension.metadata.requires = extension.metadata.get_script_requirements("Requires", "Extension")
+        extension.metadata.requires = extension.metadata.get_script_requirements(
+            "Requires", "Extension"
+        )
 
     # check for requirements
     for extension in extensions:
@@ -276,11 +328,17 @@ def list_extensions():
         for req in extension.metadata.requires:
             required_extension = loaded_extensions.get(req)
             if required_extension is None:
-                errors.report(f'Extension "{extension.name}" requires "{req}" which is not installed.', exc_info=False)
+                errors.report(
+                    f'Extension "{extension.name}" requires "{req}" which is not installed.',
+                    exc_info=False,
+                )
                 continue
 
             if not required_extension.enabled:
-                errors.report(f'Extension "{extension.name}" requires "{required_extension.name}" which is disabled.', exc_info=False)
+                errors.report(
+                    f'Extension "{extension.name}" requires "{required_extension.name}" which is disabled.',
+                    exc_info=False,
+                )
                 continue
 
 
@@ -296,4 +354,3 @@ def find_extension(filename):
         parentdir = os.path.dirname(filename)
 
     return None
-

--- a/modules/extra_networks.py
+++ b/modules/extra_networks.py
@@ -25,6 +25,7 @@ def register_extra_network_alias(extra_network, alias):
 
 def register_default_extra_networks():
     from modules.extra_networks_hypernet import ExtraNetworkHypernet
+
     register_extra_network(ExtraNetworkHypernet())
 
 
@@ -35,7 +36,7 @@ class ExtraNetworkParams:
         self.named = {}
 
         for item in self.items:
-            parts = item.split('=', 2) if isinstance(item, str) else [item]
+            parts = item.split("=", 2) if isinstance(item, str) else [item]
             if len(parts) == 2:
                 self.named[parts[0]] = parts[1]
             else:
@@ -129,13 +130,17 @@ def activate(p, extra_network_data):
 
     activated = []
 
-    for extra_network, extra_network_args in lookup_extra_networks(extra_network_data).items():
-
+    for extra_network, extra_network_args in lookup_extra_networks(
+        extra_network_data
+    ).items():
         try:
             extra_network.activate(p, extra_network_args)
             activated.append(extra_network)
         except Exception as e:
-            errors.display(e, f"activating extra network {extra_network.name} with arguments {extra_network_args}")
+            errors.display(
+                e,
+                f"activating extra network {extra_network.name} with arguments {extra_network_args}",
+            )
 
     for extra_network_name, extra_network in extra_network_registry.items():
         if extra_network in activated:
@@ -147,7 +152,14 @@ def activate(p, extra_network_data):
             errors.display(e, f"activating extra network {extra_network_name}")
 
     if p.scripts is not None:
-        p.scripts.after_extra_networks_activate(p, batch_number=p.iteration, prompts=p.prompts, seeds=p.seeds, subseeds=p.subseeds, extra_network_data=extra_network_data)
+        p.scripts.after_extra_networks_activate(
+            p,
+            batch_number=p.iteration,
+            prompts=p.prompts,
+            seeds=p.seeds,
+            subseeds=p.subseeds,
+            extra_network_data=extra_network_data,
+        )
 
 
 def deactivate(p, extra_network_data):
@@ -169,7 +181,9 @@ def deactivate(p, extra_network_data):
         try:
             extra_network.deactivate(p)
         except Exception as e:
-            errors.display(e, f"deactivating unmentioned extra network {extra_network_name}")
+            errors.display(
+                e, f"deactivating unmentioned extra network {extra_network_name}"
+            )
 
 
 re_extra_net = re.compile(r"<(\w+):([^>]+)>")
@@ -211,15 +225,21 @@ def get_user_metadata(filename, lister=None):
         return {}
 
     basename, ext = os.path.splitext(filename)
-    metadata_filename = basename + '.json'
+    metadata_filename = basename + ".json"
 
     metadata = {}
     try:
-        exists = lister.exists(metadata_filename) if lister else os.path.exists(metadata_filename)
+        exists = (
+            lister.exists(metadata_filename)
+            if lister
+            else os.path.exists(metadata_filename)
+        )
         if exists:
             with open(metadata_filename, "r", encoding="utf8") as file:
                 metadata = json.load(file)
     except Exception as e:
-        errors.display(e, f"reading extra network user metadata from {metadata_filename}")
+        errors.display(
+            e, f"reading extra network user metadata from {metadata_filename}"
+        )
 
     return metadata

--- a/modules/extra_networks_hypernet.py
+++ b/modules/extra_networks_hypernet.py
@@ -4,15 +4,25 @@ from modules.hypernetworks import hypernetwork
 
 class ExtraNetworkHypernet(extra_networks.ExtraNetwork):
     def __init__(self):
-        super().__init__('hypernet')
+        super().__init__("hypernet")
 
     def activate(self, p, params_list):
         additional = shared.opts.sd_hypernetwork
 
-        if additional != "None" and additional in shared.hypernetworks and not any(x for x in params_list if x.items[0] == additional):
+        if (
+            additional != "None"
+            and additional in shared.hypernetworks
+            and not any(x for x in params_list if x.items[0] == additional)
+        ):
             hypernet_prompt_text = f"<hypernet:{additional}:{shared.opts.extra_networks_default_multiplier}>"
-            p.all_prompts = [f"{prompt}{hypernet_prompt_text}" for prompt in p.all_prompts]
-            params_list.append(extra_networks.ExtraNetworkParams(items=[additional, shared.opts.extra_networks_default_multiplier]))
+            p.all_prompts = [
+                f"{prompt}{hypernet_prompt_text}" for prompt in p.all_prompts
+            ]
+            params_list.append(
+                extra_networks.ExtraNetworkParams(
+                    items=[additional, shared.opts.extra_networks_default_multiplier]
+                )
+            )
 
         names = []
         multipliers = []

--- a/modules/extras.py
+++ b/modules/extras.py
@@ -15,25 +15,28 @@ import safetensors.torch
 
 def run_pnginfo(image):
     if image is None:
-        return '', '', ''
+        return "", "", ""
 
     geninfo, items = images.read_info_from_image(image)
-    items = {**{'parameters': geninfo}, **items}
+    items = {**{"parameters": geninfo}, **items}
 
-    info = ''
+    info = ""
     for key, text in items.items():
-        info += f"""
+        info += (
+            f"""
 <div>
 <p><b>{plaintext_to_html(str(key))}</b></p>
 <p>{plaintext_to_html(str(text))}</p>
 </div>
-""".strip()+"\n"
+""".strip()
+            + "\n"
+        )
 
     if len(info) == 0:
         message = "Nothing found in the image."
         info = f"<div><p>{message}<p></div>"
 
-    return '', geninfo, info
+    return "", geninfo, info
 
 
 def create_config(ckpt_result, config_source, a, b, c):
@@ -62,7 +65,9 @@ def create_config(ckpt_result, config_source, a, b, c):
     shutil.copyfile(cfg, checkpoint_filename)
 
 
-checkpoint_dict_skip_on_merge = ["cond_stage_model.transformer.text_model.embeddings.position_ids"]
+checkpoint_dict_skip_on_merge = [
+    "cond_stage_model.transformer.text_model.embeddings.position_ids"
+]
 
 
 def to_half(tensor, enable):
@@ -75,7 +80,11 @@ def to_half(tensor, enable):
 def read_metadata(primary_model_name, secondary_model_name, tertiary_model_name):
     metadata = {}
 
-    for checkpoint_name in [primary_model_name, secondary_model_name, tertiary_model_name]:
+    for checkpoint_name in [
+        primary_model_name,
+        secondary_model_name,
+        tertiary_model_name,
+    ]:
         checkpoint_info = sd_models.checkpoints_list.get(checkpoint_name, None)
         if checkpoint_info is None:
             continue
@@ -85,7 +94,24 @@ def read_metadata(primary_model_name, secondary_model_name, tertiary_model_name)
     return json.dumps(metadata, indent=4, ensure_ascii=False)
 
 
-def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_model_name, interp_method, multiplier, save_as_half, custom_name, checkpoint_format, config_source, bake_in_vae, discard_weights, save_metadata, add_merge_recipe, copy_metadata_fields, metadata_json):
+def run_modelmerger(
+    id_task,
+    primary_model_name,
+    secondary_model_name,
+    tertiary_model_name,
+    interp_method,
+    multiplier,
+    save_as_half,
+    custom_name,
+    checkpoint_format,
+    config_source,
+    bake_in_vae,
+    discard_weights,
+    save_metadata,
+    add_merge_recipe,
+    copy_metadata_fields,
+    metadata_json,
+):
     shared.state.begin(job="model-merge")
 
     def fail(message):
@@ -137,12 +163,18 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     if theta_func2 and not secondary_model_name:
         return fail("Failed: Merging requires a secondary model.")
 
-    secondary_model_info = sd_models.checkpoints_list[secondary_model_name] if theta_func2 else None
+    secondary_model_info = (
+        sd_models.checkpoints_list[secondary_model_name] if theta_func2 else None
+    )
 
     if theta_func1 and not tertiary_model_name:
-        return fail(f"Failed: Interpolation method ({interp_method}) requires a tertiary model.")
+        return fail(
+            f"Failed: Interpolation method ({interp_method}) requires a tertiary model."
+        )
 
-    tertiary_model_info = sd_models.checkpoints_list[tertiary_model_name] if theta_func1 else None
+    tertiary_model_info = (
+        sd_models.checkpoints_list[tertiary_model_name] if theta_func1 else None
+    )
 
     result_is_inpainting_model = False
     result_is_instruct_pix2pix_model = False
@@ -150,22 +182,26 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     if theta_func2:
         shared.state.textinfo = "Loading B"
         print(f"Loading {secondary_model_info.filename}...")
-        theta_1 = sd_models.read_state_dict(secondary_model_info.filename, map_location='cpu')
+        theta_1 = sd_models.read_state_dict(
+            secondary_model_info.filename, map_location="cpu"
+        )
     else:
         theta_1 = None
 
     if theta_func1:
         shared.state.textinfo = "Loading C"
         print(f"Loading {tertiary_model_info.filename}...")
-        theta_2 = sd_models.read_state_dict(tertiary_model_info.filename, map_location='cpu')
+        theta_2 = sd_models.read_state_dict(
+            tertiary_model_info.filename, map_location="cpu"
+        )
 
-        shared.state.textinfo = 'Merging B and C'
+        shared.state.textinfo = "Merging B and C"
         shared.state.sampling_steps = len(theta_1.keys())
         for key in tqdm.tqdm(theta_1.keys()):
             if key in checkpoint_dict_skip_on_merge:
                 continue
 
-            if 'model' in key:
+            if "model" in key:
                 if key in theta_2:
                     t2 = theta_2.get(key, torch.zeros_like(theta_1[key]))
                     theta_1[key] = theta_func1(theta_1[key], t2)
@@ -179,14 +215,13 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     shared.state.textinfo = f"Loading {primary_model_info.filename}..."
     print(f"Loading {primary_model_info.filename}...")
-    theta_0 = sd_models.read_state_dict(primary_model_info.filename, map_location='cpu')
+    theta_0 = sd_models.read_state_dict(primary_model_info.filename, map_location="cpu")
 
     print("Merging...")
-    shared.state.textinfo = 'Merging A and B'
+    shared.state.textinfo = "Merging A and B"
     shared.state.sampling_steps = len(theta_0.keys())
     for key in tqdm.tqdm(theta_0.keys()):
-        if theta_1 and 'model' in key and key in theta_1:
-
+        if theta_1 and "model" in key and key in theta_1:
             if key in checkpoint_dict_skip_on_merge:
                 continue
 
@@ -196,18 +231,33 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
             # this enables merging an inpainting model (A) with another one (B);
             # where normal model would have 4 channels, for latenst space, inpainting model would
             # have another 4 channels for unmasked picture's latent space, plus one channel for mask, for a total of 9
-            if a.shape != b.shape and a.shape[0:1] + a.shape[2:] == b.shape[0:1] + b.shape[2:]:
+            if (
+                a.shape != b.shape
+                and a.shape[0:1] + a.shape[2:] == b.shape[0:1] + b.shape[2:]
+            ):
                 if a.shape[1] == 4 and b.shape[1] == 9:
-                    raise RuntimeError("When merging inpainting model with a normal one, A must be the inpainting model.")
+                    raise RuntimeError(
+                        "When merging inpainting model with a normal one, A must be the inpainting model."
+                    )
                 if a.shape[1] == 4 and b.shape[1] == 8:
-                    raise RuntimeError("When merging instruct-pix2pix model with a normal one, A must be the instruct-pix2pix model.")
+                    raise RuntimeError(
+                        "When merging instruct-pix2pix model with a normal one, A must be the instruct-pix2pix model."
+                    )
 
-                if a.shape[1] == 8 and b.shape[1] == 4:#If we have an Instruct-Pix2Pix model...
-                    theta_0[key][:, 0:4, :, :] = theta_func2(a[:, 0:4, :, :], b, multiplier)#Merge only the vectors the models have in common.  Otherwise we get an error due to dimension mismatch.
+                if (
+                    a.shape[1] == 8 and b.shape[1] == 4
+                ):  # If we have an Instruct-Pix2Pix model...
+                    theta_0[key][:, 0:4, :, :] = theta_func2(
+                        a[:, 0:4, :, :], b, multiplier
+                    )  # Merge only the vectors the models have in common.  Otherwise we get an error due to dimension mismatch.
                     result_is_instruct_pix2pix_model = True
                 else:
-                    assert a.shape[1] == 9 and b.shape[1] == 4, f"Bad dimensions for merged layer {key}: A={a.shape}, B={b.shape}"
-                    theta_0[key][:, 0:4, :, :] = theta_func2(a[:, 0:4, :, :], b, multiplier)
+                    assert (
+                        a.shape[1] == 9 and b.shape[1] == 4
+                    ), f"Bad dimensions for merged layer {key}: A={a.shape}, B={b.shape}"
+                    theta_0[key][:, 0:4, :, :] = theta_func2(
+                        a[:, 0:4, :, :], b, multiplier
+                    )
                     result_is_inpainting_model = True
             else:
                 theta_0[key] = theta_func2(a, b, multiplier)
@@ -221,11 +271,11 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
     bake_in_vae_filename = sd_vae.vae_dict.get(bake_in_vae, None)
     if bake_in_vae_filename is not None:
         print(f"Baking in VAE from {bake_in_vae_filename}")
-        shared.state.textinfo = 'Baking in VAE'
-        vae_dict = sd_vae.load_vae_dict(bake_in_vae_filename, map_location='cpu')
+        shared.state.textinfo = "Baking in VAE"
+        vae_dict = sd_vae.load_vae_dict(bake_in_vae_filename, map_location="cpu")
 
         for key in vae_dict.keys():
-            theta_0_key = 'first_stage_model.' + key
+            theta_0_key = "first_stage_model." + key
             if theta_0_key in theta_0:
                 theta_0[theta_0_key] = to_half(vae_dict[key], save_as_half)
 
@@ -243,7 +293,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     ckpt_dir = shared.cmd_opts.ckpt_dir or sd_models.model_path
 
-    filename = filename_generator() if custom_name == '' else custom_name
+    filename = filename_generator() if custom_name == "" else custom_name
     filename += ".inpainting" if result_is_inpainting_model else ""
     filename += ".instruct-pix2pix" if result_is_instruct_pix2pix_model else ""
     filename += "." + checkpoint_format
@@ -274,10 +324,14 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     if save_metadata and add_merge_recipe:
         merge_recipe = {
-            "type": "webui", # indicate this model was merged with webui's built-in merger
+            "type": "webui",  # indicate this model was merged with webui's built-in merger
             "primary_model_hash": primary_model_info.sha256,
-            "secondary_model_hash": secondary_model_info.sha256 if secondary_model_info else None,
-            "tertiary_model_hash": tertiary_model_info.sha256 if tertiary_model_info else None,
+            "secondary_model_hash": secondary_model_info.sha256
+            if secondary_model_info
+            else None,
+            "tertiary_model_hash": tertiary_model_info.sha256
+            if tertiary_model_info
+            else None,
             "interp_method": interp_method,
             "multiplier": multiplier,
             "save_as_half": save_as_half,
@@ -286,7 +340,7 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
             "bake_in_vae": bake_in_vae,
             "discard_weights": discard_weights,
             "is_inpainting": result_is_inpainting_model,
-            "is_instruct_pix2pix": result_is_instruct_pix2pix_model
+            "is_instruct_pix2pix": result_is_instruct_pix2pix_model,
         }
 
         sd_merge_models = {}
@@ -296,7 +350,9 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
             sd_merge_models[checkpoint_info.sha256] = {
                 "name": checkpoint_info.name,
                 "legacy_hash": checkpoint_info.hash,
-                "sd_merge_recipe": checkpoint_info.metadata.get("sd_merge_recipe", None)
+                "sd_merge_recipe": checkpoint_info.metadata.get(
+                    "sd_merge_recipe", None
+                ),
             }
 
             sd_merge_models.update(checkpoint_info.metadata.get("sd_merge_models", {}))
@@ -312,19 +368,33 @@ def run_modelmerger(id_task, primary_model_name, secondary_model_name, tertiary_
 
     _, extension = os.path.splitext(output_modelname)
     if extension.lower() == ".safetensors":
-        safetensors.torch.save_file(theta_0, output_modelname, metadata=metadata if len(metadata)>0 else None)
+        safetensors.torch.save_file(
+            theta_0, output_modelname, metadata=metadata if len(metadata) > 0 else None
+        )
     else:
         torch.save(theta_0, output_modelname)
 
     sd_models.list_models()
-    created_model = next((ckpt for ckpt in sd_models.checkpoints_list.values() if ckpt.name == filename), None)
+    created_model = next(
+        (ckpt for ckpt in sd_models.checkpoints_list.values() if ckpt.name == filename),
+        None,
+    )
     if created_model:
         created_model.calculate_shorthash()
 
-    create_config(output_modelname, config_source, primary_model_info, secondary_model_info, tertiary_model_info)
+    create_config(
+        output_modelname,
+        config_source,
+        primary_model_info,
+        secondary_model_info,
+        tertiary_model_info,
+    )
 
     print(f"Checkpoint saved to {output_modelname}.")
     shared.state.textinfo = "Checkpoint saved"
     shared.state.end()
 
-    return [*[gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)], "Checkpoint saved to " + output_modelname]
+    return [
+        *[gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)],
+        "Checkpoint saved to " + output_modelname,
+    ]

--- a/modules/face_restoration.py
+++ b/modules/face_restoration.py
@@ -10,7 +10,12 @@ class FaceRestoration:
 
 
 def restore_faces(np_image):
-    face_restorers = [x for x in shared.face_restorers if x.name() == shared.opts.face_restoration_model or shared.opts.face_restoration_model is None]
+    face_restorers = [
+        x
+        for x in shared.face_restorers
+        if x.name() == shared.opts.face_restoration_model
+        or shared.opts.face_restoration_model is None
+    ]
     if len(face_restorers) == 0:
         return np_image
 

--- a/modules/face_restoration_utils.py
+++ b/modules/face_restoration_utils.py
@@ -42,14 +42,15 @@ def rgb_tensor_to_bgr_image(tensor: torch.Tensor, *, min_max=(0.0, 1.0)) -> np.n
 def create_face_helper(device) -> FaceRestoreHelper:
     from facexlib.detection import retinaface
     from facexlib.utils.face_restoration_helper import FaceRestoreHelper
-    if hasattr(retinaface, 'device'):
+
+    if hasattr(retinaface, "device"):
         retinaface.device = device
     return FaceRestoreHelper(
         upscale_factor=1,
         face_size=512,
         crop_ratio=(1, 1),
-        det_model='retinaface_resnet50',
-        save_ext='png',
+        det_model="retinaface_resnet50",
+        save_ext="png",
         use_parse=True,
         device=device,
     )
@@ -66,6 +67,7 @@ def restore_with_face_helper(
     `restore_face` should take a cropped face image and return a restored face image.
     """
     from torchvision.transforms.functional import normalize
+
     np_image = np_image[:, :, ::-1]
     original_resolution = np_image.shape[0:2]
 
@@ -73,7 +75,9 @@ def restore_with_face_helper(
         logger.debug("Detecting faces...")
         face_helper.clean_all()
         face_helper.read_image(np_image)
-        face_helper.get_face_landmarks_5(only_center_face=False, resize=640, eye_dist_threshold=5)
+        face_helper.get_face_landmarks_5(
+            only_center_face=False, resize=640, eye_dist_threshold=5
+        )
         face_helper.align_warp_face()
         logger.debug("Found %d faces, restoring", len(face_helper.cropped_faces))
         for cropped_face in face_helper.cropped_faces:
@@ -86,10 +90,10 @@ def restore_with_face_helper(
                     cropped_face_t = restore_face(cropped_face_t)
                 devices.torch_gc()
             except Exception:
-                errors.report('Failed face-restoration inference', exc_info=True)
+                errors.report("Failed face-restoration inference", exc_info=True)
 
             restored_face = rgb_tensor_to_bgr_image(cropped_face_t, min_max=(-1, 1))
-            restored_face = (restored_face * 255.0).astype('uint8')
+            restored_face = (restored_face * 255.0).astype("uint8")
             face_helper.add_restored_face(restored_face)
 
         logger.debug("Merging restored faces into image")

--- a/modules/gfpgan_model.py
+++ b/modules/gfpgan_model.py
@@ -15,7 +15,9 @@ from modules import (
 )
 
 logger = logging.getLogger(__name__)
-model_url = "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth"
+model_url = (
+    "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth"
+)
 model_download_name = "GFPGANv1.4.pth"
 gfpgan_face_restorer: face_restoration.FaceRestoration | None = None
 
@@ -33,13 +35,13 @@ class FaceRestorerGFPGAN(face_restoration_utils.CommonFaceRestoration):
             model_url=model_url,
             command_path=self.model_path,
             download_name=model_download_name,
-            ext_filter=['.pth'],
+            ext_filter=[".pth"],
         ):
-            if 'GFPGAN' in os.path.basename(model_path):
+            if "GFPGAN" in os.path.basename(model_path):
                 return modelloader.load_spandrel_model(
                     model_path,
                     device=self.get_device(),
-                    expected_architecture='GFPGAN',
+                    expected_architecture="GFPGAN",
                 ).model
         raise ValueError("No GFPGAN model found")
 

--- a/modules/gitpython_hack.py
+++ b/modules/gitpython_hack.py
@@ -12,7 +12,9 @@ class Git(git.Git):
     """
 
     def _get_persistent_cmd(self, attr_name, cmd_name, *args, **kwargs):
-        raise NotImplementedError(f"Refusing to use persistent process: {attr_name} ({cmd_name} {args} {kwargs})")
+        raise NotImplementedError(
+            f"Refusing to use persistent process: {attr_name} ({cmd_name} {args} {kwargs})"
+        )
 
     def get_object_header(self, ref: str | bytes) -> tuple[str, str, int]:
         ret = subprocess.check_output(
@@ -23,7 +25,9 @@ class Git(git.Git):
         )
         return self._parse_object_header(ret)
 
-    def stream_object_data(self, ref: str) -> tuple[str, str, int, Git.CatFileContentStream]:
+    def stream_object_data(
+        self, ref: str
+    ) -> tuple[str, str, int, Git.CatFileContentStream]:
         # Not really streaming, per se; this buffers the entire object in memory.
         # Shouldn't be a problem for our use case, since we're only using this for
         # object headers (commit objects).

--- a/modules/gradio_extensons.py
+++ b/modules/gradio_extensons.py
@@ -10,12 +10,12 @@ def add_classes_to_gradio_component(comp):
 
     comp.elem_classes = [f"gradio-{comp.get_block_name()}", *(comp.elem_classes or [])]
 
-    if getattr(comp, 'multiselect', False):
-        comp.elem_classes.append('multiselect')
+    if getattr(comp, "multiselect", False):
+        comp.elem_classes.append("multiselect")
 
 
 def IOComponent_init(self, *args, **kwargs):
-    self.webui_tooltip = kwargs.pop('tooltip', None)
+    self.webui_tooltip = kwargs.pop("tooltip", None)
 
     if scripts.scripts_current is not None:
         scripts.scripts_current.before_component(self, **kwargs)
@@ -37,11 +37,11 @@ def IOComponent_init(self, *args, **kwargs):
 def Block_get_config(self):
     config = original_Block_get_config(self)
 
-    webui_tooltip = getattr(self, 'webui_tooltip', None)
+    webui_tooltip = getattr(self, "webui_tooltip", None)
     if webui_tooltip:
         config["webui_tooltip"] = webui_tooltip
 
-    config.pop('example_inputs', None)
+    config.pop("example_inputs", None)
 
     return config
 
@@ -74,10 +74,27 @@ def Blocks_get_config_file(self, *args, **kwargs):
     return config
 
 
-original_IOComponent_init = patches.patch(__name__, obj=gr.components.IOComponent, field="__init__", replacement=IOComponent_init)
-original_Block_get_config = patches.patch(__name__, obj=gr.blocks.Block, field="get_config", replacement=Block_get_config)
-original_BlockContext_init = patches.patch(__name__, obj=gr.blocks.BlockContext, field="__init__", replacement=BlockContext_init)
-original_Blocks_get_config_file = patches.patch(__name__, obj=gr.blocks.Blocks, field="get_config_file", replacement=Blocks_get_config_file)
+original_IOComponent_init = patches.patch(
+    __name__,
+    obj=gr.components.IOComponent,
+    field="__init__",
+    replacement=IOComponent_init,
+)
+original_Block_get_config = patches.patch(
+    __name__, obj=gr.blocks.Block, field="get_config", replacement=Block_get_config
+)
+original_BlockContext_init = patches.patch(
+    __name__,
+    obj=gr.blocks.BlockContext,
+    field="__init__",
+    replacement=BlockContext_init,
+)
+original_Blocks_get_config_file = patches.patch(
+    __name__,
+    obj=gr.blocks.Blocks,
+    field="get_config_file",
+    replacement=Blocks_get_config_file,
+)
 
 
 ui_tempdir.install_ui_tempdir_override()

--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -48,7 +48,7 @@ def sha256(filename, title, use_addnet_hash=False):
     if shared.cmd_opts.no_hashing:
         return None
 
-    print(f"Calculating sha256 for {filename}: ", end='')
+    print(f"Calculating sha256 for {filename}: ", end="")
     if use_addnet_hash:
         with open(filename, "rb") as file:
             sha256_value = addnet_hash_safetensors(file)
@@ -81,4 +81,3 @@ def addnet_hash_safetensors(b):
         hash_sha256.update(chunk)
 
     return hash_sha256.hexdigest()
-

--- a/modules/hat_model.py
+++ b/modules/hat_model.py
@@ -39,5 +39,5 @@ class UpscalerHAT(Upscaler):
         return modelloader.load_spandrel_model(
             path,
             device=devices.device_esrgan,  # TODO: should probably be device_hat
-            expected_architecture='HAT',
+            expected_architecture="HAT",
         )

--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -960,7 +960,6 @@ def train_hypernetwork(
                     shared.sd_model.first_stage_model.to(devices.device)
 
                     p = processing.StableDiffusionProcessingTxt2Img(
-                        sd_model=shared.sd_model,
                         do_not_save_grid=True,
                         do_not_save_samples=True,
                     )

--- a/modules/hypernetworks/hypernetwork.py
+++ b/modules/hypernetworks/hypernetwork.py
@@ -10,17 +10,37 @@ import torch
 import tqdm
 from einops import rearrange, repeat
 from ldm.util import default
-from modules import devices, sd_models, shared, sd_samplers, hashes, sd_hijack_checkpoint, errors
+from modules import (
+    devices,
+    sd_models,
+    shared,
+    sd_samplers,
+    hashes,
+    sd_hijack_checkpoint,
+    errors,
+)
 from modules.textual_inversion import textual_inversion, saving_settings
 from modules.textual_inversion.learn_schedule import LearnRateScheduler
 from torch import einsum
-from torch.nn.init import normal_, xavier_normal_, xavier_uniform_, kaiming_normal_, kaiming_uniform_, zeros_
+from torch.nn.init import (
+    normal_,
+    xavier_normal_,
+    xavier_uniform_,
+    kaiming_normal_,
+    kaiming_uniform_,
+    zeros_,
+)
 
 from collections import deque
 from statistics import stdev, mean
 
 
-optimizer_dict = {optim_name : cls_obj for optim_name, cls_obj in inspect.getmembers(torch.optim, inspect.isclass) if optim_name != "Optimizer"}
+optimizer_dict = {
+    optim_name: cls_obj
+    for optim_name, cls_obj in inspect.getmembers(torch.optim, inspect.isclass)
+    if optim_name != "Optimizer"
+}
+
 
 class HypernetworkModule(torch.nn.Module):
     activation_dict = {
@@ -32,10 +52,26 @@ class HypernetworkModule(torch.nn.Module):
         "tanh": torch.nn.Tanh,
         "sigmoid": torch.nn.Sigmoid,
     }
-    activation_dict.update({cls_name.lower(): cls_obj for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation) if inspect.isclass(cls_obj) and cls_obj.__module__ == 'torch.nn.modules.activation'})
+    activation_dict.update(
+        {
+            cls_name.lower(): cls_obj
+            for cls_name, cls_obj in inspect.getmembers(torch.nn.modules.activation)
+            if inspect.isclass(cls_obj)
+            and cls_obj.__module__ == "torch.nn.modules.activation"
+        }
+    )
 
-    def __init__(self, dim, state_dict=None, layer_structure=None, activation_func=None, weight_init='Normal',
-                 add_layer_norm=False, activate_output=False, dropout_structure=None):
+    def __init__(
+        self,
+        dim,
+        state_dict=None,
+        layer_structure=None,
+        activation_func=None,
+        weight_init="Normal",
+        add_layer_norm=False,
+        activate_output=False,
+        dropout_structure=None,
+    ):
         super().__init__()
 
         self.multiplier = 1.0
@@ -46,27 +82,38 @@ class HypernetworkModule(torch.nn.Module):
 
         linears = []
         for i in range(len(layer_structure) - 1):
-
             # Add a fully-connected layer
-            linears.append(torch.nn.Linear(int(dim * layer_structure[i]), int(dim * layer_structure[i+1])))
+            linears.append(
+                torch.nn.Linear(
+                    int(dim * layer_structure[i]), int(dim * layer_structure[i + 1])
+                )
+            )
 
             # Add an activation func except last layer
-            if activation_func == "linear" or activation_func is None or (i >= len(layer_structure) - 2 and not activate_output):
+            if (
+                activation_func == "linear"
+                or activation_func is None
+                or (i >= len(layer_structure) - 2 and not activate_output)
+            ):
                 pass
             elif activation_func in self.activation_dict:
                 linears.append(self.activation_dict[activation_func]())
             else:
-                raise RuntimeError(f'hypernetwork uses an unsupported activation function: {activation_func}')
+                raise RuntimeError(
+                    f"hypernetwork uses an unsupported activation function: {activation_func}"
+                )
 
             # Add layer normalization
             if add_layer_norm:
-                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i+1])))
+                linears.append(torch.nn.LayerNorm(int(dim * layer_structure[i + 1])))
 
             # Everything should be now parsed into dropout structure, and applied here.
             # Since we only have dropouts after layers, dropout structure should start with 0 and end with 0.
-            if dropout_structure is not None and dropout_structure[i+1] > 0:
-                assert 0 < dropout_structure[i+1] < 1, "Dropout probability should be 0 or float between 0 and 1!"
-                linears.append(torch.nn.Dropout(p=dropout_structure[i+1]))
+            if dropout_structure is not None and dropout_structure[i + 1] > 0:
+                assert (
+                    0 < dropout_structure[i + 1] < 1
+                ), "Dropout probability should be 0 or float between 0 and 1!"
+                linears.append(torch.nn.Dropout(p=dropout_structure[i + 1]))
             # Code explanation : [1, 2, 1] -> dropout is missing when last_layer_dropout is false. [1, 2, 2, 1] -> [0, 0.3, 0, 0], when its True, [0, 0.3, 0.3, 0].
 
         self.linear = torch.nn.Sequential(*linears)
@@ -81,29 +128,41 @@ class HypernetworkModule(torch.nn.Module):
                     if weight_init == "Normal" or type(layer) == torch.nn.LayerNorm:
                         normal_(w, mean=0.0, std=0.01)
                         normal_(b, mean=0.0, std=0)
-                    elif weight_init == 'XavierUniform':
+                    elif weight_init == "XavierUniform":
                         xavier_uniform_(w)
                         zeros_(b)
-                    elif weight_init == 'XavierNormal':
+                    elif weight_init == "XavierNormal":
                         xavier_normal_(w)
                         zeros_(b)
-                    elif weight_init == 'KaimingUniform':
-                        kaiming_uniform_(w, nonlinearity='leaky_relu' if 'leakyrelu' == activation_func else 'relu')
+                    elif weight_init == "KaimingUniform":
+                        kaiming_uniform_(
+                            w,
+                            nonlinearity="leaky_relu"
+                            if "leakyrelu" == activation_func
+                            else "relu",
+                        )
                         zeros_(b)
-                    elif weight_init == 'KaimingNormal':
-                        kaiming_normal_(w, nonlinearity='leaky_relu' if 'leakyrelu' == activation_func else 'relu')
+                    elif weight_init == "KaimingNormal":
+                        kaiming_normal_(
+                            w,
+                            nonlinearity="leaky_relu"
+                            if "leakyrelu" == activation_func
+                            else "relu",
+                        )
                         zeros_(b)
                     else:
-                        raise KeyError(f"Key {weight_init} is not defined as initialization!")
+                        raise KeyError(
+                            f"Key {weight_init} is not defined as initialization!"
+                        )
         devices.torch_npu_set_device()
         self.to(devices.device)
 
     def fix_old_state_dict(self, state_dict):
         changes = {
-            'linear1.bias': 'linear.0.bias',
-            'linear1.weight': 'linear.0.weight',
-            'linear2.bias': 'linear.1.bias',
-            'linear2.weight': 'linear.1.weight',
+            "linear1.bias": "linear.0.bias",
+            "linear1.weight": "linear.0.weight",
+            "linear2.bias": "linear.1.bias",
+            "linear2.weight": "linear.1.weight",
         }
 
         for fr, to in changes.items():
@@ -125,7 +184,7 @@ class HypernetworkModule(torch.nn.Module):
         return layer_structure
 
 
-#param layer_structure : sequence used for length, use_dropout : controlling boolean, last_layer_dropout : for compatibility check.
+# param layer_structure : sequence used for length, use_dropout : controlling boolean, last_layer_dropout : for compatibility check.
 def parse_dropout_structure(layer_structure, use_dropout, last_layer_dropout):
     if layer_structure is None:
         layer_structure = [1, 2, 1]
@@ -145,7 +204,18 @@ class Hypernetwork:
     filename = None
     name = None
 
-    def __init__(self, name=None, enable_sizes=None, layer_structure=None, activation_func=None, weight_init=None, add_layer_norm=False, use_dropout=False, activate_output=False, **kwargs):
+    def __init__(
+        self,
+        name=None,
+        enable_sizes=None,
+        layer_structure=None,
+        activation_func=None,
+        weight_init=None,
+        add_layer_norm=False,
+        use_dropout=False,
+        activate_output=False,
+        **kwargs,
+    ):
         self.filename = None
         self.name = name
         self.layers = {}
@@ -158,20 +228,38 @@ class Hypernetwork:
         self.add_layer_norm = add_layer_norm
         self.use_dropout = use_dropout
         self.activate_output = activate_output
-        self.last_layer_dropout = kwargs.get('last_layer_dropout', True)
-        self.dropout_structure = kwargs.get('dropout_structure', None)
+        self.last_layer_dropout = kwargs.get("last_layer_dropout", True)
+        self.dropout_structure = kwargs.get("dropout_structure", None)
         if self.dropout_structure is None:
-            self.dropout_structure = parse_dropout_structure(self.layer_structure, self.use_dropout, self.last_layer_dropout)
+            self.dropout_structure = parse_dropout_structure(
+                self.layer_structure, self.use_dropout, self.last_layer_dropout
+            )
         self.optimizer_name = None
         self.optimizer_state_dict = None
         self.optional_info = None
 
         for size in enable_sizes or []:
             self.layers[size] = (
-                HypernetworkModule(size, None, self.layer_structure, self.activation_func, self.weight_init,
-                                   self.add_layer_norm, self.activate_output, dropout_structure=self.dropout_structure),
-                HypernetworkModule(size, None, self.layer_structure, self.activation_func, self.weight_init,
-                                   self.add_layer_norm, self.activate_output, dropout_structure=self.dropout_structure),
+                HypernetworkModule(
+                    size,
+                    None,
+                    self.layer_structure,
+                    self.activation_func,
+                    self.weight_init,
+                    self.add_layer_norm,
+                    self.activate_output,
+                    dropout_structure=self.dropout_structure,
+                ),
+                HypernetworkModule(
+                    size,
+                    None,
+                    self.layer_structure,
+                    self.activation_func,
+                    self.weight_init,
+                    self.add_layer_norm,
+                    self.activate_output,
+                    dropout_structure=self.dropout_structure,
+                ),
             )
         self.eval()
 
@@ -217,48 +305,58 @@ class Hypernetwork:
         for k, v in self.layers.items():
             state_dict[k] = (v[0].state_dict(), v[1].state_dict())
 
-        state_dict['step'] = self.step
-        state_dict['name'] = self.name
-        state_dict['layer_structure'] = self.layer_structure
-        state_dict['activation_func'] = self.activation_func
-        state_dict['is_layer_norm'] = self.add_layer_norm
-        state_dict['weight_initialization'] = self.weight_init
-        state_dict['sd_checkpoint'] = self.sd_checkpoint
-        state_dict['sd_checkpoint_name'] = self.sd_checkpoint_name
-        state_dict['activate_output'] = self.activate_output
-        state_dict['use_dropout'] = self.use_dropout
-        state_dict['dropout_structure'] = self.dropout_structure
-        state_dict['last_layer_dropout'] = (self.dropout_structure[-2] != 0) if self.dropout_structure is not None else self.last_layer_dropout
-        state_dict['optional_info'] = self.optional_info if self.optional_info else None
+        state_dict["step"] = self.step
+        state_dict["name"] = self.name
+        state_dict["layer_structure"] = self.layer_structure
+        state_dict["activation_func"] = self.activation_func
+        state_dict["is_layer_norm"] = self.add_layer_norm
+        state_dict["weight_initialization"] = self.weight_init
+        state_dict["sd_checkpoint"] = self.sd_checkpoint
+        state_dict["sd_checkpoint_name"] = self.sd_checkpoint_name
+        state_dict["activate_output"] = self.activate_output
+        state_dict["use_dropout"] = self.use_dropout
+        state_dict["dropout_structure"] = self.dropout_structure
+        state_dict["last_layer_dropout"] = (
+            (self.dropout_structure[-2] != 0)
+            if self.dropout_structure is not None
+            else self.last_layer_dropout
+        )
+        state_dict["optional_info"] = self.optional_info if self.optional_info else None
 
         if self.optimizer_name is not None:
-            optimizer_saved_dict['optimizer_name'] = self.optimizer_name
+            optimizer_saved_dict["optimizer_name"] = self.optimizer_name
 
         torch.save(state_dict, filename)
         if shared.opts.save_optimizer_state and self.optimizer_state_dict:
-            optimizer_saved_dict['hash'] = self.shorthash()
-            optimizer_saved_dict['optimizer_state_dict'] = self.optimizer_state_dict
-            torch.save(optimizer_saved_dict, filename + '.optim')
+            optimizer_saved_dict["hash"] = self.shorthash()
+            optimizer_saved_dict["optimizer_state_dict"] = self.optimizer_state_dict
+            torch.save(optimizer_saved_dict, filename + ".optim")
 
     def load(self, filename):
         self.filename = filename
         if self.name is None:
             self.name = os.path.splitext(os.path.basename(filename))[0]
 
-        state_dict = torch.load(filename, map_location='cpu')
+        state_dict = torch.load(filename, map_location="cpu")
 
-        self.layer_structure = state_dict.get('layer_structure', [1, 2, 1])
-        self.optional_info = state_dict.get('optional_info', None)
-        self.activation_func = state_dict.get('activation_func', None)
-        self.weight_init = state_dict.get('weight_initialization', 'Normal')
-        self.add_layer_norm = state_dict.get('is_layer_norm', False)
-        self.dropout_structure = state_dict.get('dropout_structure', None)
-        self.use_dropout = True if self.dropout_structure is not None and any(self.dropout_structure) else state_dict.get('use_dropout', False)
-        self.activate_output = state_dict.get('activate_output', True)
-        self.last_layer_dropout = state_dict.get('last_layer_dropout', False)
+        self.layer_structure = state_dict.get("layer_structure", [1, 2, 1])
+        self.optional_info = state_dict.get("optional_info", None)
+        self.activation_func = state_dict.get("activation_func", None)
+        self.weight_init = state_dict.get("weight_initialization", "Normal")
+        self.add_layer_norm = state_dict.get("is_layer_norm", False)
+        self.dropout_structure = state_dict.get("dropout_structure", None)
+        self.use_dropout = (
+            True
+            if self.dropout_structure is not None and any(self.dropout_structure)
+            else state_dict.get("use_dropout", False)
+        )
+        self.activate_output = state_dict.get("activate_output", True)
+        self.last_layer_dropout = state_dict.get("last_layer_dropout", False)
         # Dropout structure should have same length as layer structure, Every digits should be in [0,1), and last digit must be 0.
         if self.dropout_structure is None:
-            self.dropout_structure = parse_dropout_structure(self.layer_structure, self.use_dropout, self.last_layer_dropout)
+            self.dropout_structure = parse_dropout_structure(
+                self.layer_structure, self.use_dropout, self.last_layer_dropout
+            )
 
         if shared.opts.print_hypernet_extra:
             if self.optional_info is not None:
@@ -268,18 +366,24 @@ class Hypernetwork:
             print(f"  Activation function: {self.activation_func}")
             print(f"  Weight initialization: {self.weight_init}")
             print(f"  Layer norm: {self.add_layer_norm}")
-            print(f"  Dropout usage: {self.use_dropout}" )
+            print(f"  Dropout usage: {self.use_dropout}")
             print(f"  Activate last layer: {self.activate_output}")
             print(f"  Dropout structure: {self.dropout_structure}")
 
-        optimizer_saved_dict = torch.load(self.filename + '.optim', map_location='cpu') if os.path.exists(self.filename + '.optim') else {}
+        optimizer_saved_dict = (
+            torch.load(self.filename + ".optim", map_location="cpu")
+            if os.path.exists(self.filename + ".optim")
+            else {}
+        )
 
-        if self.shorthash() == optimizer_saved_dict.get('hash', None):
-            self.optimizer_state_dict = optimizer_saved_dict.get('optimizer_state_dict', None)
+        if self.shorthash() == optimizer_saved_dict.get("hash", None):
+            self.optimizer_state_dict = optimizer_saved_dict.get(
+                "optimizer_state_dict", None
+            )
         else:
             self.optimizer_state_dict = None
         if self.optimizer_state_dict:
-            self.optimizer_name = optimizer_saved_dict.get('optimizer_name', 'AdamW')
+            self.optimizer_name = optimizer_saved_dict.get("optimizer_name", "AdamW")
             if shared.opts.print_hypernet_extra:
                 print("Loaded existing optimizer from checkpoint")
                 print(f"Optimizer name is {self.optimizer_name}")
@@ -291,27 +395,45 @@ class Hypernetwork:
         for size, sd in state_dict.items():
             if type(size) == int:
                 self.layers[size] = (
-                    HypernetworkModule(size, sd[0], self.layer_structure, self.activation_func, self.weight_init,
-                                       self.add_layer_norm, self.activate_output, self.dropout_structure),
-                    HypernetworkModule(size, sd[1], self.layer_structure, self.activation_func, self.weight_init,
-                                       self.add_layer_norm, self.activate_output, self.dropout_structure),
+                    HypernetworkModule(
+                        size,
+                        sd[0],
+                        self.layer_structure,
+                        self.activation_func,
+                        self.weight_init,
+                        self.add_layer_norm,
+                        self.activate_output,
+                        self.dropout_structure,
+                    ),
+                    HypernetworkModule(
+                        size,
+                        sd[1],
+                        self.layer_structure,
+                        self.activation_func,
+                        self.weight_init,
+                        self.add_layer_norm,
+                        self.activate_output,
+                        self.dropout_structure,
+                    ),
                 )
 
-        self.name = state_dict.get('name', self.name)
-        self.step = state_dict.get('step', 0)
-        self.sd_checkpoint = state_dict.get('sd_checkpoint', None)
-        self.sd_checkpoint_name = state_dict.get('sd_checkpoint_name', None)
+        self.name = state_dict.get("name", self.name)
+        self.step = state_dict.get("step", 0)
+        self.sd_checkpoint = state_dict.get("sd_checkpoint", None)
+        self.sd_checkpoint_name = state_dict.get("sd_checkpoint_name", None)
         self.eval()
 
     def shorthash(self):
-        sha256 = hashes.sha256(self.filename, f'hypernet/{self.name}')
+        sha256 = hashes.sha256(self.filename, f"hypernet/{self.name}")
 
         return sha256[0:10] if sha256 else None
 
 
 def list_hypernetworks(path):
     res = {}
-    for filename in sorted(glob.iglob(os.path.join(path, '**/*.pt'), recursive=True), key=str.lower):
+    for filename in sorted(
+        glob.iglob(os.path.join(path, "**/*.pt"), recursive=True), key=str.lower
+    ):
         name = os.path.splitext(os.path.basename(filename))[0]
         # Prevent a hypothetical "None.pt" from being listed.
         if name != "None":
@@ -356,7 +478,9 @@ def load_hypernetworks(names, multipliers=None):
 
 
 def apply_single_hypernetwork(hypernetwork, context_k, context_v, layer=None):
-    hypernetwork_layers = (hypernetwork.layers if hypernetwork is not None else {}).get(context_k.shape[2], None)
+    hypernetwork_layers = (hypernetwork.layers if hypernetwork is not None else {}).get(
+        context_k.shape[2], None
+    )
 
     if hypernetwork_layers is None:
         return context_k, context_v
@@ -365,8 +489,12 @@ def apply_single_hypernetwork(hypernetwork, context_k, context_v, layer=None):
         layer.hyper_k = hypernetwork_layers[0]
         layer.hyper_v = hypernetwork_layers[1]
 
-    context_k = devices.cond_cast_unet(hypernetwork_layers[0](devices.cond_cast_float(context_k)))
-    context_v = devices.cond_cast_unet(hypernetwork_layers[1](devices.cond_cast_float(context_v)))
+    context_k = devices.cond_cast_unet(
+        hypernetwork_layers[0](devices.cond_cast_float(context_k))
+    )
+    context_v = devices.cond_cast_unet(
+        hypernetwork_layers[1](devices.cond_cast_float(context_v))
+    )
     return context_k, context_v
 
 
@@ -374,7 +502,9 @@ def apply_hypernetworks(hypernetworks, context, layer=None):
     context_k = context
     context_v = context
     for hypernetwork in hypernetworks:
-        context_k, context_v = apply_single_hypernetwork(hypernetwork, context_k, context_v, layer)
+        context_k, context_v = apply_single_hypernetwork(
+            hypernetwork, context_k, context_v, layer
+        )
 
     return context_k, context_v
 
@@ -385,25 +515,27 @@ def attention_CrossAttention_forward(self, x, context=None, mask=None, **kwargs)
     q = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = apply_hypernetworks(shared.loaded_hypernetworks, context, self)
+    context_k, context_v = apply_hypernetworks(
+        shared.loaded_hypernetworks, context, self
+    )
     k = self.to_k(context_k)
     v = self.to_v(context_v)
 
-    q, k, v = (rearrange(t, 'b n (h d) -> (b h) n d', h=h) for t in (q, k, v))
+    q, k, v = (rearrange(t, "b n (h d) -> (b h) n d", h=h) for t in (q, k, v))
 
-    sim = einsum('b i d, b j d -> b i j', q, k) * self.scale
+    sim = einsum("b i d, b j d -> b i j", q, k) * self.scale
 
     if mask is not None:
-        mask = rearrange(mask, 'b ... -> b (...)')
+        mask = rearrange(mask, "b ... -> b (...)")
         max_neg_value = -torch.finfo(sim.dtype).max
-        mask = repeat(mask, 'b j -> (b h) () j', h=h)
+        mask = repeat(mask, "b j -> (b h) () j", h=h)
         sim.masked_fill_(~mask, max_neg_value)
 
     # attention, what we cannot get enough of
     attn = sim.softmax(dim=-1)
 
-    out = einsum('b i j, b j d -> b i d', attn, v)
-    out = rearrange(out, '(b h) n d -> b n (h d)', h=h)
+    out = einsum("b i j, b j d -> b i d", attn, v)
+    out = rearrange(out, "(b h) n d -> b n (h d)", h=h)
     return self.to_out(out)
 
 
@@ -416,7 +548,9 @@ def stack_conds(conds):
     for i in range(len(conds)):
         if conds[i].shape[0] != token_count:
             last_vector = conds[i][-1:]
-            last_vector_repeated = last_vector.repeat([token_count - conds[i].shape[0], 1])
+            last_vector_repeated = last_vector.repeat(
+                [token_count - conds[i].shape[0], 1]
+            )
             conds[i] = torch.vstack([conds[i], last_vector_repeated])
 
     return torch.stack(conds)
@@ -427,19 +561,35 @@ def statistics(data):
         std = 0
     else:
         std = stdev(data)
-    total_information = f"loss:{mean(data):.3f}" + u"\u00B1" + f"({std/ (len(data) ** 0.5):.3f})"
+    total_information = (
+        f"loss:{mean(data):.3f}" + "\u00b1" + f"({std/ (len(data) ** 0.5):.3f})"
+    )
     recent_data = data[-32:]
     if len(recent_data) < 2:
         std = 0
     else:
         std = stdev(recent_data)
-    recent_information = f"recent 32 loss:{mean(recent_data):.3f}" + u"\u00B1" + f"({std / (len(recent_data) ** 0.5):.3f})"
+    recent_information = (
+        f"recent 32 loss:{mean(recent_data):.3f}"
+        + "\u00b1"
+        + f"({std / (len(recent_data) ** 0.5):.3f})"
+    )
     return total_information, recent_information
 
 
-def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None, activation_func=None, weight_init=None, add_layer_norm=False, use_dropout=False, dropout_structure=None):
+def create_hypernetwork(
+    name,
+    enable_sizes,
+    overwrite_old,
+    layer_structure=None,
+    activation_func=None,
+    weight_init=None,
+    add_layer_norm=False,
+    use_dropout=False,
+    dropout_structure=None,
+):
     # Remove illegal characters from name.
-    name = "".join( x for x in name if (x.isalnum() or x in "._- "))
+    name = "".join(x for x in name if (x.isalnum() or x in "._- "))
     assert name, "Name cannot be empty!"
 
     fn = os.path.join(shared.cmd_opts.hypernetwork_dir, f"{name}.pt")
@@ -462,20 +612,65 @@ def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None,
         weight_init=weight_init,
         add_layer_norm=add_layer_norm,
         use_dropout=use_dropout,
-        dropout_structure=dropout_structure
+        dropout_structure=dropout_structure,
     )
     hypernet.save(fn)
 
     shared.reload_hypernetworks()
 
 
-def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch_size: int, gradient_step: int, data_root: str, log_directory: str, training_width: int, training_height: int, varsize: bool, steps: int, clip_grad_mode: str, clip_grad_value: float, shuffle_tags: bool, tag_drop_out: bool, latent_sampling_method: str, use_weight: bool, create_image_every: int, save_hypernetwork_every: int, template_filename: str, preview_from_txt2img: bool, preview_prompt: str, preview_negative_prompt: str, preview_steps: int, preview_sampler_name: str, preview_cfg_scale: float, preview_seed: int, preview_width: int, preview_height: int):
+def train_hypernetwork(
+    id_task,
+    hypernetwork_name: str,
+    learn_rate: float,
+    batch_size: int,
+    gradient_step: int,
+    data_root: str,
+    log_directory: str,
+    training_width: int,
+    training_height: int,
+    varsize: bool,
+    steps: int,
+    clip_grad_mode: str,
+    clip_grad_value: float,
+    shuffle_tags: bool,
+    tag_drop_out: bool,
+    latent_sampling_method: str,
+    use_weight: bool,
+    create_image_every: int,
+    save_hypernetwork_every: int,
+    template_filename: str,
+    preview_from_txt2img: bool,
+    preview_prompt: str,
+    preview_negative_prompt: str,
+    preview_steps: int,
+    preview_sampler_name: str,
+    preview_cfg_scale: float,
+    preview_seed: int,
+    preview_width: int,
+    preview_height: int,
+):
     from modules import images, processing
 
     save_hypernetwork_every = save_hypernetwork_every or 0
     create_image_every = create_image_every or 0
-    template_file = textual_inversion.textual_inversion_templates.get(template_filename, None)
-    textual_inversion.validate_train_inputs(hypernetwork_name, learn_rate, batch_size, gradient_step, data_root, template_file, template_filename, steps, save_hypernetwork_every, create_image_every, log_directory, name="hypernetwork")
+    template_file = textual_inversion.textual_inversion_templates.get(
+        template_filename, None
+    )
+    textual_inversion.validate_train_inputs(
+        hypernetwork_name,
+        learn_rate,
+        batch_size,
+        gradient_step,
+        data_root,
+        template_file,
+        template_filename,
+        steps,
+        save_hypernetwork_every,
+        create_image_every,
+        log_directory,
+        name="hypernetwork",
+    )
     template_file = template_file.path
 
     path = shared.hypernetworks.get(hypernetwork_name, None)
@@ -487,10 +682,12 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
     shared.state.textinfo = "Initializing hypernetwork training..."
     shared.state.job_count = steps
 
-    hypernetwork_name = hypernetwork_name.rsplit('(', 1)[0]
-    filename = os.path.join(shared.cmd_opts.hypernetwork_dir, f'{hypernetwork_name}.pt')
+    hypernetwork_name = hypernetwork_name.rsplit("(", 1)[0]
+    filename = os.path.join(shared.cmd_opts.hypernetwork_dir, f"{hypernetwork_name}.pt")
 
-    log_directory = os.path.join(log_directory, datetime.datetime.now().strftime("%Y-%m-%d"), hypernetwork_name)
+    log_directory = os.path.join(
+        log_directory, datetime.datetime.now().strftime("%Y-%m-%d"), hypernetwork_name
+    )
     unload = shared.opts.unload_models_when_training
 
     if save_hypernetwork_every > 0:
@@ -509,14 +706,24 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
 
     initial_step = hypernetwork.step or 0
     if initial_step >= steps:
-        shared.state.textinfo = "Model has already been trained beyond specified max steps"
+        shared.state.textinfo = (
+            "Model has already been trained beyond specified max steps"
+        )
         return hypernetwork, filename
 
     scheduler = LearnRateScheduler(learn_rate, steps, initial_step)
 
-    clip_grad = torch.nn.utils.clip_grad_value_ if clip_grad_mode == "value" else torch.nn.utils.clip_grad_norm_ if clip_grad_mode == "norm" else None
+    clip_grad = (
+        torch.nn.utils.clip_grad_value_
+        if clip_grad_mode == "value"
+        else torch.nn.utils.clip_grad_norm_
+        if clip_grad_mode == "norm"
+        else None
+    )
     if clip_grad:
-        clip_grad_sched = LearnRateScheduler(clip_grad_value, steps, initial_step, verbose=False)
+        clip_grad_sched = LearnRateScheduler(
+            clip_grad_value, steps, initial_step, verbose=False
+        )
 
     if shared.opts.training_enable_tensorboard:
         tensorboard_writer = textual_inversion.tensorboard_setup(log_directory)
@@ -526,18 +733,54 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
 
     pin_memory = shared.opts.pin_memory
 
-    ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=hypernetwork_name, model=shared.sd_model, cond_model=shared.sd_model.cond_stage_model, device=devices.device, template_file=template_file, include_cond=True, batch_size=batch_size, gradient_step=gradient_step, shuffle_tags=shuffle_tags, tag_drop_out=tag_drop_out, latent_sampling_method=latent_sampling_method, varsize=varsize, use_weight=use_weight)
+    ds = modules.textual_inversion.dataset.PersonalizedBase(
+        data_root=data_root,
+        width=training_width,
+        height=training_height,
+        repeats=shared.opts.training_image_repeats_per_epoch,
+        placeholder_token=hypernetwork_name,
+        model=shared.sd_model,
+        cond_model=shared.sd_model.cond_stage_model,
+        device=devices.device,
+        template_file=template_file,
+        include_cond=True,
+        batch_size=batch_size,
+        gradient_step=gradient_step,
+        shuffle_tags=shuffle_tags,
+        tag_drop_out=tag_drop_out,
+        latent_sampling_method=latent_sampling_method,
+        varsize=varsize,
+        use_weight=use_weight,
+    )
 
     if shared.opts.save_training_settings_to_txt:
         saved_params = dict(
-            model_name=checkpoint.model_name, model_hash=checkpoint.shorthash, num_of_dataset_images=len(ds),
-            **{field: getattr(hypernetwork, field) for field in ['layer_structure', 'activation_func', 'weight_init', 'add_layer_norm', 'use_dropout', ]}
+            model_name=checkpoint.model_name,
+            model_hash=checkpoint.shorthash,
+            num_of_dataset_images=len(ds),
+            **{
+                field: getattr(hypernetwork, field)
+                for field in [
+                    "layer_structure",
+                    "activation_func",
+                    "weight_init",
+                    "add_layer_norm",
+                    "use_dropout",
+                ]
+            },
         )
-        saving_settings.save_settings_to_file(log_directory, {**saved_params, **locals()})
+        saving_settings.save_settings_to_file(
+            log_directory, {**saved_params, **locals()}
+        )
 
     latent_sampling_method = ds.latent_sampling_method
 
-    dl = modules.textual_inversion.dataset.PersonalizedDataLoader(ds, latent_sampling_method=latent_sampling_method, batch_size=ds.batch_size, pin_memory=pin_memory)
+    dl = modules.textual_inversion.dataset.PersonalizedDataLoader(
+        ds,
+        latent_sampling_method=latent_sampling_method,
+        batch_size=ds.batch_size,
+        pin_memory=pin_memory,
+    )
 
     old_parallel_processing_allowed = shared.parallel_processing_allowed
 
@@ -551,12 +794,14 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
 
     # Here we use optimizer from saved HN, or we can specify as UI option.
     if hypernetwork.optimizer_name in optimizer_dict:
-        optimizer = optimizer_dict[hypernetwork.optimizer_name](params=weights, lr=scheduler.learn_rate)
+        optimizer = optimizer_dict[hypernetwork.optimizer_name](
+            params=weights, lr=scheduler.learn_rate
+        )
         optimizer_name = hypernetwork.optimizer_name
     else:
         print(f"Optimizer type {hypernetwork.optimizer_name} is not defined!")
         optimizer = torch.optim.AdamW(params=weights, lr=scheduler.learn_rate)
-        optimizer_name = 'AdamW'
+        optimizer_name = "AdamW"
 
     if hypernetwork.optimizer_state_dict:  # This line must be changed if Optimizer type can be different from saved optimizer.
         try:
@@ -571,12 +816,16 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
     gradient_step = ds.gradient_step
     # n steps = batch_size * gradient_step * n image processed
     steps_per_epoch = len(ds) // batch_size // gradient_step
-    max_steps_per_epoch = len(ds) // batch_size - (len(ds) // batch_size) % gradient_step
+    max_steps_per_epoch = (
+        len(ds) // batch_size - (len(ds) // batch_size) % gradient_step
+    )
     loss_step = 0
-    _loss_step = 0 #internal
+    _loss_step = 0  # internal
     # size = len(ds.indexes)
     # loss_dict = defaultdict(lambda : deque(maxlen = 1024))
-    loss_logging = deque(maxlen=len(ds) * 3)  # this should be configurable parameter, this is 3 * epoch(dataset size)
+    loss_logging = deque(
+        maxlen=len(ds) * 3
+    )  # this should be configurable parameter, this is 3 * epoch(dataset size)
     # losses = torch.zeros((size,))
     # previous_mean_losses = [0]
     # previous_mean_loss = 0
@@ -592,7 +841,7 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
     try:
         sd_hijack_checkpoint.add()
 
-        for _ in range((steps-initial_step) * gradient_step):
+        for _ in range((steps - initial_step) * gradient_step):
             if scheduler.finished:
                 break
             if shared.state.interrupted:
@@ -616,12 +865,18 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
                         w = batch.weight.to(devices.device, non_blocking=pin_memory)
                     if tag_drop_out != 0 or shuffle_tags:
                         shared.sd_model.cond_stage_model.to(devices.device)
-                        c = shared.sd_model.cond_stage_model(batch.cond_text).to(devices.device, non_blocking=pin_memory)
+                        c = shared.sd_model.cond_stage_model(batch.cond_text).to(
+                            devices.device, non_blocking=pin_memory
+                        )
                         shared.sd_model.cond_stage_model.to(devices.cpu)
                     else:
-                        c = stack_conds(batch.cond).to(devices.device, non_blocking=pin_memory)
+                        c = stack_conds(batch.cond).to(
+                            devices.device, non_blocking=pin_memory
+                        )
                     if use_weight:
-                        loss = shared.sd_model.weighted_forward(x, c, w)[0] / gradient_step
+                        loss = (
+                            shared.sd_model.weighted_forward(x, c, w)[0] / gradient_step
+                        )
                         del w
                     else:
                         loss = shared.sd_model.forward(x, c)[0] / gradient_step
@@ -653,31 +908,48 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
 
                 description = f"Training hypernetwork [Epoch {epoch_num}: {epoch_step+1}/{steps_per_epoch}]loss: {loss_step:.7f}"
                 pbar.set_description(description)
-                if hypernetwork_dir is not None and steps_done % save_hypernetwork_every == 0:
+                if (
+                    hypernetwork_dir is not None
+                    and steps_done % save_hypernetwork_every == 0
+                ):
                     # Before saving, change name to match current checkpoint.
-                    hypernetwork_name_every = f'{hypernetwork_name}-{steps_done}'
-                    last_saved_file = os.path.join(hypernetwork_dir, f'{hypernetwork_name_every}.pt')
+                    hypernetwork_name_every = f"{hypernetwork_name}-{steps_done}"
+                    last_saved_file = os.path.join(
+                        hypernetwork_dir, f"{hypernetwork_name_every}.pt"
+                    )
                     hypernetwork.optimizer_name = optimizer_name
                     if shared.opts.save_optimizer_state:
                         hypernetwork.optimizer_state_dict = optimizer.state_dict()
-                    save_hypernetwork(hypernetwork, checkpoint, hypernetwork_name, last_saved_file)
-                    hypernetwork.optimizer_state_dict = None  # dereference it after saving, to save memory.
-
-
+                    save_hypernetwork(
+                        hypernetwork, checkpoint, hypernetwork_name, last_saved_file
+                    )
+                    hypernetwork.optimizer_state_dict = (
+                        None  # dereference it after saving, to save memory.
+                    )
 
                 if shared.opts.training_enable_tensorboard:
                     epoch_num = hypernetwork.step // len(ds)
                     epoch_step = hypernetwork.step - (epoch_num * len(ds)) + 1
                     mean_loss = sum(loss_logging) / len(loss_logging)
-                    textual_inversion.tensorboard_add(tensorboard_writer, loss=mean_loss, global_step=hypernetwork.step, step=epoch_step, learn_rate=scheduler.learn_rate, epoch_num=epoch_num)
+                    textual_inversion.tensorboard_add(
+                        tensorboard_writer,
+                        loss=mean_loss,
+                        global_step=hypernetwork.step,
+                        step=epoch_step,
+                        learn_rate=scheduler.learn_rate,
+                        epoch_num=epoch_num,
+                    )
 
-                textual_inversion.write_loss(log_directory, "hypernetwork_loss.csv", hypernetwork.step, steps_per_epoch, {
-                    "loss": f"{loss_step:.7f}",
-                    "learn_rate": scheduler.learn_rate
-                })
+                textual_inversion.write_loss(
+                    log_directory,
+                    "hypernetwork_loss.csv",
+                    hypernetwork.step,
+                    steps_per_epoch,
+                    {"loss": f"{loss_step:.7f}", "learn_rate": scheduler.learn_rate},
+                )
 
                 if images_dir is not None and steps_done % create_image_every == 0:
-                    forced_filename = f'{hypernetwork_name}-{steps_done}'
+                    forced_filename = f"{hypernetwork_name}-{steps_done}"
                     last_saved_image = os.path.join(images_dir, forced_filename)
                     hypernetwork.eval()
                     rng_state = torch.get_rng_state()
@@ -699,7 +971,9 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
                         p.prompt = preview_prompt
                         p.negative_prompt = preview_negative_prompt
                         p.steps = preview_steps
-                        p.sampler_name = sd_samplers.samplers_map[preview_sampler_name.lower()]
+                        p.sampler_name = sd_samplers.samplers_map[
+                            preview_sampler_name.lower()
+                        ]
                         p.cfg_scale = preview_cfg_scale
                         p.seed = preview_seed
                         p.width = preview_width
@@ -714,7 +988,9 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
 
                     with closing(p):
                         processed = processing.process_images(p)
-                        image = processed.images[0] if len(processed.images) > 0 else None
+                        image = (
+                            processed.images[0] if len(processed.images) > 0 else None
+                        )
 
                     if unload:
                         shared.sd_model.cond_stage_model.to(devices.cpu)
@@ -725,11 +1001,28 @@ def train_hypernetwork(id_task, hypernetwork_name: str, learn_rate: float, batch
                     hypernetwork.train()
                     if image is not None:
                         shared.state.assign_current_image(image)
-                        if shared.opts.training_enable_tensorboard and shared.opts.training_tensorboard_save_images:
-                            textual_inversion.tensorboard_add_image(tensorboard_writer,
-                                                                    f"Validation at epoch {epoch_num}", image,
-                                                                    hypernetwork.step)
-                        last_saved_image, last_text_info = images.save_image(image, images_dir, "", p.seed, p.prompt, shared.opts.samples_format, processed.infotexts[0], p=p, forced_filename=forced_filename, save_to_dirs=False)
+                        if (
+                            shared.opts.training_enable_tensorboard
+                            and shared.opts.training_tensorboard_save_images
+                        ):
+                            textual_inversion.tensorboard_add_image(
+                                tensorboard_writer,
+                                f"Validation at epoch {epoch_num}",
+                                image,
+                                hypernetwork.step,
+                            )
+                        last_saved_image, last_text_info = images.save_image(
+                            image,
+                            images_dir,
+                            "",
+                            p.seed,
+                            p.prompt,
+                            shared.opts.samples_format,
+                            processed.infotexts[0],
+                            p=p,
+                            forced_filename=forced_filename,
+                            save_to_dirs=False,
+                        )
                         last_saved_image += f", prompt: {preview_text}"
 
                 shared.state.job_no = hypernetwork.step
@@ -751,26 +1044,33 @@ Last saved image: {html.escape(last_saved_image)}<br/>
         hypernetwork.eval()
         sd_hijack_checkpoint.remove()
 
-
-
-    filename = os.path.join(shared.cmd_opts.hypernetwork_dir, f'{hypernetwork_name}.pt')
+    filename = os.path.join(shared.cmd_opts.hypernetwork_dir, f"{hypernetwork_name}.pt")
     hypernetwork.optimizer_name = optimizer_name
     if shared.opts.save_optimizer_state:
         hypernetwork.optimizer_state_dict = optimizer.state_dict()
     save_hypernetwork(hypernetwork, checkpoint, hypernetwork_name, filename)
 
     del optimizer
-    hypernetwork.optimizer_state_dict = None  # dereference it after saving, to save memory.
+    hypernetwork.optimizer_state_dict = (
+        None  # dereference it after saving, to save memory.
+    )
     shared.sd_model.cond_stage_model.to(devices.device)
     shared.sd_model.first_stage_model.to(devices.device)
     shared.parallel_processing_allowed = old_parallel_processing_allowed
 
     return hypernetwork, filename
 
+
 def save_hypernetwork(hypernetwork, checkpoint, hypernetwork_name, filename):
     old_hypernetwork_name = hypernetwork.name
-    old_sd_checkpoint = hypernetwork.sd_checkpoint if hasattr(hypernetwork, "sd_checkpoint") else None
-    old_sd_checkpoint_name = hypernetwork.sd_checkpoint_name if hasattr(hypernetwork, "sd_checkpoint_name") else None
+    old_sd_checkpoint = (
+        hypernetwork.sd_checkpoint if hasattr(hypernetwork, "sd_checkpoint") else None
+    )
+    old_sd_checkpoint_name = (
+        hypernetwork.sd_checkpoint_name
+        if hasattr(hypernetwork, "sd_checkpoint_name")
+        else None
+    )
     try:
         hypernetwork.sd_checkpoint = checkpoint.shorthash
         hypernetwork.sd_checkpoint_name = checkpoint.model_name

--- a/modules/hypernetworks/ui.py
+++ b/modules/hypernetworks/ui.py
@@ -5,24 +5,54 @@ import modules.hypernetworks.hypernetwork
 from modules import devices, sd_hijack, shared
 
 not_available = ["hardswish", "multiheadattention"]
-keys = [x for x in modules.hypernetworks.hypernetwork.HypernetworkModule.activation_dict if x not in not_available]
+keys = [
+    x
+    for x in modules.hypernetworks.hypernetwork.HypernetworkModule.activation_dict
+    if x not in not_available
+]
 
 
-def create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure=None, activation_func=None, weight_init=None, add_layer_norm=False, use_dropout=False, dropout_structure=None):
-    filename = modules.hypernetworks.hypernetwork.create_hypernetwork(name, enable_sizes, overwrite_old, layer_structure, activation_func, weight_init, add_layer_norm, use_dropout, dropout_structure)
+def create_hypernetwork(
+    name,
+    enable_sizes,
+    overwrite_old,
+    layer_structure=None,
+    activation_func=None,
+    weight_init=None,
+    add_layer_norm=False,
+    use_dropout=False,
+    dropout_structure=None,
+):
+    filename = modules.hypernetworks.hypernetwork.create_hypernetwork(
+        name,
+        enable_sizes,
+        overwrite_old,
+        layer_structure,
+        activation_func,
+        weight_init,
+        add_layer_norm,
+        use_dropout,
+        dropout_structure,
+    )
 
-    return gr.Dropdown.update(choices=sorted(shared.hypernetworks)), f"Created: {filename}", ""
+    return (
+        gr.Dropdown.update(choices=sorted(shared.hypernetworks)),
+        f"Created: {filename}",
+        "",
+    )
 
 
 def train_hypernetwork(*args):
     shared.loaded_hypernetworks = []
 
-    assert not shared.cmd_opts.lowvram, 'Training models with lowvram is not possible'
+    assert not shared.cmd_opts.lowvram, "Training models with lowvram is not possible"
 
     try:
         sd_hijack.undo_optimizations()
 
-        hypernetwork, filename = modules.hypernetworks.hypernetwork.train_hypernetwork(*args)
+        hypernetwork, filename = modules.hypernetworks.hypernetwork.train_hypernetwork(
+            *args
+        )
 
         res = f"""
 Training {'interrupted' if shared.state.interrupted else 'finished'} at {hypernetwork.step} steps.
@@ -35,4 +65,3 @@ Hypernetwork saved to {html.escape(filename)}
         shared.sd_model.cond_stage_model.to(devices.device)
         shared.sd_model.first_stage_model.to(devices.device)
         sd_hijack.apply_optimizations()
-

--- a/modules/images.py
+++ b/modules/images.py
@@ -13,8 +13,9 @@ import numpy as np
 import piexif
 import piexif.helper
 from PIL import Image, ImageFont, ImageDraw, ImageColor, PngImagePlugin, ImageOps
+
 # pillow_avif needs to be imported somewhere in code for it to work
-import pillow_avif # noqa: F401
+import pillow_avif  # noqa: F401
 import string
 import json
 import hashlib
@@ -23,7 +24,7 @@ from modules import sd_samplers, shared, script_callbacks, errors
 from modules.paths_internal import roboto_ttf_file
 from modules.shared import opts
 
-LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
+LANCZOS = Image.Resampling.LANCZOS if hasattr(Image, "Resampling") else Image.LANCZOS
 
 
 def get_font(fontsize: int):
@@ -55,18 +56,27 @@ def image_grid(imgs, batch_size=1, rows=None):
     script_callbacks.image_grid_callback(params)
 
     w, h = map(max, zip(*(img.size for img in imgs)))
-    grid_background_color = ImageColor.getcolor(opts.grid_background_color, 'RGB')
-    grid = Image.new('RGB', size=(params.cols * w, params.rows * h), color=grid_background_color)
+    grid_background_color = ImageColor.getcolor(opts.grid_background_color, "RGB")
+    grid = Image.new(
+        "RGB", size=(params.cols * w, params.rows * h), color=grid_background_color
+    )
 
     for i, img in enumerate(params.imgs):
         img_w, img_h = img.size
-        w_offset, h_offset = 0 if img_w == w else (w - img_w) // 2, 0 if img_h == h else (h - img_h) // 2
-        grid.paste(img, box=(i % params.cols * w + w_offset, i // params.cols * h + h_offset))
+        w_offset, h_offset = (
+            0 if img_w == w else (w - img_w) // 2,
+            0 if img_h == h else (h - img_h) // 2,
+        )
+        grid.paste(
+            img, box=(i % params.cols * w + w_offset, i // params.cols * h + h_offset)
+        )
 
     return grid
 
 
-class Grid(namedtuple("_Grid", ["tiles", "tile_w", "tile_h", "image_w", "image_h", "overlap"])):
+class Grid(
+    namedtuple("_Grid", ["tiles", "tile_w", "tile_h", "image_w", "image_h", "overlap"])
+):
     @property
     def tile_count(self) -> int:
         """
@@ -75,7 +85,9 @@ class Grid(namedtuple("_Grid", ["tiles", "tile_w", "tile_h", "image_w", "image_h
         return sum(len(row[2]) for row in self.tiles)
 
 
-def split_grid(image: Image.Image, tile_w: int = 512, tile_h: int = 512, overlap: int = 64) -> Grid:
+def split_grid(
+    image: Image.Image, tile_w: int = 512, tile_h: int = 512, overlap: int = 64
+) -> Grid:
     w, h = image.size
 
     non_overlap_width = tile_w - overlap
@@ -115,10 +127,18 @@ def combine_grid(grid):
     def make_mask_image(r):
         r = r * 255 / grid.overlap
         r = r.astype(np.uint8)
-        return Image.fromarray(r, 'L')
+        return Image.fromarray(r, "L")
 
-    mask_w = make_mask_image(np.arange(grid.overlap, dtype=np.float32).reshape((1, grid.overlap)).repeat(grid.tile_h, axis=0))
-    mask_h = make_mask_image(np.arange(grid.overlap, dtype=np.float32).reshape((grid.overlap, 1)).repeat(grid.image_w, axis=1))
+    mask_w = make_mask_image(
+        np.arange(grid.overlap, dtype=np.float32)
+        .reshape((1, grid.overlap))
+        .repeat(grid.tile_h, axis=0)
+    )
+    mask_h = make_mask_image(
+        np.arange(grid.overlap, dtype=np.float32)
+        .reshape((grid.overlap, 1))
+        .repeat(grid.image_w, axis=1)
+    )
 
     combined_image = Image.new("RGB", (grid.image_w, grid.image_h))
     for y, h, row in grid.tiles:
@@ -129,35 +149,43 @@ def combine_grid(grid):
                 continue
 
             combined_row.paste(tile.crop((0, 0, grid.overlap, h)), (x, 0), mask=mask_w)
-            combined_row.paste(tile.crop((grid.overlap, 0, w, h)), (x + grid.overlap, 0))
+            combined_row.paste(
+                tile.crop((grid.overlap, 0, w, h)), (x + grid.overlap, 0)
+            )
 
         if y == 0:
             combined_image.paste(combined_row, (0, 0))
             continue
 
-        combined_image.paste(combined_row.crop((0, 0, combined_row.width, grid.overlap)), (0, y), mask=mask_h)
-        combined_image.paste(combined_row.crop((0, grid.overlap, combined_row.width, h)), (0, y + grid.overlap))
+        combined_image.paste(
+            combined_row.crop((0, 0, combined_row.width, grid.overlap)),
+            (0, y),
+            mask=mask_h,
+        )
+        combined_image.paste(
+            combined_row.crop((0, grid.overlap, combined_row.width, h)),
+            (0, y + grid.overlap),
+        )
 
     return combined_image
 
 
 class GridAnnotation:
-    def __init__(self, text='', is_active=True):
+    def __init__(self, text="", is_active=True):
         self.text = text
         self.is_active = is_active
         self.size = None
 
 
 def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
-
-    color_active = ImageColor.getcolor(opts.grid_text_active_color, 'RGB')
-    color_inactive = ImageColor.getcolor(opts.grid_text_inactive_color, 'RGB')
-    color_background = ImageColor.getcolor(opts.grid_background_color, 'RGB')
+    color_active = ImageColor.getcolor(opts.grid_text_active_color, "RGB")
+    color_inactive = ImageColor.getcolor(opts.grid_text_inactive_color, "RGB")
+    color_background = ImageColor.getcolor(opts.grid_background_color, "RGB")
 
     def wrap(drawing, text, font, line_length):
-        lines = ['']
+        lines = [""]
         for word in text.split():
-            line = f'{lines[-1]} {word}'.strip()
+            line = f"{lines[-1]} {word}".strip()
             if drawing.textlength(line, font=font) <= line_length:
                 lines[-1] = line
             else:
@@ -168,13 +196,32 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
         for line in lines:
             fnt = initial_fnt
             fontsize = initial_fontsize
-            while drawing.multiline_textsize(line.text, font=fnt)[0] > line.allowed_width and fontsize > 0:
+            while (
+                drawing.multiline_textsize(line.text, font=fnt)[0] > line.allowed_width
+                and fontsize > 0
+            ):
                 fontsize -= 1
                 fnt = get_font(fontsize)
-            drawing.multiline_text((draw_x, draw_y + line.size[1] / 2), line.text, font=fnt, fill=color_active if line.is_active else color_inactive, anchor="mm", align="center")
+            drawing.multiline_text(
+                (draw_x, draw_y + line.size[1] / 2),
+                line.text,
+                font=fnt,
+                fill=color_active if line.is_active else color_inactive,
+                anchor="mm",
+                align="center",
+            )
 
             if not line.is_active:
-                drawing.line((draw_x - line.size[0] // 2, draw_y + line.size[1] // 2, draw_x + line.size[0] // 2, draw_y + line.size[1] // 2), fill=color_inactive, width=4)
+                drawing.line(
+                    (
+                        draw_x - line.size[0] // 2,
+                        draw_y + line.size[1] // 2,
+                        draw_x + line.size[0] // 2,
+                        draw_y + line.size[1] // 2,
+                    ),
+                    fill=color_inactive,
+                    width=4,
+                )
 
             draw_y += line.size[1] + line_spacing
 
@@ -183,18 +230,28 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
 
     fnt = get_font(fontsize)
 
-    pad_left = 0 if sum([sum([len(line.text) for line in lines]) for lines in ver_texts]) == 0 else width * 3 // 4
+    pad_left = (
+        0
+        if sum([sum([len(line.text) for line in lines]) for lines in ver_texts]) == 0
+        else width * 3 // 4
+    )
 
     cols = im.width // width
     rows = im.height // height
 
-    assert cols == len(hor_texts), f'bad number of horizontal texts: {len(hor_texts)}; must be {cols}'
-    assert rows == len(ver_texts), f'bad number of vertical texts: {len(ver_texts)}; must be {rows}'
+    assert cols == len(
+        hor_texts
+    ), f"bad number of horizontal texts: {len(hor_texts)}; must be {cols}"
+    assert rows == len(
+        ver_texts
+    ), f"bad number of vertical texts: {len(ver_texts)}; must be {rows}"
 
     calc_img = Image.new("RGB", (1, 1), color_background)
     calc_d = ImageDraw.Draw(calc_img)
 
-    for texts, allowed_width in zip(hor_texts + ver_texts, [width] * len(hor_texts) + [pad_left] * len(ver_texts)):
+    for texts, allowed_width in zip(
+        hor_texts + ver_texts, [width] * len(hor_texts) + [pad_left] * len(ver_texts)
+    ):
         items = [] + texts
         texts.clear()
 
@@ -207,17 +264,37 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
             line.size = (bbox[2] - bbox[0], bbox[3] - bbox[1])
             line.allowed_width = allowed_width
 
-    hor_text_heights = [sum([line.size[1] + line_spacing for line in lines]) - line_spacing for lines in hor_texts]
-    ver_text_heights = [sum([line.size[1] + line_spacing for line in lines]) - line_spacing * len(lines) for lines in ver_texts]
+    hor_text_heights = [
+        sum([line.size[1] + line_spacing for line in lines]) - line_spacing
+        for lines in hor_texts
+    ]
+    ver_text_heights = [
+        sum([line.size[1] + line_spacing for line in lines]) - line_spacing * len(lines)
+        for lines in ver_texts
+    ]
 
-    pad_top = 0 if sum(hor_text_heights) == 0 else max(hor_text_heights) + line_spacing * 2
+    pad_top = (
+        0 if sum(hor_text_heights) == 0 else max(hor_text_heights) + line_spacing * 2
+    )
 
-    result = Image.new("RGB", (im.width + pad_left + margin * (cols-1), im.height + pad_top + margin * (rows-1)), color_background)
+    result = Image.new(
+        "RGB",
+        (
+            im.width + pad_left + margin * (cols - 1),
+            im.height + pad_top + margin * (rows - 1),
+        ),
+        color_background,
+    )
 
     for row in range(rows):
         for col in range(cols):
-            cell = im.crop((width * col, height * row, width * (col+1), height * (row+1)))
-            result.paste(cell, (pad_left + (width + margin) * col, pad_top + (height + margin) * row))
+            cell = im.crop(
+                (width * col, height * row, width * (col + 1), height * (row + 1))
+            )
+            result.paste(
+                cell,
+                (pad_left + (width + margin) * col, pad_top + (height + margin) * row),
+            )
 
     d = ImageDraw.Draw(result)
 
@@ -243,8 +320,20 @@ def draw_prompt_matrix(im, width, height, all_prompts, margin=0):
     prompts_horiz = prompts[:boundary]
     prompts_vert = prompts[boundary:]
 
-    hor_texts = [[GridAnnotation(x, is_active=pos & (1 << i) != 0) for i, x in enumerate(prompts_horiz)] for pos in range(1 << len(prompts_horiz))]
-    ver_texts = [[GridAnnotation(x, is_active=pos & (1 << i) != 0) for i, x in enumerate(prompts_vert)] for pos in range(1 << len(prompts_vert))]
+    hor_texts = [
+        [
+            GridAnnotation(x, is_active=pos & (1 << i) != 0)
+            for i, x in enumerate(prompts_horiz)
+        ]
+        for pos in range(1 << len(prompts_horiz))
+    ]
+    ver_texts = [
+        [
+            GridAnnotation(x, is_active=pos & (1 << i) != 0)
+            for i, x in enumerate(prompts_vert)
+        ]
+        for pos in range(1 << len(prompts_vert))
+    ]
 
     return draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin)
 
@@ -267,7 +356,7 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
     upscaler_name = upscaler_name or opts.upscaler_for_img2img
 
     def resize(im, w, h):
-        if upscaler_name is None or upscaler_name == "None" or im.mode == 'L':
+        if upscaler_name is None or upscaler_name == "None" or im.mode == "L":
             return im.resize((w, h), resample=LANCZOS)
 
         scale = max(w / im.width, h / im.height)
@@ -276,7 +365,9 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
             upscalers = [x for x in shared.sd_upscalers if x.name == upscaler_name]
             if len(upscalers) == 0:
                 upscaler = shared.sd_upscalers[0]
-                print(f"could not find upscaler named {upscaler_name or '<empty string>'}, using {upscaler.name} as a fallback")
+                print(
+                    f"could not find upscaler named {upscaler_name or '<empty string>'}, using {upscaler.name} as a fallback"
+                )
             else:
                 upscaler = upscalers[0]
 
@@ -315,13 +406,31 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
         if ratio < src_ratio:
             fill_height = height // 2 - src_h // 2
             if fill_height > 0:
-                res.paste(resized.resize((width, fill_height), box=(0, 0, width, 0)), box=(0, 0))
-                res.paste(resized.resize((width, fill_height), box=(0, resized.height, width, resized.height)), box=(0, fill_height + src_h))
+                res.paste(
+                    resized.resize((width, fill_height), box=(0, 0, width, 0)),
+                    box=(0, 0),
+                )
+                res.paste(
+                    resized.resize(
+                        (width, fill_height),
+                        box=(0, resized.height, width, resized.height),
+                    ),
+                    box=(0, fill_height + src_h),
+                )
         elif ratio > src_ratio:
             fill_width = width // 2 - src_w // 2
             if fill_width > 0:
-                res.paste(resized.resize((fill_width, height), box=(0, 0, 0, height)), box=(0, 0))
-                res.paste(resized.resize((fill_width, height), box=(resized.width, 0, resized.width, height)), box=(fill_width + src_w, 0))
+                res.paste(
+                    resized.resize((fill_width, height), box=(0, 0, 0, height)),
+                    box=(0, 0),
+                )
+                res.paste(
+                    resized.resize(
+                        (fill_width, height),
+                        box=(resized.width, 0, resized.width, height),
+                    ),
+                    box=(fill_width + src_w, 0),
+                )
 
     return res
 
@@ -329,10 +438,10 @@ def resize_image(resize_mode, im, width, height, upscaler_name=None):
 if not shared.cmd_opts.unix_filenames_sanitization:
     invalid_filename_chars = '#<>:"/\\|?*\n\r\t'
 else:
-    invalid_filename_chars = '/'
-invalid_filename_prefix = ' '
-invalid_filename_postfix = ' .'
-re_nonletters = re.compile(r'[\s' + string.punctuation + ']+')
+    invalid_filename_chars = "/"
+invalid_filename_prefix = " "
+invalid_filename_postfix = " ."
+re_nonletters = re.compile(r"[\s" + string.punctuation + "]+")
 re_pattern = re.compile(r"(.*?)(?:\[([^\[\]]+)\]|$)")
 re_pattern_arg = re.compile(r"(.*)<([^>]*)>$")
 max_filename_part_length = shared.cmd_opts.filenames_max_length
@@ -344,9 +453,9 @@ def sanitize_filename_part(text, replace_spaces=True):
         return None
 
     if replace_spaces:
-        text = text.replace(' ', '_')
+        text = text.replace(" ", "_")
 
-    text = text.translate({ord(x): '_' for x in invalid_filename_chars})
+    text = text.translate({ord(x): "_" for x in invalid_filename_chars})
     text = text.lstrip(invalid_filename_prefix)[:max_filename_part_length]
     text = text.rstrip(invalid_filename_postfix)
     return text
@@ -355,21 +464,21 @@ def sanitize_filename_part(text, replace_spaces=True):
 @functools.cache
 def get_scheduler_str(sampler_name, scheduler_name):
     """Returns {Scheduler} if the scheduler is applicable to the sampler"""
-    if scheduler_name == 'Automatic':
+    if scheduler_name == "Automatic":
         config = sd_samplers.find_sampler_config(sampler_name)
-        scheduler_name = config.options.get('scheduler', 'Automatic')
+        scheduler_name = config.options.get("scheduler", "Automatic")
     return scheduler_name.capitalize()
 
 
 @functools.cache
 def get_sampler_scheduler_str(sampler_name, scheduler_name):
     """Returns the '{Sampler} {Scheduler}' if the scheduler is applicable to the sampler"""
-    return f'{sampler_name} {get_scheduler_str(sampler_name, scheduler_name)}'
+    return f"{sampler_name} {get_scheduler_str(sampler_name, scheduler_name)}"
 
 
 def get_sampler_scheduler(p, sampler):
     """Returns '{Sampler} {Scheduler}' / '{Scheduler}' / 'NOTHING_AND_SKIP_PREVIOUS_TEXT'"""
-    if hasattr(p, 'scheduler') and hasattr(p, 'sampler_name'):
+    if hasattr(p, "scheduler") and hasattr(p, "sampler_name"):
         if sampler:
             sampler_scheduler = get_sampler_scheduler_str(p.sampler_name, p.scheduler)
         else:
@@ -380,42 +489,77 @@ def get_sampler_scheduler(p, sampler):
 
 class FilenameGenerator:
     replacements = {
-        'basename': lambda self: self.basename or 'img',
-        'seed': lambda self: self.seed if self.seed is not None else '',
-        'seed_first': lambda self: self.seed if self.p.batch_size == 1 else self.p.all_seeds[0],
-        'seed_last': lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT if self.p.batch_size == 1 else self.p.all_seeds[-1],
-        'steps': lambda self:  self.p and self.p.steps,
-        'cfg': lambda self: self.p and self.p.cfg_scale,
-        'width': lambda self: self.image.width,
-        'height': lambda self: self.image.height,
-        'styles': lambda self: self.p and sanitize_filename_part(", ".join([style for style in self.p.styles if not style == "None"]) or "None", replace_spaces=False),
-        'sampler': lambda self: self.p and sanitize_filename_part(self.p.sampler_name, replace_spaces=False),
-        'sampler_scheduler': lambda self: self.p and get_sampler_scheduler(self.p, True),
-        'scheduler': lambda self: self.p and get_sampler_scheduler(self.p, False),
-        'model_hash': lambda self: getattr(self.p, "sd_model_hash", shared.sd_model.sd_model_hash),
-        'model_name': lambda self: sanitize_filename_part(shared.sd_model.sd_checkpoint_info.name_for_extra, replace_spaces=False),
-        'date': lambda self: datetime.datetime.now().strftime('%Y-%m-%d'),
-        'datetime': lambda self, *args: self.datetime(*args),  # accepts formats: [datetime], [datetime<Format>], [datetime<Format><Time Zone>]
-        'job_timestamp': lambda self: getattr(self.p, "job_timestamp", shared.state.job_timestamp),
-        'prompt_hash': lambda self, *args: self.string_hash(self.prompt, *args),
-        'negative_prompt_hash': lambda self, *args: self.string_hash(self.p.negative_prompt, *args),
-        'full_prompt_hash': lambda self, *args: self.string_hash(f"{self.p.prompt} {self.p.negative_prompt}", *args),  # a space in between to create a unique string
-        'prompt': lambda self: sanitize_filename_part(self.prompt),
-        'prompt_no_styles': lambda self: self.prompt_no_style(),
-        'prompt_spaces': lambda self: sanitize_filename_part(self.prompt, replace_spaces=False),
-        'prompt_words': lambda self: self.prompt_words(),
-        'batch_number': lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT if self.p.batch_size == 1 or self.zip else self.p.batch_index + 1,
-        'batch_size': lambda self: self.p.batch_size,
-        'generation_number': lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT if (self.p.n_iter == 1 and self.p.batch_size == 1) or self.zip else self.p.iteration * self.p.batch_size + self.p.batch_index + 1,
-        'hasprompt': lambda self, *args: self.hasprompt(*args),  # accepts formats:[hasprompt<prompt1|default><prompt2>..]
-        'clip_skip': lambda self: opts.data["CLIP_stop_at_last_layers"],
-        'denoising': lambda self: self.p.denoising_strength if self.p and self.p.denoising_strength else NOTHING_AND_SKIP_PREVIOUS_TEXT,
-        'user': lambda self: self.p.user,
-        'vae_filename': lambda self: self.get_vae_filename(),
-        'none': lambda self: '',  # Overrides the default, so you can get just the sequence number
-        'image_hash': lambda self, *args: self.image_hash(*args)  # accepts formats: [image_hash<length>] default full hash
+        "basename": lambda self: self.basename or "img",
+        "seed": lambda self: self.seed if self.seed is not None else "",
+        "seed_first": lambda self: self.seed
+        if self.p.batch_size == 1
+        else self.p.all_seeds[0],
+        "seed_last": lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT
+        if self.p.batch_size == 1
+        else self.p.all_seeds[-1],
+        "steps": lambda self: self.p and self.p.steps,
+        "cfg": lambda self: self.p and self.p.cfg_scale,
+        "width": lambda self: self.image.width,
+        "height": lambda self: self.image.height,
+        "styles": lambda self: self.p
+        and sanitize_filename_part(
+            ", ".join([style for style in self.p.styles if not style == "None"])
+            or "None",
+            replace_spaces=False,
+        ),
+        "sampler": lambda self: self.p
+        and sanitize_filename_part(self.p.sampler_name, replace_spaces=False),
+        "sampler_scheduler": lambda self: self.p
+        and get_sampler_scheduler(self.p, True),
+        "scheduler": lambda self: self.p and get_sampler_scheduler(self.p, False),
+        "model_hash": lambda self: getattr(
+            self.p, "sd_model_hash", shared.sd_model.sd_model_hash
+        ),
+        "model_name": lambda self: sanitize_filename_part(
+            shared.sd_model.sd_checkpoint_info.name_for_extra, replace_spaces=False
+        ),
+        "date": lambda self: datetime.datetime.now().strftime("%Y-%m-%d"),
+        "datetime": lambda self, *args: self.datetime(
+            *args
+        ),  # accepts formats: [datetime], [datetime<Format>], [datetime<Format><Time Zone>]
+        "job_timestamp": lambda self: getattr(
+            self.p, "job_timestamp", shared.state.job_timestamp
+        ),
+        "prompt_hash": lambda self, *args: self.string_hash(self.prompt, *args),
+        "negative_prompt_hash": lambda self, *args: self.string_hash(
+            self.p.negative_prompt, *args
+        ),
+        "full_prompt_hash": lambda self, *args: self.string_hash(
+            f"{self.p.prompt} {self.p.negative_prompt}", *args
+        ),  # a space in between to create a unique string
+        "prompt": lambda self: sanitize_filename_part(self.prompt),
+        "prompt_no_styles": lambda self: self.prompt_no_style(),
+        "prompt_spaces": lambda self: sanitize_filename_part(
+            self.prompt, replace_spaces=False
+        ),
+        "prompt_words": lambda self: self.prompt_words(),
+        "batch_number": lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT
+        if self.p.batch_size == 1 or self.zip
+        else self.p.batch_index + 1,
+        "batch_size": lambda self: self.p.batch_size,
+        "generation_number": lambda self: NOTHING_AND_SKIP_PREVIOUS_TEXT
+        if (self.p.n_iter == 1 and self.p.batch_size == 1) or self.zip
+        else self.p.iteration * self.p.batch_size + self.p.batch_index + 1,
+        "hasprompt": lambda self, *args: self.hasprompt(
+            *args
+        ),  # accepts formats:[hasprompt<prompt1|default><prompt2>..]
+        "clip_skip": lambda self: opts.data["CLIP_stop_at_last_layers"],
+        "denoising": lambda self: self.p.denoising_strength
+        if self.p and self.p.denoising_strength
+        else NOTHING_AND_SKIP_PREVIOUS_TEXT,
+        "user": lambda self: self.p.user,
+        "vae_filename": lambda self: self.get_vae_filename(),
+        "none": lambda self: "",  # Overrides the default, so you can get just the sequence number
+        "image_hash": lambda self, *args: self.image_hash(
+            *args
+        ),  # accepts formats: [image_hash<length>] default full hash
     }
-    default_time_format = '%Y%m%d%H%M%S'
+    default_time_format = "%Y%m%d%H%M%S"
 
     def __init__(self, p, seed, prompt, image, zip=False, basename=""):
         self.p = p
@@ -434,12 +578,13 @@ class FilenameGenerator:
             return "NoneType"
 
         file_name = os.path.basename(sd_vae.loaded_vae_file)
-        split_file_name = file_name.split('.')
-        if len(split_file_name) > 1 and split_file_name[0] == '':
-            return split_file_name[1]  # if the first character of the filename is "." then [1] is obtained.
+        split_file_name = file_name.split(".")
+        if len(split_file_name) > 1 and split_file_name[0] == "":
+            return split_file_name[
+                1
+            ]  # if the first character of the filename is "." then [1] is obtained.
         else:
             return split_file_name[0]
-
 
     def hasprompt(self, *args):
         lower = self.prompt.lower()
@@ -452,9 +597,9 @@ class FilenameGenerator:
                 expected = division[0].lower()
                 default = division[1] if len(division) > 1 else ""
                 if lower.find(expected) >= 0:
-                    outres = f'{outres}{expected}'
+                    outres = f"{outres}{expected}"
                 else:
-                    outres = outres if default == "" else f'{outres}{default}'
+                    outres = outres if default == "" else f"{outres}{default}"
         return sanitize_filename_part(outres)
 
     def prompt_no_style(self):
@@ -465,9 +610,16 @@ class FilenameGenerator:
         for style in shared.prompt_styles.get_style_prompts(self.p.styles):
             if style:
                 for part in style.split("{prompt}"):
-                    prompt_no_style = prompt_no_style.replace(part, "").replace(", ,", ",").strip().strip(',')
+                    prompt_no_style = (
+                        prompt_no_style.replace(part, "")
+                        .replace(", ,", ",")
+                        .strip()
+                        .strip(",")
+                    )
 
-                prompt_no_style = prompt_no_style.replace(style, "").strip().strip(',').strip()
+                prompt_no_style = (
+                    prompt_no_style.replace(style, "").strip().strip(",").strip()
+                )
 
         return sanitize_filename_part(prompt_no_style, replace_spaces=False)
 
@@ -475,7 +627,9 @@ class FilenameGenerator:
         words = [x for x in re_nonletters.split(self.prompt or "") if x]
         if len(words) == 0:
             words = ["empty"]
-        return sanitize_filename_part(" ".join(words[0:opts.directories_max_prompt_words]), replace_spaces=False)
+        return sanitize_filename_part(
+            " ".join(words[0 : opts.directories_max_prompt_words]), replace_spaces=False
+        )
 
     def datetime(self, *args):
         time_datetime = datetime.datetime.now()
@@ -503,7 +657,7 @@ class FilenameGenerator:
         return hashlib.sha256(text.encode()).hexdigest()[0:length]
 
     def apply(self, x):
-        res = ''
+        res = ""
 
         for m in re_pattern.finditer(x):
             text, pattern = m.groups()
@@ -527,7 +681,9 @@ class FilenameGenerator:
                     replacement = fun(self, *pattern_args)
                 except Exception:
                     replacement = None
-                    errors.report(f"Error adding [{pattern}] to filename", exc_info=True)
+                    errors.report(
+                        f"Error adding [{pattern}] to filename", exc_info=True
+                    )
 
                 if replacement == NOTHING_AND_SKIP_PREVIOUS_TEXT:
                     continue
@@ -535,7 +691,7 @@ class FilenameGenerator:
                     res += text + str(replacement)
                     continue
 
-            res += f'{text}[{pattern}]'
+            res += f"{text}[{pattern}]"
 
         return res
 
@@ -547,13 +703,19 @@ def get_next_sequence_number(path, basename):
     The sequence starts at 0.
     """
     result = -1
-    if basename != '':
+    if basename != "":
         basename = f"{basename}-"
 
     prefix_length = len(basename)
     for p in os.listdir(path):
         if p.startswith(basename):
-            parts = os.path.splitext(p[prefix_length:])[0].split('-')  # splits the filename (removing the basename first if one is defined, so the sequence number is always the first element)
+            parts = os.path.splitext(
+                p[prefix_length:]
+            )[
+                0
+            ].split(
+                "-"
+            )  # splits the filename (removing the basename first if one is defined, so the sequence number is always the first element)
             try:
                 result = max(int(parts[0]), result)
             except ValueError:
@@ -562,7 +724,14 @@ def get_next_sequence_number(path, basename):
     return result + 1
 
 
-def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_pnginfo=None, pnginfo_section_name='parameters'):
+def save_image_with_geninfo(
+    image,
+    geninfo,
+    filename,
+    extension=None,
+    existing_pnginfo=None,
+    pnginfo_section_name="parameters",
+):
     """
     Saves image to filename, including geninfo as text information for generation info.
     For PNG images, geninfo is added to existing pnginfo dictionary using the pnginfo_section_name argument as key.
@@ -574,7 +743,7 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
 
     image_format = Image.registered_extensions()[extension]
 
-    if extension.lower() == '.png':
+    if extension.lower() == ".png":
         existing_pnginfo = existing_pnginfo or {}
         if opts.enable_pnginfo:
             existing_pnginfo[pnginfo_section_name] = geninfo
@@ -586,42 +755,81 @@ def save_image_with_geninfo(image, geninfo, filename, extension=None, existing_p
         else:
             pnginfo_data = None
 
-        image.save(filename, format=image_format, quality=opts.jpeg_quality, pnginfo=pnginfo_data)
+        image.save(
+            filename,
+            format=image_format,
+            quality=opts.jpeg_quality,
+            pnginfo=pnginfo_data,
+        )
 
     elif extension.lower() in (".jpg", ".jpeg", ".webp"):
-        if image.mode == 'RGBA':
+        if image.mode == "RGBA":
             image = image.convert("RGB")
-        elif image.mode == 'I;16':
-            image = image.point(lambda p: p * 0.0038910505836576).convert("RGB" if extension.lower() == ".webp" else "L")
+        elif image.mode == "I;16":
+            image = image.point(lambda p: p * 0.0038910505836576).convert(
+                "RGB" if extension.lower() == ".webp" else "L"
+            )
 
-        image.save(filename, format=image_format, quality=opts.jpeg_quality, lossless=opts.webp_lossless)
+        image.save(
+            filename,
+            format=image_format,
+            quality=opts.jpeg_quality,
+            lossless=opts.webp_lossless,
+        )
 
         if opts.enable_pnginfo and geninfo is not None:
-            exif_bytes = piexif.dump({
-                "Exif": {
-                    piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(geninfo or "", encoding="unicode")
-                },
-            })
+            exif_bytes = piexif.dump(
+                {
+                    "Exif": {
+                        piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(
+                            geninfo or "", encoding="unicode"
+                        )
+                    },
+                }
+            )
 
             piexif.insert(exif_bytes, filename)
-    elif extension.lower() == '.avif':
+    elif extension.lower() == ".avif":
         if opts.enable_pnginfo and geninfo is not None:
-            exif_bytes = piexif.dump({
-                "Exif": {
-                    piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(geninfo or "", encoding="unicode")
-                },
-            })
+            exif_bytes = piexif.dump(
+                {
+                    "Exif": {
+                        piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(
+                            geninfo or "", encoding="unicode"
+                        )
+                    },
+                }
+            )
         else:
             exif_bytes = None
 
-        image.save(filename,format=image_format, quality=opts.jpeg_quality, exif=exif_bytes)
+        image.save(
+            filename, format=image_format, quality=opts.jpeg_quality, exif=exif_bytes
+        )
     elif extension.lower() == ".gif":
         image.save(filename, format=image_format, comment=geninfo)
     else:
         image.save(filename, format=image_format, quality=opts.jpeg_quality)
 
 
-def save_image(image, path, basename, seed=None, prompt=None, extension='png', info=None, short_filename=False, no_prompt=False, grid=False, pnginfo_section_name='parameters', p=None, existing_info=None, forced_filename=None, suffix="", save_to_dirs=None):
+def save_image(
+    image,
+    path,
+    basename,
+    seed=None,
+    prompt=None,
+    extension="png",
+    info=None,
+    short_filename=False,
+    no_prompt=False,
+    grid=False,
+    pnginfo_section_name="parameters",
+    p=None,
+    existing_info=None,
+    forced_filename=None,
+    suffix="",
+    save_to_dirs=None,
+):
     """Save an image.
 
     Args:
@@ -657,15 +865,26 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
     namegen = FilenameGenerator(p, seed, prompt, image, basename=basename)
 
     # WebP and JPG formats have maximum dimension limits of 16383 and 65535 respectively. switch to PNG which has a much higher limit
-    if (image.height > 65535 or image.width > 65535) and extension.lower() in ("jpg", "jpeg") or (image.height > 16383 or image.width > 16383) and extension.lower() == "webp":
-        print('Image dimensions too large; saving as PNG')
+    if (
+        (image.height > 65535 or image.width > 65535)
+        and extension.lower() in ("jpg", "jpeg")
+        or (image.height > 16383 or image.width > 16383)
+        and extension.lower() == "webp"
+    ):
+        print("Image dimensions too large; saving as PNG")
         extension = "png"
 
     if save_to_dirs is None:
-        save_to_dirs = (grid and opts.grid_save_to_dirs) or (not grid and opts.save_to_dirs and not no_prompt)
+        save_to_dirs = (grid and opts.grid_save_to_dirs) or (
+            not grid and opts.save_to_dirs and not no_prompt
+        )
 
     if save_to_dirs:
-        dirname = namegen.apply(opts.directories_filename_pattern or "[prompt_words]").lstrip(' ').rstrip('\\ /')
+        dirname = (
+            namegen.apply(opts.directories_filename_pattern or "[prompt_words]")
+            .lstrip(" ")
+            .rstrip("\\ /")
+        )
         path = os.path.join(path, dirname)
 
     os.makedirs(path, exist_ok=True)
@@ -680,7 +899,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
         file_decoration = namegen.apply(file_decoration) + suffix
 
-        add_number = opts.save_images_add_number or file_decoration == ''
+        add_number = opts.save_images_add_number or file_decoration == ""
 
         if file_decoration != "" and add_number:
             file_decoration = f"-{file_decoration}"
@@ -689,7 +908,11 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
             basecount = get_next_sequence_number(path, basename)
             fullfn = None
             for i in range(500):
-                fn = f"{basecount + i:05}" if basename == '' else f"{basename}-{basecount + i:04}"
+                fn = (
+                    f"{basecount + i:05}"
+                    if basename == ""
+                    else f"{basename}-{basecount + i:04}"
+                )
                 fullfn = os.path.join(path, f"{fn}{file_decoration}.{extension}")
                 if not os.path.exists(fullfn):
                     break
@@ -715,7 +938,14 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         """
         temp_file_path = f"{filename_without_extension}.tmp"
 
-        save_image_with_geninfo(image_to_save, info, temp_file_path, extension, existing_pnginfo=params.pnginfo, pnginfo_section_name=pnginfo_section_name)
+        save_image_with_geninfo(
+            image_to_save,
+            info,
+            temp_file_path,
+            extension,
+            existing_pnginfo=params.pnginfo,
+            pnginfo_section_name=pnginfo_section_name,
+        )
 
         filename = filename_without_extension + extension
         if shared.opts.save_images_replace_action != "Replace":
@@ -726,23 +956,35 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         os.replace(temp_file_path, filename)
 
     fullfn_without_extension, extension = os.path.splitext(params.filename)
-    if hasattr(os, 'statvfs'):
+    if hasattr(os, "statvfs"):
         max_name_len = os.statvfs(path).f_namemax
-        fullfn_without_extension = fullfn_without_extension[:max_name_len - max(4, len(extension))]
+        fullfn_without_extension = fullfn_without_extension[
+            : max_name_len - max(4, len(extension))
+        ]
         params.filename = fullfn_without_extension + extension
         fullfn = params.filename
     _atomically_save_image(image, fullfn_without_extension, extension)
 
     image.already_saved_as = fullfn
 
-    oversize = image.width > opts.target_side_length or image.height > opts.target_side_length
-    if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > opts.img_downscale_threshold * 1024 * 1024):
+    oversize = (
+        image.width > opts.target_side_length or image.height > opts.target_side_length
+    )
+    if opts.export_for_4chan and (
+        oversize or os.stat(fullfn).st_size > opts.img_downscale_threshold * 1024 * 1024
+    ):
         ratio = image.width / image.height
         resize_to = None
         if oversize and ratio > 1:
-            resize_to = round(opts.target_side_length), round(image.height * opts.target_side_length / image.width)
+            resize_to = (
+                round(opts.target_side_length),
+                round(image.height * opts.target_side_length / image.width),
+            )
         elif oversize:
-            resize_to = round(image.width * opts.target_side_length / image.height), round(opts.target_side_length)
+            resize_to = (
+                round(image.width * opts.target_side_length / image.height),
+                round(opts.target_side_length),
+            )
 
         if resize_to is not None:
             try:
@@ -768,16 +1010,28 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
 
 IGNORED_INFO_KEYS = {
-    'jfif', 'jfif_version', 'jfif_unit', 'jfif_density', 'dpi', 'exif',
-    'loop', 'background', 'timestamp', 'duration', 'progressive', 'progression',
-    'icc_profile', 'chromaticity', 'photoshop',
+    "jfif",
+    "jfif_version",
+    "jfif_unit",
+    "jfif_density",
+    "dpi",
+    "exif",
+    "loop",
+    "background",
+    "timestamp",
+    "duration",
+    "progressive",
+    "progression",
+    "icc_profile",
+    "chromaticity",
+    "photoshop",
 }
 
 
 def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
     items = (image.info or {}).copy()
 
-    geninfo = items.pop('parameters', None)
+    geninfo = items.pop("parameters", None)
 
     if "exif" in items:
         exif_data = items["exif"]
@@ -786,17 +1040,17 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
         except OSError:
             # memory / exif was not valid so piexif tried to read from a file
             exif = None
-        exif_comment = (exif or {}).get("Exif", {}).get(piexif.ExifIFD.UserComment, b'')
+        exif_comment = (exif or {}).get("Exif", {}).get(piexif.ExifIFD.UserComment, b"")
         try:
             exif_comment = piexif.helper.UserComment.load(exif_comment)
         except ValueError:
-            exif_comment = exif_comment.decode('utf8', errors="ignore")
+            exif_comment = exif_comment.decode("utf8", errors="ignore")
 
         if exif_comment:
             geninfo = exif_comment
-    elif "comment" in items: # for gif
+    elif "comment" in items:  # for gif
         if isinstance(items["comment"], bytes):
-            geninfo = items["comment"].decode('utf8', errors="ignore")
+            geninfo = items["comment"].decode("utf8", errors="ignore")
         else:
             geninfo = items["comment"]
 
@@ -812,7 +1066,9 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
 Negative prompt: {json_info["uc"]}
 Steps: {json_info["steps"]}, Sampler: {sampler}, CFG scale: {json_info["scale"]}, Seed: {json_info["seed"]}, Size: {image.width}x{image.height}, Clip skip: 2, ENSD: 31337"""
         except Exception:
-            errors.report("Error parsing NovelAI image generation parameters", exc_info=True)
+            errors.report(
+                "Error parsing NovelAI image generation parameters", exc_info=True
+            )
 
     return geninfo, items
 
@@ -828,7 +1084,7 @@ def image_data(data):
         pass
 
     try:
-        text = data.decode('utf8')
+        text = data.decode("utf8")
         assert len(text) < 10000
         return text, None
 
@@ -842,11 +1098,11 @@ def flatten(img, bgcolor):
     """replaces transparency with bgcolor (example: "#ffffff"), returning an RGB mode image with no transparency"""
 
     if img.mode == "RGBA":
-        background = Image.new('RGBA', img.size, bgcolor)
+        background = Image.new("RGBA", img.size, bgcolor)
         background.paste(img, mask=img)
         img = background
 
-    return img.convert('RGB')
+    return img.convert("RGB")
 
 
 def read(fp, **kwargs):
@@ -870,7 +1126,9 @@ def fix_image(image: Image.Image):
 
 
 def fix_png_transparency(image: Image.Image):
-    if image.mode not in ("RGB", "P") or not isinstance(image.info.get("transparency"), bytes):
+    if image.mode not in ("RGB", "P") or not isinstance(
+        image.info.get("transparency"), bytes
+    ):
         return image
 
     image = image.convert("RGBA")

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -7,8 +7,15 @@ from PIL import Image, ImageOps, ImageFilter, ImageEnhance, UnidentifiedImageErr
 import gradio as gr
 
 from modules import images
-from modules.infotext_utils import create_override_settings_dict, parse_generation_parameters
-from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
+from modules.infotext_utils import (
+    create_override_settings_dict,
+    parse_generation_parameters,
+)
+from modules.processing import (
+    Processed,
+    StableDiffusionProcessingImg2Img,
+    process_images,
+)
 from modules.shared import opts, state
 from modules.sd_models import get_closet_checkpoint_match
 import modules.shared as shared
@@ -17,12 +24,28 @@ from modules.ui import plaintext_to_html
 import modules.scripts
 
 
-def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, scale_by=1.0, use_png_info=False, png_info_props=None, png_info_dir=None):
+def process_batch(
+    p,
+    input,
+    output_dir,
+    inpaint_mask_dir,
+    args,
+    to_scale=False,
+    scale_by=1.0,
+    use_png_info=False,
+    png_info_props=None,
+    png_info_dir=None,
+):
     output_dir = output_dir.strip()
     processing.fix_seed(p)
 
     if isinstance(input, str):
-        batch_images = list(shared.walk_files(input, allowed_extensions=(".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff")))
+        batch_images = list(
+            shared.walk_files(
+                input,
+                allowed_extensions=(".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff"),
+            )
+        )
     else:
         batch_images = [os.path.abspath(x.name) for x in input]
 
@@ -34,7 +57,9 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
         if is_inpaint_batch:
             print(f"\nInpaint batch is enabled. {len(inpaint_masks)} masks found.")
 
-    print(f"Will process {len(batch_images)} images, creating {p.n_iter * p.batch_size} new images for each.")
+    print(
+        f"Will process {len(batch_images)} images, creating {p.n_iter * p.batch_size} new images for each."
+    )
 
     state.job_count = len(batch_images) * p.n_iter
 
@@ -46,7 +71,9 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
     sampler_name = p.sampler_name
     steps = p.steps
     override_settings = p.override_settings
-    sd_model_checkpoint_override = get_closet_checkpoint_match(override_settings.get("sd_model_checkpoint", None))
+    sd_model_checkpoint_override = get_closet_checkpoint_match(
+        override_settings.get("sd_model_checkpoint", None)
+    )
     batch_results = None
     discard_further_results = False
     for i, image in enumerate(batch_images):
@@ -82,7 +109,9 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
                 masks_found = list(mask_image_dir.glob(f"{image_path.stem}.*"))
 
                 if len(masks_found) == 0:
-                    print(f"Warning: mask is not found for {image_path} in {mask_image_dir}. Skipping it.")
+                    print(
+                        f"Warning: mask is not found for {image_path} in {mask_image_dir}. Skipping it."
+                    )
                     continue
 
                 # it should contain only 1 matching mask
@@ -100,38 +129,56 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
                     info_img = images.read(info_img_path)
                 geninfo, _ = images.read_info_from_image(info_img)
                 parsed_parameters = parse_generation_parameters(geninfo)
-                parsed_parameters = {k: v for k, v in parsed_parameters.items() if k in (png_info_props or {})}
+                parsed_parameters = {
+                    k: v
+                    for k, v in parsed_parameters.items()
+                    if k in (png_info_props or {})
+                }
             except Exception:
                 parsed_parameters = {}
 
-            p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "")
-            p.negative_prompt = negative_prompt + (" " + parsed_parameters["Negative prompt"] if "Negative prompt" in parsed_parameters else "")
+            p.prompt = prompt + (
+                " " + parsed_parameters["Prompt"]
+                if "Prompt" in parsed_parameters
+                else ""
+            )
+            p.negative_prompt = negative_prompt + (
+                " " + parsed_parameters["Negative prompt"]
+                if "Negative prompt" in parsed_parameters
+                else ""
+            )
             p.seed = int(parsed_parameters.get("Seed", seed))
             p.cfg_scale = float(parsed_parameters.get("CFG scale", cfg_scale))
             p.sampler_name = parsed_parameters.get("Sampler", sampler_name)
             p.steps = int(parsed_parameters.get("Steps", steps))
 
-            model_info = get_closet_checkpoint_match(parsed_parameters.get("Model hash", None))
+            model_info = get_closet_checkpoint_match(
+                parsed_parameters.get("Model hash", None)
+            )
             if model_info is not None:
-                p.override_settings['sd_model_checkpoint'] = model_info.name
+                p.override_settings["sd_model_checkpoint"] = model_info.name
             elif sd_model_checkpoint_override:
-                p.override_settings['sd_model_checkpoint'] = sd_model_checkpoint_override
+                p.override_settings["sd_model_checkpoint"] = (
+                    sd_model_checkpoint_override
+                )
             else:
                 p.override_settings.pop("sd_model_checkpoint", None)
 
         if output_dir:
             p.outpath_samples = output_dir
-            p.override_settings['save_to_dirs'] = False
-            p.override_settings['save_images_replace_action'] = "Add number suffix"
+            p.override_settings["save_to_dirs"] = False
+            p.override_settings["save_images_replace_action"] = "Add number suffix"
             if p.n_iter > 1 or p.batch_size > 1:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
+                p.override_settings["samples_filename_pattern"] = (
+                    f"{image_path.stem}-[generation_number]"
+                )
             else:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
+                p.override_settings["samples_filename_pattern"] = f"{image_path.stem}"
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
 
         if proc is None:
-            p.override_settings.pop('save_images_replace_action', None)
+            p.override_settings.pop("save_images_replace_action", None)
             proc = process_images(p)
 
         if not discard_further_results and proc:
@@ -141,15 +188,63 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
             else:
                 batch_results = proc
 
-            if 0 <= shared.opts.img2img_batch_show_results_limit < len(batch_results.images):
+            if (
+                0
+                <= shared.opts.img2img_batch_show_results_limit
+                < len(batch_results.images)
+            ):
                 discard_further_results = True
-                batch_results.images = batch_results.images[:int(shared.opts.img2img_batch_show_results_limit)]
-                batch_results.infotexts = batch_results.infotexts[:int(shared.opts.img2img_batch_show_results_limit)]
+                batch_results.images = batch_results.images[
+                    : int(shared.opts.img2img_batch_show_results_limit)
+                ]
+                batch_results.infotexts = batch_results.infotexts[
+                    : int(shared.opts.img2img_batch_show_results_limit)
+                ]
 
     return batch_results
 
 
-def img2img(id_task: str, request: gr.Request, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch, init_img_with_mask, inpaint_color_sketch, inpaint_color_sketch_orig, init_img_inpaint, init_mask_inpaint, mask_blur: int, mask_alpha: float, inpainting_fill: int, n_iter: int, batch_size: int, cfg_scale: float, image_cfg_scale: float, denoising_strength: float, selected_scale_tab: int, height: int, width: int, scale_by: float, resize_mode: int, inpaint_full_res: bool, inpaint_full_res_padding: int, inpainting_mask_invert: int, img2img_batch_input_dir: str, img2img_batch_output_dir: str, img2img_batch_inpaint_mask_dir: str, override_settings_texts, img2img_batch_use_png_info: bool, img2img_batch_png_info_props: list, img2img_batch_png_info_dir: str, img2img_batch_source_type: str, img2img_batch_upload: list, *args):
+def img2img(
+    id_task: str,
+    request: gr.Request,
+    mode: int,
+    prompt: str,
+    negative_prompt: str,
+    prompt_styles,
+    init_img,
+    sketch,
+    init_img_with_mask,
+    inpaint_color_sketch,
+    inpaint_color_sketch_orig,
+    init_img_inpaint,
+    init_mask_inpaint,
+    mask_blur: int,
+    mask_alpha: float,
+    inpainting_fill: int,
+    n_iter: int,
+    batch_size: int,
+    cfg_scale: float,
+    image_cfg_scale: float,
+    denoising_strength: float,
+    selected_scale_tab: int,
+    height: int,
+    width: int,
+    scale_by: float,
+    resize_mode: int,
+    inpaint_full_res: bool,
+    inpaint_full_res_padding: int,
+    inpainting_mask_invert: int,
+    img2img_batch_input_dir: str,
+    img2img_batch_output_dir: str,
+    img2img_batch_inpaint_mask_dir: str,
+    override_settings_texts,
+    img2img_batch_use_png_info: bool,
+    img2img_batch_png_info_props: list,
+    img2img_batch_png_info_dir: str,
+    img2img_batch_source_type: str,
+    img2img_batch_upload: list,
+    *args,
+):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     is_batch = mode == 5
@@ -187,7 +282,7 @@ def img2img(id_task: str, request: gr.Request, mode: int, prompt: str, negative_
         width = int(image.width * scale_by)
         height = int(image.height * scale_by)
 
-    assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
+    assert 0.0 <= denoising_strength <= 1.0, "can only work with strength in [0.0, 1.0]"
 
     p = StableDiffusionProcessingImg2Img(
         sd_model=shared.sd_model,
@@ -228,11 +323,39 @@ def img2img(id_task: str, request: gr.Request, mode: int, prompt: str, negative_
                 assert isinstance(img2img_batch_upload, list) and img2img_batch_upload
                 output_dir = ""
                 inpaint_mask_dir = ""
-                png_info_dir = img2img_batch_png_info_dir if not shared.cmd_opts.hide_ui_dir_config else ""
-                processed = process_batch(p, img2img_batch_upload, output_dir, inpaint_mask_dir, args, to_scale=selected_scale_tab == 1, scale_by=scale_by, use_png_info=img2img_batch_use_png_info, png_info_props=img2img_batch_png_info_props, png_info_dir=png_info_dir)
-            else: # "from dir"
-                assert not shared.cmd_opts.hide_ui_dir_config, "Launched with --hide-ui-dir-config, batch img2img disabled"
-                processed = process_batch(p, img2img_batch_input_dir, img2img_batch_output_dir, img2img_batch_inpaint_mask_dir, args, to_scale=selected_scale_tab == 1, scale_by=scale_by, use_png_info=img2img_batch_use_png_info, png_info_props=img2img_batch_png_info_props, png_info_dir=img2img_batch_png_info_dir)
+                png_info_dir = (
+                    img2img_batch_png_info_dir
+                    if not shared.cmd_opts.hide_ui_dir_config
+                    else ""
+                )
+                processed = process_batch(
+                    p,
+                    img2img_batch_upload,
+                    output_dir,
+                    inpaint_mask_dir,
+                    args,
+                    to_scale=selected_scale_tab == 1,
+                    scale_by=scale_by,
+                    use_png_info=img2img_batch_use_png_info,
+                    png_info_props=img2img_batch_png_info_props,
+                    png_info_dir=png_info_dir,
+                )
+            else:  # "from dir"
+                assert (
+                    not shared.cmd_opts.hide_ui_dir_config
+                ), "Launched with --hide-ui-dir-config, batch img2img disabled"
+                processed = process_batch(
+                    p,
+                    img2img_batch_input_dir,
+                    img2img_batch_output_dir,
+                    img2img_batch_inpaint_mask_dir,
+                    args,
+                    to_scale=selected_scale_tab == 1,
+                    scale_by=scale_by,
+                    use_png_info=img2img_batch_use_png_info,
+                    png_info_props=img2img_batch_png_info_props,
+                    png_info_dir=img2img_batch_png_info_dir,
+                )
 
             if processed is None:
                 processed = Processed(p, [], p.seed, "")
@@ -250,4 +373,9 @@ def img2img(id_task: str, request: gr.Request, mode: int, prompt: str, negative_
     if opts.do_not_show_images:
         processed.images = []
 
-    return processed.images, generation_info_js, plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
+    return (
+        processed.images,
+        generation_info_js,
+        plaintext_to_html(processed.info),
+        plaintext_to_html(processed.comments, classname="comments"),
+    )

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -285,7 +285,6 @@ def img2img(
     assert 0.0 <= denoising_strength <= 1.0, "can only work with strength in [0.0, 1.0]"
 
     p = StableDiffusionProcessingImg2Img(
-        sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_img2img_samples,
         outpath_grids=opts.outdir_grids or opts.outdir_img2img_grids,
         prompt=prompt,
@@ -298,7 +297,8 @@ def img2img(
         height=height,
         init_images=[image],
         mask=mask,
-        mask_blur=mask_blur,
+        mask_blur_x=mask_blur,
+        mask_blur_y=mask_blur,
         inpainting_fill=inpainting_fill,
         resize_mode=resize_mode,
         denoising_strength=denoising_strength,

--- a/modules/import_hook.py
+++ b/modules/import_hook.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     try:
         import torchvision.transforms.functional as functional
+
         sys.modules["torchvision.transforms.functional_tensor"] = functional
     except ImportError:
         pass  # shrug...

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -8,10 +8,21 @@ import sys
 
 import gradio as gr
 from modules.paths import data_path
-from modules import shared, ui_tempdir, script_callbacks, processing, infotext_versions, images, prompt_parser, errors
+from modules import (
+    shared,
+    ui_tempdir,
+    script_callbacks,
+    processing,
+    infotext_versions,
+    images,
+    prompt_parser,
+    errors,
+)
 from PIL import Image
 
-sys.modules['modules.generation_parameters_copypaste'] = sys.modules[__name__]  # alias for old name
+sys.modules["modules.generation_parameters_copypaste"] = sys.modules[
+    __name__
+]  # alias for old name
 
 re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'
 re_param = re.compile(re_param_code)
@@ -21,7 +32,16 @@ type_of_gr_update = type(gr.update())
 
 
 class ParamBinding:
-    def __init__(self, paste_button, tabname, source_text_component=None, source_image_component=None, source_tabname=None, override_settings_component=None, paste_field_names=None):
+    def __init__(
+        self,
+        paste_button,
+        tabname,
+        source_text_component=None,
+        source_image_component=None,
+        source_tabname=None,
+        override_settings_component=None,
+        paste_field_names=None,
+    ):
         self.paste_button = paste_button
         self.tabname = tabname
         self.source_text_component = source_text_component
@@ -54,7 +74,7 @@ def reset():
 
 
 def quote(text):
-    if ',' not in str(text) and '\n' not in str(text) and ':' not in str(text):
+    if "," not in str(text) and "\n" not in str(text) and ":" not in str(text):
         return text
 
     return json.dumps(text, ensure_ascii=False)
@@ -74,15 +94,22 @@ def image_from_url_text(filedata):
     if filedata is None:
         return None
 
-    if type(filedata) == list and filedata and type(filedata[0]) == dict and filedata[0].get("is_file", False):
+    if (
+        type(filedata) == list
+        and filedata
+        and type(filedata[0]) == dict
+        and filedata[0].get("is_file", False)
+    ):
         filedata = filedata[0]
 
     if type(filedata) == dict and filedata.get("is_file", False):
         filename = filedata["name"]
         is_in_right_dir = ui_tempdir.check_tmp_file(shared.demo, filename)
-        assert is_in_right_dir, 'trying to open image file outside of allowed directories'
+        assert (
+            is_in_right_dir
+        ), "trying to open image file outside of allowed directories"
 
-        filename = filename.rsplit('?', 1)[0]
+        filename = filename.rsplit("?", 1)[0]
         return images.read(filename)
 
     if type(filedata) == list:
@@ -92,27 +119,31 @@ def image_from_url_text(filedata):
         filedata = filedata[0]
 
     if filedata.startswith("data:image/png;base64,"):
-        filedata = filedata[len("data:image/png;base64,"):]
+        filedata = filedata[len("data:image/png;base64,") :]
 
-    filedata = base64.decodebytes(filedata.encode('utf-8'))
+    filedata = base64.decodebytes(filedata.encode("utf-8"))
     image = images.read(io.BytesIO(filedata))
     return image
 
 
 def add_paste_fields(tabname, init_img, fields, override_settings_component=None):
-
     if fields:
         for i in range(len(fields)):
             if not isinstance(fields[i], PasteField):
                 fields[i] = PasteField(*fields[i])
 
-    paste_fields[tabname] = {"init_img": init_img, "fields": fields, "override_settings_component": override_settings_component}
+    paste_fields[tabname] = {
+        "init_img": init_img,
+        "fields": fields,
+        "override_settings_component": override_settings_component,
+    }
 
     # backwards compatibility for existing extensions
     import modules.ui
-    if tabname == 'txt2img':
+
+    if tabname == "txt2img":
         modules.ui.txt2img_paste_fields = fields
-    elif tabname == 'img2img':
+    elif tabname == "img2img":
         modules.ui.img2img_paste_fields = fields
 
 
@@ -126,10 +157,24 @@ def create_buttons(tabs_list):
 def bind_buttons(buttons, send_image, send_generate_info):
     """old function for backwards compatibility; do not use this, use register_paste_params_button"""
     for tabname, button in buttons.items():
-        source_text_component = send_generate_info if isinstance(send_generate_info, gr.components.Component) else None
-        source_tabname = send_generate_info if isinstance(send_generate_info, str) else None
+        source_text_component = (
+            send_generate_info
+            if isinstance(send_generate_info, gr.components.Component)
+            else None
+        )
+        source_tabname = (
+            send_generate_info if isinstance(send_generate_info, str) else None
+        )
 
-        register_paste_params_button(ParamBinding(paste_button=button, tabname=tabname, source_text_component=source_text_component, source_image_component=send_image, source_tabname=source_tabname))
+        register_paste_params_button(
+            ParamBinding(
+                paste_button=button,
+                tabname=tabname,
+                source_text_component=source_text_component,
+                source_image_component=send_image,
+                source_tabname=source_tabname,
+            )
+        )
 
 
 def register_paste_params_button(binding: ParamBinding):
@@ -140,36 +185,77 @@ def connect_paste_params_buttons():
     for binding in registered_param_bindings:
         destination_image_component = paste_fields[binding.tabname]["init_img"]
         fields = paste_fields[binding.tabname]["fields"]
-        override_settings_component = binding.override_settings_component or paste_fields[binding.tabname]["override_settings_component"]
+        override_settings_component = (
+            binding.override_settings_component
+            or paste_fields[binding.tabname]["override_settings_component"]
+        )
 
-        destination_width_component = next(iter([field for field, name in fields if name == "Size-1"] if fields else []), None)
-        destination_height_component = next(iter([field for field, name in fields if name == "Size-2"] if fields else []), None)
+        destination_width_component = next(
+            iter(
+                [field for field, name in fields if name == "Size-1"] if fields else []
+            ),
+            None,
+        )
+        destination_height_component = next(
+            iter(
+                [field for field, name in fields if name == "Size-2"] if fields else []
+            ),
+            None,
+        )
 
         if binding.source_image_component and destination_image_component:
-            need_send_dementions = destination_width_component and binding.tabname != 'inpaint'
+            need_send_dementions = (
+                destination_width_component and binding.tabname != "inpaint"
+            )
             if isinstance(binding.source_image_component, gr.Gallery):
-                func = send_image_and_dimensions if need_send_dementions else image_from_url_text
+                func = (
+                    send_image_and_dimensions
+                    if need_send_dementions
+                    else image_from_url_text
+                )
                 jsfunc = "extract_image_from_gallery"
             else:
-                func = send_image_and_dimensions if need_send_dementions else lambda x: x
+                func = (
+                    send_image_and_dimensions if need_send_dementions else lambda x: x
+                )
                 jsfunc = None
 
             binding.paste_button.click(
                 fn=func,
                 _js=jsfunc,
                 inputs=[binding.source_image_component],
-                outputs=[destination_image_component, destination_width_component, destination_height_component] if need_send_dementions else [destination_image_component],
+                outputs=[
+                    destination_image_component,
+                    destination_width_component,
+                    destination_height_component,
+                ]
+                if need_send_dementions
+                else [destination_image_component],
                 show_progress=False,
             )
 
         if binding.source_text_component is not None and fields is not None:
-            connect_paste(binding.paste_button, fields, binding.source_text_component, override_settings_component, binding.tabname)
+            connect_paste(
+                binding.paste_button,
+                fields,
+                binding.source_text_component,
+                override_settings_component,
+                binding.tabname,
+            )
 
         if binding.source_tabname is not None and fields is not None:
-            paste_field_names = ['Prompt', 'Negative prompt', 'Steps', 'Face restoration'] + (["Seed"] if shared.opts.send_seed else []) + binding.paste_field_names
+            paste_field_names = (
+                ["Prompt", "Negative prompt", "Steps", "Face restoration"]
+                + (["Seed"] if shared.opts.send_seed else [])
+                + binding.paste_field_names
+            )
             binding.paste_button.click(
                 fn=lambda *x: x,
-                inputs=[field for field, name in paste_fields[binding.source_tabname]["fields"] if name in paste_field_names],
+                inputs=[
+                    field
+                    for field, name in paste_fields[binding.source_tabname]["fields"]
+                    if name in paste_field_names
+                ],
                 outputs=[field for field, name in fields if name in paste_field_names],
                 show_progress=False,
             )
@@ -203,16 +289,16 @@ def restore_old_hires_fix_params(res):
     """for infotexts that specify old First pass size parameter, convert it into
     width, height, and hr scale"""
 
-    firstpass_width = res.get('First pass size-1', None)
-    firstpass_height = res.get('First pass size-2', None)
+    firstpass_width = res.get("First pass size-1", None)
+    firstpass_height = res.get("First pass size-2", None)
 
     if shared.opts.use_old_hires_fix_width_height:
         hires_width = int(res.get("Hires resize-1", 0))
         hires_height = int(res.get("Hires resize-2", 0))
 
         if hires_width and hires_height:
-            res['Size-1'] = hires_width
-            res['Size-2'] = hires_height
+            res["Size-1"] = hires_width
+            res["Size-2"] = hires_height
             return
 
     if firstpass_width is None or firstpass_height is None:
@@ -223,23 +309,25 @@ def restore_old_hires_fix_params(res):
     height = int(res.get("Size-2", 512))
 
     if firstpass_width == 0 or firstpass_height == 0:
-        firstpass_width, firstpass_height = processing.old_hires_fix_first_pass_dimensions(width, height)
+        firstpass_width, firstpass_height = (
+            processing.old_hires_fix_first_pass_dimensions(width, height)
+        )
 
-    res['Size-1'] = firstpass_width
-    res['Size-2'] = firstpass_height
-    res['Hires resize-1'] = width
-    res['Hires resize-2'] = height
+    res["Size-1"] = firstpass_width
+    res["Size-2"] = firstpass_height
+    res["Hires resize-1"] = width
+    res["Hires resize-2"] = height
 
 
 def parse_generation_parameters(x: str, skip_fields: list[str] | None = None):
     """parses generation parameters string, the one you see in text field under the picture in UI:
-```
-girl with an artist's beret, determined, blue eyes, desert scene, computer monitors, heavy makeup, by Alphonse Mucha and Charlie Bowater, ((eyeshadow)), (coquettish), detailed, intricate
-Negative prompt: ugly, fat, obese, chubby, (((deformed))), [blurry], bad anatomy, disfigured, poorly drawn face, mutation, mutated, (extra_limb), (ugly), (poorly drawn hands), messy drawing
-Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model hash: 45dee52b
-```
+    ```
+    girl with an artist's beret, determined, blue eyes, desert scene, computer monitors, heavy makeup, by Alphonse Mucha and Charlie Bowater, ((eyeshadow)), (coquettish), detailed, intricate
+    Negative prompt: ugly, fat, obese, chubby, (((deformed))), [blurry], bad anatomy, disfigured, poorly drawn face, mutation, mutated, (extra_limb), (ugly), (poorly drawn hands), messy drawing
+    Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model hash: 45dee52b
+    ```
 
-    returns a dict with field values
+        returns a dict with field values
     """
     if skip_fields is None:
         skip_fields = shared.opts.infotext_skip_pasting
@@ -254,7 +342,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     *lines, lastline = x.strip().split("\n")
     if len(re_param.findall(lastline)) < 3:
         lines.append(lastline)
-        lastline = ''
+        lastline = ""
 
     for line in lines:
         line = line.strip()
@@ -278,24 +366,47 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
             else:
                 res[k] = v
         except Exception:
-            print(f"Error parsing \"{k}: {v}\"")
+            print(f'Error parsing "{k}: {v}"')
 
     # Extract styles from prompt
     if shared.opts.infotext_styles != "Ignore":
-        found_styles, prompt_no_styles, negative_prompt_no_styles = shared.prompt_styles.extract_styles_from_prompt(prompt, negative_prompt)
+        found_styles, prompt_no_styles, negative_prompt_no_styles = (
+            shared.prompt_styles.extract_styles_from_prompt(prompt, negative_prompt)
+        )
 
         same_hr_styles = True
-        if ("Hires prompt" in res or "Hires negative prompt" in res) and (infotext_ver > infotext_versions.v180_hr_styles if (infotext_ver := infotext_versions.parse_version(res.get("Version"))) else True):
-            hr_prompt, hr_negative_prompt = res.get("Hires prompt", prompt), res.get("Hires negative prompt", negative_prompt)
-            hr_found_styles, hr_prompt_no_styles, hr_negative_prompt_no_styles = shared.prompt_styles.extract_styles_from_prompt(hr_prompt, hr_negative_prompt)
+        if ("Hires prompt" in res or "Hires negative prompt" in res) and (
+            infotext_ver > infotext_versions.v180_hr_styles
+            if (infotext_ver := infotext_versions.parse_version(res.get("Version")))
+            else True
+        ):
+            hr_prompt, hr_negative_prompt = (
+                res.get("Hires prompt", prompt),
+                res.get("Hires negative prompt", negative_prompt),
+            )
+            hr_found_styles, hr_prompt_no_styles, hr_negative_prompt_no_styles = (
+                shared.prompt_styles.extract_styles_from_prompt(
+                    hr_prompt, hr_negative_prompt
+                )
+            )
             if same_hr_styles := found_styles == hr_found_styles:
-                res["Hires prompt"] = '' if hr_prompt_no_styles == prompt_no_styles else hr_prompt_no_styles
-                res['Hires negative prompt'] = '' if hr_negative_prompt_no_styles == negative_prompt_no_styles else hr_negative_prompt_no_styles
+                res["Hires prompt"] = (
+                    ""
+                    if hr_prompt_no_styles == prompt_no_styles
+                    else hr_prompt_no_styles
+                )
+                res["Hires negative prompt"] = (
+                    ""
+                    if hr_negative_prompt_no_styles == negative_prompt_no_styles
+                    else hr_negative_prompt_no_styles
+                )
 
         if same_hr_styles:
             prompt, negative_prompt = prompt_no_styles, negative_prompt_no_styles
-            if (shared.opts.infotext_styles == "Apply if any" and found_styles) or shared.opts.infotext_styles == "Apply":
-                res['Styles array'] = found_styles
+            if (
+                shared.opts.infotext_styles == "Apply if any" and found_styles
+            ) or shared.opts.infotext_styles == "Apply":
+                res["Styles array"] = found_styles
 
     res["Prompt"] = prompt
     res["Negative prompt"] = negative_prompt
@@ -306,7 +417,9 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     hypernet = res.get("Hypernet", None)
     if hypernet is not None:
-        res["Prompt"] += f"""<hypernet:{hypernet}:{res.get("Hypernet strength", "1.0")}>"""
+        res["Prompt"] += (
+            f"""<hypernet:{hypernet}:{res.get("Hypernet strength", "1.0")}>"""
+        )
 
     if "Hires resize-1" not in res:
         res["Hires resize-1"] = 0
@@ -331,7 +444,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         res["Mask mode"] = "Inpaint masked"
 
     if "Masked content" not in res:
-        res["Masked content"] = 'original'
+        res["Masked content"] = "original"
 
     if "Inpaint area" not in res:
         res["Inpaint area"] = "Whole picture"
@@ -371,7 +484,9 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
 
     prompt_attention = prompt_parser.parse_prompt_attention(prompt)
     prompt_attention += prompt_parser.parse_prompt_attention(negative_prompt)
-    prompt_uses_emphasis = len(prompt_attention) != len([p for p in prompt_attention if p[1] == 1.0 or p[0] == 'BREAK'])
+    prompt_uses_emphasis = len(prompt_attention) != len(
+        [p for p in prompt_attention if p[1] == 1.0 or p[0] == "BREAK"]
+    )
     if "Emphasis" not in res and prompt_uses_emphasis:
         res["Emphasis"] = "Original"
 
@@ -386,9 +501,7 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
     return res
 
 
-infotext_to_setting_name_mapping = [
-
-]
+infotext_to_setting_name_mapping = []
 """Mapping of infotext labels to setting names. Only left for backwards compatibility - use OptionInfo(..., infotext='...') instead.
 Example content:
 
@@ -419,7 +532,11 @@ def create_override_settings_dict(text_pairs):
 
         params[k] = v.strip()
 
-    mapping = [(info.infotext, k) for k, info in shared.opts.data_labels.items() if info.infotext]
+    mapping = [
+        (info.infotext, k)
+        for k, info in shared.opts.data_labels.items()
+        if info.infotext
+    ]
     for param_name, setting_name in mapping + infotext_to_setting_name_mapping:
         value = params.get(param_name, None)
 
@@ -450,7 +567,11 @@ def get_override_settings(params, *, skip_fields=None):
 
     res = []
 
-    mapping = [(info.infotext, k) for k, info in shared.opts.data_labels.items() if info.infotext]
+    mapping = [
+        (info.infotext, k)
+        for k, info in shared.opts.data_labels.items()
+        if info.infotext
+    ]
     for param_name, setting_name in mapping + infotext_to_setting_name_mapping:
         if param_name in (skip_fields or {}):
             continue
@@ -459,7 +580,10 @@ def get_override_settings(params, *, skip_fields=None):
         if v is None:
             continue
 
-        if setting_name == "sd_model_checkpoint" and shared.opts.disable_weights_auto_swap:
+        if (
+            setting_name == "sd_model_checkpoint"
+            and shared.opts.disable_weights_auto_swap
+        ):
             continue
 
         v = shared.opts.cast_value(setting_name, v)
@@ -473,9 +597,15 @@ def get_override_settings(params, *, skip_fields=None):
     return res
 
 
-def connect_paste(button, paste_fields, input_comp, override_settings_component, tabname):
+def connect_paste(
+    button, paste_fields, input_comp, override_settings_component, tabname
+):
     def paste_func(prompt):
-        if not prompt and not shared.cmd_opts.hide_ui_dir_config and not shared.cmd_opts.no_prompt_history:
+        if (
+            not prompt
+            and not shared.cmd_opts.hide_ui_dir_config
+            and not shared.cmd_opts.no_prompt_history
+        ):
             filename = os.path.join(data_path, "params.txt")
             try:
                 with open(filename, "r", encoding="utf8") as file:
@@ -524,9 +654,14 @@ def connect_paste(button, paste_fields, input_comp, override_settings_component,
         def paste_settings(params):
             vals = get_override_settings(params, skip_fields=already_handled_fields)
 
-            vals_pairs = [f"{infotext_text}: {value}" for infotext_text, setting_name, value in vals]
+            vals_pairs = [
+                f"{infotext_text}: {value}"
+                for infotext_text, setting_name, value in vals
+            ]
 
-            return gr.Dropdown.update(value=vals_pairs, choices=vals_pairs, visible=bool(vals_pairs))
+            return gr.Dropdown.update(
+                value=vals_pairs, choices=vals_pairs, visible=bool(vals_pairs)
+            )
 
         paste_fields = paste_fields + [(override_settings_component, paste_settings)]
 
@@ -543,4 +678,3 @@ def connect_paste(button, paste_fields, input_comp, override_settings_component,
         outputs=[],
         show_progress=False,
     )
-

--- a/modules/infotext_versions.py
+++ b/modules/infotext_versions.py
@@ -13,7 +13,7 @@ def parse_version(text):
     if text is None:
         return None
 
-    m = re.match(r'([^-]+-[^-]+)-.*', text)
+    m = re.match(r"([^-]+-[^-]+)-.*", text)
     if m:
         text = m.group(1)
 
@@ -33,14 +33,14 @@ def backcompat(d):
     if ver is None:
         return
 
-    if ver < v160 and '[' in d.get('Prompt', ''):
+    if ver < v160 and "[" in d.get("Prompt", ""):
         d["Old prompt editing timelines"] = True
 
-    if ver < v160 and d.get('Sampler', '') in ('DDIM', 'PLMS'):
+    if ver < v160 and d.get("Sampler", "") in ("DDIM", "PLMS"):
         d["Pad conds v0"] = True
 
     if ver < v170_tsnr:
         d["Downcast alphas_cumprod"] = True
 
-    if ver < v180 and d.get('Refiner'):
+    if ver < v180 and d.get("Refiner"):
         d["Refiner switch by sampling steps"] = True

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -10,33 +10,45 @@ from modules.timer import startup_timer
 
 def imports():
     logging.getLogger("torch.distributed.nn").setLevel(logging.ERROR)  # sshh...
-    logging.getLogger("xformers").addFilter(lambda record: 'A matching Triton is not available' not in record.getMessage())
+    logging.getLogger("xformers").addFilter(
+        lambda record: "A matching Triton is not available" not in record.getMessage()
+    )
 
     import torch  # noqa: F401
+
     startup_timer.record("import torch")
     import pytorch_lightning  # noqa: F401
+
     startup_timer.record("import torch")
-    warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="pytorch_lightning")
+    warnings.filterwarnings(
+        action="ignore", category=DeprecationWarning, module="pytorch_lightning"
+    )
     warnings.filterwarnings(action="ignore", category=UserWarning, module="torchvision")
 
-    os.environ.setdefault('GRADIO_ANALYTICS_ENABLED', 'False')
+    os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
     import gradio  # noqa: F401
+
     startup_timer.record("import gradio")
 
     from modules import paths, timer, import_hook, errors  # noqa: F401
+
     startup_timer.record("setup paths")
 
     import ldm.modules.encoders.modules  # noqa: F401
+
     startup_timer.record("import ldm")
 
     import sgm.modules.encoders.modules  # noqa: F401
+
     startup_timer.record("import sgm")
 
     from modules import shared_init
+
     shared_init.initialize()
     startup_timer.record("initialize shared")
 
     from modules import processing, gradio_extensons, ui  # noqa: F401
+
     startup_timer.record("other imports")
 
 
@@ -45,11 +57,13 @@ def check_versions():
 
     if not cmd_opts.skip_version_check:
         from modules import errors
+
         errors.check_versions()
 
 
 def initialize():
     from modules import initialize_util
+
     initialize_util.fix_torch_version()
     initialize_util.fix_pytorch_lightning()
     initialize_util.fix_asyncio_event_loop_policy()
@@ -58,17 +72,24 @@ def initialize():
     initialize_util.configure_opts_onchange()
 
     from modules import sd_models
+
     sd_models.setup_model()
     startup_timer.record("setup SD model")
 
     from modules.shared_cmd_options import cmd_opts
 
     from modules import codeformer_model
-    warnings.filterwarnings(action="ignore", category=UserWarning, module="torchvision.transforms.functional_tensor")
+
+    warnings.filterwarnings(
+        action="ignore",
+        category=UserWarning,
+        module="torchvision.transforms.functional_tensor",
+    )
     codeformer_model.setup_model(cmd_opts.codeformer_models_path)
     startup_timer.record("setup codeformer")
 
     from modules import gfpgan_model
+
     gfpgan_model.setup_model(cmd_opts.gfpgan_models_path)
     startup_timer.record("setup gfpgan")
 
@@ -82,28 +103,34 @@ def initialize_rest(*, reload_script_modules=False):
     from modules.shared_cmd_options import cmd_opts
 
     from modules import sd_samplers
+
     sd_samplers.set_samplers()
     startup_timer.record("set samplers")
 
     from modules import extensions
+
     extensions.list_extensions()
     startup_timer.record("list extensions")
 
     from modules import initialize_util
+
     initialize_util.restore_config_state_file()
     startup_timer.record("restore config state file")
 
     from modules import shared, upscaler, scripts
+
     if cmd_opts.ui_debug_mode:
         shared.sd_upscalers = upscaler.UpscalerLanczos().scalers
         scripts.load_scripts()
         return
 
     from modules import sd_models
+
     sd_models.list_models()
     startup_timer.record("list SD models")
 
     from modules import localization
+
     localization.list_localizations(cmd_opts.localizations_dir)
     startup_timer.record("list localizations")
 
@@ -111,28 +138,37 @@ def initialize_rest(*, reload_script_modules=False):
         scripts.load_scripts()
 
     if reload_script_modules and shared.opts.enable_reloading_ui_scripts:
-        for module in [module for name, module in sys.modules.items() if name.startswith("modules.ui")]:
+        for module in [
+            module
+            for name, module in sys.modules.items()
+            if name.startswith("modules.ui")
+        ]:
             importlib.reload(module)
         startup_timer.record("reload script modules")
 
     from modules import modelloader
+
     modelloader.load_upscalers()
     startup_timer.record("load upscalers")
 
     from modules import sd_vae
+
     sd_vae.refresh_vae_list()
     startup_timer.record("refresh VAE")
 
     from modules import textual_inversion
+
     textual_inversion.textual_inversion.list_textual_inversion_templates()
     startup_timer.record("refresh textual inversion templates")
 
     from modules import script_callbacks, sd_hijack_optimizations, sd_hijack
+
     script_callbacks.on_list_optimizers(sd_hijack_optimizations.list_optimizers)
     sd_hijack.list_optimizers()
     startup_timer.record("scripts list_optimizers")
 
     from modules import sd_unet
+
     sd_unet.list_unets()
     startup_timer.record("scripts list_unets")
 
@@ -144,6 +180,7 @@ def initialize_rest(*, reload_script_modules=False):
         by that time, so we apply optimization again.
         """
         from modules import devices
+
         devices.torch_npu_set_device()
 
         shared.sd_model  # noqa: B018
@@ -152,18 +189,22 @@ def initialize_rest(*, reload_script_modules=False):
             sd_hijack.apply_optimizations()
 
         devices.first_time_calculation()
+
     if not shared.cmd_opts.skip_load_model_at_start:
         Thread(target=load_model).start()
 
     from modules import shared_items
+
     shared_items.reload_hypernetworks()
     startup_timer.record("reload hypernetworks")
 
     from modules import ui_extra_networks
+
     ui_extra_networks.initialize()
     ui_extra_networks.register_default_pages()
 
     from modules import extra_networks
+
     extra_networks.initialize()
     extra_networks.register_default_extra_networks()
     startup_timer.record("initialize extra networks")

--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -22,24 +22,31 @@ def fix_torch_version():
     # Truncate version number of nightly/local build of PyTorch to not cause exceptions with CodeFormer or Safetensors
     if ".dev" in torch.__version__ or "+git" in torch.__version__:
         torch.__long_version__ = torch.__version__
-        torch.__version__ = re.search(r'[\d.]+[\d]', torch.__version__).group(0)
+        torch.__version__ = re.search(r"[\d.]+[\d]", torch.__version__).group(0)
+
 
 def fix_pytorch_lightning():
     # Checks if pytorch_lightning.utilities.distributed already exists in the sys.modules cache
-    if 'pytorch_lightning.utilities.distributed' not in sys.modules:
+    if "pytorch_lightning.utilities.distributed" not in sys.modules:
         import pytorch_lightning
+
         # Lets the user know that the library was not found and then will set it to pytorch_lightning.utilities.rank_zero
-        print("Pytorch_lightning.distributed not found, attempting pytorch_lightning.rank_zero")
-        sys.modules["pytorch_lightning.utilities.distributed"] = pytorch_lightning.utilities.rank_zero
+        print(
+            "Pytorch_lightning.distributed not found, attempting pytorch_lightning.rank_zero"
+        )
+        sys.modules["pytorch_lightning.utilities.distributed"] = (
+            pytorch_lightning.utilities.rank_zero
+        )
+
 
 def fix_asyncio_event_loop_policy():
     """
-        The default `asyncio` event loop policy only automatically creates
-        event loops in the main threads. Other threads must create event
-        loops explicitly or `asyncio.get_event_loop` (and therefore
-        `.IOLoop.current`) will fail. Installing this policy allows event
-        loops to be created automatically on any thread, matching the
-        behavior of Tornado versions prior to 5.0 (or 5.0 on Python 2).
+    The default `asyncio` event loop policy only automatically creates
+    event loops in the main threads. Other threads must create event
+    loops explicitly or `asyncio.get_event_loop` (and therefore
+    `.IOLoop.current`) will fail. Installing this policy allows event
+    loops to be created automatically on any thread, matching the
+    behavior of Tornado versions prior to 5.0 (or 5.0 on Python 2).
     """
 
     import asyncio
@@ -122,18 +129,18 @@ def get_gradio_auth_creds():
         s = s.strip()
         if not s:
             return None
-        return tuple(s.split(':', 1))
+        return tuple(s.split(":", 1))
 
     if cmd_opts.gradio_auth:
-        for cred in cmd_opts.gradio_auth.split(','):
+        for cred in cmd_opts.gradio_auth.split(","):
             cred = process_credential_line(cred)
             if cred:
                 yield cred
 
     if cmd_opts.gradio_auth_path:
-        with open(cmd_opts.gradio_auth_path, 'r', encoding="utf8") as file:
+        with open(cmd_opts.gradio_auth_path, "r", encoding="utf8") as file:
             for line in file.readlines():
-                for cred in line.strip().split(','):
+                for cred in line.strip().split(","):
                     cred = process_credential_line(cred)
                     if cred:
                         yield cred
@@ -161,7 +168,7 @@ def configure_sigint_handler():
     from modules import shared
 
     def sigint_handler(sig, frame):
-        print(f'Interrupted with signal {sig} in {frame}')
+        print(f"Interrupted with signal {sig} in {frame}")
 
         if shared.opts.dump_stacks_on_signal:
             dumpstacks()
@@ -178,21 +185,45 @@ def configure_opts_onchange():
     from modules import shared, sd_models, sd_vae, ui_tempdir, sd_hijack
     from modules.call_queue import wrap_queued_call
 
-    shared.opts.onchange("sd_model_checkpoint", wrap_queued_call(lambda: sd_models.reload_model_weights()), call=False)
-    shared.opts.onchange("sd_vae", wrap_queued_call(lambda: sd_vae.reload_vae_weights()), call=False)
-    shared.opts.onchange("sd_vae_overrides_per_model_preferences", wrap_queued_call(lambda: sd_vae.reload_vae_weights()), call=False)
+    shared.opts.onchange(
+        "sd_model_checkpoint",
+        wrap_queued_call(lambda: sd_models.reload_model_weights()),
+        call=False,
+    )
+    shared.opts.onchange(
+        "sd_vae", wrap_queued_call(lambda: sd_vae.reload_vae_weights()), call=False
+    )
+    shared.opts.onchange(
+        "sd_vae_overrides_per_model_preferences",
+        wrap_queued_call(lambda: sd_vae.reload_vae_weights()),
+        call=False,
+    )
     shared.opts.onchange("temp_dir", ui_tempdir.on_tmpdir_changed)
     shared.opts.onchange("gradio_theme", shared.reload_gradio_theme)
-    shared.opts.onchange("cross_attention_optimization", wrap_queued_call(lambda: sd_hijack.model_hijack.redo_hijack(shared.sd_model)), call=False)
-    shared.opts.onchange("fp8_storage", wrap_queued_call(lambda: sd_models.reload_model_weights()), call=False)
-    shared.opts.onchange("cache_fp16_weight", wrap_queued_call(lambda: sd_models.reload_model_weights(forced_reload=True)), call=False)
+    shared.opts.onchange(
+        "cross_attention_optimization",
+        wrap_queued_call(lambda: sd_hijack.model_hijack.redo_hijack(shared.sd_model)),
+        call=False,
+    )
+    shared.opts.onchange(
+        "fp8_storage",
+        wrap_queued_call(lambda: sd_models.reload_model_weights()),
+        call=False,
+    )
+    shared.opts.onchange(
+        "cache_fp16_weight",
+        wrap_queued_call(lambda: sd_models.reload_model_weights(forced_reload=True)),
+        call=False,
+    )
     startup_timer.record("opts onchange")
 
 
 def setup_middleware(app):
     from starlette.middleware.gzip import GZipMiddleware
 
-    app.middleware_stack = None  # reset current middleware to allow modifying user provided list
+    app.middleware_stack = (
+        None  # reset current middleware to allow modifying user provided list
+    )
     app.add_middleware(GZipMiddleware, minimum_size=1000)
     configure_cors_middleware(app)
     app.build_middleware_stack()  # rebuild middleware stack on-the-fly
@@ -208,8 +239,7 @@ def configure_cors_middleware(app):
         "allow_credentials": True,
     }
     if cmd_opts.cors_allow_origins:
-        cors_options["allow_origins"] = cmd_opts.cors_allow_origins.split(',')
+        cors_options["allow_origins"] = cmd_opts.cors_allow_origins.split(",")
     if cmd_opts.cors_allow_origins_regex:
         cors_options["allow_origin_regex"] = cmd_opts.cors_allow_origins_regex
     app.add_middleware(CORSMiddleware, **cors_options)
-

--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -13,14 +13,15 @@ from torchvision.transforms.functional import InterpolationMode
 from modules import devices, paths, shared, lowvram, modelloader, errors, torch_utils
 
 blip_image_eval_size = 384
-clip_model_name = 'ViT-L/14'
+clip_model_name = "ViT-L/14"
 
 Category = namedtuple("Category", ["name", "topn", "items"])
 
 re_topn = re.compile(r"\.top(\d+)$")
 
+
 def category_types():
-    return [f.stem for f in Path(shared.interrogator.content_dir).glob('*.txt')]
+    return [f.stem for f in Path(shared.interrogator.content_dir).glob("*.txt")]
 
 
 def download_default_clip_interrogate_categories(content_dir):
@@ -32,7 +33,10 @@ def download_default_clip_interrogate_categories(content_dir):
     try:
         os.makedirs(tmpdir, exist_ok=True)
         for category_type in category_types:
-            torch.hub.download_url_to_file(f"https://raw.githubusercontent.com/pharmapsychotic/clip-interrogator/main/clip_interrogator/data/{category_type}.txt", os.path.join(tmpdir, f"{category_type}.txt"))
+            torch.hub.download_url_to_file(
+                f"https://raw.githubusercontent.com/pharmapsychotic/clip-interrogator/main/clip_interrogator/data/{category_type}.txt",
+                os.path.join(tmpdir, f"{category_type}.txt"),
+            )
         os.rename(tmpdir, content_dir)
 
     except Exception as e:
@@ -59,15 +63,18 @@ class InterrogateModels:
         if not os.path.exists(self.content_dir):
             download_default_clip_interrogate_categories(self.content_dir)
 
-        if self.loaded_categories is not None and self.skip_categories == shared.opts.interrogate_clip_skip_categories:
-           return self.loaded_categories
+        if (
+            self.loaded_categories is not None
+            and self.skip_categories == shared.opts.interrogate_clip_skip_categories
+        ):
+            return self.loaded_categories
 
         self.loaded_categories = []
 
         if os.path.exists(self.content_dir):
             self.skip_categories = shared.opts.interrogate_clip_skip_categories
             category_types = []
-            for filename in Path(self.content_dir).glob('*.txt'):
+            for filename in Path(self.content_dir).glob("*.txt"):
                 category_types.append(filename.stem)
                 if filename.stem in self.skip_categories:
                     continue
@@ -76,7 +83,9 @@ class InterrogateModels:
                 with open(filename, "r", encoding="utf8") as file:
                     lines = [x.strip() for x in file.readlines()]
 
-                self.loaded_categories.append(Category(name=filename.stem, topn=topn, items=lines))
+                self.loaded_categories.append(
+                    Category(name=filename.stem, topn=topn, items=lines)
+                )
 
         return self.loaded_categories
 
@@ -93,12 +102,17 @@ class InterrogateModels:
 
         files = modelloader.load_models(
             model_path=os.path.join(paths.models_path, "BLIP"),
-            model_url='https://storage.googleapis.com/sfr-vision-language-research/BLIP/models/model_base_caption_capfilt_large.pth',
+            model_url="https://storage.googleapis.com/sfr-vision-language-research/BLIP/models/model_base_caption_capfilt_large.pth",
             ext_filter=[".pth"],
-            download_name='model_base_caption_capfilt_large.pth',
+            download_name="model_base_caption_capfilt_large.pth",
         )
 
-        blip_model = models.blip.blip_decoder(pretrained=files[0], image_size=blip_image_eval_size, vit='base', med_config=os.path.join(paths.paths["BLIP"], "configs", "med_config.json"))
+        blip_model = models.blip.blip_decoder(
+            pretrained=files[0],
+            image_size=blip_image_eval_size,
+            vit="base",
+            med_config=os.path.join(paths.paths["BLIP"], "configs", "med_config.json"),
+        )
         blip_model.eval()
 
         return blip_model
@@ -107,9 +121,15 @@ class InterrogateModels:
         import clip
 
         if self.running_on_cpu:
-            model, preprocess = clip.load(clip_model_name, device="cpu", download_root=shared.cmd_opts.clip_models_path)
+            model, preprocess = clip.load(
+                clip_model_name,
+                device="cpu",
+                download_root=shared.cmd_opts.clip_models_path,
+            )
         else:
-            model, preprocess = clip.load(clip_model_name, download_root=shared.cmd_opts.clip_models_path)
+            model, preprocess = clip.load(
+                clip_model_name, download_root=shared.cmd_opts.clip_models_path
+            )
 
         model.eval()
         model = model.to(devices.device_interrogate)
@@ -155,30 +175,56 @@ class InterrogateModels:
         devices.torch_gc()
 
         if shared.opts.interrogate_clip_dict_limit != 0:
-            text_array = text_array[0:int(shared.opts.interrogate_clip_dict_limit)]
+            text_array = text_array[0 : int(shared.opts.interrogate_clip_dict_limit)]
 
         top_count = min(top_count, len(text_array))
-        text_tokens = clip.tokenize(list(text_array), truncate=True).to(devices.device_interrogate)
+        text_tokens = clip.tokenize(list(text_array), truncate=True).to(
+            devices.device_interrogate
+        )
         text_features = self.clip_model.encode_text(text_tokens).type(self.dtype)
         text_features /= text_features.norm(dim=-1, keepdim=True)
 
         similarity = torch.zeros((1, len(text_array))).to(devices.device_interrogate)
         for i in range(image_features.shape[0]):
-            similarity += (100.0 * image_features[i].unsqueeze(0) @ text_features.T).softmax(dim=-1)
+            similarity += (
+                100.0 * image_features[i].unsqueeze(0) @ text_features.T
+            ).softmax(dim=-1)
         similarity /= image_features.shape[0]
 
         top_probs, top_labels = similarity.cpu().topk(top_count, dim=-1)
-        return [(text_array[top_labels[0][i].numpy()], (top_probs[0][i].numpy()*100)) for i in range(top_count)]
+        return [
+            (text_array[top_labels[0][i].numpy()], (top_probs[0][i].numpy() * 100))
+            for i in range(top_count)
+        ]
 
     def generate_caption(self, pil_image):
-        gpu_image = transforms.Compose([
-            transforms.Resize((blip_image_eval_size, blip_image_eval_size), interpolation=InterpolationMode.BICUBIC),
-            transforms.ToTensor(),
-            transforms.Normalize((0.48145466, 0.4578275, 0.40821073), (0.26862954, 0.26130258, 0.27577711))
-        ])(pil_image).unsqueeze(0).type(self.dtype).to(devices.device_interrogate)
+        gpu_image = (
+            transforms.Compose(
+                [
+                    transforms.Resize(
+                        (blip_image_eval_size, blip_image_eval_size),
+                        interpolation=InterpolationMode.BICUBIC,
+                    ),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        (0.48145466, 0.4578275, 0.40821073),
+                        (0.26862954, 0.26130258, 0.27577711),
+                    ),
+                ]
+            )(pil_image)
+            .unsqueeze(0)
+            .type(self.dtype)
+            .to(devices.device_interrogate)
+        )
 
         with torch.no_grad():
-            caption = self.blip_model.generate(gpu_image, sample=False, num_beams=shared.opts.interrogate_clip_num_beams, min_length=shared.opts.interrogate_clip_min_length, max_length=shared.opts.interrogate_clip_max_length)
+            caption = self.blip_model.generate(
+                gpu_image,
+                sample=False,
+                num_beams=shared.opts.interrogate_clip_num_beams,
+                min_length=shared.opts.interrogate_clip_min_length,
+                max_length=shared.opts.interrogate_clip_max_length,
+            )
 
         return caption[0]
 
@@ -197,10 +243,17 @@ class InterrogateModels:
 
             res = caption
 
-            clip_image = self.clip_preprocess(pil_image).unsqueeze(0).type(self.dtype).to(devices.device_interrogate)
+            clip_image = (
+                self.clip_preprocess(pil_image)
+                .unsqueeze(0)
+                .type(self.dtype)
+                .to(devices.device_interrogate)
+            )
 
             with torch.no_grad(), devices.autocast():
-                image_features = self.clip_model.encode_image(clip_image).type(self.dtype)
+                image_features = self.clip_model.encode_image(clip_image).type(
+                    self.dtype
+                )
 
                 image_features /= image_features.norm(dim=-1, keepdim=True)
 

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -21,14 +21,14 @@ args, _ = cmd_args.parser.parse_known_args()
 logging_config.setup_logging(args.loglevel)
 
 python = sys.executable
-git = os.environ.get('GIT', "git")
-index_url = os.environ.get('INDEX_URL', "")
+git = os.environ.get("GIT", "git")
+index_url = os.environ.get("INDEX_URL", "")
 dir_repos = "repositories"
 
 # Whether to default to printing command output
-default_command_live = (os.environ.get('WEBUI_LAUNCH_LIVE_OUTPUT') == "1")
+default_command_live = os.environ.get("WEBUI_LAUNCH_LIVE_OUTPUT") == "1"
 
-os.environ.setdefault('GRADIO_ANALYTICS_ENABLED', 'False')
+os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
 
 
 def check_python_version():
@@ -65,7 +65,9 @@ Use --skip-python-version-check to suppress this warning.
 @lru_cache()
 def commit_hash():
     try:
-        return subprocess.check_output([git, "-C", script_path, "rev-parse", "HEAD"], shell=False, encoding='utf8').strip()
+        return subprocess.check_output(
+            [git, "-C", script_path, "rev-parse", "HEAD"], shell=False, encoding="utf8"
+        ).strip()
     except Exception:
         return "<none>"
 
@@ -73,10 +75,11 @@ def commit_hash():
 @lru_cache()
 def git_tag():
     try:
-        return subprocess.check_output([git, "-C", script_path, "describe", "--tags"], shell=False, encoding='utf8').strip()
+        return subprocess.check_output(
+            [git, "-C", script_path, "describe", "--tags"], shell=False, encoding="utf8"
+        ).strip()
     except Exception:
         try:
-
             changelog_md = os.path.join(script_path, "CHANGELOG.md")
             with open(changelog_md, "r", encoding="utf-8") as file:
                 line = next((line.strip() for line in file if line.strip()), "<none>")
@@ -86,7 +89,9 @@ def git_tag():
             return "<none>"
 
 
-def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live) -> str:
+def run(
+    command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live
+) -> str:
     if desc is not None:
         print(desc)
 
@@ -94,8 +99,8 @@ def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_
         "args": command,
         "shell": True,
         "env": os.environ if custom_env is None else custom_env,
-        "encoding": 'utf8',
-        "errors": 'ignore',
+        "encoding": "utf8",
+        "errors": "ignore",
     }
 
     if not live:
@@ -115,7 +120,7 @@ def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_
             error_bits.append(f"stderr: {result.stderr}")
         raise RuntimeError("\n".join(error_bits))
 
-    return (result.stdout or "")
+    return result.stdout or ""
 
 
 def is_installed(package):
@@ -140,8 +145,13 @@ def run_pip(command, desc=None, live=default_command_live):
     if args.skip_install:
         return
 
-    index_url_line = f' --index-url {index_url}' if index_url != '' else ''
-    return run(f'"{python}" -m pip {command} --prefer-binary{index_url_line}', desc=f"Installing {desc}", errdesc=f"Couldn't install {desc}", live=live)
+    index_url_line = f" --index-url {index_url}" if index_url != "" else ""
+    return run(
+        f'"{python}" -m pip {command} --prefer-binary{index_url_line}',
+        desc=f"Installing {desc}",
+        errdesc=f"Couldn't install {desc}",
+        live=live,
+    )
 
 
 def check_run_python(code: str) -> bool:
@@ -150,14 +160,39 @@ def check_run_python(code: str) -> bool:
 
 
 def git_fix_workspace(dir, name):
-    run(f'"{git}" -C "{dir}" fetch --refetch --no-auto-gc', f"Fetching all contents for {name}", f"Couldn't fetch {name}", live=True)
-    run(f'"{git}" -C "{dir}" gc --aggressive --prune=now', f"Pruning {name}", f"Couldn't prune {name}", live=True)
+    run(
+        f'"{git}" -C "{dir}" fetch --refetch --no-auto-gc',
+        f"Fetching all contents for {name}",
+        f"Couldn't fetch {name}",
+        live=True,
+    )
+    run(
+        f'"{git}" -C "{dir}" gc --aggressive --prune=now',
+        f"Pruning {name}",
+        f"Couldn't prune {name}",
+        live=True,
+    )
     return
 
 
-def run_git(dir, name, command, desc=None, errdesc=None, custom_env=None, live: bool = default_command_live, autofix=True):
+def run_git(
+    dir,
+    name,
+    command,
+    desc=None,
+    errdesc=None,
+    custom_env=None,
+    live: bool = default_command_live,
+    autofix=True,
+):
     try:
-        return run(f'"{git}" -C "{dir}" {command}', desc=desc, errdesc=errdesc, custom_env=custom_env, live=live)
+        return run(
+            f'"{git}" -C "{dir}" {command}',
+            desc=desc,
+            errdesc=errdesc,
+            custom_env=custom_env,
+            live=live,
+        )
     except RuntimeError:
         if not autofix:
             raise
@@ -165,7 +200,13 @@ def run_git(dir, name, command, desc=None, errdesc=None, custom_env=None, live: 
     print(f"{errdesc}, attempting autofix...")
     git_fix_workspace(dir, name)
 
-    return run(f'"{git}" -C "{dir}" {command}', desc=desc, errdesc=errdesc, custom_env=custom_env, live=live)
+    return run(
+        f'"{git}" -C "{dir}" {command}',
+        desc=desc,
+        errdesc=errdesc,
+        custom_env=custom_env,
+        live=live,
+    )
 
 
 def git_clone(url, dir, name, commithash=None):
@@ -175,49 +216,105 @@ def git_clone(url, dir, name, commithash=None):
         if commithash is None:
             return
 
-        current_hash = run_git(dir, name, 'rev-parse HEAD', None, f"Couldn't determine {name}'s hash: {commithash}", live=False).strip()
+        current_hash = run_git(
+            dir,
+            name,
+            "rev-parse HEAD",
+            None,
+            f"Couldn't determine {name}'s hash: {commithash}",
+            live=False,
+        ).strip()
         if current_hash == commithash:
             return
 
-        if run_git(dir, name, 'config --get remote.origin.url', None, f"Couldn't determine {name}'s origin URL", live=False).strip() != url:
-            run_git(dir, name, f'remote set-url origin "{url}"', None, f"Failed to set {name}'s origin URL", live=False)
+        if (
+            run_git(
+                dir,
+                name,
+                "config --get remote.origin.url",
+                None,
+                f"Couldn't determine {name}'s origin URL",
+                live=False,
+            ).strip()
+            != url
+        ):
+            run_git(
+                dir,
+                name,
+                f'remote set-url origin "{url}"',
+                None,
+                f"Failed to set {name}'s origin URL",
+                live=False,
+            )
 
-        run_git(dir, name, 'fetch', f"Fetching updates for {name}...", f"Couldn't fetch {name}", autofix=False)
+        run_git(
+            dir,
+            name,
+            "fetch",
+            f"Fetching updates for {name}...",
+            f"Couldn't fetch {name}",
+            autofix=False,
+        )
 
-        run_git(dir, name, f'checkout {commithash}', f"Checking out commit for {name} with hash: {commithash}...", f"Couldn't checkout commit {commithash} for {name}", live=True)
+        run_git(
+            dir,
+            name,
+            f"checkout {commithash}",
+            f"Checking out commit for {name} with hash: {commithash}...",
+            f"Couldn't checkout commit {commithash} for {name}",
+            live=True,
+        )
 
         return
 
     try:
-        run(f'"{git}" clone --config core.filemode=false "{url}" "{dir}"', f"Cloning {name} into {dir}...", f"Couldn't clone {name}", live=True)
+        run(
+            f'"{git}" clone --config core.filemode=false "{url}" "{dir}"',
+            f"Cloning {name} into {dir}...",
+            f"Couldn't clone {name}",
+            live=True,
+        )
     except RuntimeError:
         shutil.rmtree(dir, ignore_errors=True)
         raise
 
     if commithash is not None:
-        run(f'"{git}" -C "{dir}" checkout {commithash}', None, "Couldn't checkout {name}'s hash: {commithash}")
+        run(
+            f'"{git}" -C "{dir}" checkout {commithash}',
+            None,
+            "Couldn't checkout {name}'s hash: {commithash}",
+        )
 
 
 def git_pull_recursive(dir):
     for subdir, _, _ in os.walk(dir):
-        if os.path.exists(os.path.join(subdir, '.git')):
+        if os.path.exists(os.path.join(subdir, ".git")):
             try:
-                output = subprocess.check_output([git, '-C', subdir, 'pull', '--autostash'])
-                print(f"Pulled changes for repository in '{subdir}':\n{output.decode('utf-8').strip()}\n")
+                output = subprocess.check_output(
+                    [git, "-C", subdir, "pull", "--autostash"]
+                )
+                print(
+                    f"Pulled changes for repository in '{subdir}':\n{output.decode('utf-8').strip()}\n"
+                )
             except subprocess.CalledProcessError as e:
-                print(f"Couldn't perform 'git pull' on repository in '{subdir}':\n{e.output.decode('utf-8').strip()}\n")
+                print(
+                    f"Couldn't perform 'git pull' on repository in '{subdir}':\n{e.output.decode('utf-8').strip()}\n"
+                )
 
 
 def version_check(commit):
     try:
         import requests
-        commits = requests.get('https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master').json()
-        if commit != "<none>" and commits['commit']['sha'] != commit:
+
+        commits = requests.get(
+            "https://api.github.com/repos/AUTOMATIC1111/stable-diffusion-webui/branches/master"
+        ).json()
+        if commit != "<none>" and commits["commit"]["sha"] != commit:
             print("--------------------------------------------------------")
             print("| You are not up to date with the most recent release. |")
             print("| Consider running `git pull` to update.               |")
             print("--------------------------------------------------------")
-        elif commits['commit']['sha'] == commit:
+        elif commits["commit"]["sha"] == commit:
             print("You are up to date with the most recent release.")
         else:
             print("Not a git clone, can't perform version check.")
@@ -232,9 +329,13 @@ def run_extension_installer(extension_dir):
 
     try:
         env = os.environ.copy()
-        env['PYTHONPATH'] = f"{script_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
+        env["PYTHONPATH"] = f"{script_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
 
-        stdout = run(f'"{python}" "{path_installer}"', errdesc=f"Error running install.py for extension {extension_dir}", custom_env=env).strip()
+        stdout = run(
+            f'"{python}" "{path_installer}"',
+            errdesc=f"Error running install.py for extension {extension_dir}",
+            custom_env=env,
+        ).strip()
         if stdout:
             print(stdout)
     except Exception as e:
@@ -250,13 +351,22 @@ def list_extensions(settings_file):
     except FileNotFoundError:
         pass
     except Exception:
-        errors.report(f'\nCould not load settings\nThe config file "{settings_file}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+        errors.report(
+            f'\nCould not load settings\nThe config file "{settings_file}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n'
+            "",
+            exc_info=True,
+        )
         os.replace(settings_file, os.path.join(script_path, "tmp", "config.json"))
 
-    disabled_extensions = set(settings.get('disabled_extensions', []))
-    disable_all_extensions = settings.get('disable_all_extensions', 'none')
+    disabled_extensions = set(settings.get("disabled_extensions", []))
+    disable_all_extensions = settings.get("disable_all_extensions", "none")
 
-    if disable_all_extensions != 'none' or args.disable_extra_extensions or args.disable_all_extensions or not os.path.isdir(extensions_dir):
+    if (
+        disable_all_extensions != "none"
+        or args.disable_extra_extensions
+        or args.disable_all_extensions
+        or not os.path.isdir(extensions_dir)
+    ):
         return []
 
     return [x for x in os.listdir(extensions_dir) if x not in disabled_extensions]
@@ -309,15 +419,22 @@ def requirements_met(requirements_file):
             except Exception:
                 return False
 
-            if packaging.version.parse(version_required) != packaging.version.parse(version_installed):
+            if packaging.version.parse(version_required) != packaging.version.parse(
+                version_installed
+            ):
                 return False
 
     return True
 
 
 def prepare_environment():
-    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
-    torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.1.2 torchvision==0.16.2 --extra-index-url {torch_index_url}")
+    torch_index_url = os.environ.get(
+        "TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu121"
+    )
+    torch_command = os.environ.get(
+        "TORCH_COMMAND",
+        f"pip install torch==2.1.2 torchvision==0.16.2 --extra-index-url {torch_index_url}",
+    )
     if args.use_ipex:
         if platform.system() == "Windows":
             # The "Nuullll/intel-extension-for-pytorch" wheels were built from IPEX source for Intel Arc GPU: https://github.com/intel/intel-extension-for-pytorch/tree/xpu-main
@@ -331,36 +448,73 @@ def prepare_environment():
             # Limitation:
             #   - Only works for python 3.10
             url_prefix = "https://github.com/Nuullll/intel-extension-for-pytorch/releases/download/v2.0.110%2Bxpu-master%2Bdll-bundle"
-            torch_command = os.environ.get('TORCH_COMMAND', f"pip install {url_prefix}/torch-2.0.0a0+gite9ebda2-cp310-cp310-win_amd64.whl {url_prefix}/torchvision-0.15.2a0+fa99a53-cp310-cp310-win_amd64.whl {url_prefix}/intel_extension_for_pytorch-2.0.110+gitc6ea20b-cp310-cp310-win_amd64.whl")
+            torch_command = os.environ.get(
+                "TORCH_COMMAND",
+                f"pip install {url_prefix}/torch-2.0.0a0+gite9ebda2-cp310-cp310-win_amd64.whl {url_prefix}/torchvision-0.15.2a0+fa99a53-cp310-cp310-win_amd64.whl {url_prefix}/intel_extension_for_pytorch-2.0.110+gitc6ea20b-cp310-cp310-win_amd64.whl",
+            )
         else:
             # Using official IPEX release for linux since it's already an AOT build.
             # However, users still have to install oneAPI toolkit and activate oneAPI environment manually.
             # See https://intel.github.io/intel-extension-for-pytorch/index.html#installation for details.
-            torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://pytorch-extension.intel.com/release-whl/stable/xpu/us/")
-            torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.0.0a0 intel-extension-for-pytorch==2.0.110+gitba7f6c1 --extra-index-url {torch_index_url}")
-    requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
-    requirements_file_for_npu = os.environ.get('REQS_FILE_FOR_NPU', "requirements_npu.txt")
+            torch_index_url = os.environ.get(
+                "TORCH_INDEX_URL",
+                "https://pytorch-extension.intel.com/release-whl/stable/xpu/us/",
+            )
+            torch_command = os.environ.get(
+                "TORCH_COMMAND",
+                f"pip install torch==2.0.0a0 intel-extension-for-pytorch==2.0.110+gitba7f6c1 --extra-index-url {torch_index_url}",
+            )
+    requirements_file = os.environ.get("REQS_FILE", "requirements_versions.txt")
+    requirements_file_for_npu = os.environ.get(
+        "REQS_FILE_FOR_NPU", "requirements_npu.txt"
+    )
 
-    xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.23.post1')
-    clip_package = os.environ.get('CLIP_PACKAGE', "https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip")
-    openclip_package = os.environ.get('OPENCLIP_PACKAGE', "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip")
+    xformers_package = os.environ.get("XFORMERS_PACKAGE", "xformers==0.0.23.post1")
+    clip_package = os.environ.get(
+        "CLIP_PACKAGE",
+        "https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip",
+    )
+    openclip_package = os.environ.get(
+        "OPENCLIP_PACKAGE",
+        "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip",
+    )
 
-    assets_repo = os.environ.get('ASSETS_REPO', "https://github.com/AUTOMATIC1111/stable-diffusion-webui-assets.git")
-    stable_diffusion_repo = os.environ.get('STABLE_DIFFUSION_REPO', "https://github.com/Stability-AI/stablediffusion.git")
-    stable_diffusion_xl_repo = os.environ.get('STABLE_DIFFUSION_XL_REPO', "https://github.com/Stability-AI/generative-models.git")
-    k_diffusion_repo = os.environ.get('K_DIFFUSION_REPO', 'https://github.com/crowsonkb/k-diffusion.git')
-    blip_repo = os.environ.get('BLIP_REPO', 'https://github.com/salesforce/BLIP.git')
+    assets_repo = os.environ.get(
+        "ASSETS_REPO",
+        "https://github.com/AUTOMATIC1111/stable-diffusion-webui-assets.git",
+    )
+    stable_diffusion_repo = os.environ.get(
+        "STABLE_DIFFUSION_REPO", "https://github.com/Stability-AI/stablediffusion.git"
+    )
+    stable_diffusion_xl_repo = os.environ.get(
+        "STABLE_DIFFUSION_XL_REPO",
+        "https://github.com/Stability-AI/generative-models.git",
+    )
+    k_diffusion_repo = os.environ.get(
+        "K_DIFFUSION_REPO", "https://github.com/crowsonkb/k-diffusion.git"
+    )
+    blip_repo = os.environ.get("BLIP_REPO", "https://github.com/salesforce/BLIP.git")
 
-    assets_commit_hash = os.environ.get('ASSETS_COMMIT_HASH', "6f7db241d2f8ba7457bac5ca9753331f0c266917")
-    stable_diffusion_commit_hash = os.environ.get('STABLE_DIFFUSION_COMMIT_HASH', "cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf")
-    stable_diffusion_xl_commit_hash = os.environ.get('STABLE_DIFFUSION_XL_COMMIT_HASH', "45c443b316737a4ab6e40413d7794a7f5657c19f")
-    k_diffusion_commit_hash = os.environ.get('K_DIFFUSION_COMMIT_HASH', "ab527a9a6d347f364e3d185ba6d714e22d80cb3c")
-    blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
+    assets_commit_hash = os.environ.get(
+        "ASSETS_COMMIT_HASH", "6f7db241d2f8ba7457bac5ca9753331f0c266917"
+    )
+    stable_diffusion_commit_hash = os.environ.get(
+        "STABLE_DIFFUSION_COMMIT_HASH", "cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf"
+    )
+    stable_diffusion_xl_commit_hash = os.environ.get(
+        "STABLE_DIFFUSION_XL_COMMIT_HASH", "45c443b316737a4ab6e40413d7794a7f5657c19f"
+    )
+    k_diffusion_commit_hash = os.environ.get(
+        "K_DIFFUSION_COMMIT_HASH", "ab527a9a6d347f364e3d185ba6d714e22d80cb3c"
+    )
+    blip_commit_hash = os.environ.get(
+        "BLIP_COMMIT_HASH", "48211a1594f1321b00f14c9f7a5b4813144b2fb9"
+    )
 
     try:
         # the existence of this file is a signal to webui.sh/bat that webui needs to be restarted when it stops execution
         os.remove(os.path.join(script_path, "tmp", "restart"))
-        os.environ.setdefault('SD_WEBUI_RESTARTING', '1')
+        os.environ.setdefault("SD_WEBUI_RESTARTING", "1")
     except OSError:
         pass
 
@@ -377,16 +531,27 @@ def prepare_environment():
     print(f"Version: {tag}")
     print(f"Commit hash: {commit}")
 
-    if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision"):
-        run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
+    if (
+        args.reinstall_torch
+        or not is_installed("torch")
+        or not is_installed("torchvision")
+    ):
+        run(
+            f'"{python}" -m {torch_command}',
+            "Installing torch and torchvision",
+            "Couldn't install torch",
+            live=True,
+        )
         startup_timer.record("install torch")
 
     if args.use_ipex:
         args.skip_torch_cuda_test = True
-    if not args.skip_torch_cuda_test and not check_run_python("import torch; assert torch.cuda.is_available()"):
+    if not args.skip_torch_cuda_test and not check_run_python(
+        "import torch; assert torch.cuda.is_available()"
+    ):
         raise RuntimeError(
-            'Torch is not able to use GPU; '
-            'add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check'
+            "Torch is not able to use GPU; "
+            "add --skip-torch-cuda-test to COMMANDLINE_ARGS variable to disable this check"
         )
     startup_timer.record("torch GPU test")
 
@@ -408,11 +573,31 @@ def prepare_environment():
 
     os.makedirs(os.path.join(script_path, dir_repos), exist_ok=True)
 
-    git_clone(assets_repo, repo_dir('stable-diffusion-webui-assets'), "assets", assets_commit_hash)
-    git_clone(stable_diffusion_repo, repo_dir('stable-diffusion-stability-ai'), "Stable Diffusion", stable_diffusion_commit_hash)
-    git_clone(stable_diffusion_xl_repo, repo_dir('generative-models'), "Stable Diffusion XL", stable_diffusion_xl_commit_hash)
-    git_clone(k_diffusion_repo, repo_dir('k-diffusion'), "K-diffusion", k_diffusion_commit_hash)
-    git_clone(blip_repo, repo_dir('BLIP'), "BLIP", blip_commit_hash)
+    git_clone(
+        assets_repo,
+        repo_dir("stable-diffusion-webui-assets"),
+        "assets",
+        assets_commit_hash,
+    )
+    git_clone(
+        stable_diffusion_repo,
+        repo_dir("stable-diffusion-stability-ai"),
+        "Stable Diffusion",
+        stable_diffusion_commit_hash,
+    )
+    git_clone(
+        stable_diffusion_xl_repo,
+        repo_dir("generative-models"),
+        "Stable Diffusion XL",
+        stable_diffusion_xl_commit_hash,
+    )
+    git_clone(
+        k_diffusion_repo,
+        repo_dir("k-diffusion"),
+        "K-diffusion",
+        k_diffusion_commit_hash,
+    )
+    git_clone(blip_repo, repo_dir("BLIP"), "BLIP", blip_commit_hash)
 
     startup_timer.record("clone repositores")
 
@@ -420,14 +605,14 @@ def prepare_environment():
         requirements_file = os.path.join(script_path, requirements_file)
 
     if not requirements_met(requirements_file):
-        run_pip(f"install -r \"{requirements_file}\"", "requirements")
+        run_pip(f'install -r "{requirements_file}"', "requirements")
         startup_timer.record("install requirements")
 
     if not os.path.isfile(requirements_file_for_npu):
         requirements_file_for_npu = os.path.join(script_path, requirements_file_for_npu)
 
     if "torch_npu" in torch_command and not requirements_met(requirements_file_for_npu):
-        run_pip(f"install -r \"{requirements_file_for_npu}\"", "requirements_for_npu")
+        run_pip(f'install -r "{requirements_file_for_npu}"', "requirements_for_npu")
         startup_timer.record("install requirements_for_npu")
 
     if not args.skip_install:
@@ -457,13 +642,16 @@ def configure_for_tests():
     if "--disable-nan-check" not in sys.argv:
         sys.argv.append("--disable-nan-check")
 
-    os.environ['COMMANDLINE_ARGS'] = ""
+    os.environ["COMMANDLINE_ARGS"] = ""
 
 
 def start():
-    print(f"Launching {'API server' if '--nowebui' in sys.argv else 'Web UI'} with arguments: {shlex.join(sys.argv[1:])}")
+    print(
+        f"Launching {'API server' if '--nowebui' in sys.argv else 'Web UI'} with arguments: {shlex.join(sys.argv[1:])}"
+    )
     import webui
-    if '--nowebui' in sys.argv:
+
+    if "--nowebui" in sys.argv:
         webui.api_only()
     else:
         webui.webui()

--- a/modules/logging_config.py
+++ b/modules/logging_config.py
@@ -4,7 +4,6 @@ import os
 try:
     from tqdm import tqdm
 
-
     class TqdmLoggingHandler(logging.Handler):
         def __init__(self, fallback_handler: logging.Handler):
             super().__init__()
@@ -37,12 +36,13 @@ def setup_logging(loglevel):
         return
 
     formatter = logging.Formatter(
-        '%(asctime)s %(levelname)s [%(name)s] %(message)s',
-        '%Y-%m-%d %H:%M:%S',
+        "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        "%Y-%m-%d %H:%M:%S",
     )
 
     if os.environ.get("SD_WEBUI_RICH_LOG"):
         from rich.logging import RichHandler
+
         handler = RichHandler()
     else:
         handler = logging.StreamHandler()

--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -6,7 +6,10 @@ from modules import devices, shared
 module_in_gpu = None
 cpu = torch.device("cpu")
 
-ModuleWithParent = namedtuple('ModuleWithParent', ['module', 'parent'], defaults=['None'])
+ModuleWithParent = namedtuple(
+    "ModuleWithParent", ["module", "parent"], defaults=["None"]
+)
+
 
 def send_everything_to_cpu():
     global module_in_gpu
@@ -18,7 +21,12 @@ def send_everything_to_cpu():
 
 
 def is_needed(sd_model):
-    return shared.cmd_opts.lowvram or shared.cmd_opts.medvram or shared.cmd_opts.medvram_sdxl and hasattr(sd_model, 'conditioner')
+    return (
+        shared.cmd_opts.lowvram
+        or shared.cmd_opts.medvram
+        or shared.cmd_opts.medvram_sdxl
+        and hasattr(sd_model, "conditioner")
+    )
 
 
 def apply(sd_model):
@@ -32,7 +40,7 @@ def apply(sd_model):
 
 
 def setup_for_low_vram(sd_model, use_medvram):
-    if getattr(sd_model, 'lowvram', False):
+    if getattr(sd_model, "lowvram", False):
         return
 
     sd_model.lowvram = True
@@ -74,23 +82,23 @@ def setup_for_low_vram(sd_model, use_medvram):
         return first_stage_model_decode(z)
 
     to_remain_in_cpu = [
-        (sd_model, 'first_stage_model'),
-        (sd_model, 'depth_model'),
-        (sd_model, 'embedder'),
-        (sd_model, 'model'),
+        (sd_model, "first_stage_model"),
+        (sd_model, "depth_model"),
+        (sd_model, "embedder"),
+        (sd_model, "model"),
     ]
 
-    is_sdxl = hasattr(sd_model, 'conditioner')
-    is_sd2 = not is_sdxl and hasattr(sd_model.cond_stage_model, 'model')
+    is_sdxl = hasattr(sd_model, "conditioner")
+    is_sd2 = not is_sdxl and hasattr(sd_model.cond_stage_model, "model")
 
-    if hasattr(sd_model, 'medvram_fields'):
+    if hasattr(sd_model, "medvram_fields"):
         to_remain_in_cpu = sd_model.medvram_fields()
     elif is_sdxl:
-        to_remain_in_cpu.append((sd_model, 'conditioner'))
+        to_remain_in_cpu.append((sd_model, "conditioner"))
     elif is_sd2:
-        to_remain_in_cpu.append((sd_model.cond_stage_model, 'model'))
+        to_remain_in_cpu.append((sd_model.cond_stage_model, "model"))
     else:
-        to_remain_in_cpu.append((sd_model.cond_stage_model, 'transformer'))
+        to_remain_in_cpu.append((sd_model.cond_stage_model, "transformer"))
 
     # remove several big modules: cond, first_stage, depth/embedder (if applicable), and unet from the model
     stored = []
@@ -107,7 +115,9 @@ def setup_for_low_vram(sd_model, use_medvram):
         setattr(obj, field, module)
 
     # register hooks for those the first three models
-    if hasattr(sd_model, "cond_stage_model") and hasattr(sd_model.cond_stage_model, "medvram_modules"):
+    if hasattr(sd_model, "cond_stage_model") and hasattr(
+        sd_model.cond_stage_model, "medvram_modules"
+    ):
         for module in sd_model.cond_stage_model.medvram_modules():
             if isinstance(module, ModuleWithParent):
                 parent = module.parent
@@ -125,9 +135,13 @@ def setup_for_low_vram(sd_model, use_medvram):
         sd_model.conditioner.register_forward_pre_hook(send_me_to_gpu)
     elif is_sd2:
         sd_model.cond_stage_model.model.register_forward_pre_hook(send_me_to_gpu)
-        sd_model.cond_stage_model.model.token_embedding.register_forward_pre_hook(send_me_to_gpu)
+        sd_model.cond_stage_model.model.token_embedding.register_forward_pre_hook(
+            send_me_to_gpu
+        )
         parents[sd_model.cond_stage_model.model] = sd_model.cond_stage_model
-        parents[sd_model.cond_stage_model.model.token_embedding] = sd_model.cond_stage_model
+        parents[sd_model.cond_stage_model.model.token_embedding] = (
+            sd_model.cond_stage_model
+        )
     else:
         sd_model.cond_stage_model.transformer.register_forward_pre_hook(send_me_to_gpu)
         parents[sd_model.cond_stage_model.transformer] = sd_model.cond_stage_model
@@ -135,9 +149,9 @@ def setup_for_low_vram(sd_model, use_medvram):
     sd_model.first_stage_model.register_forward_pre_hook(send_me_to_gpu)
     sd_model.first_stage_model.encode = first_stage_model_encode_wrap
     sd_model.first_stage_model.decode = first_stage_model_decode_wrap
-    if getattr(sd_model, 'depth_model', None) is not None:
+    if getattr(sd_model, "depth_model", None) is not None:
         sd_model.depth_model.register_forward_pre_hook(send_me_to_gpu)
-    if getattr(sd_model, 'embedder', None) is not None:
+    if getattr(sd_model, "embedder", None) is not None:
         sd_model.embedder.register_forward_pre_hook(send_me_to_gpu)
 
     if use_medvram:
@@ -147,10 +161,25 @@ def setup_for_low_vram(sd_model, use_medvram):
 
         # the third remaining model is still too big for 4 GB, so we also do the same for its submodules
         # so that only one of them is in GPU at a time
-        stored = diff_model.input_blocks, diff_model.middle_block, diff_model.output_blocks, diff_model.time_embed
-        diff_model.input_blocks, diff_model.middle_block, diff_model.output_blocks, diff_model.time_embed = None, None, None, None
+        stored = (
+            diff_model.input_blocks,
+            diff_model.middle_block,
+            diff_model.output_blocks,
+            diff_model.time_embed,
+        )
+        (
+            diff_model.input_blocks,
+            diff_model.middle_block,
+            diff_model.output_blocks,
+            diff_model.time_embed,
+        ) = None, None, None, None
         sd_model.model.to(devices.device)
-        diff_model.input_blocks, diff_model.middle_block, diff_model.output_blocks, diff_model.time_embed = stored
+        (
+            diff_model.input_blocks,
+            diff_model.middle_block,
+            diff_model.output_blocks,
+            diff_model.time_embed,
+        ) = stored
 
         # install hooks for bits of third model
         diff_model.time_embed.register_forward_pre_hook(send_me_to_gpu)

--- a/modules/mac_specific.py
+++ b/modules/mac_specific.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # since torch 2.0.1+ nightly build, getattr(torch, 'has_mps', False) was deprecated, see https://github.com/pytorch/pytorch/pull/103279
 def check_for_mps() -> bool:
     if version.parse(torch.__version__) <= version.parse("2.0.1"):
-        if not getattr(torch, 'has_mps', False):
+        if not getattr(torch, "has_mps", False):
             return False
         try:
             torch.zeros(1).to(torch.device("mps"))
@@ -36,6 +36,7 @@ def torch_mps_gc() -> None:
             log.debug("`current_latent` is set, skipping MPS garbage collection")
             return
         from torch.mps import empty_cache
+
         empty_cache()
     except Exception:
         log.warning("MPS garbage collection failed", exc_info=True)
@@ -43,11 +44,15 @@ def torch_mps_gc() -> None:
 
 # MPS workaround for https://github.com/pytorch/pytorch/issues/89784
 def cumsum_fix(input, cumsum_func, *args, **kwargs):
-    if input.device.type == 'mps':
-        output_dtype = kwargs.get('dtype', input.dtype)
+    if input.device.type == "mps":
+        output_dtype = kwargs.get("dtype", input.dtype)
         if output_dtype == torch.int64:
             return cumsum_func(input.cpu(), *args, **kwargs).to(input.device)
-        elif output_dtype == torch.bool or cumsum_needs_int_fix and (output_dtype == torch.int8 or output_dtype == torch.int16):
+        elif (
+            output_dtype == torch.bool
+            or cumsum_needs_int_fix
+            and (output_dtype == torch.int8 or output_dtype == torch.int16)
+        ):
             return cumsum_func(input.to(torch.int32), *args, **kwargs).to(torch.int64)
     return cumsum_func(input, *args, **kwargs)
 
@@ -59,40 +64,111 @@ def interpolate_with_fp32_fallback(orig_func, *args, **kwargs) -> Tensor:
     except RuntimeError as e:
         if "not implemented for" in str(e) and "Half" in str(e):
             input_tensor = args[0]
-            return orig_func(input_tensor.to(torch.float32), *args[1:], **kwargs).to(input_tensor.dtype)
+            return orig_func(input_tensor.to(torch.float32), *args[1:], **kwargs).to(
+                input_tensor.dtype
+            )
         else:
             print(f"An unexpected RuntimeError occurred: {str(e)}")
+
 
 if has_mps:
     if platform.mac_ver()[0].startswith("13.2."):
         # MPS workaround for https://github.com/pytorch/pytorch/issues/95188, thanks to danieldk (https://github.com/explosion/curated-transformers/pull/124)
-        CondFunc('torch.nn.functional.linear', lambda _, input, weight, bias: (torch.matmul(input, weight.t()) + bias) if bias is not None else torch.matmul(input, weight.t()), lambda _, input, weight, bias: input.numel() > 10485760)
+        CondFunc(
+            "torch.nn.functional.linear",
+            lambda _, input, weight, bias: (torch.matmul(input, weight.t()) + bias)
+            if bias is not None
+            else torch.matmul(input, weight.t()),
+            lambda _, input, weight, bias: input.numel() > 10485760,
+        )
 
     if version.parse(torch.__version__) < version.parse("1.13"):
         # PyTorch 1.13 doesn't need these fixes but unfortunately is slower and has regressions that prevent training from working
 
         # MPS workaround for https://github.com/pytorch/pytorch/issues/79383
-        CondFunc('torch.Tensor.to', lambda orig_func, self, *args, **kwargs: orig_func(self.contiguous(), *args, **kwargs),
-                                                          lambda _, self, *args, **kwargs: self.device.type != 'mps' and (args and isinstance(args[0], torch.device) and args[0].type == 'mps' or isinstance(kwargs.get('device'), torch.device) and kwargs['device'].type == 'mps'))
+        CondFunc(
+            "torch.Tensor.to",
+            lambda orig_func, self, *args, **kwargs: orig_func(
+                self.contiguous(), *args, **kwargs
+            ),
+            lambda _, self, *args, **kwargs: self.device.type != "mps"
+            and (
+                args
+                and isinstance(args[0], torch.device)
+                and args[0].type == "mps"
+                or isinstance(kwargs.get("device"), torch.device)
+                and kwargs["device"].type == "mps"
+            ),
+        )
         # MPS workaround for https://github.com/pytorch/pytorch/issues/80800
-        CondFunc('torch.nn.functional.layer_norm', lambda orig_func, *args, **kwargs: orig_func(*([args[0].contiguous()] + list(args[1:])), **kwargs),
-                                                                                        lambda _, *args, **kwargs: args and isinstance(args[0], torch.Tensor) and args[0].device.type == 'mps')
+        CondFunc(
+            "torch.nn.functional.layer_norm",
+            lambda orig_func, *args, **kwargs: orig_func(
+                *([args[0].contiguous()] + list(args[1:])), **kwargs
+            ),
+            lambda _, *args, **kwargs: args
+            and isinstance(args[0], torch.Tensor)
+            and args[0].device.type == "mps",
+        )
         # MPS workaround for https://github.com/pytorch/pytorch/issues/90532
-        CondFunc('torch.Tensor.numpy', lambda orig_func, self, *args, **kwargs: orig_func(self.detach(), *args, **kwargs), lambda _, self, *args, **kwargs: self.requires_grad)
+        CondFunc(
+            "torch.Tensor.numpy",
+            lambda orig_func, self, *args, **kwargs: orig_func(
+                self.detach(), *args, **kwargs
+            ),
+            lambda _, self, *args, **kwargs: self.requires_grad,
+        )
     elif version.parse(torch.__version__) > version.parse("1.13.1"):
-        cumsum_needs_int_fix = not torch.Tensor([1,2]).to(torch.device("mps")).equal(torch.ShortTensor([1,1]).to(torch.device("mps")).cumsum(0))
-        cumsum_fix_func = lambda orig_func, input, *args, **kwargs: cumsum_fix(input, orig_func, *args, **kwargs)
-        CondFunc('torch.cumsum', cumsum_fix_func, None)
-        CondFunc('torch.Tensor.cumsum', cumsum_fix_func, None)
-        CondFunc('torch.narrow', lambda orig_func, *args, **kwargs: orig_func(*args, **kwargs).clone(), None)
+        cumsum_needs_int_fix = (
+            not torch.Tensor([1, 2])
+            .to(torch.device("mps"))
+            .equal(torch.ShortTensor([1, 1]).to(torch.device("mps")).cumsum(0))
+        )
+        cumsum_fix_func = lambda orig_func, input, *args, **kwargs: cumsum_fix(
+            input, orig_func, *args, **kwargs
+        )
+        CondFunc("torch.cumsum", cumsum_fix_func, None)
+        CondFunc("torch.Tensor.cumsum", cumsum_fix_func, None)
+        CondFunc(
+            "torch.narrow",
+            lambda orig_func, *args, **kwargs: orig_func(*args, **kwargs).clone(),
+            None,
+        )
 
         # MPS workaround for https://github.com/pytorch/pytorch/issues/96113
-        CondFunc('torch.nn.functional.layer_norm', lambda orig_func, x, normalized_shape, weight, bias, eps, **kwargs: orig_func(x.float(), normalized_shape, weight.float() if weight is not None else None, bias.float() if bias is not None else bias, eps).to(x.dtype), lambda _, input, *args, **kwargs: len(args) == 4 and input.device.type == 'mps')
+        CondFunc(
+            "torch.nn.functional.layer_norm",
+            lambda orig_func,
+            x,
+            normalized_shape,
+            weight,
+            bias,
+            eps,
+            **kwargs: orig_func(
+                x.float(),
+                normalized_shape,
+                weight.float() if weight is not None else None,
+                bias.float() if bias is not None else bias,
+                eps,
+            ).to(x.dtype),
+            lambda _, input, *args, **kwargs: len(args) == 4
+            and input.device.type == "mps",
+        )
 
         # MPS workaround for https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14046
-        CondFunc('torch.nn.functional.interpolate', interpolate_with_fp32_fallback, None)
+        CondFunc(
+            "torch.nn.functional.interpolate", interpolate_with_fp32_fallback, None
+        )
 
         # MPS workaround for https://github.com/pytorch/pytorch/issues/92311
-        if platform.processor() == 'i386':
-            for funcName in ['torch.argmax', 'torch.Tensor.argmax']:
-                CondFunc(funcName, lambda _, input, *args, **kwargs: torch.max(input.float() if input.dtype == torch.int64 else input, *args, **kwargs)[1], lambda _, input, *args, **kwargs: input.device.type == 'mps')
+        if platform.processor() == "i386":
+            for funcName in ["torch.argmax", "torch.Tensor.argmax"]:
+                CondFunc(
+                    funcName,
+                    lambda _, input, *args, **kwargs: torch.max(
+                        input.float() if input.dtype == torch.int64 else input,
+                        *args,
+                        **kwargs,
+                    )[1],
+                    lambda _, input, *args, **kwargs: input.device.type == "mps",
+                )

--- a/modules/masking.py
+++ b/modules/masking.py
@@ -16,7 +16,16 @@ def get_crop_region_v2(mask, pad=0):
     mask = mask if isinstance(mask, Image.Image) else Image.fromarray(mask)
     if box := mask.getbbox():
         x1, y1, x2, y2 = box
-        return (max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask.size[0]), min(y2 + pad, mask.size[1])) if pad else box
+        return (
+            (
+                max(x1 - pad, 0),
+                max(y1 - pad, 0),
+                min(x2 + pad, mask.size[0]),
+                min(y2 + pad, mask.size[1]),
+            )
+            if pad
+            else box
+        )
 
 
 def get_crop_region(mask, pad=0):
@@ -33,10 +42,17 @@ def get_crop_region(mask, pad=0):
         return box
     x1, y1 = mask.size
     x2 = y2 = 0
-    return max(x1 - pad, 0), max(y1 - pad, 0), min(x2 + pad, mask.size[0]), min(y2 + pad, mask.size[1])
+    return (
+        max(x1 - pad, 0),
+        max(y1 - pad, 0),
+        min(x2 + pad, mask.size[0]),
+        min(y2 + pad, mask.size[1]),
+    )
 
 
-def expand_crop_region(crop_region, processing_width, processing_height, image_width, image_height):
+def expand_crop_region(
+    crop_region, processing_width, processing_height, image_width, image_height
+):
     """expands crop region get_crop_region() to match the ratio of the image the region will processed in; returns expanded region
     for example, if user drew mask in a 128x32 region, and the dimensions for processing are 512x512, the region will be expanded to 128x128."""
 
@@ -47,9 +63,9 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
 
     if ratio_crop_region > ratio_processing:
         desired_height = (x2 - x1) / ratio_processing
-        desired_height_diff = int(desired_height - (y2-y1))
-        y1 -= desired_height_diff//2
-        y2 += desired_height_diff - desired_height_diff//2
+        desired_height_diff = int(desired_height - (y2 - y1))
+        y1 -= desired_height_diff // 2
+        y2 += desired_height_diff - desired_height_diff // 2
         if y2 >= image_height:
             diff = y2 - image_height
             y2 -= diff
@@ -61,9 +77,9 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
             y2 = image_height
     else:
         desired_width = (y2 - y1) * ratio_processing
-        desired_width_diff = int(desired_width - (x2-x1))
-        x1 -= desired_width_diff//2
-        x2 += desired_width_diff - desired_width_diff//2
+        desired_width_diff = int(desired_width - (x2 - x1))
+        x1 -= desired_width_diff // 2
+        x2 += desired_width_diff - desired_width_diff // 2
         if x2 >= image_width:
             diff = x2 - image_width
             x2 -= diff
@@ -80,17 +96,18 @@ def expand_crop_region(crop_region, processing_width, processing_height, image_w
 def fill(image, mask):
     """fills masked regions with colors from image using blur. Not extremely effective."""
 
-    image_mod = Image.new('RGBA', (image.width, image.height))
+    image_mod = Image.new("RGBA", (image.width, image.height))
 
-    image_masked = Image.new('RGBa', (image.width, image.height))
-    image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(mask.convert('L')))
+    image_masked = Image.new("RGBa", (image.width, image.height))
+    image_masked.paste(
+        image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(mask.convert("L"))
+    )
 
-    image_masked = image_masked.convert('RGBa')
+    image_masked = image_masked.convert("RGBa")
 
     for radius, repeats in [(256, 1), (64, 1), (16, 2), (4, 4), (2, 2), (0, 1)]:
-        blurred = image_masked.filter(ImageFilter.GaussianBlur(radius)).convert('RGBA')
+        blurred = image_masked.filter(ImageFilter.GaussianBlur(radius)).convert("RGBA")
         for _ in range(repeats):
             image_mod.alpha_composite(blurred)
 
     return image_mod.convert("RGB")
-

--- a/modules/memmon.py
+++ b/modules/memmon.py
@@ -30,7 +30,11 @@ class MemUsageMonitor(threading.Thread):
             self.disabled = True
 
     def cuda_mem_get_info(self):
-        index = self.device.index if self.device.index is not None else torch.cuda.current_device()
+        index = (
+            self.device.index
+            if self.device.index is not None
+            else torch.cuda.current_device()
+        )
         return torch.cuda.mem_get_info(index)
 
     def run(self):
@@ -56,16 +60,16 @@ class MemUsageMonitor(threading.Thread):
                 time.sleep(1 / self.opts.memmon_poll_rate)
 
     def dump_debug(self):
-        print(self, 'recorded data:')
+        print(self, "recorded data:")
         for k, v in self.read().items():
-            print(k, -(v // -(1024 ** 2)))
+            print(k, -(v // -(1024**2)))
 
-        print(self, 'raw torch memory stats:')
+        print(self, "raw torch memory stats:")
         tm = torch.cuda.memory_stats(self.device)
         for k, v in tm.items():
-            if 'bytes' not in k:
+            if "bytes" not in k:
                 continue
-            print('\t' if 'peak' in k else '', k, -(v // -(1024 ** 2)))
+            print("\t" if "peak" in k else "", k, -(v // -(1024**2)))
 
         print(torch.cuda.memory_summary())
 

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -37,11 +37,22 @@ def load_file_from_url(
     if not os.path.exists(cached_file):
         print(f'Downloading: "{url}" to {cached_file}\n')
         from torch.hub import download_url_to_file
-        download_url_to_file(url, cached_file, progress=progress, hash_prefix=hash_prefix)
+
+        download_url_to_file(
+            url, cached_file, progress=progress, hash_prefix=hash_prefix
+        )
     return cached_file
 
 
-def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None, ext_blacklist=None, hash_prefix=None) -> list:
+def load_models(
+    model_path: str,
+    model_url: str = None,
+    command_path: str = None,
+    ext_filter=None,
+    download_name=None,
+    ext_blacklist=None,
+    hash_prefix=None,
+) -> list:
     """
     A one-and done loader to try finding the desired models in specified directories.
 
@@ -59,7 +70,9 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
         places = []
 
         if command_path is not None and command_path != model_path:
-            pretrained_path = os.path.join(command_path, 'experiments/pretrained_models')
+            pretrained_path = os.path.join(
+                command_path, "experiments/pretrained_models"
+            )
             if os.path.exists(pretrained_path):
                 print(f"Appending path: {pretrained_path}")
                 places.append(pretrained_path)
@@ -73,14 +86,23 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
                 if os.path.islink(full_path) and not os.path.exists(full_path):
                     print(f"Skipping broken symlink: {full_path}")
                     continue
-                if ext_blacklist is not None and any(full_path.endswith(x) for x in ext_blacklist):
+                if ext_blacklist is not None and any(
+                    full_path.endswith(x) for x in ext_blacklist
+                ):
                     continue
                 if full_path not in output:
                     output.append(full_path)
 
         if model_url is not None and len(output) == 0:
             if download_name is not None:
-                output.append(load_file_from_url(model_url, model_dir=places[0], file_name=download_name, hash_prefix=hash_prefix))
+                output.append(
+                    load_file_from_url(
+                        model_url,
+                        model_dir=places[0],
+                        file_name=download_name,
+                        hash_prefix=hash_prefix,
+                    )
+                )
             else:
                 output.append(model_url)
 
@@ -136,8 +158,11 @@ def load_upscalers():
     shared.sd_upscalers = sorted(
         data,
         # Special case for UpscalerNone keeps it at the beginning of the list.
-        key=lambda x: x.name.lower() if not isinstance(x.scaler, (UpscalerNone, UpscalerLanczos, UpscalerNearest)) else ""
+        key=lambda x: x.name.lower()
+        if not isinstance(x.scaler, (UpscalerNone, UpscalerLanczos, UpscalerNearest))
+        else "",
     )
+
 
 # None: not loaded, False: failed to load, True: loaded
 _spandrel_extra_init_state = None
@@ -154,6 +179,7 @@ def _init_spandrel_extra_archs() -> None:
     try:
         import spandrel
         import spandrel_extra_arches
+
         spandrel.MAIN_REGISTRY.add(*spandrel_extra_arches.EXTRA_REGISTRY)
         _spandrel_extra_init_state = True
     except Exception:
@@ -172,6 +198,7 @@ def load_spandrel_model(
     global _spandrel_extra_init_state
 
     import spandrel
+
     _init_spandrel_extra_archs()
 
     model_descriptor = spandrel.ModelLoader(device=device).load_from_file(str(path))
@@ -186,12 +213,18 @@ def load_spandrel_model(
             model_descriptor.model.half()
             half = True
         else:
-            logger.info("Model %s does not support half precision, ignoring --half", path)
+            logger.info(
+                "Model %s does not support half precision, ignoring --half", path
+            )
     if dtype:
         model_descriptor.model.to(dtype=dtype)
     model_descriptor.model.eval()
     logger.debug(
         "Loaded %s from %s (device=%s, half=%s, dtype=%s)",
-        arch, path, device, half, dtype,
+        arch,
+        path,
+        device,
+        half,
+        dtype,
     )
     return model_descriptor

--- a/modules/models/diffusion/ddpm_edit.py
+++ b/modules/models/diffusion/ddpm_edit.py
@@ -21,22 +21,38 @@ from tqdm import tqdm
 from torchvision.utils import make_grid
 from pytorch_lightning.utilities.distributed import rank_zero_only
 
-from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
+from ldm.util import (
+    log_txt_as_img,
+    exists,
+    default,
+    ismap,
+    isimage,
+    mean_flat,
+    count_params,
+    instantiate_from_config,
+)
 from ldm.modules.ema import LitEma
-from ldm.modules.distributions.distributions import normal_kl, DiagonalGaussianDistribution
+from ldm.modules.distributions.distributions import (
+    normal_kl,
+    DiagonalGaussianDistribution,
+)
 from ldm.models.autoencoder import IdentityFirstStage, AutoencoderKL
-from ldm.modules.diffusionmodules.util import make_beta_schedule, extract_into_tensor, noise_like
+from ldm.modules.diffusionmodules.util import (
+    make_beta_schedule,
+    extract_into_tensor,
+    noise_like,
+)
 from ldm.models.diffusion.ddim import DDIMSampler
 
 try:
     from ldm.models.autoencoder import VQModelInterface
 except Exception:
+
     class VQModelInterface:
         pass
 
-__conditioning_keys__ = {'concat': 'c_concat',
-                         'crossattn': 'c_crossattn',
-                         'adm': 'y'}
+
+__conditioning_keys__ = {"concat": "c_concat", "crossattn": "c_crossattn", "adm": "y"}
 
 
 def disabled_train(self, mode=True):
@@ -51,40 +67,46 @@ def uniform_on_device(r1, r2, shape, device):
 
 class DDPM(pl.LightningModule):
     # classic DDPM with Gaussian diffusion, in image space
-    def __init__(self,
-                 unet_config,
-                 timesteps=1000,
-                 beta_schedule="linear",
-                 loss_type="l2",
-                 ckpt_path=None,
-                 ignore_keys=None,
-                 load_only_unet=False,
-                 monitor="val/loss",
-                 use_ema=True,
-                 first_stage_key="image",
-                 image_size=256,
-                 channels=3,
-                 log_every_t=100,
-                 clip_denoised=True,
-                 linear_start=1e-4,
-                 linear_end=2e-2,
-                 cosine_s=8e-3,
-                 given_betas=None,
-                 original_elbo_weight=0.,
-                 v_posterior=0.,  # weight for choosing posterior variance as sigma = (1-v) * beta_tilde + v * beta
-                 l_simple_weight=1.,
-                 conditioning_key=None,
-                 parameterization="eps",  # all assuming fixed variance schedules
-                 scheduler_config=None,
-                 use_positional_encodings=False,
-                 learn_logvar=False,
-                 logvar_init=0.,
-                 load_ema=True,
-                 ):
+    def __init__(
+        self,
+        unet_config,
+        timesteps=1000,
+        beta_schedule="linear",
+        loss_type="l2",
+        ckpt_path=None,
+        ignore_keys=None,
+        load_only_unet=False,
+        monitor="val/loss",
+        use_ema=True,
+        first_stage_key="image",
+        image_size=256,
+        channels=3,
+        log_every_t=100,
+        clip_denoised=True,
+        linear_start=1e-4,
+        linear_end=2e-2,
+        cosine_s=8e-3,
+        given_betas=None,
+        original_elbo_weight=0.0,
+        v_posterior=0.0,  # weight for choosing posterior variance as sigma = (1-v) * beta_tilde + v * beta
+        l_simple_weight=1.0,
+        conditioning_key=None,
+        parameterization="eps",  # all assuming fixed variance schedules
+        scheduler_config=None,
+        use_positional_encodings=False,
+        learn_logvar=False,
+        logvar_init=0.0,
+        load_ema=True,
+    ):
         super().__init__()
-        assert parameterization in ["eps", "x0"], 'currently only supporting "eps" and "x0"'
+        assert parameterization in [
+            "eps",
+            "x0",
+        ], 'currently only supporting "eps" and "x0"'
         self.parameterization = parameterization
-        print(f"{self.__class__.__name__}: Running in {self.parameterization}-prediction mode")
+        print(
+            f"{self.__class__.__name__}: Running in {self.parameterization}-prediction mode"
+        )
         self.cond_stage_model = None
         self.clip_denoised = clip_denoised
         self.log_every_t = log_every_t
@@ -112,15 +134,23 @@ class DDPM(pl.LightningModule):
             print(f"Keeping EMAs of {len(list(self.model_ema.buffers()))}.")
 
         if ckpt_path is not None:
-            self.init_from_ckpt(ckpt_path, ignore_keys=ignore_keys or [], only_model=load_only_unet)
+            self.init_from_ckpt(
+                ckpt_path, ignore_keys=ignore_keys or [], only_model=load_only_unet
+            )
 
             # If initialing from EMA-only checkpoint, create EMA model after loading.
             if self.use_ema and not load_ema:
                 self.model_ema = LitEma(self.model)
                 print(f"Keeping EMAs of {len(list(self.model_ema.buffers()))}.")
 
-        self.register_schedule(given_betas=given_betas, beta_schedule=beta_schedule, timesteps=timesteps,
-                               linear_start=linear_start, linear_end=linear_end, cosine_s=cosine_s)
+        self.register_schedule(
+            given_betas=given_betas,
+            beta_schedule=beta_schedule,
+            timesteps=timesteps,
+            linear_start=linear_start,
+            linear_end=linear_end,
+            cosine_s=cosine_s,
+        )
 
         self.loss_type = loss_type
 
@@ -129,59 +159,98 @@ class DDPM(pl.LightningModule):
         if self.learn_logvar:
             self.logvar = nn.Parameter(self.logvar, requires_grad=True)
 
-
-    def register_schedule(self, given_betas=None, beta_schedule="linear", timesteps=1000,
-                          linear_start=1e-4, linear_end=2e-2, cosine_s=8e-3):
+    def register_schedule(
+        self,
+        given_betas=None,
+        beta_schedule="linear",
+        timesteps=1000,
+        linear_start=1e-4,
+        linear_end=2e-2,
+        cosine_s=8e-3,
+    ):
         if exists(given_betas):
             betas = given_betas
         else:
-            betas = make_beta_schedule(beta_schedule, timesteps, linear_start=linear_start, linear_end=linear_end,
-                                       cosine_s=cosine_s)
-        alphas = 1. - betas
+            betas = make_beta_schedule(
+                beta_schedule,
+                timesteps,
+                linear_start=linear_start,
+                linear_end=linear_end,
+                cosine_s=cosine_s,
+            )
+        alphas = 1.0 - betas
         alphas_cumprod = np.cumprod(alphas, axis=0)
-        alphas_cumprod_prev = np.append(1., alphas_cumprod[:-1])
+        alphas_cumprod_prev = np.append(1.0, alphas_cumprod[:-1])
 
-        timesteps, = betas.shape
+        (timesteps,) = betas.shape
         self.num_timesteps = int(timesteps)
         self.linear_start = linear_start
         self.linear_end = linear_end
-        assert alphas_cumprod.shape[0] == self.num_timesteps, 'alphas have to be defined for each timestep'
+        assert (
+            alphas_cumprod.shape[0] == self.num_timesteps
+        ), "alphas have to be defined for each timestep"
 
         to_torch = partial(torch.tensor, dtype=torch.float32)
 
-        self.register_buffer('betas', to_torch(betas))
-        self.register_buffer('alphas_cumprod', to_torch(alphas_cumprod))
-        self.register_buffer('alphas_cumprod_prev', to_torch(alphas_cumprod_prev))
+        self.register_buffer("betas", to_torch(betas))
+        self.register_buffer("alphas_cumprod", to_torch(alphas_cumprod))
+        self.register_buffer("alphas_cumprod_prev", to_torch(alphas_cumprod_prev))
 
         # calculations for diffusion q(x_t | x_{t-1}) and others
-        self.register_buffer('sqrt_alphas_cumprod', to_torch(np.sqrt(alphas_cumprod)))
-        self.register_buffer('sqrt_one_minus_alphas_cumprod', to_torch(np.sqrt(1. - alphas_cumprod)))
-        self.register_buffer('log_one_minus_alphas_cumprod', to_torch(np.log(1. - alphas_cumprod)))
-        self.register_buffer('sqrt_recip_alphas_cumprod', to_torch(np.sqrt(1. / alphas_cumprod)))
-        self.register_buffer('sqrt_recipm1_alphas_cumprod', to_torch(np.sqrt(1. / alphas_cumprod - 1)))
+        self.register_buffer("sqrt_alphas_cumprod", to_torch(np.sqrt(alphas_cumprod)))
+        self.register_buffer(
+            "sqrt_one_minus_alphas_cumprod", to_torch(np.sqrt(1.0 - alphas_cumprod))
+        )
+        self.register_buffer(
+            "log_one_minus_alphas_cumprod", to_torch(np.log(1.0 - alphas_cumprod))
+        )
+        self.register_buffer(
+            "sqrt_recip_alphas_cumprod", to_torch(np.sqrt(1.0 / alphas_cumprod))
+        )
+        self.register_buffer(
+            "sqrt_recipm1_alphas_cumprod", to_torch(np.sqrt(1.0 / alphas_cumprod - 1))
+        )
 
         # calculations for posterior q(x_{t-1} | x_t, x_0)
-        posterior_variance = (1 - self.v_posterior) * betas * (1. - alphas_cumprod_prev) / (
-                    1. - alphas_cumprod) + self.v_posterior * betas
+        posterior_variance = (1 - self.v_posterior) * betas * (
+            1.0 - alphas_cumprod_prev
+        ) / (1.0 - alphas_cumprod) + self.v_posterior * betas
         # above: equal to 1. / (1. / (1. - alpha_cumprod_tm1) + alpha_t / beta_t)
-        self.register_buffer('posterior_variance', to_torch(posterior_variance))
+        self.register_buffer("posterior_variance", to_torch(posterior_variance))
         # below: log calculation clipped because the posterior variance is 0 at the beginning of the diffusion chain
-        self.register_buffer('posterior_log_variance_clipped', to_torch(np.log(np.maximum(posterior_variance, 1e-20))))
-        self.register_buffer('posterior_mean_coef1', to_torch(
-            betas * np.sqrt(alphas_cumprod_prev) / (1. - alphas_cumprod)))
-        self.register_buffer('posterior_mean_coef2', to_torch(
-            (1. - alphas_cumprod_prev) * np.sqrt(alphas) / (1. - alphas_cumprod)))
+        self.register_buffer(
+            "posterior_log_variance_clipped",
+            to_torch(np.log(np.maximum(posterior_variance, 1e-20))),
+        )
+        self.register_buffer(
+            "posterior_mean_coef1",
+            to_torch(betas * np.sqrt(alphas_cumprod_prev) / (1.0 - alphas_cumprod)),
+        )
+        self.register_buffer(
+            "posterior_mean_coef2",
+            to_torch(
+                (1.0 - alphas_cumprod_prev) * np.sqrt(alphas) / (1.0 - alphas_cumprod)
+            ),
+        )
 
         if self.parameterization == "eps":
-            lvlb_weights = self.betas ** 2 / (
-                        2 * self.posterior_variance * to_torch(alphas) * (1 - self.alphas_cumprod))
+            lvlb_weights = self.betas**2 / (
+                2
+                * self.posterior_variance
+                * to_torch(alphas)
+                * (1 - self.alphas_cumprod)
+            )
         elif self.parameterization == "x0":
-            lvlb_weights = 0.5 * np.sqrt(torch.Tensor(alphas_cumprod)) / (2. * 1 - torch.Tensor(alphas_cumprod))
+            lvlb_weights = (
+                0.5
+                * np.sqrt(torch.Tensor(alphas_cumprod))
+                / (2.0 * 1 - torch.Tensor(alphas_cumprod))
+            )
         else:
             raise NotImplementedError("mu not supported")
         # TODO how to choose this term
         lvlb_weights[0] = lvlb_weights[1]
-        self.register_buffer('lvlb_weights', lvlb_weights, persistent=False)
+        self.register_buffer("lvlb_weights", lvlb_weights, persistent=False)
         assert not torch.isnan(self.lvlb_weights).all()
 
     @contextmanager
@@ -232,9 +301,14 @@ class DDPM(pl.LightningModule):
                 if k.startswith(ik):
                     print(f"Deleting key {k} from state_dict.")
                     del sd[k]
-        missing, unexpected = self.load_state_dict(sd, strict=False) if not only_model else self.model.load_state_dict(
-            sd, strict=False)
-        print(f"Restored from {path} with {len(missing)} missing and {len(unexpected)} unexpected keys")
+        missing, unexpected = (
+            self.load_state_dict(sd, strict=False)
+            if not only_model
+            else self.model.load_state_dict(sd, strict=False)
+        )
+        print(
+            f"Restored from {path} with {len(missing)} missing and {len(unexpected)} unexpected keys"
+        )
         if missing:
             print(f"Missing Keys: {missing}")
         if unexpected:
@@ -247,24 +321,29 @@ class DDPM(pl.LightningModule):
         :param t: the number of diffusion steps (minus 1). Here, 0 means one step.
         :return: A tuple (mean, variance, log_variance), all of x_start's shape.
         """
-        mean = (extract_into_tensor(self.sqrt_alphas_cumprod, t, x_start.shape) * x_start)
+        mean = extract_into_tensor(self.sqrt_alphas_cumprod, t, x_start.shape) * x_start
         variance = extract_into_tensor(1.0 - self.alphas_cumprod, t, x_start.shape)
-        log_variance = extract_into_tensor(self.log_one_minus_alphas_cumprod, t, x_start.shape)
+        log_variance = extract_into_tensor(
+            self.log_one_minus_alphas_cumprod, t, x_start.shape
+        )
         return mean, variance, log_variance
 
     def predict_start_from_noise(self, x_t, t, noise):
         return (
-                extract_into_tensor(self.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t -
-                extract_into_tensor(self.sqrt_recipm1_alphas_cumprod, t, x_t.shape) * noise
+            extract_into_tensor(self.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t
+            - extract_into_tensor(self.sqrt_recipm1_alphas_cumprod, t, x_t.shape)
+            * noise
         )
 
     def q_posterior(self, x_start, x_t, t):
         posterior_mean = (
-                extract_into_tensor(self.posterior_mean_coef1, t, x_t.shape) * x_start +
-                extract_into_tensor(self.posterior_mean_coef2, t, x_t.shape) * x_t
+            extract_into_tensor(self.posterior_mean_coef1, t, x_t.shape) * x_start
+            + extract_into_tensor(self.posterior_mean_coef2, t, x_t.shape) * x_t
         )
         posterior_variance = extract_into_tensor(self.posterior_variance, t, x_t.shape)
-        posterior_log_variance_clipped = extract_into_tensor(self.posterior_log_variance_clipped, t, x_t.shape)
+        posterior_log_variance_clipped = extract_into_tensor(
+            self.posterior_log_variance_clipped, t, x_t.shape
+        )
         return posterior_mean, posterior_variance, posterior_log_variance_clipped
 
     def p_mean_variance(self, x, t, clip_denoised: bool):
@@ -274,15 +353,19 @@ class DDPM(pl.LightningModule):
         elif self.parameterization == "x0":
             x_recon = model_out
         if clip_denoised:
-            x_recon.clamp_(-1., 1.)
+            x_recon.clamp_(-1.0, 1.0)
 
-        model_mean, posterior_variance, posterior_log_variance = self.q_posterior(x_start=x_recon, x_t=x, t=t)
+        model_mean, posterior_variance, posterior_log_variance = self.q_posterior(
+            x_start=x_recon, x_t=x, t=t
+        )
         return model_mean, posterior_variance, posterior_log_variance
 
     @torch.no_grad()
     def p_sample(self, x, t, clip_denoised=True, repeat_noise=False):
         b, *_, device = *x.shape, x.device
-        model_mean, _, model_log_variance = self.p_mean_variance(x=x, t=t, clip_denoised=clip_denoised)
+        model_mean, _, model_log_variance = self.p_mean_variance(
+            x=x, t=t, clip_denoised=clip_denoised
+        )
         noise = noise_like(x.shape, device, repeat_noise)
         # no noise when t == 0
         nonzero_mask = (1 - (t == 0).float()).reshape(b, *((1,) * (len(x.shape) - 1)))
@@ -294,9 +377,16 @@ class DDPM(pl.LightningModule):
         b = shape[0]
         img = torch.randn(shape, device=device)
         intermediates = [img]
-        for i in tqdm(reversed(range(0, self.num_timesteps)), desc='Sampling t', total=self.num_timesteps):
-            img = self.p_sample(img, torch.full((b,), i, device=device, dtype=torch.long),
-                                clip_denoised=self.clip_denoised)
+        for i in tqdm(
+            reversed(range(0, self.num_timesteps)),
+            desc="Sampling t",
+            total=self.num_timesteps,
+        ):
+            img = self.p_sample(
+                img,
+                torch.full((b,), i, device=device, dtype=torch.long),
+                clip_denoised=self.clip_denoised,
+            )
             if i % self.log_every_t == 0 or i == self.num_timesteps - 1:
                 intermediates.append(img)
         if return_intermediates:
@@ -307,24 +397,29 @@ class DDPM(pl.LightningModule):
     def sample(self, batch_size=16, return_intermediates=False):
         image_size = self.image_size
         channels = self.channels
-        return self.p_sample_loop((batch_size, channels, image_size, image_size),
-                                  return_intermediates=return_intermediates)
+        return self.p_sample_loop(
+            (batch_size, channels, image_size, image_size),
+            return_intermediates=return_intermediates,
+        )
 
     def q_sample(self, x_start, t, noise=None):
         noise = default(noise, lambda: torch.randn_like(x_start))
-        return (extract_into_tensor(self.sqrt_alphas_cumprod, t, x_start.shape) * x_start +
-                extract_into_tensor(self.sqrt_one_minus_alphas_cumprod, t, x_start.shape) * noise)
+        return (
+            extract_into_tensor(self.sqrt_alphas_cumprod, t, x_start.shape) * x_start
+            + extract_into_tensor(self.sqrt_one_minus_alphas_cumprod, t, x_start.shape)
+            * noise
+        )
 
     def get_loss(self, pred, target, mean=True):
-        if self.loss_type == 'l1':
+        if self.loss_type == "l1":
             loss = (target - pred).abs()
             if mean:
                 loss = loss.mean()
-        elif self.loss_type == 'l2':
+        elif self.loss_type == "l2":
             if mean:
                 loss = torch.nn.functional.mse_loss(target, pred)
             else:
-                loss = torch.nn.functional.mse_loss(target, pred, reduction='none')
+                loss = torch.nn.functional.mse_loss(target, pred, reduction="none")
         else:
             raise NotImplementedError("unknown loss type '{loss_type}'")
 
@@ -341,28 +436,32 @@ class DDPM(pl.LightningModule):
         elif self.parameterization == "x0":
             target = x_start
         else:
-            raise NotImplementedError(f"Parameterization {self.parameterization} not yet supported")
+            raise NotImplementedError(
+                f"Parameterization {self.parameterization} not yet supported"
+            )
 
         loss = self.get_loss(model_out, target, mean=False).mean(dim=[1, 2, 3])
 
-        log_prefix = 'train' if self.training else 'val'
+        log_prefix = "train" if self.training else "val"
 
-        loss_dict.update({f'{log_prefix}/loss_simple': loss.mean()})
+        loss_dict.update({f"{log_prefix}/loss_simple": loss.mean()})
         loss_simple = loss.mean() * self.l_simple_weight
 
         loss_vlb = (self.lvlb_weights[t] * loss).mean()
-        loss_dict.update({f'{log_prefix}/loss_vlb': loss_vlb})
+        loss_dict.update({f"{log_prefix}/loss_vlb": loss_vlb})
 
         loss = loss_simple + self.original_elbo_weight * loss_vlb
 
-        loss_dict.update({f'{log_prefix}/loss': loss})
+        loss_dict.update({f"{log_prefix}/loss": loss})
 
         return loss, loss_dict
 
     def forward(self, x, *args, **kwargs):
         # b, c, h, w, device, img_size, = *x.shape, x.device, self.image_size
         # assert h == img_size and w == img_size, f'height and width of image must be {img_size}'
-        t = torch.randint(0, self.num_timesteps, (x.shape[0],), device=self.device).long()
+        t = torch.randint(
+            0, self.num_timesteps, (x.shape[0],), device=self.device
+        ).long()
         return self.p_losses(x, t, *args, **kwargs)
 
     def get_input(self, batch, k):
@@ -376,15 +475,24 @@ class DDPM(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         loss, loss_dict = self.shared_step(batch)
 
-        self.log_dict(loss_dict, prog_bar=True,
-                      logger=True, on_step=True, on_epoch=True)
+        self.log_dict(
+            loss_dict, prog_bar=True, logger=True, on_step=True, on_epoch=True
+        )
 
-        self.log("global_step", self.global_step,
-                 prog_bar=True, logger=True, on_step=True, on_epoch=False)
+        self.log(
+            "global_step",
+            self.global_step,
+            prog_bar=True,
+            logger=True,
+            on_step=True,
+            on_epoch=False,
+        )
 
         if self.use_scheduler:
-            lr = self.optimizers().param_groups[0]['lr']
-            self.log('lr_abs', lr, prog_bar=True, logger=True, on_step=True, on_epoch=False)
+            lr = self.optimizers().param_groups[0]["lr"]
+            self.log(
+                "lr_abs", lr, prog_bar=True, logger=True, on_step=True, on_epoch=False
+            )
 
         return loss
 
@@ -394,8 +502,12 @@ class DDPM(pl.LightningModule):
         with self.ema_scope():
             _, loss_dict_ema = self.shared_step(batch)
             loss_dict_ema = {f"{key}_ema": loss_dict_ema[key] for key in loss_dict_ema}
-        self.log_dict(loss_dict_no_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True)
-        self.log_dict(loss_dict_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True)
+        self.log_dict(
+            loss_dict_no_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True
+        )
+        self.log_dict(
+            loss_dict_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True
+        )
 
     def on_train_batch_end(self, *args, **kwargs):
         if self.use_ema:
@@ -403,8 +515,8 @@ class DDPM(pl.LightningModule):
 
     def _get_rows_from_list(self, samples):
         n_imgs_per_row = len(samples)
-        denoise_grid = rearrange(samples, 'n b c h w -> b n c h w')
-        denoise_grid = rearrange(denoise_grid, 'b n c h w -> (b n) c h w')
+        denoise_grid = rearrange(samples, "n b c h w -> b n c h w")
+        denoise_grid = rearrange(denoise_grid, "b n c h w -> (b n) c h w")
         denoise_grid = make_grid(denoise_grid, nrow=n_imgs_per_row)
         return denoise_grid
 
@@ -423,7 +535,7 @@ class DDPM(pl.LightningModule):
 
         for t in range(self.num_timesteps):
             if t % self.log_every_t == 0 or t == self.num_timesteps - 1:
-                t = repeat(torch.tensor([t]), '1 -> b', b=n_row)
+                t = repeat(torch.tensor([t]), "1 -> b", b=n_row)
                 t = t.to(self.device).long()
                 noise = torch.randn_like(x_start)
                 x_noisy = self.q_sample(x_start=x_start, t=t, noise=noise)
@@ -434,7 +546,9 @@ class DDPM(pl.LightningModule):
         if sample:
             # get denoise row
             with self.ema_scope("Plotting"):
-                samples, denoise_row = self.sample(batch_size=N, return_intermediates=True)
+                samples, denoise_row = self.sample(
+                    batch_size=N, return_intermediates=True
+                )
 
             log["samples"] = samples
             log["denoise_row"] = self._get_rows_from_list(denoise_row)
@@ -457,30 +571,36 @@ class DDPM(pl.LightningModule):
 
 class LatentDiffusion(DDPM):
     """main class"""
-    def __init__(self,
-                 first_stage_config,
-                 cond_stage_config,
-                 num_timesteps_cond=None,
-                 cond_stage_key="image",
-                 cond_stage_trainable=False,
-                 concat_mode=True,
-                 cond_stage_forward=None,
-                 conditioning_key=None,
-                 scale_factor=1.0,
-                 scale_by_std=False,
-                 load_ema=True,
-                 *args, **kwargs):
+
+    def __init__(
+        self,
+        first_stage_config,
+        cond_stage_config,
+        num_timesteps_cond=None,
+        cond_stage_key="image",
+        cond_stage_trainable=False,
+        concat_mode=True,
+        cond_stage_forward=None,
+        conditioning_key=None,
+        scale_factor=1.0,
+        scale_by_std=False,
+        load_ema=True,
+        *args,
+        **kwargs,
+    ):
         self.num_timesteps_cond = default(num_timesteps_cond, 1)
         self.scale_by_std = scale_by_std
-        assert self.num_timesteps_cond <= kwargs['timesteps']
+        assert self.num_timesteps_cond <= kwargs["timesteps"]
         # for backwards compatibility after implementation of DiffusionWrapper
         if conditioning_key is None:
-            conditioning_key = 'concat' if concat_mode else 'crossattn'
-        if cond_stage_config == '__is_unconditional__':
+            conditioning_key = "concat" if concat_mode else "crossattn"
+        if cond_stage_config == "__is_unconditional__":
             conditioning_key = None
         ckpt_path = kwargs.pop("ckpt_path", None)
         ignore_keys = kwargs.pop("ignore_keys", [])
-        super().__init__(*args, conditioning_key=conditioning_key, load_ema=load_ema, **kwargs)
+        super().__init__(
+            *args, conditioning_key=conditioning_key, load_ema=load_ema, **kwargs
+        )
         self.concat_mode = concat_mode
         self.cond_stage_trainable = cond_stage_trainable
         self.cond_stage_key = cond_stage_key
@@ -491,7 +611,7 @@ class LatentDiffusion(DDPM):
         if not scale_by_std:
             self.scale_factor = scale_factor
         else:
-            self.register_buffer('scale_factor', torch.tensor(scale_factor))
+            self.register_buffer("scale_factor", torch.tensor(scale_factor))
         self.instantiate_first_stage(first_stage_config)
         self.instantiate_cond_stage(cond_stage_config)
         self.cond_stage_forward = cond_stage_forward
@@ -507,17 +627,33 @@ class LatentDiffusion(DDPM):
                 self.model_ema = LitEma(self.model)
                 print(f"Keeping EMAs of {len(list(self.model_ema.buffers()))}.")
 
-    def make_cond_schedule(self, ):
-        self.cond_ids = torch.full(size=(self.num_timesteps,), fill_value=self.num_timesteps - 1, dtype=torch.long)
-        ids = torch.round(torch.linspace(0, self.num_timesteps - 1, self.num_timesteps_cond)).long()
-        self.cond_ids[:self.num_timesteps_cond] = ids
+    def make_cond_schedule(
+        self,
+    ):
+        self.cond_ids = torch.full(
+            size=(self.num_timesteps,),
+            fill_value=self.num_timesteps - 1,
+            dtype=torch.long,
+        )
+        ids = torch.round(
+            torch.linspace(0, self.num_timesteps - 1, self.num_timesteps_cond)
+        ).long()
+        self.cond_ids[: self.num_timesteps_cond] = ids
 
     @rank_zero_only
     @torch.no_grad()
     def on_train_batch_start(self, batch, batch_idx, dataloader_idx):
         # only for very first batch
-        if self.scale_by_std and self.current_epoch == 0 and self.global_step == 0 and batch_idx == 0 and not self.restarted_from_ckpt:
-            assert self.scale_factor == 1., 'rather not use custom rescaling and std-rescaling simultaneously'
+        if (
+            self.scale_by_std
+            and self.current_epoch == 0
+            and self.global_step == 0
+            and batch_idx == 0
+            and not self.restarted_from_ckpt
+        ):
+            assert (
+                self.scale_factor == 1.0
+            ), "rather not use custom rescaling and std-rescaling simultaneously"
             # set rescale weight to 1./std of encodings
             print("### USING STD-RESCALING ###")
             x = super().get_input(batch, self.first_stage_key)
@@ -525,14 +661,22 @@ class LatentDiffusion(DDPM):
             encoder_posterior = self.encode_first_stage(x)
             z = self.get_first_stage_encoding(encoder_posterior).detach()
             del self.scale_factor
-            self.register_buffer('scale_factor', 1. / z.flatten().std())
+            self.register_buffer("scale_factor", 1.0 / z.flatten().std())
             print(f"setting self.scale_factor to {self.scale_factor}")
             print("### USING STD-RESCALING ###")
 
-    def register_schedule(self,
-                          given_betas=None, beta_schedule="linear", timesteps=1000,
-                          linear_start=1e-4, linear_end=2e-2, cosine_s=8e-3):
-        super().register_schedule(given_betas, beta_schedule, timesteps, linear_start, linear_end, cosine_s)
+    def register_schedule(
+        self,
+        given_betas=None,
+        beta_schedule="linear",
+        timesteps=1000,
+        linear_start=1e-4,
+        linear_end=2e-2,
+        cosine_s=8e-3,
+    ):
+        super().register_schedule(
+            given_betas, beta_schedule, timesteps, linear_start, linear_end, cosine_s
+        )
 
         self.shorten_cond_schedule = self.num_timesteps_cond > 1
         if self.shorten_cond_schedule:
@@ -561,20 +705,25 @@ class LatentDiffusion(DDPM):
                 for param in self.cond_stage_model.parameters():
                     param.requires_grad = False
         else:
-            assert config != '__is_first_stage__'
-            assert config != '__is_unconditional__'
+            assert config != "__is_first_stage__"
+            assert config != "__is_unconditional__"
             model = instantiate_from_config(config)
             self.cond_stage_model = model
 
-    def _get_denoise_row_from_list(self, samples, desc='', force_no_decoder_quantization=False):
+    def _get_denoise_row_from_list(
+        self, samples, desc="", force_no_decoder_quantization=False
+    ):
         denoise_row = []
         for zd in tqdm(samples, desc=desc):
-            denoise_row.append(self.decode_first_stage(zd.to(self.device),
-                                                            force_not_quantize=force_no_decoder_quantization))
+            denoise_row.append(
+                self.decode_first_stage(
+                    zd.to(self.device), force_not_quantize=force_no_decoder_quantization
+                )
+            )
         n_imgs_per_row = len(denoise_row)
         denoise_row = torch.stack(denoise_row)  # n_log_step, n_row, C, H, W
-        denoise_grid = rearrange(denoise_row, 'n b c h w -> b n c h w')
-        denoise_grid = rearrange(denoise_grid, 'b n c h w -> (b n) c h w')
+        denoise_grid = rearrange(denoise_row, "n b c h w -> b n c h w")
+        denoise_grid = rearrange(denoise_grid, "b n c h w -> (b n) c h w")
         denoise_grid = make_grid(denoise_grid, nrow=n_imgs_per_row)
         return denoise_grid
 
@@ -584,12 +733,16 @@ class LatentDiffusion(DDPM):
         elif isinstance(encoder_posterior, torch.Tensor):
             z = encoder_posterior
         else:
-            raise NotImplementedError(f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented")
+            raise NotImplementedError(
+                f"encoder_posterior of type '{type(encoder_posterior)}' not yet implemented"
+            )
         return self.scale_factor * z
 
     def get_learned_conditioning(self, c):
         if self.cond_stage_forward is None:
-            if hasattr(self.cond_stage_model, 'encode') and callable(self.cond_stage_model.encode):
+            if hasattr(self.cond_stage_model, "encode") and callable(
+                self.cond_stage_model.encode
+            ):
                 c = self.cond_stage_model.encode(c)
                 if isinstance(c, DiagonalGaussianDistribution):
                     c = c.mode()
@@ -618,26 +771,35 @@ class LatentDiffusion(DDPM):
         arr = self.meshgrid(h, w) / lower_right_corner
         dist_left_up = torch.min(arr, dim=-1, keepdims=True)[0]
         dist_right_down = torch.min(1 - arr, dim=-1, keepdims=True)[0]
-        edge_dist = torch.min(torch.cat([dist_left_up, dist_right_down], dim=-1), dim=-1)[0]
+        edge_dist = torch.min(
+            torch.cat([dist_left_up, dist_right_down], dim=-1), dim=-1
+        )[0]
         return edge_dist
 
     def get_weighting(self, h, w, Ly, Lx, device):
         weighting = self.delta_border(h, w)
-        weighting = torch.clip(weighting, self.split_input_params["clip_min_weight"],
-                               self.split_input_params["clip_max_weight"], )
+        weighting = torch.clip(
+            weighting,
+            self.split_input_params["clip_min_weight"],
+            self.split_input_params["clip_max_weight"],
+        )
         weighting = weighting.view(1, h * w, 1).repeat(1, 1, Ly * Lx).to(device)
 
         if self.split_input_params["tie_braker"]:
             L_weighting = self.delta_border(Ly, Lx)
-            L_weighting = torch.clip(L_weighting,
-                                     self.split_input_params["clip_min_tie_weight"],
-                                     self.split_input_params["clip_max_tie_weight"])
+            L_weighting = torch.clip(
+                L_weighting,
+                self.split_input_params["clip_min_tie_weight"],
+                self.split_input_params["clip_max_tie_weight"],
+            )
 
             L_weighting = L_weighting.view(1, 1, Ly * Lx).to(device)
             weighting = weighting * L_weighting
         return weighting
 
-    def get_fold_unfold(self, x, kernel_size, stride, uf=1, df=1):  # todo load once not every time, shorten code
+    def get_fold_unfold(
+        self, x, kernel_size, stride, uf=1, df=1
+    ):  # todo load once not every time, shorten code
         """
         :param x: img of size (bs, c, h, w)
         :return: n img crops of size (n, bs, c, kernel_size[0], kernel_size[1])
@@ -649,40 +811,70 @@ class LatentDiffusion(DDPM):
         Lx = (w - kernel_size[1]) // stride[1] + 1
 
         if uf == 1 and df == 1:
-            fold_params = dict(kernel_size=kernel_size, dilation=1, padding=0, stride=stride)
+            fold_params = dict(
+                kernel_size=kernel_size, dilation=1, padding=0, stride=stride
+            )
             unfold = torch.nn.Unfold(**fold_params)
 
             fold = torch.nn.Fold(output_size=x.shape[2:], **fold_params)
 
-            weighting = self.get_weighting(kernel_size[0], kernel_size[1], Ly, Lx, x.device).to(x.dtype)
+            weighting = self.get_weighting(
+                kernel_size[0], kernel_size[1], Ly, Lx, x.device
+            ).to(x.dtype)
             normalization = fold(weighting).view(1, 1, h, w)  # normalizes the overlap
             weighting = weighting.view((1, 1, kernel_size[0], kernel_size[1], Ly * Lx))
 
         elif uf > 1 and df == 1:
-            fold_params = dict(kernel_size=kernel_size, dilation=1, padding=0, stride=stride)
+            fold_params = dict(
+                kernel_size=kernel_size, dilation=1, padding=0, stride=stride
+            )
             unfold = torch.nn.Unfold(**fold_params)
 
-            fold_params2 = dict(kernel_size=(kernel_size[0] * uf, kernel_size[0] * uf),
-                                dilation=1, padding=0,
-                                stride=(stride[0] * uf, stride[1] * uf))
-            fold = torch.nn.Fold(output_size=(x.shape[2] * uf, x.shape[3] * uf), **fold_params2)
+            fold_params2 = dict(
+                kernel_size=(kernel_size[0] * uf, kernel_size[0] * uf),
+                dilation=1,
+                padding=0,
+                stride=(stride[0] * uf, stride[1] * uf),
+            )
+            fold = torch.nn.Fold(
+                output_size=(x.shape[2] * uf, x.shape[3] * uf), **fold_params2
+            )
 
-            weighting = self.get_weighting(kernel_size[0] * uf, kernel_size[1] * uf, Ly, Lx, x.device).to(x.dtype)
-            normalization = fold(weighting).view(1, 1, h * uf, w * uf)  # normalizes the overlap
-            weighting = weighting.view((1, 1, kernel_size[0] * uf, kernel_size[1] * uf, Ly * Lx))
+            weighting = self.get_weighting(
+                kernel_size[0] * uf, kernel_size[1] * uf, Ly, Lx, x.device
+            ).to(x.dtype)
+            normalization = fold(weighting).view(
+                1, 1, h * uf, w * uf
+            )  # normalizes the overlap
+            weighting = weighting.view(
+                (1, 1, kernel_size[0] * uf, kernel_size[1] * uf, Ly * Lx)
+            )
 
         elif df > 1 and uf == 1:
-            fold_params = dict(kernel_size=kernel_size, dilation=1, padding=0, stride=stride)
+            fold_params = dict(
+                kernel_size=kernel_size, dilation=1, padding=0, stride=stride
+            )
             unfold = torch.nn.Unfold(**fold_params)
 
-            fold_params2 = dict(kernel_size=(kernel_size[0] // df, kernel_size[0] // df),
-                                dilation=1, padding=0,
-                                stride=(stride[0] // df, stride[1] // df))
-            fold = torch.nn.Fold(output_size=(x.shape[2] // df, x.shape[3] // df), **fold_params2)
+            fold_params2 = dict(
+                kernel_size=(kernel_size[0] // df, kernel_size[0] // df),
+                dilation=1,
+                padding=0,
+                stride=(stride[0] // df, stride[1] // df),
+            )
+            fold = torch.nn.Fold(
+                output_size=(x.shape[2] // df, x.shape[3] // df), **fold_params2
+            )
 
-            weighting = self.get_weighting(kernel_size[0] // df, kernel_size[1] // df, Ly, Lx, x.device).to(x.dtype)
-            normalization = fold(weighting).view(1, 1, h // df, w // df)  # normalizes the overlap
-            weighting = weighting.view((1, 1, kernel_size[0] // df, kernel_size[1] // df, Ly * Lx))
+            weighting = self.get_weighting(
+                kernel_size[0] // df, kernel_size[1] // df, Ly, Lx, x.device
+            ).to(x.dtype)
+            normalization = fold(weighting).view(
+                1, 1, h // df, w // df
+            )  # normalizes the overlap
+            weighting = weighting.view(
+                (1, 1, kernel_size[0] // df, kernel_size[1] // df, Ly * Lx)
+            )
 
         else:
             raise NotImplementedError
@@ -690,8 +882,17 @@ class LatentDiffusion(DDPM):
         return fold, unfold, normalization, weighting
 
     @torch.no_grad()
-    def get_input(self, batch, k, return_first_stage_outputs=False, force_c_encode=False,
-                  cond_key=None, return_original_cond=False, bs=None, uncond=0.05):
+    def get_input(
+        self,
+        batch,
+        k,
+        return_first_stage_outputs=False,
+        force_c_encode=False,
+        cond_key=None,
+        return_original_cond=False,
+        bs=None,
+        uncond=0.05,
+    ):
         x = super().get_input(batch, k)
         if bs is not None:
             x = x[:bs]
@@ -708,11 +909,22 @@ class LatentDiffusion(DDPM):
         # To support classifier-free guidance, randomly drop out only text conditioning 5%, only image conditioning 5%, and both 5%.
         random = torch.rand(x.size(0), device=x.device)
         prompt_mask = rearrange(random < 2 * uncond, "n -> n 1 1")
-        input_mask = 1 - rearrange((random >= uncond).float() * (random < 3 * uncond).float(), "n -> n 1 1 1")
+        input_mask = 1 - rearrange(
+            (random >= uncond).float() * (random < 3 * uncond).float(), "n -> n 1 1 1"
+        )
 
         null_prompt = self.get_learned_conditioning([""])
-        cond["c_crossattn"] = [torch.where(prompt_mask, null_prompt, self.get_learned_conditioning(xc["c_crossattn"]).detach())]
-        cond["c_concat"] = [input_mask * self.encode_first_stage((xc["c_concat"].to(self.device))).mode().detach()]
+        cond["c_crossattn"] = [
+            torch.where(
+                prompt_mask,
+                null_prompt,
+                self.get_learned_conditioning(xc["c_crossattn"]).detach(),
+            )
+        ]
+        cond["c_concat"] = [
+            input_mask
+            * self.encode_first_stage((xc["c_concat"].to(self.device))).mode().detach()
+        ]
 
         out = [z, cond]
         if return_first_stage_outputs:
@@ -728,9 +940,9 @@ class LatentDiffusion(DDPM):
             if z.dim() == 4:
                 z = torch.argmax(z.exp(), dim=1).long()
             z = self.first_stage_model.quantize.get_codebook_entry(z, shape=None)
-            z = rearrange(z, 'b h w c -> b c h w').contiguous()
+            z = rearrange(z, "b h w c -> b c h w").contiguous()
 
-        z = 1. / self.scale_factor * z
+        z = 1.0 / self.scale_factor * z
 
         if hasattr(self, "split_input_params"):
             if self.split_input_params["patch_distributed_vq"]:
@@ -746,21 +958,30 @@ class LatentDiffusion(DDPM):
                     stride = (min(stride[0], h), min(stride[1], w))
                     print("reducing stride")
 
-                fold, unfold, normalization, weighting = self.get_fold_unfold(z, ks, stride, uf=uf)
+                fold, unfold, normalization, weighting = self.get_fold_unfold(
+                    z, ks, stride, uf=uf
+                )
 
                 z = unfold(z)  # (bn, nc * prod(**ks), L)
                 # 1. Reshape to img shape
-                z = z.view((z.shape[0], -1, ks[0], ks[1], z.shape[-1]))  # (bn, nc, ks[0], ks[1], L )
+                z = z.view(
+                    (z.shape[0], -1, ks[0], ks[1], z.shape[-1])
+                )  # (bn, nc, ks[0], ks[1], L )
 
                 # 2. apply model loop over last dim
                 if isinstance(self.first_stage_model, VQModelInterface):
-                    output_list = [self.first_stage_model.decode(z[:, :, :, :, i],
-                                                                 force_not_quantize=predict_cids or force_not_quantize)
-                                   for i in range(z.shape[-1])]
+                    output_list = [
+                        self.first_stage_model.decode(
+                            z[:, :, :, :, i],
+                            force_not_quantize=predict_cids or force_not_quantize,
+                        )
+                        for i in range(z.shape[-1])
+                    ]
                 else:
-
-                    output_list = [self.first_stage_model.decode(z[:, :, :, :, i])
-                                   for i in range(z.shape[-1])]
+                    output_list = [
+                        self.first_stage_model.decode(z[:, :, :, :, i])
+                        for i in range(z.shape[-1])
+                    ]
 
                 o = torch.stack(output_list, axis=-1)  # # (bn, nc, ks[0], ks[1], L)
                 o = o * weighting
@@ -772,25 +993,31 @@ class LatentDiffusion(DDPM):
                 return decoded
             else:
                 if isinstance(self.first_stage_model, VQModelInterface):
-                    return self.first_stage_model.decode(z, force_not_quantize=predict_cids or force_not_quantize)
+                    return self.first_stage_model.decode(
+                        z, force_not_quantize=predict_cids or force_not_quantize
+                    )
                 else:
                     return self.first_stage_model.decode(z)
 
         else:
             if isinstance(self.first_stage_model, VQModelInterface):
-                return self.first_stage_model.decode(z, force_not_quantize=predict_cids or force_not_quantize)
+                return self.first_stage_model.decode(
+                    z, force_not_quantize=predict_cids or force_not_quantize
+                )
             else:
                 return self.first_stage_model.decode(z)
 
     # same as above but without decorator
-    def differentiable_decode_first_stage(self, z, predict_cids=False, force_not_quantize=False):
+    def differentiable_decode_first_stage(
+        self, z, predict_cids=False, force_not_quantize=False
+    ):
         if predict_cids:
             if z.dim() == 4:
                 z = torch.argmax(z.exp(), dim=1).long()
             z = self.first_stage_model.quantize.get_codebook_entry(z, shape=None)
-            z = rearrange(z, 'b h w c -> b c h w').contiguous()
+            z = rearrange(z, "b h w c -> b c h w").contiguous()
 
-        z = 1. / self.scale_factor * z
+        z = 1.0 / self.scale_factor * z
 
         if hasattr(self, "split_input_params"):
             if self.split_input_params["patch_distributed_vq"]:
@@ -806,21 +1033,30 @@ class LatentDiffusion(DDPM):
                     stride = (min(stride[0], h), min(stride[1], w))
                     print("reducing stride")
 
-                fold, unfold, normalization, weighting = self.get_fold_unfold(z, ks, stride, uf=uf)
+                fold, unfold, normalization, weighting = self.get_fold_unfold(
+                    z, ks, stride, uf=uf
+                )
 
                 z = unfold(z)  # (bn, nc * prod(**ks), L)
                 # 1. Reshape to img shape
-                z = z.view((z.shape[0], -1, ks[0], ks[1], z.shape[-1]))  # (bn, nc, ks[0], ks[1], L )
+                z = z.view(
+                    (z.shape[0], -1, ks[0], ks[1], z.shape[-1])
+                )  # (bn, nc, ks[0], ks[1], L )
 
                 # 2. apply model loop over last dim
                 if isinstance(self.first_stage_model, VQModelInterface):
-                    output_list = [self.first_stage_model.decode(z[:, :, :, :, i],
-                                                                 force_not_quantize=predict_cids or force_not_quantize)
-                                   for i in range(z.shape[-1])]
+                    output_list = [
+                        self.first_stage_model.decode(
+                            z[:, :, :, :, i],
+                            force_not_quantize=predict_cids or force_not_quantize,
+                        )
+                        for i in range(z.shape[-1])
+                    ]
                 else:
-
-                    output_list = [self.first_stage_model.decode(z[:, :, :, :, i])
-                                   for i in range(z.shape[-1])]
+                    output_list = [
+                        self.first_stage_model.decode(z[:, :, :, :, i])
+                        for i in range(z.shape[-1])
+                    ]
 
                 o = torch.stack(output_list, axis=-1)  # # (bn, nc, ks[0], ks[1], L)
                 o = o * weighting
@@ -832,13 +1068,17 @@ class LatentDiffusion(DDPM):
                 return decoded
             else:
                 if isinstance(self.first_stage_model, VQModelInterface):
-                    return self.first_stage_model.decode(z, force_not_quantize=predict_cids or force_not_quantize)
+                    return self.first_stage_model.decode(
+                        z, force_not_quantize=predict_cids or force_not_quantize
+                    )
                 else:
                     return self.first_stage_model.decode(z)
 
         else:
             if isinstance(self.first_stage_model, VQModelInterface):
-                return self.first_stage_model.decode(z, force_not_quantize=predict_cids or force_not_quantize)
+                return self.first_stage_model.decode(
+                    z, force_not_quantize=predict_cids or force_not_quantize
+                )
             else:
                 return self.first_stage_model.decode(z)
 
@@ -849,7 +1089,7 @@ class LatentDiffusion(DDPM):
                 ks = self.split_input_params["ks"]  # eg. (128, 128)
                 stride = self.split_input_params["stride"]  # eg. (64, 64)
                 df = self.split_input_params["vqf"]
-                self.split_input_params['original_image_size'] = x.shape[-2:]
+                self.split_input_params["original_image_size"] = x.shape[-2:]
                 bs, nc, h, w = x.shape
                 if ks[0] > h or ks[1] > w:
                     ks = (min(ks[0], h), min(ks[1], w))
@@ -859,13 +1099,19 @@ class LatentDiffusion(DDPM):
                     stride = (min(stride[0], h), min(stride[1], w))
                     print("reducing stride")
 
-                fold, unfold, normalization, weighting = self.get_fold_unfold(x, ks, stride, df=df)
+                fold, unfold, normalization, weighting = self.get_fold_unfold(
+                    x, ks, stride, df=df
+                )
                 z = unfold(x)  # (bn, nc * prod(**ks), L)
                 # Reshape to img shape
-                z = z.view((z.shape[0], -1, ks[0], ks[1], z.shape[-1]))  # (bn, nc, ks[0], ks[1], L )
+                z = z.view(
+                    (z.shape[0], -1, ks[0], ks[1], z.shape[-1])
+                )  # (bn, nc, ks[0], ks[1], L )
 
-                output_list = [self.first_stage_model.encode(z[:, :, :, :, i])
-                               for i in range(z.shape[-1])]
+                output_list = [
+                    self.first_stage_model.encode(z[:, :, :, :, i])
+                    for i in range(z.shape[-1])
+                ]
 
                 o = torch.stack(output_list, axis=-1)
                 o = o * weighting
@@ -888,7 +1134,9 @@ class LatentDiffusion(DDPM):
         return loss
 
     def forward(self, x, c, *args, **kwargs):
-        t = torch.randint(0, self.num_timesteps, (x.shape[0],), device=self.device).long()
+        t = torch.randint(
+            0, self.num_timesteps, (x.shape[0],), device=self.device
+        ).long()
         if self.model.conditioning_key is not None:
             assert c is not None
             if self.cond_stage_trainable:
@@ -899,14 +1147,15 @@ class LatentDiffusion(DDPM):
         return self.p_losses(x, c, t, *args, **kwargs)
 
     def apply_model(self, x_noisy, t, cond, return_ids=False):
-
         if isinstance(cond, dict):
             # hybrid case, cond is expected to be a dict
             pass
         else:
             if not isinstance(cond, list):
                 cond = [cond]
-            key = 'c_concat' if self.model.conditioning_key == 'concat' else 'c_crossattn'
+            key = (
+                "c_concat" if self.model.conditioning_key == "concat" else "c_crossattn"
+            )
             cond = {key: cond}
 
         if hasattr(self, "split_input_params"):
@@ -917,31 +1166,41 @@ class LatentDiffusion(DDPM):
 
             h, w = x_noisy.shape[-2:]
 
-            fold, unfold, normalization, weighting = self.get_fold_unfold(x_noisy, ks, stride)
+            fold, unfold, normalization, weighting = self.get_fold_unfold(
+                x_noisy, ks, stride
+            )
 
             z = unfold(x_noisy)  # (bn, nc * prod(**ks), L)
             # Reshape to img shape
-            z = z.view((z.shape[0], -1, ks[0], ks[1], z.shape[-1]))  # (bn, nc, ks[0], ks[1], L )
+            z = z.view(
+                (z.shape[0], -1, ks[0], ks[1], z.shape[-1])
+            )  # (bn, nc, ks[0], ks[1], L )
             z_list = [z[:, :, :, :, i] for i in range(z.shape[-1])]
 
-            if self.cond_stage_key in ["image", "LR_image", "segmentation",
-                                       'bbox_img'] and self.model.conditioning_key:  # todo check for completeness
+            if (
+                self.cond_stage_key in ["image", "LR_image", "segmentation", "bbox_img"]
+                and self.model.conditioning_key
+            ):  # todo check for completeness
                 c_key = next(iter(cond.keys()))  # get key
                 c = next(iter(cond.values()))  # get value
-                assert (len(c) == 1)  # todo extend to list with more than one elem
+                assert len(c) == 1  # todo extend to list with more than one elem
                 c = c[0]  # get element
 
                 c = unfold(c)
-                c = c.view((c.shape[0], -1, ks[0], ks[1], c.shape[-1]))  # (bn, nc, ks[0], ks[1], L )
+                c = c.view(
+                    (c.shape[0], -1, ks[0], ks[1], c.shape[-1])
+                )  # (bn, nc, ks[0], ks[1], L )
 
                 cond_list = [{c_key: [c[:, :, :, :, i]]} for i in range(c.shape[-1])]
 
-            elif self.cond_stage_key == 'coordinates_bbox':
-                assert 'original_image_size' in self.split_input_params, 'BoundingBoxRescaling is missing original_image_size'
+            elif self.cond_stage_key == "coordinates_bbox":
+                assert (
+                    "original_image_size" in self.split_input_params
+                ), "BoundingBoxRescaling is missing original_image_size"
 
                 # assuming padding of unfold is always 0 and its dilation is always 1
                 n_patches_per_row = int((w - ks[0]) / stride[0] + 1)
-                full_img_h, full_img_w = self.split_input_params['original_image_size']
+                full_img_h, full_img_w = self.split_input_params["original_image_size"]
                 # as we are operating on latents, we need the factor from the original image size to the
                 # spatial latent size to properly rescale the crops for regenerating the bbox annotations
                 num_downs = self.first_stage_model.encoder.num_resolutions - 1
@@ -949,42 +1208,71 @@ class LatentDiffusion(DDPM):
 
                 # get top left positions of patches as conforming for the bbbox tokenizer, therefore we
                 # need to rescale the tl patch coordinates to be in between (0,1)
-                tl_patch_coordinates = [(rescale_latent * stride[0] * (patch_nr % n_patches_per_row) / full_img_w,
-                                         rescale_latent * stride[1] * (patch_nr // n_patches_per_row) / full_img_h)
-                                        for patch_nr in range(z.shape[-1])]
+                tl_patch_coordinates = [
+                    (
+                        rescale_latent
+                        * stride[0]
+                        * (patch_nr % n_patches_per_row)
+                        / full_img_w,
+                        rescale_latent
+                        * stride[1]
+                        * (patch_nr // n_patches_per_row)
+                        / full_img_h,
+                    )
+                    for patch_nr in range(z.shape[-1])
+                ]
 
                 # patch_limits are tl_coord, width and height coordinates as (x_tl, y_tl, h, w)
-                patch_limits = [(x_tl, y_tl,
-                                 rescale_latent * ks[0] / full_img_w,
-                                 rescale_latent * ks[1] / full_img_h) for x_tl, y_tl in tl_patch_coordinates]
+                patch_limits = [
+                    (
+                        x_tl,
+                        y_tl,
+                        rescale_latent * ks[0] / full_img_w,
+                        rescale_latent * ks[1] / full_img_h,
+                    )
+                    for x_tl, y_tl in tl_patch_coordinates
+                ]
                 # patch_values = [(np.arange(x_tl,min(x_tl+ks, 1.)),np.arange(y_tl,min(y_tl+ks, 1.))) for x_tl, y_tl in tl_patch_coordinates]
 
                 # tokenize crop coordinates for the bounding boxes of the respective patches
-                patch_limits_tknzd = [torch.LongTensor(self.bbox_tokenizer._crop_encoder(bbox))[None].to(self.device)
-                                      for bbox in patch_limits]  # list of length l with tensors of shape (1, 2)
+                patch_limits_tknzd = [
+                    torch.LongTensor(self.bbox_tokenizer._crop_encoder(bbox))[None].to(
+                        self.device
+                    )
+                    for bbox in patch_limits
+                ]  # list of length l with tensors of shape (1, 2)
                 print(patch_limits_tknzd[0].shape)
                 # cut tknzd crop position from conditioning
-                assert isinstance(cond, dict), 'cond must be dict to be fed into model'
-                cut_cond = cond['c_crossattn'][0][..., :-2].to(self.device)
+                assert isinstance(cond, dict), "cond must be dict to be fed into model"
+                cut_cond = cond["c_crossattn"][0][..., :-2].to(self.device)
                 print(cut_cond.shape)
 
-                adapted_cond = torch.stack([torch.cat([cut_cond, p], dim=1) for p in patch_limits_tknzd])
-                adapted_cond = rearrange(adapted_cond, 'l b n -> (l b) n')
+                adapted_cond = torch.stack(
+                    [torch.cat([cut_cond, p], dim=1) for p in patch_limits_tknzd]
+                )
+                adapted_cond = rearrange(adapted_cond, "l b n -> (l b) n")
                 print(adapted_cond.shape)
                 adapted_cond = self.get_learned_conditioning(adapted_cond)
                 print(adapted_cond.shape)
-                adapted_cond = rearrange(adapted_cond, '(l b) n d -> l b n d', l=z.shape[-1])
+                adapted_cond = rearrange(
+                    adapted_cond, "(l b) n d -> l b n d", l=z.shape[-1]
+                )
                 print(adapted_cond.shape)
 
-                cond_list = [{'c_crossattn': [e]} for e in adapted_cond]
+                cond_list = [{"c_crossattn": [e]} for e in adapted_cond]
 
             else:
-                cond_list = [cond for i in range(z.shape[-1])]  # Todo make this more efficient
+                cond_list = [
+                    cond for i in range(z.shape[-1])
+                ]  # Todo make this more efficient
 
             # apply model by loop over crops
-            output_list = [self.model(z_list[i], t, **cond_list[i]) for i in range(z.shape[-1])]
-            assert not isinstance(output_list[0],
-                                  tuple)  # todo cant deal with multiple model outputs check this never happens
+            output_list = [
+                self.model(z_list[i], t, **cond_list[i]) for i in range(z.shape[-1])
+            ]
+            assert not isinstance(
+                output_list[0], tuple
+            )  # todo cant deal with multiple model outputs check this never happens
 
             o = torch.stack(output_list, axis=-1)
             o = o * weighting
@@ -1002,8 +1290,10 @@ class LatentDiffusion(DDPM):
             return x_recon
 
     def _predict_eps_from_xstart(self, x_t, t, pred_xstart):
-        return (extract_into_tensor(self.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t - pred_xstart) / \
-               extract_into_tensor(self.sqrt_recipm1_alphas_cumprod, t, x_t.shape)
+        return (
+            extract_into_tensor(self.sqrt_recip_alphas_cumprod, t, x_t.shape) * x_t
+            - pred_xstart
+        ) / extract_into_tensor(self.sqrt_recipm1_alphas_cumprod, t, x_t.shape)
 
     def _prior_bpd(self, x_start):
         """
@@ -1016,7 +1306,9 @@ class LatentDiffusion(DDPM):
         batch_size = x_start.shape[0]
         t = torch.tensor([self.num_timesteps - 1] * batch_size, device=x_start.device)
         qt_mean, _, qt_log_variance = self.q_mean_variance(x_start, t)
-        kl_prior = normal_kl(mean1=qt_mean, logvar1=qt_log_variance, mean2=0.0, logvar2=0.0)
+        kl_prior = normal_kl(
+            mean1=qt_mean, logvar1=qt_log_variance, mean2=0.0, logvar2=0.0
+        )
         return mean_flat(kl_prior) / np.log(2.0)
 
     def p_losses(self, x_start, cond, t, noise=None):
@@ -1025,7 +1317,7 @@ class LatentDiffusion(DDPM):
         model_output = self.apply_model(x_noisy, t, cond)
 
         loss_dict = {}
-        prefix = 'train' if self.training else 'val'
+        prefix = "train" if self.training else "val"
 
         if self.parameterization == "x0":
             target = x_start
@@ -1035,33 +1327,45 @@ class LatentDiffusion(DDPM):
             raise NotImplementedError()
 
         loss_simple = self.get_loss(model_output, target, mean=False).mean([1, 2, 3])
-        loss_dict.update({f'{prefix}/loss_simple': loss_simple.mean()})
+        loss_dict.update({f"{prefix}/loss_simple": loss_simple.mean()})
 
         logvar_t = self.logvar[t].to(self.device)
         loss = loss_simple / torch.exp(logvar_t) + logvar_t
         # loss = loss_simple / torch.exp(self.logvar) + self.logvar
         if self.learn_logvar:
-            loss_dict.update({f'{prefix}/loss_gamma': loss.mean()})
-            loss_dict.update({'logvar': self.logvar.data.mean()})
+            loss_dict.update({f"{prefix}/loss_gamma": loss.mean()})
+            loss_dict.update({"logvar": self.logvar.data.mean()})
 
         loss = self.l_simple_weight * loss.mean()
 
         loss_vlb = self.get_loss(model_output, target, mean=False).mean(dim=(1, 2, 3))
         loss_vlb = (self.lvlb_weights[t] * loss_vlb).mean()
-        loss_dict.update({f'{prefix}/loss_vlb': loss_vlb})
-        loss += (self.original_elbo_weight * loss_vlb)
-        loss_dict.update({f'{prefix}/loss': loss})
+        loss_dict.update({f"{prefix}/loss_vlb": loss_vlb})
+        loss += self.original_elbo_weight * loss_vlb
+        loss_dict.update({f"{prefix}/loss": loss})
 
         return loss, loss_dict
 
-    def p_mean_variance(self, x, c, t, clip_denoised: bool, return_codebook_ids=False, quantize_denoised=False,
-                        return_x0=False, score_corrector=None, corrector_kwargs=None):
+    def p_mean_variance(
+        self,
+        x,
+        c,
+        t,
+        clip_denoised: bool,
+        return_codebook_ids=False,
+        quantize_denoised=False,
+        return_x0=False,
+        score_corrector=None,
+        corrector_kwargs=None,
+    ):
         t_in = t
         model_out = self.apply_model(x, t_in, c, return_ids=return_codebook_ids)
 
         if score_corrector is not None:
             assert self.parameterization == "eps"
-            model_out = score_corrector.modify_score(self, model_out, x, t, c, **corrector_kwargs)
+            model_out = score_corrector.modify_score(
+                self, model_out, x, t, c, **corrector_kwargs
+            )
 
         if return_codebook_ids:
             model_out, logits = model_out
@@ -1074,10 +1378,12 @@ class LatentDiffusion(DDPM):
             raise NotImplementedError()
 
         if clip_denoised:
-            x_recon.clamp_(-1., 1.)
+            x_recon.clamp_(-1.0, 1.0)
         if quantize_denoised:
             x_recon, _, [_, _, indices] = self.first_stage_model.quantize(x_recon)
-        model_mean, posterior_variance, posterior_log_variance = self.q_posterior(x_start=x_recon, x_t=x, t=t)
+        model_mean, posterior_variance, posterior_log_variance = self.q_posterior(
+            x_start=x_recon, x_t=x, t=t
+        )
         if return_codebook_ids:
             return model_mean, posterior_variance, posterior_log_variance, logits
         elif return_x0:
@@ -1086,15 +1392,33 @@ class LatentDiffusion(DDPM):
             return model_mean, posterior_variance, posterior_log_variance
 
     @torch.no_grad()
-    def p_sample(self, x, c, t, clip_denoised=False, repeat_noise=False,
-                 return_codebook_ids=False, quantize_denoised=False, return_x0=False,
-                 temperature=1., noise_dropout=0., score_corrector=None, corrector_kwargs=None):
+    def p_sample(
+        self,
+        x,
+        c,
+        t,
+        clip_denoised=False,
+        repeat_noise=False,
+        return_codebook_ids=False,
+        quantize_denoised=False,
+        return_x0=False,
+        temperature=1.0,
+        noise_dropout=0.0,
+        score_corrector=None,
+        corrector_kwargs=None,
+    ):
         b, *_, device = *x.shape, x.device
-        outputs = self.p_mean_variance(x=x, c=c, t=t, clip_denoised=clip_denoised,
-                                       return_codebook_ids=return_codebook_ids,
-                                       quantize_denoised=quantize_denoised,
-                                       return_x0=return_x0,
-                                       score_corrector=score_corrector, corrector_kwargs=corrector_kwargs)
+        outputs = self.p_mean_variance(
+            x=x,
+            c=c,
+            t=t,
+            clip_denoised=clip_denoised,
+            return_codebook_ids=return_codebook_ids,
+            quantize_denoised=quantize_denoised,
+            return_x0=return_x0,
+            score_corrector=score_corrector,
+            corrector_kwargs=corrector_kwargs,
+        )
         if return_codebook_ids:
             raise DeprecationWarning("Support dropped.")
             model_mean, _, model_log_variance, logits = outputs
@@ -1104,23 +1428,42 @@ class LatentDiffusion(DDPM):
             model_mean, _, model_log_variance = outputs
 
         noise = noise_like(x.shape, device, repeat_noise) * temperature
-        if noise_dropout > 0.:
+        if noise_dropout > 0.0:
             noise = torch.nn.functional.dropout(noise, p=noise_dropout)
         # no noise when t == 0
         nonzero_mask = (1 - (t == 0).float()).reshape(b, *((1,) * (len(x.shape) - 1)))
 
         if return_codebook_ids:
-            return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise, logits.argmax(dim=1)
+            return model_mean + nonzero_mask * (
+                0.5 * model_log_variance
+            ).exp() * noise, logits.argmax(dim=1)
         if return_x0:
-            return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise, x0
+            return model_mean + nonzero_mask * (
+                0.5 * model_log_variance
+            ).exp() * noise, x0
         else:
             return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise
 
     @torch.no_grad()
-    def progressive_denoising(self, cond, shape, verbose=True, callback=None, quantize_denoised=False,
-                              img_callback=None, mask=None, x0=None, temperature=1., noise_dropout=0.,
-                              score_corrector=None, corrector_kwargs=None, batch_size=None, x_T=None, start_T=None,
-                              log_every_t=None):
+    def progressive_denoising(
+        self,
+        cond,
+        shape,
+        verbose=True,
+        callback=None,
+        quantize_denoised=False,
+        img_callback=None,
+        mask=None,
+        x0=None,
+        temperature=1.0,
+        noise_dropout=0.0,
+        score_corrector=None,
+        corrector_kwargs=None,
+        batch_size=None,
+        x_T=None,
+        start_T=None,
+        log_every_t=None,
+    ):
         if not log_every_t:
             log_every_t = self.log_every_t
         timesteps = self.num_timesteps
@@ -1136,35 +1479,56 @@ class LatentDiffusion(DDPM):
         intermediates = []
         if cond is not None:
             if isinstance(cond, dict):
-                cond = {key: cond[key][:batch_size] if not isinstance(cond[key], list) else
-                [x[:batch_size] for x in cond[key]] for key in cond}
+                cond = {
+                    key: cond[key][:batch_size]
+                    if not isinstance(cond[key], list)
+                    else [x[:batch_size] for x in cond[key]]
+                    for key in cond
+                }
             else:
-                cond = [c[:batch_size] for c in cond] if isinstance(cond, list) else cond[:batch_size]
+                cond = (
+                    [c[:batch_size] for c in cond]
+                    if isinstance(cond, list)
+                    else cond[:batch_size]
+                )
 
         if start_T is not None:
             timesteps = min(timesteps, start_T)
-        iterator = tqdm(reversed(range(0, timesteps)), desc='Progressive Generation',
-                        total=timesteps) if verbose else reversed(
-            range(0, timesteps))
+        iterator = (
+            tqdm(
+                reversed(range(0, timesteps)),
+                desc="Progressive Generation",
+                total=timesteps,
+            )
+            if verbose
+            else reversed(range(0, timesteps))
+        )
         if type(temperature) == float:
             temperature = [temperature] * timesteps
 
         for i in iterator:
             ts = torch.full((b,), i, device=self.device, dtype=torch.long)
             if self.shorten_cond_schedule:
-                assert self.model.conditioning_key != 'hybrid'
+                assert self.model.conditioning_key != "hybrid"
                 tc = self.cond_ids[ts].to(cond.device)
                 cond = self.q_sample(x_start=cond, t=tc, noise=torch.randn_like(cond))
 
-            img, x0_partial = self.p_sample(img, cond, ts,
-                                            clip_denoised=self.clip_denoised,
-                                            quantize_denoised=quantize_denoised, return_x0=True,
-                                            temperature=temperature[i], noise_dropout=noise_dropout,
-                                            score_corrector=score_corrector, corrector_kwargs=corrector_kwargs)
+            img, x0_partial = self.p_sample(
+                img,
+                cond,
+                ts,
+                clip_denoised=self.clip_denoised,
+                quantize_denoised=quantize_denoised,
+                return_x0=True,
+                temperature=temperature[i],
+                noise_dropout=noise_dropout,
+                score_corrector=score_corrector,
+                corrector_kwargs=corrector_kwargs,
+            )
             if mask is not None:
                 assert x0 is not None
                 img_orig = self.q_sample(x0, ts)
-                img = img_orig * mask + (1. - mask) * img
+                img = img_orig * mask + (1.0 - mask) * img
 
             if i % log_every_t == 0 or i == timesteps - 1:
                 intermediates.append(x0_partial)
@@ -1175,11 +1539,22 @@ class LatentDiffusion(DDPM):
         return img, intermediates
 
     @torch.no_grad()
-    def p_sample_loop(self, cond, shape, return_intermediates=False,
-                      x_T=None, verbose=True, callback=None, timesteps=None, quantize_denoised=False,
-                      mask=None, x0=None, img_callback=None, start_T=None,
-                      log_every_t=None):
-
+    def p_sample_loop(
+        self,
+        cond,
+        shape,
+        return_intermediates=False,
+        x_T=None,
+        verbose=True,
+        callback=None,
+        timesteps=None,
+        quantize_denoised=False,
+        mask=None,
+        x0=None,
+        img_callback=None,
+        start_T=None,
+        log_every_t=None,
+    ):
         if not log_every_t:
             log_every_t = self.log_every_t
         device = self.betas.device
@@ -1195,8 +1570,11 @@ class LatentDiffusion(DDPM):
 
         if start_T is not None:
             timesteps = min(timesteps, start_T)
-        iterator = tqdm(reversed(range(0, timesteps)), desc='Sampling t', total=timesteps) if verbose else reversed(
-            range(0, timesteps))
+        iterator = (
+            tqdm(reversed(range(0, timesteps)), desc="Sampling t", total=timesteps)
+            if verbose
+            else reversed(range(0, timesteps))
+        )
 
         if mask is not None:
             assert x0 is not None
@@ -1205,16 +1583,20 @@ class LatentDiffusion(DDPM):
         for i in iterator:
             ts = torch.full((b,), i, device=device, dtype=torch.long)
             if self.shorten_cond_schedule:
-                assert self.model.conditioning_key != 'hybrid'
+                assert self.model.conditioning_key != "hybrid"
                 tc = self.cond_ids[ts].to(cond.device)
                 cond = self.q_sample(x_start=cond, t=tc, noise=torch.randn_like(cond))
 
-            img = self.p_sample(img, cond, ts,
-                                clip_denoised=self.clip_denoised,
-                                quantize_denoised=quantize_denoised)
+            img = self.p_sample(
+                img,
+                cond,
+                ts,
+                clip_denoised=self.clip_denoised,
+                quantize_denoised=quantize_denoised,
+            )
             if mask is not None:
                 img_orig = self.q_sample(x0, ts)
-                img = img_orig * mask + (1. - mask) * img
+                img = img_orig * mask + (1.0 - mask) * img
 
             if i % log_every_t == 0 or i == timesteps - 1:
                 intermediates.append(img)
@@ -1228,52 +1610,93 @@ class LatentDiffusion(DDPM):
         return img
 
     @torch.no_grad()
-    def sample(self, cond, batch_size=16, return_intermediates=False, x_T=None,
-               verbose=True, timesteps=None, quantize_denoised=False,
-               mask=None, x0=None, shape=None,**kwargs):
+    def sample(
+        self,
+        cond,
+        batch_size=16,
+        return_intermediates=False,
+        x_T=None,
+        verbose=True,
+        timesteps=None,
+        quantize_denoised=False,
+        mask=None,
+        x0=None,
+        shape=None,
+        **kwargs,
+    ):
         if shape is None:
             shape = (batch_size, self.channels, self.image_size, self.image_size)
         if cond is not None:
             if isinstance(cond, dict):
-                cond = {key: cond[key][:batch_size] if not isinstance(cond[key], list) else
-                [x[:batch_size] for x in cond[key]] for key in cond}
+                cond = {
+                    key: cond[key][:batch_size]
+                    if not isinstance(cond[key], list)
+                    else [x[:batch_size] for x in cond[key]]
+                    for key in cond
+                }
             else:
-                cond = [c[:batch_size] for c in cond] if isinstance(cond, list) else cond[:batch_size]
-        return self.p_sample_loop(cond,
-                                  shape,
-                                  return_intermediates=return_intermediates, x_T=x_T,
-                                  verbose=verbose, timesteps=timesteps, quantize_denoised=quantize_denoised,
-                                  mask=mask, x0=x0)
+                cond = (
+                    [c[:batch_size] for c in cond]
+                    if isinstance(cond, list)
+                    else cond[:batch_size]
+                )
+        return self.p_sample_loop(
+            cond,
+            shape,
+            return_intermediates=return_intermediates,
+            x_T=x_T,
+            verbose=verbose,
+            timesteps=timesteps,
+            quantize_denoised=quantize_denoised,
+            mask=mask,
+            x0=x0,
+        )
 
     @torch.no_grad()
-    def sample_log(self,cond,batch_size,ddim, ddim_steps,**kwargs):
-
+    def sample_log(self, cond, batch_size, ddim, ddim_steps, **kwargs):
         if ddim:
             ddim_sampler = DDIMSampler(self)
             shape = (self.channels, self.image_size, self.image_size)
-            samples, intermediates =ddim_sampler.sample(ddim_steps,batch_size,
-                                                        shape,cond,verbose=False,**kwargs)
+            samples, intermediates = ddim_sampler.sample(
+                ddim_steps, batch_size, shape, cond, verbose=False, **kwargs
+            )
 
         else:
-            samples, intermediates = self.sample(cond=cond, batch_size=batch_size,
-                                                 return_intermediates=True,**kwargs)
+            samples, intermediates = self.sample(
+                cond=cond, batch_size=batch_size, return_intermediates=True, **kwargs
+            )
 
         return samples, intermediates
 
-
     @torch.no_grad()
-    def log_images(self, batch, N=4, n_row=4, sample=True, ddim_steps=200, ddim_eta=1., return_keys=None,
-                   quantize_denoised=True, inpaint=False, plot_denoise_rows=False, plot_progressive_rows=False,
-                   plot_diffusion_rows=False, **kwargs):
-
+    def log_images(
+        self,
+        batch,
+        N=4,
+        n_row=4,
+        sample=True,
+        ddim_steps=200,
+        ddim_eta=1.0,
+        return_keys=None,
+        quantize_denoised=True,
+        inpaint=False,
+        plot_denoise_rows=False,
+        plot_progressive_rows=False,
+        plot_diffusion_rows=False,
+        **kwargs,
+    ):
         use_ddim = False
 
         log = {}
-        z, c, x, xrec, xc = self.get_input(batch, self.first_stage_key,
-                                           return_first_stage_outputs=True,
-                                           force_c_encode=True,
-                                           return_original_cond=True,
-                                           bs=N, uncond=0)
+        z, c, x, xrec, xc = self.get_input(
+            batch,
+            self.first_stage_key,
+            return_first_stage_outputs=True,
+            force_c_encode=True,
+            return_original_cond=True,
+            bs=N,
+            uncond=0,
+        )
         N = min(x.shape[0], N)
         n_row = min(x.shape[0], n_row)
         log["inputs"] = x
@@ -1286,9 +1709,9 @@ class LatentDiffusion(DDPM):
             elif self.cond_stage_key in ["caption"]:
                 xc = log_txt_as_img((x.shape[2], x.shape[3]), batch["caption"])
                 log["conditioning"] = xc
-            elif self.cond_stage_key == 'class_label':
+            elif self.cond_stage_key == "class_label":
                 xc = log_txt_as_img((x.shape[2], x.shape[3]), batch["human_label"])
-                log['conditioning'] = xc
+                log["conditioning"] = xc
             elif isimage(xc):
                 log["conditioning"] = xc
             if ismap(xc):
@@ -1300,23 +1723,28 @@ class LatentDiffusion(DDPM):
             z_start = z[:n_row]
             for t in range(self.num_timesteps):
                 if t % self.log_every_t == 0 or t == self.num_timesteps - 1:
-                    t = repeat(torch.tensor([t]), '1 -> b', b=n_row)
+                    t = repeat(torch.tensor([t]), "1 -> b", b=n_row)
                     t = t.to(self.device).long()
                     noise = torch.randn_like(z_start)
                     z_noisy = self.q_sample(x_start=z_start, t=t, noise=noise)
                     diffusion_row.append(self.decode_first_stage(z_noisy))
 
             diffusion_row = torch.stack(diffusion_row)  # n_log_step, n_row, C, H, W
-            diffusion_grid = rearrange(diffusion_row, 'n b c h w -> b n c h w')
-            diffusion_grid = rearrange(diffusion_grid, 'b n c h w -> (b n) c h w')
+            diffusion_grid = rearrange(diffusion_row, "n b c h w -> b n c h w")
+            diffusion_grid = rearrange(diffusion_grid, "b n c h w -> (b n) c h w")
             diffusion_grid = make_grid(diffusion_grid, nrow=diffusion_row.shape[0])
             log["diffusion_row"] = diffusion_grid
 
         if sample:
             # get denoise row
             with self.ema_scope("Plotting"):
-                samples, z_denoise_row = self.sample_log(cond=c,batch_size=N,ddim=use_ddim,
-                                                         ddim_steps=ddim_steps,eta=ddim_eta)
+                samples, z_denoise_row = self.sample_log(
+                    cond=c,
+                    batch_size=N,
+                    ddim=use_ddim,
+                    ddim_steps=ddim_steps,
+                    eta=ddim_eta,
+                )
                 # samples, z_denoise_row = self.sample(cond=c, batch_size=N, return_intermediates=True)
             x_samples = self.decode_first_stage(samples)
             log["samples"] = x_samples
@@ -1324,13 +1752,21 @@ class LatentDiffusion(DDPM):
                 denoise_grid = self._get_denoise_row_from_list(z_denoise_row)
                 log["denoise_row"] = denoise_grid
 
-            if quantize_denoised and not isinstance(self.first_stage_model, AutoencoderKL) and not isinstance(
-                    self.first_stage_model, IdentityFirstStage):
+            if (
+                quantize_denoised
+                and not isinstance(self.first_stage_model, AutoencoderKL)
+                and not isinstance(self.first_stage_model, IdentityFirstStage)
+            ):
                 # also display when quantizing x0 while sampling
                 with self.ema_scope("Plotting Quantized Denoised"):
-                    samples, z_denoise_row = self.sample_log(cond=c,batch_size=N,ddim=use_ddim,
-                                                             ddim_steps=ddim_steps,eta=ddim_eta,
-                                                             quantize_denoised=True)
+                    samples, z_denoise_row = self.sample_log(
+                        cond=c,
+                        batch_size=N,
+                        ddim=use_ddim,
+                        ddim_steps=ddim_steps,
+                        eta=ddim_eta,
+                        quantize_denoised=True,
+                    )
                     # samples, z_denoise_row = self.sample(cond=c, batch_size=N, return_intermediates=True,
                     #                                      quantize_denoised=True)
                 x_samples = self.decode_first_stage(samples.to(self.device))
@@ -1341,29 +1777,46 @@ class LatentDiffusion(DDPM):
                 h, w = z.shape[2], z.shape[3]
                 mask = torch.ones(N, h, w).to(self.device)
                 # zeros will be filled in
-                mask[:, h // 4:3 * h // 4, w // 4:3 * w // 4] = 0.
+                mask[:, h // 4 : 3 * h // 4, w // 4 : 3 * w // 4] = 0.0
                 mask = mask[:, None, ...]
                 with self.ema_scope("Plotting Inpaint"):
-
-                    samples, _ = self.sample_log(cond=c,batch_size=N,ddim=use_ddim, eta=ddim_eta,
-                                                ddim_steps=ddim_steps, x0=z[:N], mask=mask)
+                    samples, _ = self.sample_log(
+                        cond=c,
+                        batch_size=N,
+                        ddim=use_ddim,
+                        eta=ddim_eta,
+                        ddim_steps=ddim_steps,
+                        x0=z[:N],
+                        mask=mask,
+                    )
                 x_samples = self.decode_first_stage(samples.to(self.device))
                 log["samples_inpainting"] = x_samples
                 log["mask"] = mask
 
                 # outpaint
                 with self.ema_scope("Plotting Outpaint"):
-                    samples, _ = self.sample_log(cond=c, batch_size=N, ddim=use_ddim,eta=ddim_eta,
-                                                ddim_steps=ddim_steps, x0=z[:N], mask=mask)
+                    samples, _ = self.sample_log(
+                        cond=c,
+                        batch_size=N,
+                        ddim=use_ddim,
+                        eta=ddim_eta,
+                        ddim_steps=ddim_steps,
+                        x0=z[:N],
+                        mask=mask,
+                    )
                 x_samples = self.decode_first_stage(samples.to(self.device))
                 log["samples_outpainting"] = x_samples
 
         if plot_progressive_rows:
             with self.ema_scope("Plotting Progressives"):
-                img, progressives = self.progressive_denoising(c,
-                                                               shape=(self.channels, self.image_size, self.image_size),
-                                                               batch_size=N)
-            prog_row = self._get_denoise_row_from_list(progressives, desc="Progressive Generation")
+                img, progressives = self.progressive_denoising(
+                    c,
+                    shape=(self.channels, self.image_size, self.image_size),
+                    batch_size=N,
+                )
+            prog_row = self._get_denoise_row_from_list(
+                progressives, desc="Progressive Generation"
+            )
             log["progressive_row"] = prog_row
 
         if return_keys:
@@ -1380,20 +1833,21 @@ class LatentDiffusion(DDPM):
             print(f"{self.__class__.__name__}: Also optimizing conditioner params!")
             params = params + list(self.cond_stage_model.parameters())
         if self.learn_logvar:
-            print('Diffusion model optimizing logvar')
+            print("Diffusion model optimizing logvar")
             params.append(self.logvar)
         opt = torch.optim.AdamW(params, lr=lr)
         if self.use_scheduler:
-            assert 'target' in self.scheduler_config
+            assert "target" in self.scheduler_config
             scheduler = instantiate_from_config(self.scheduler_config)
 
             print("Setting up LambdaLR scheduler...")
             scheduler = [
                 {
-                    'scheduler': LambdaLR(opt, lr_lambda=scheduler.schedule),
-                    'interval': 'step',
-                    'frequency': 1
-                }]
+                    "scheduler": LambdaLR(opt, lr_lambda=scheduler.schedule),
+                    "interval": "step",
+                    "frequency": 1,
+                }
+            ]
             return [opt], scheduler
         return opt
 
@@ -1403,7 +1857,7 @@ class LatentDiffusion(DDPM):
         if not hasattr(self, "colorize"):
             self.colorize = torch.randn(3, x.shape[1], 1, 1).to(x)
         x = nn.functional.conv2d(x, weight=self.colorize)
-        x = 2. * (x - x.min()) / (x.max() - x.min()) - 1.
+        x = 2.0 * (x - x.min()) / (x.max() - x.min()) - 1.0
         return x
 
 
@@ -1412,22 +1866,22 @@ class DiffusionWrapper(pl.LightningModule):
         super().__init__()
         self.diffusion_model = instantiate_from_config(diff_model_config)
         self.conditioning_key = conditioning_key
-        assert self.conditioning_key in [None, 'concat', 'crossattn', 'hybrid', 'adm']
+        assert self.conditioning_key in [None, "concat", "crossattn", "hybrid", "adm"]
 
     def forward(self, x, t, c_concat: list = None, c_crossattn: list = None):
         if self.conditioning_key is None:
             out = self.diffusion_model(x, t)
-        elif self.conditioning_key == 'concat':
+        elif self.conditioning_key == "concat":
             xc = torch.cat([x] + c_concat, dim=1)
             out = self.diffusion_model(xc, t)
-        elif self.conditioning_key == 'crossattn':
+        elif self.conditioning_key == "crossattn":
             cc = torch.cat(c_crossattn, 1)
             out = self.diffusion_model(x, t, context=cc)
-        elif self.conditioning_key == 'hybrid':
+        elif self.conditioning_key == "hybrid":
             xc = torch.cat([x] + c_concat, dim=1)
             cc = torch.cat(c_crossattn, 1)
             out = self.diffusion_model(xc, t, context=cc)
-        elif self.conditioning_key == 'adm':
+        elif self.conditioning_key == "adm":
             cc = c_crossattn[0]
             out = self.diffusion_model(x, t, y=cc)
         else:
@@ -1439,13 +1893,15 @@ class DiffusionWrapper(pl.LightningModule):
 class Layout2ImgDiffusion(LatentDiffusion):
     # TODO: move all layout-specific hacks to this class
     def __init__(self, cond_stage_key, *args, **kwargs):
-        assert cond_stage_key == 'coordinates_bbox', 'Layout2ImgDiffusion only for cond_stage_key="coordinates_bbox"'
+        assert (
+            cond_stage_key == "coordinates_bbox"
+        ), 'Layout2ImgDiffusion only for cond_stage_key="coordinates_bbox"'
         super().__init__(*args, cond_stage_key=cond_stage_key, **kwargs)
 
     def log_images(self, batch, N=8, *args, **kwargs):
         logs = super().log_images(*args, batch=batch, N=N, **kwargs)
 
-        key = 'train' if self.training else 'validation'
+        key = "train" if self.training else "validation"
         dset = self.trainer.datamodule.datasets[key]
         mapper = dset.conditional_builders[self.cond_stage_key]
 
@@ -1456,5 +1912,5 @@ class Layout2ImgDiffusion(LatentDiffusion):
             bbox_imgs.append(bboximg)
 
         cond_img = torch.stack(bbox_imgs, dim=0)
-        logs['bbox_image'] = cond_img
+        logs["bbox_image"] = cond_img
         return logs

--- a/modules/models/diffusion/uni_pc/sampler.py
+++ b/modules/models/diffusion/uni_pc/sampler.py
@@ -13,7 +13,7 @@ class UniPCSampler(object):
         to_torch = lambda x: x.clone().detach().to(torch.float32).to(model.device)
         self.before_sample = None
         self.after_sample = None
-        self.register_buffer('alphas_cumprod', to_torch(model.alphas_cumprod))
+        self.register_buffer("alphas_cumprod", to_torch(model.alphas_cumprod))
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
@@ -27,30 +27,31 @@ class UniPCSampler(object):
         self.after_update = after_update
 
     @torch.no_grad()
-    def sample(self,
-               S,
-               batch_size,
-               shape,
-               conditioning=None,
-               callback=None,
-               normals_sequence=None,
-               img_callback=None,
-               quantize_x0=False,
-               eta=0.,
-               mask=None,
-               x0=None,
-               temperature=1.,
-               noise_dropout=0.,
-               score_corrector=None,
-               corrector_kwargs=None,
-               verbose=True,
-               x_T=None,
-               log_every_t=100,
-               unconditional_guidance_scale=1.,
-               unconditional_conditioning=None,
-               # this has to come in the same format as the conditioning, # e.g. as encoded tokens, ...
-               **kwargs
-               ):
+    def sample(
+        self,
+        S,
+        batch_size,
+        shape,
+        conditioning=None,
+        callback=None,
+        normals_sequence=None,
+        img_callback=None,
+        quantize_x0=False,
+        eta=0.0,
+        mask=None,
+        x0=None,
+        temperature=1.0,
+        noise_dropout=0.0,
+        score_corrector=None,
+        corrector_kwargs=None,
+        verbose=True,
+        x_T=None,
+        log_every_t=100,
+        unconditional_guidance_scale=1.0,
+        unconditional_conditioning=None,
+        # this has to come in the same format as the conditioning, # e.g. as encoded tokens, ...
+        **kwargs,
+    ):
         if conditioning is not None:
             if isinstance(conditioning, dict):
                 ctmp = conditioning[list(conditioning.keys())[0]]
@@ -58,16 +59,22 @@ class UniPCSampler(object):
                     ctmp = ctmp[0]
                 cbs = ctmp.shape[0]
                 if cbs != batch_size:
-                    print(f"Warning: Got {cbs} conditionings but batch-size is {batch_size}")
+                    print(
+                        f"Warning: Got {cbs} conditionings but batch-size is {batch_size}"
+                    )
 
             elif isinstance(conditioning, list):
                 for ctmp in conditioning:
                     if ctmp.shape[0] != batch_size:
-                        print(f"Warning: Got {cbs} conditionings but batch-size is {batch_size}")
+                        print(
+                            f"Warning: Got {cbs} conditionings but batch-size is {batch_size}"
+                        )
 
             else:
                 if conditioning.shape[0] != batch_size:
-                    print(f"Warning: Got {conditioning.shape[0]} conditionings but batch-size is {batch_size}")
+                    print(
+                        f"Warning: Got {conditioning.shape[0]} conditionings but batch-size is {batch_size}"
+                    )
 
         # sampling
         C, H, W = shape
@@ -80,7 +87,7 @@ class UniPCSampler(object):
         else:
             img = x_T
 
-        ns = NoiseScheduleVP('discrete', alphas_cumprod=self.alphas_cumprod)
+        ns = NoiseScheduleVP("discrete", alphas_cumprod=self.alphas_cumprod)
 
         # SD 1.X is "noise", SD 2.X is "v"
         model_type = "v" if self.model.parameterization == "v" else "noise"
@@ -90,12 +97,30 @@ class UniPCSampler(object):
             ns,
             model_type=model_type,
             guidance_type="classifier-free",
-            #condition=conditioning,
-            #unconditional_condition=unconditional_conditioning,
+            # condition=conditioning,
+            # unconditional_condition=unconditional_conditioning,
             guidance_scale=unconditional_guidance_scale,
         )
 
-        uni_pc = UniPC(model_fn, ns, predict_x0=True, thresholding=False, variant=shared.opts.uni_pc_variant, condition=conditioning, unconditional_condition=unconditional_conditioning, before_sample=self.before_sample, after_sample=self.after_sample, after_update=self.after_update)
-        x = uni_pc.sample(img, steps=S, skip_type=shared.opts.uni_pc_skip_type, method="multistep", order=shared.opts.uni_pc_order, lower_order_final=shared.opts.uni_pc_lower_order_final)
+        uni_pc = UniPC(
+            model_fn,
+            ns,
+            predict_x0=True,
+            thresholding=False,
+            variant=shared.opts.uni_pc_variant,
+            condition=conditioning,
+            unconditional_condition=unconditional_conditioning,
+            before_sample=self.before_sample,
+            after_sample=self.after_sample,
+            after_update=self.after_update,
+        )
+        x = uni_pc.sample(
+            img,
+            steps=S,
+            skip_type=shared.opts.uni_pc_skip_type,
+            method="multistep",
+            order=shared.opts.uni_pc_order,
+            lower_order_final=shared.opts.uni_pc_lower_order_final,
+        )
 
         return x.to(device), None

--- a/modules/models/diffusion/uni_pc/uni_pc.py
+++ b/modules/models/diffusion/uni_pc/uni_pc.py
@@ -5,13 +5,13 @@ import tqdm
 
 class NoiseScheduleVP:
     def __init__(
-            self,
-            schedule='discrete',
-            betas=None,
-            alphas_cumprod=None,
-            continuous_beta_0=0.1,
-            continuous_beta_1=20.,
-        ):
+        self,
+        schedule="discrete",
+        betas=None,
+        alphas_cumprod=None,
+        continuous_beta_0=0.1,
+        continuous_beta_1=20.0,
+    ):
         """Create a wrapper class for the forward SDE (VP type).
 
         ***
@@ -92,47 +92,70 @@ class NoiseScheduleVP:
 
         """
 
-        if schedule not in ['discrete', 'linear', 'cosine']:
-            raise ValueError(f"Unsupported noise schedule {schedule}. The schedule needs to be 'discrete' or 'linear' or 'cosine'")
+        if schedule not in ["discrete", "linear", "cosine"]:
+            raise ValueError(
+                f"Unsupported noise schedule {schedule}. The schedule needs to be 'discrete' or 'linear' or 'cosine'"
+            )
 
         self.schedule = schedule
-        if schedule == 'discrete':
+        if schedule == "discrete":
             if betas is not None:
                 log_alphas = 0.5 * torch.log(1 - betas).cumsum(dim=0)
             else:
                 assert alphas_cumprod is not None
                 log_alphas = 0.5 * torch.log(alphas_cumprod)
             self.total_N = len(log_alphas)
-            self.T = 1.
-            self.t_array = torch.linspace(0., 1., self.total_N + 1)[1:].reshape((1, -1))
-            self.log_alpha_array = log_alphas.reshape((1, -1,))
+            self.T = 1.0
+            self.t_array = torch.linspace(0.0, 1.0, self.total_N + 1)[1:].reshape(
+                (1, -1)
+            )
+            self.log_alpha_array = log_alphas.reshape(
+                (
+                    1,
+                    -1,
+                )
+            )
         else:
             self.total_N = 1000
             self.beta_0 = continuous_beta_0
             self.beta_1 = continuous_beta_1
             self.cosine_s = 0.008
-            self.cosine_beta_max = 999.
-            self.cosine_t_max = math.atan(self.cosine_beta_max * (1. + self.cosine_s) / math.pi) * 2. * (1. + self.cosine_s) / math.pi - self.cosine_s
-            self.cosine_log_alpha_0 = math.log(math.cos(self.cosine_s / (1. + self.cosine_s) * math.pi / 2.))
+            self.cosine_beta_max = 999.0
+            self.cosine_t_max = (
+                math.atan(self.cosine_beta_max * (1.0 + self.cosine_s) / math.pi)
+                * 2.0
+                * (1.0 + self.cosine_s)
+                / math.pi
+                - self.cosine_s
+            )
+            self.cosine_log_alpha_0 = math.log(
+                math.cos(self.cosine_s / (1.0 + self.cosine_s) * math.pi / 2.0)
+            )
             self.schedule = schedule
-            if schedule == 'cosine':
+            if schedule == "cosine":
                 # For the cosine schedule, T = 1 will have numerical issues. So we manually set the ending time T.
                 # Note that T = 0.9946 may be not the optimal setting. However, we find it works well.
                 self.T = 0.9946
             else:
-                self.T = 1.
+                self.T = 1.0
 
     def marginal_log_mean_coeff(self, t):
         """
         Compute log(alpha_t) of a given continuous-time label t in [0, T].
         """
-        if self.schedule == 'discrete':
-            return interpolate_fn(t.reshape((-1, 1)), self.t_array.to(t.device), self.log_alpha_array.to(t.device)).reshape((-1))
-        elif self.schedule == 'linear':
-            return -0.25 * t ** 2 * (self.beta_1 - self.beta_0) - 0.5 * t * self.beta_0
-        elif self.schedule == 'cosine':
-            log_alpha_fn = lambda s: torch.log(torch.cos((s + self.cosine_s) / (1. + self.cosine_s) * math.pi / 2.))
-            log_alpha_t =  log_alpha_fn(t) - self.cosine_log_alpha_0
+        if self.schedule == "discrete":
+            return interpolate_fn(
+                t.reshape((-1, 1)),
+                self.t_array.to(t.device),
+                self.log_alpha_array.to(t.device),
+            ).reshape((-1))
+        elif self.schedule == "linear":
+            return -0.25 * t**2 * (self.beta_1 - self.beta_0) - 0.5 * t * self.beta_0
+        elif self.schedule == "cosine":
+            log_alpha_fn = lambda s: torch.log(
+                torch.cos((s + self.cosine_s) / (1.0 + self.cosine_s) * math.pi / 2.0)
+            )
+            log_alpha_t = log_alpha_fn(t) - self.cosine_log_alpha_0
             return log_alpha_t
 
     def marginal_alpha(self, t):
@@ -145,31 +168,49 @@ class NoiseScheduleVP:
         """
         Compute sigma_t of a given continuous-time label t in [0, T].
         """
-        return torch.sqrt(1. - torch.exp(2. * self.marginal_log_mean_coeff(t)))
+        return torch.sqrt(1.0 - torch.exp(2.0 * self.marginal_log_mean_coeff(t)))
 
     def marginal_lambda(self, t):
         """
         Compute lambda_t = log(alpha_t) - log(sigma_t) of a given continuous-time label t in [0, T].
         """
         log_mean_coeff = self.marginal_log_mean_coeff(t)
-        log_std = 0.5 * torch.log(1. - torch.exp(2. * log_mean_coeff))
+        log_std = 0.5 * torch.log(1.0 - torch.exp(2.0 * log_mean_coeff))
         return log_mean_coeff - log_std
 
     def inverse_lambda(self, lamb):
         """
         Compute the continuous-time label t in [0, T] of a given half-logSNR lambda_t.
         """
-        if self.schedule == 'linear':
-            tmp = 2. * (self.beta_1 - self.beta_0) * torch.logaddexp(-2. * lamb, torch.zeros((1,)).to(lamb))
+        if self.schedule == "linear":
+            tmp = (
+                2.0
+                * (self.beta_1 - self.beta_0)
+                * torch.logaddexp(-2.0 * lamb, torch.zeros((1,)).to(lamb))
+            )
             Delta = self.beta_0**2 + tmp
             return tmp / (torch.sqrt(Delta) + self.beta_0) / (self.beta_1 - self.beta_0)
-        elif self.schedule == 'discrete':
-            log_alpha = -0.5 * torch.logaddexp(torch.zeros((1,)).to(lamb.device), -2. * lamb)
-            t = interpolate_fn(log_alpha.reshape((-1, 1)), torch.flip(self.log_alpha_array.to(lamb.device), [1]), torch.flip(self.t_array.to(lamb.device), [1]))
+        elif self.schedule == "discrete":
+            log_alpha = -0.5 * torch.logaddexp(
+                torch.zeros((1,)).to(lamb.device), -2.0 * lamb
+            )
+            t = interpolate_fn(
+                log_alpha.reshape((-1, 1)),
+                torch.flip(self.log_alpha_array.to(lamb.device), [1]),
+                torch.flip(self.t_array.to(lamb.device), [1]),
+            )
             return t.reshape((-1,))
         else:
-            log_alpha = -0.5 * torch.logaddexp(-2. * lamb, torch.zeros((1,)).to(lamb))
-            t_fn = lambda log_alpha_t: torch.arccos(torch.exp(log_alpha_t + self.cosine_log_alpha_0)) * 2. * (1. + self.cosine_s) / math.pi - self.cosine_s
+            log_alpha = -0.5 * torch.logaddexp(-2.0 * lamb, torch.zeros((1,)).to(lamb))
+            t_fn = (
+                lambda log_alpha_t: torch.arccos(
+                    torch.exp(log_alpha_t + self.cosine_log_alpha_0)
+                )
+                * 2.0
+                * (1.0 + self.cosine_s)
+                / math.pi
+                - self.cosine_s
+            )
             t = t_fn(log_alpha)
             return t
 
@@ -180,9 +221,9 @@ def model_wrapper(
     model_type="noise",
     model_kwargs=None,
     guidance_type="uncond",
-    #condition=None,
-    #unconditional_condition=None,
-    guidance_scale=1.,
+    # condition=None,
+    # unconditional_condition=None,
+    guidance_scale=1.0,
     classifier_fn=None,
     classifier_kwargs=None,
 ):
@@ -284,8 +325,8 @@ def model_wrapper(
         For discrete-time DPMs, we convert `t_continuous` in [1 / N, 1] to `t_input` in [0, 1000 * (N - 1) / N].
         For continuous-time DPMs, we just use `t_continuous`.
         """
-        if noise_schedule.schedule == 'discrete':
-            return (t_continuous - 1. / noise_schedule.total_N) * 1000.
+        if noise_schedule.schedule == "discrete":
+            return (t_continuous - 1.0 / noise_schedule.total_N) * 1000.0
         else:
             return t_continuous
 
@@ -300,11 +341,19 @@ def model_wrapper(
         if model_type == "noise":
             return output
         elif model_type == "x_start":
-            alpha_t, sigma_t = noise_schedule.marginal_alpha(t_continuous), noise_schedule.marginal_std(t_continuous)
+            alpha_t, sigma_t = (
+                noise_schedule.marginal_alpha(t_continuous),
+                noise_schedule.marginal_std(t_continuous),
+            )
             dims = x.dim()
-            return (x - expand_dims(alpha_t, dims) * output) / expand_dims(sigma_t, dims)
+            return (x - expand_dims(alpha_t, dims) * output) / expand_dims(
+                sigma_t, dims
+            )
         elif model_type == "v":
-            alpha_t, sigma_t = noise_schedule.marginal_alpha(t_continuous), noise_schedule.marginal_std(t_continuous)
+            alpha_t, sigma_t = (
+                noise_schedule.marginal_alpha(t_continuous),
+                noise_schedule.marginal_std(t_continuous),
+            )
             dims = x.dim()
             return expand_dims(alpha_t, dims) * output + expand_dims(sigma_t, dims) * x
         elif model_type == "score":
@@ -335,9 +384,14 @@ def model_wrapper(
             cond_grad = cond_grad_fn(x, t_input, condition)
             sigma_t = noise_schedule.marginal_std(t_continuous)
             noise = noise_pred_fn(x, t_continuous)
-            return noise - guidance_scale * expand_dims(sigma_t, dims=cond_grad.dim()) * cond_grad
+            return (
+                noise
+                - guidance_scale
+                * expand_dims(sigma_t, dims=cond_grad.dim())
+                * cond_grad
+            )
         elif guidance_type == "classifier-free":
-            if guidance_scale == 1. or unconditional_condition is None:
+            if guidance_scale == 1.0 or unconditional_condition is None:
                 return noise_pred_fn(x, t_continuous, cond=condition)
             else:
                 x_in = torch.cat([x] * 2)
@@ -347,18 +401,23 @@ def model_wrapper(
                     c_in = {}
                     for k in condition:
                         if isinstance(condition[k], list):
-                            c_in[k] = [torch.cat([
-                                unconditional_condition[k][i],
-                                condition[k][i]]) for i in range(len(condition[k]))]
+                            c_in[k] = [
+                                torch.cat(
+                                    [unconditional_condition[k][i], condition[k][i]]
+                                )
+                                for i in range(len(condition[k]))
+                            ]
                         else:
-                            c_in[k] = torch.cat([
-                                unconditional_condition[k],
-                                condition[k]])
+                            c_in[k] = torch.cat(
+                                [unconditional_condition[k], condition[k]]
+                            )
                 elif isinstance(condition, list):
                     c_in = []
                     assert isinstance(unconditional_condition, list)
                     for i in range(len(condition)):
-                        c_in.append(torch.cat([unconditional_condition[i], condition[i]]))
+                        c_in.append(
+                            torch.cat([unconditional_condition[i], condition[i]])
+                        )
                 else:
                     c_in = torch.cat([unconditional_condition, condition])
                 noise_uncond, noise = noise_pred_fn(x_in, t_in, cond=c_in).chunk(2)
@@ -376,13 +435,13 @@ class UniPC:
         noise_schedule,
         predict_x0=True,
         thresholding=False,
-        max_val=1.,
-        variant='bh1',
+        max_val=1.0,
+        variant="bh1",
         condition=None,
         unconditional_condition=None,
         before_sample=None,
         after_sample=None,
-        after_update=None
+        after_update=None,
     ):
         """Construct a UniPC.
 
@@ -407,7 +466,12 @@ class UniPC:
         dims = x0.dim()
         p = self.dynamic_thresholding_ratio
         s = torch.quantile(torch.abs(x0).reshape((x0.shape[0], -1)), p, dim=1)
-        s = expand_dims(torch.maximum(s, self.thresholding_max_val * torch.ones_like(s).to(s.device)), dims)
+        s = expand_dims(
+            torch.maximum(
+                s, self.thresholding_max_val * torch.ones_like(s).to(s.device)
+            ),
+            dims,
+        )
         x0 = torch.clamp(x0, -s, s) / s
         return x0
 
@@ -438,12 +502,17 @@ class UniPC:
         """
         noise = self.noise_prediction_fn(x, t)
         dims = x.dim()
-        alpha_t, sigma_t = self.noise_schedule.marginal_alpha(t), self.noise_schedule.marginal_std(t)
+        alpha_t, sigma_t = (
+            self.noise_schedule.marginal_alpha(t),
+            self.noise_schedule.marginal_std(t),
+        )
         x0 = (x - expand_dims(sigma_t, dims) * noise) / expand_dims(alpha_t, dims)
         if self.thresholding:
-            p = 0.995   # A hyperparameter in the paper of "Imagen" [1].
+            p = 0.995  # A hyperparameter in the paper of "Imagen" [1].
             s = torch.quantile(torch.abs(x0).reshape((x0.shape[0], -1)), p, dim=1)
-            s = expand_dims(torch.maximum(s, self.max_val * torch.ones_like(s).to(s.device)), dims)
+            s = expand_dims(
+                torch.maximum(s, self.max_val * torch.ones_like(s).to(s.device)), dims
+            )
             x0 = torch.clamp(x0, -s, s) / s
         return x0
 
@@ -457,51 +526,82 @@ class UniPC:
             return self.noise_prediction_fn(x, t)
 
     def get_time_steps(self, skip_type, t_T, t_0, N, device):
-        """Compute the intermediate time steps for sampling.
-        """
-        if skip_type == 'logSNR':
+        """Compute the intermediate time steps for sampling."""
+        if skip_type == "logSNR":
             lambda_T = self.noise_schedule.marginal_lambda(torch.tensor(t_T).to(device))
             lambda_0 = self.noise_schedule.marginal_lambda(torch.tensor(t_0).to(device))
-            logSNR_steps = torch.linspace(lambda_T.cpu().item(), lambda_0.cpu().item(), N + 1).to(device)
+            logSNR_steps = torch.linspace(
+                lambda_T.cpu().item(), lambda_0.cpu().item(), N + 1
+            ).to(device)
             return self.noise_schedule.inverse_lambda(logSNR_steps)
-        elif skip_type == 'time_uniform':
+        elif skip_type == "time_uniform":
             return torch.linspace(t_T, t_0, N + 1).to(device)
-        elif skip_type == 'time_quadratic':
+        elif skip_type == "time_quadratic":
             t_order = 2
-            t = torch.linspace(t_T**(1. / t_order), t_0**(1. / t_order), N + 1).pow(t_order).to(device)
+            t = (
+                torch.linspace(t_T ** (1.0 / t_order), t_0 ** (1.0 / t_order), N + 1)
+                .pow(t_order)
+                .to(device)
+            )
             return t
         else:
-            raise ValueError(f"Unsupported skip_type {skip_type}, need to be 'logSNR' or 'time_uniform' or 'time_quadratic'")
+            raise ValueError(
+                f"Unsupported skip_type {skip_type}, need to be 'logSNR' or 'time_uniform' or 'time_quadratic'"
+            )
 
-    def get_orders_and_timesteps_for_singlestep_solver(self, steps, order, skip_type, t_T, t_0, device):
+    def get_orders_and_timesteps_for_singlestep_solver(
+        self, steps, order, skip_type, t_T, t_0, device
+    ):
         """
         Get the order of each step for sampling by the singlestep DPM-Solver.
         """
         if order == 3:
             K = steps // 3 + 1
             if steps % 3 == 0:
-                orders = [3,] * (K - 2) + [2, 1]
+                orders = [
+                    3,
+                ] * (K - 2) + [2, 1]
             elif steps % 3 == 1:
-                orders = [3,] * (K - 1) + [1]
+                orders = [
+                    3,
+                ] * (K - 1) + [1]
             else:
-                orders = [3,] * (K - 1) + [2]
+                orders = [
+                    3,
+                ] * (K - 1) + [2]
         elif order == 2:
             if steps % 2 == 0:
                 K = steps // 2
-                orders = [2,] * K
+                orders = [
+                    2,
+                ] * K
             else:
                 K = steps // 2 + 1
-                orders = [2,] * (K - 1) + [1]
+                orders = [
+                    2,
+                ] * (K - 1) + [1]
         elif order == 1:
             K = steps
-            orders = [1,] * steps
+            orders = [
+                1,
+            ] * steps
         else:
             raise ValueError("'order' must be '1' or '2' or '3'.")
-        if skip_type == 'logSNR':
+        if skip_type == "logSNR":
             # To reproduce the results in DPM-Solver paper
             timesteps_outer = self.get_time_steps(skip_type, t_T, t_0, K, device)
         else:
-            timesteps_outer = self.get_time_steps(skip_type, t_T, t_0, steps, device)[torch.cumsum(torch.tensor([0,] + orders), 0).to(device)]
+            timesteps_outer = self.get_time_steps(skip_type, t_T, t_0, steps, device)[
+                torch.cumsum(
+                    torch.tensor(
+                        [
+                            0,
+                        ]
+                        + orders
+                    ),
+                    0,
+                ).to(device)
+            ]
         return timesteps_outer, orders
 
     def denoise_to_zero_fn(self, x, s):
@@ -510,17 +610,25 @@ class UniPC:
         """
         return self.data_prediction_fn(x, s)
 
-    def multistep_uni_pc_update(self, x, model_prev_list, t_prev_list, t, order, **kwargs):
+    def multistep_uni_pc_update(
+        self, x, model_prev_list, t_prev_list, t, order, **kwargs
+    ):
         if len(t.shape) == 0:
             t = t.view(-1)
-        if 'bh' in self.variant:
-            return self.multistep_uni_pc_bh_update(x, model_prev_list, t_prev_list, t, order, **kwargs)
+        if "bh" in self.variant:
+            return self.multistep_uni_pc_bh_update(
+                x, model_prev_list, t_prev_list, t, order, **kwargs
+            )
         else:
-            assert self.variant == 'vary_coeff'
-            return self.multistep_uni_pc_vary_update(x, model_prev_list, t_prev_list, t, order, **kwargs)
+            assert self.variant == "vary_coeff"
+            return self.multistep_uni_pc_vary_update(
+                x, model_prev_list, t_prev_list, t, order, **kwargs
+            )
 
-    def multistep_uni_pc_vary_update(self, x, model_prev_list, t_prev_list, t, order, use_corrector=True):
-        #print(f'using unified predictor-corrector with order {order} (solver type: vary coeff)')
+    def multistep_uni_pc_vary_update(
+        self, x, model_prev_list, t_prev_list, t, order, use_corrector=True
+    ):
+        # print(f'using unified predictor-corrector with order {order} (solver type: vary coeff)')
         ns = self.noise_schedule
         assert order <= len(model_prev_list)
 
@@ -545,7 +653,7 @@ class UniPC:
             rks.append(rk)
             D1s.append((model_prev_i - model_prev_0) / rk)
 
-        rks.append(1.)
+        rks.append(1.0)
         rks = torch.tensor(rks, device=x.device)
 
         K = len(rks)
@@ -559,12 +667,12 @@ class UniPC:
         C = torch.stack(C, dim=1)
 
         if len(D1s) > 0:
-            D1s = torch.stack(D1s, dim=1) # (B, K)
+            D1s = torch.stack(D1s, dim=1)  # (B, K)
             C_inv_p = torch.linalg.inv(C[:-1, :-1])
             A_p = C_inv_p
 
         if use_corrector:
-            #print('using corrector')
+            # print('using corrector')
             C_inv = torch.linalg.inv(C)
             A_c = C_inv
 
@@ -576,54 +684,63 @@ class UniPC:
         for k in range(1, K + 2):
             h_phi_ks.append(h_phi_k)
             h_phi_k = h_phi_k / hh - 1 / factorial_k
-            factorial_k *= (k + 1)
+            factorial_k *= k + 1
 
         model_t = None
         if self.predict_x0:
-            x_t_ = (
-                sigma_t / sigma_prev_0 * x
-                - alpha_t * h_phi_1 * model_prev_0
-            )
+            x_t_ = sigma_t / sigma_prev_0 * x - alpha_t * h_phi_1 * model_prev_0
             # now predictor
             x_t = x_t_
             if len(D1s) > 0:
                 # compute the residuals for predictor
                 for k in range(K - 1):
-                    x_t = x_t - alpha_t * h_phi_ks[k + 1] * torch.einsum('bkchw,k->bchw', D1s, A_p[k])
+                    x_t = x_t - alpha_t * h_phi_ks[k + 1] * torch.einsum(
+                        "bkchw,k->bchw", D1s, A_p[k]
+                    )
             # now corrector
             if use_corrector:
                 model_t = self.model_fn(x_t, t)
-                D1_t = (model_t - model_prev_0)
+                D1_t = model_t - model_prev_0
                 x_t = x_t_
                 k = 0
                 for k in range(K - 1):
-                    x_t = x_t - alpha_t * h_phi_ks[k + 1] * torch.einsum('bkchw,k->bchw', D1s, A_c[k][:-1])
+                    x_t = x_t - alpha_t * h_phi_ks[k + 1] * torch.einsum(
+                        "bkchw,k->bchw", D1s, A_c[k][:-1]
+                    )
                 x_t = x_t - alpha_t * h_phi_ks[K] * (D1_t * A_c[k][-1])
         else:
-            log_alpha_prev_0, log_alpha_t = ns.marginal_log_mean_coeff(t_prev_0), ns.marginal_log_mean_coeff(t)
-            x_t_ = (
-                (torch.exp(log_alpha_t - log_alpha_prev_0)) * x
-                - (sigma_t * h_phi_1) * model_prev_0
+            log_alpha_prev_0, log_alpha_t = (
+                ns.marginal_log_mean_coeff(t_prev_0),
+                ns.marginal_log_mean_coeff(t),
             )
+            x_t_ = (torch.exp(log_alpha_t - log_alpha_prev_0)) * x - (
+                sigma_t * h_phi_1
+            ) * model_prev_0
             # now predictor
             x_t = x_t_
             if len(D1s) > 0:
                 # compute the residuals for predictor
                 for k in range(K - 1):
-                    x_t = x_t - sigma_t * h_phi_ks[k + 1] * torch.einsum('bkchw,k->bchw', D1s, A_p[k])
+                    x_t = x_t - sigma_t * h_phi_ks[k + 1] * torch.einsum(
+                        "bkchw,k->bchw", D1s, A_p[k]
+                    )
             # now corrector
             if use_corrector:
                 model_t = self.model_fn(x_t, t)
-                D1_t = (model_t - model_prev_0)
+                D1_t = model_t - model_prev_0
                 x_t = x_t_
                 k = 0
                 for k in range(K - 1):
-                    x_t = x_t - sigma_t * h_phi_ks[k + 1] * torch.einsum('bkchw,k->bchw', D1s, A_c[k][:-1])
+                    x_t = x_t - sigma_t * h_phi_ks[k + 1] * torch.einsum(
+                        "bkchw,k->bchw", D1s, A_c[k][:-1]
+                    )
                 x_t = x_t - sigma_t * h_phi_ks[K] * (D1_t * A_c[k][-1])
         return x_t, model_t
 
-    def multistep_uni_pc_bh_update(self, x, model_prev_list, t_prev_list, t, order, x_t=None, use_corrector=True):
-        #print(f'using unified predictor-corrector with order {order} (solver type: B(h))')
+    def multistep_uni_pc_bh_update(
+        self, x, model_prev_list, t_prev_list, t, order, x_t=None, use_corrector=True
+    ):
+        # print(f'using unified predictor-corrector with order {order} (solver type: B(h))')
         ns = self.noise_schedule
         assert order <= len(model_prev_list)
         dims = x.dim()
@@ -634,7 +751,10 @@ class UniPC:
         lambda_t = ns.marginal_lambda(t)
         model_prev_0 = model_prev_list[-1]
         sigma_prev_0, sigma_t = ns.marginal_std(t_prev_0), ns.marginal_std(t)
-        log_alpha_prev_0, log_alpha_t = ns.marginal_log_mean_coeff(t_prev_0), ns.marginal_log_mean_coeff(t)
+        log_alpha_prev_0, log_alpha_t = (
+            ns.marginal_log_mean_coeff(t_prev_0),
+            ns.marginal_log_mean_coeff(t),
+        )
         alpha_t = torch.exp(log_alpha_t)
 
         h = lambda_t - lambda_prev_0
@@ -649,21 +769,21 @@ class UniPC:
             rks.append(rk)
             D1s.append((model_prev_i - model_prev_0) / rk)
 
-        rks.append(1.)
+        rks.append(1.0)
         rks = torch.tensor(rks, device=x.device)
 
         R = []
         b = []
 
         hh = -h[0] if self.predict_x0 else h[0]
-        h_phi_1 = torch.expm1(hh) # h\phi_1(h) = e^h - 1
+        h_phi_1 = torch.expm1(hh)  # h\phi_1(h) = e^h - 1
         h_phi_k = h_phi_1 / hh - 1
 
         factorial_i = 1
 
-        if self.variant == 'bh1':
+        if self.variant == "bh1":
             B_h = hh
-        elif self.variant == 'bh2':
+        elif self.variant == "bh2":
             B_h = torch.expm1(hh)
         else:
             raise NotImplementedError()
@@ -671,7 +791,7 @@ class UniPC:
         for i in range(1, order + 1):
             R.append(torch.pow(rks, i - 1))
             b.append(h_phi_k * factorial_i / B_h)
-            factorial_i *= (i + 1)
+            factorial_i *= i + 1
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
@@ -680,7 +800,7 @@ class UniPC:
         # now predictor
         use_predictor = len(D1s) > 0 and x_t is None
         if len(D1s) > 0:
-            D1s = torch.stack(D1s, dim=1) # (B, K)
+            D1s = torch.stack(D1s, dim=1)  # (B, K)
             if x_t is None:
                 # for order 2, we use a simplified version
                 if order == 2:
@@ -691,7 +811,7 @@ class UniPC:
             D1s = None
 
         if use_corrector:
-            #print('using corrector')
+            # print('using corrector')
             # for order 1, we use a simplified version
             if order == 1:
                 rhos_c = torch.tensor([0.5], device=b.device)
@@ -702,12 +822,12 @@ class UniPC:
         if self.predict_x0:
             x_t_ = (
                 expand_dims(sigma_t / sigma_prev_0, dims) * x
-                - expand_dims(alpha_t * h_phi_1, dims)* model_prev_0
+                - expand_dims(alpha_t * h_phi_1, dims) * model_prev_0
             )
 
             if x_t is None:
                 if use_predictor:
-                    pred_res = torch.einsum('k,bkchw->bchw', rhos_p, D1s)
+                    pred_res = torch.einsum("k,bkchw->bchw", rhos_p, D1s)
                 else:
                     pred_res = 0
                 x_t = x_t_ - expand_dims(alpha_t * B_h, dims) * pred_res
@@ -715,11 +835,13 @@ class UniPC:
             if use_corrector:
                 model_t = self.model_fn(x_t, t)
                 if D1s is not None:
-                    corr_res = torch.einsum('k,bkchw->bchw', rhos_c[:-1], D1s)
+                    corr_res = torch.einsum("k,bkchw->bchw", rhos_c[:-1], D1s)
                 else:
                     corr_res = 0
-                D1_t = (model_t - model_prev_0)
-                x_t = x_t_ - expand_dims(alpha_t * B_h, dims) * (corr_res + rhos_c[-1] * D1_t)
+                D1_t = model_t - model_prev_0
+                x_t = x_t_ - expand_dims(alpha_t * B_h, dims) * (
+                    corr_res + rhos_c[-1] * D1_t
+                )
         else:
             x_t_ = (
                 expand_dims(torch.exp(log_alpha_t - log_alpha_prev_0), dims) * x
@@ -727,7 +849,7 @@ class UniPC:
             )
             if x_t is None:
                 if use_predictor:
-                    pred_res = torch.einsum('k,bkchw->bchw', rhos_p, D1s)
+                    pred_res = torch.einsum("k,bkchw->bchw", rhos_p, D1s)
                 else:
                     pred_res = 0
                 x_t = x_t_ - expand_dims(sigma_t * B_h, dims) * pred_res
@@ -735,25 +857,40 @@ class UniPC:
             if use_corrector:
                 model_t = self.model_fn(x_t, t)
                 if D1s is not None:
-                    corr_res = torch.einsum('k,bkchw->bchw', rhos_c[:-1], D1s)
+                    corr_res = torch.einsum("k,bkchw->bchw", rhos_c[:-1], D1s)
                 else:
                     corr_res = 0
-                D1_t = (model_t - model_prev_0)
-                x_t = x_t_ - expand_dims(sigma_t * B_h, dims) * (corr_res + rhos_c[-1] * D1_t)
+                D1_t = model_t - model_prev_0
+                x_t = x_t_ - expand_dims(sigma_t * B_h, dims) * (
+                    corr_res + rhos_c[-1] * D1_t
+                )
         return x_t, model_t
 
-
-    def sample(self, x, steps=20, t_start=None, t_end=None, order=3, skip_type='time_uniform',
-        method='singlestep', lower_order_final=True, denoise_to_zero=False, solver_type='dpm_solver',
-        atol=0.0078, rtol=0.05, corrector=False,
+    def sample(
+        self,
+        x,
+        steps=20,
+        t_start=None,
+        t_end=None,
+        order=3,
+        skip_type="time_uniform",
+        method="singlestep",
+        lower_order_final=True,
+        denoise_to_zero=False,
+        solver_type="dpm_solver",
+        atol=0.0078,
+        rtol=0.05,
+        corrector=False,
     ):
-        t_0 = 1. / self.noise_schedule.total_N if t_end is None else t_end
+        t_0 = 1.0 / self.noise_schedule.total_N if t_end is None else t_end
         t_T = self.noise_schedule.T if t_start is None else t_start
         device = x.device
-        if method == 'multistep':
+        if method == "multistep":
             assert steps >= order, "UniPC order must be < sampling steps"
-            timesteps = self.get_time_steps(skip_type=skip_type, t_T=t_T, t_0=t_0, N=steps, device=device)
-            #print(f"Running UniPC Sampling with {timesteps.shape[0]} timesteps, order {order}")
+            timesteps = self.get_time_steps(
+                skip_type=skip_type, t_T=t_T, t_0=t_0, N=steps, device=device
+            )
+            # print(f"Running UniPC Sampling with {timesteps.shape[0]} timesteps, order {order}")
             assert timesteps.shape[0] - 1 == steps
             with torch.no_grad():
                 vec_t = timesteps[0].expand((x.shape[0]))
@@ -763,7 +900,14 @@ class UniPC:
                     # Init the first `order` values by lower order multistep DPM-Solver.
                     for init_order in range(1, order):
                         vec_t = timesteps[init_order].expand(x.shape[0])
-                        x, model_x = self.multistep_uni_pc_update(x, model_prev_list, t_prev_list, vec_t, init_order, use_corrector=True)
+                        x, model_x = self.multistep_uni_pc_update(
+                            x,
+                            model_prev_list,
+                            t_prev_list,
+                            vec_t,
+                            init_order,
+                            use_corrector=True,
+                        )
                         if model_x is None:
                             model_x = self.model_fn(x, vec_t)
                         if self.after_update is not None:
@@ -778,13 +922,20 @@ class UniPC:
                             step_order = min(order, steps + 1 - step)
                         else:
                             step_order = order
-                        #print('this step order:', step_order)
+                        # print('this step order:', step_order)
                         if step == steps:
-                            #print('do not run corrector at the last step')
+                            # print('do not run corrector at the last step')
                             use_corrector = False
                         else:
                             use_corrector = True
-                        x, model_x =  self.multistep_uni_pc_update(x, model_prev_list, t_prev_list, vec_t, step_order, use_corrector=use_corrector)
+                        x, model_x = self.multistep_uni_pc_update(
+                            x,
+                            model_prev_list,
+                            t_prev_list,
+                            vec_t,
+                            step_order,
+                            use_corrector=use_corrector,
+                        )
                         if self.after_update is not None:
                             self.after_update(x, model_x)
                         for i in range(order - 1):
@@ -808,6 +959,7 @@ class UniPC:
 # other utility functions
 #############################################################
 
+
 def interpolate_fn(x, xp, yp):
     """
     A piecewise linear function y = f(x), using xp and yp as keypoints.
@@ -830,22 +982,32 @@ def interpolate_fn(x, xp, yp):
         torch.eq(x_idx, 0),
         torch.tensor(1, device=x.device),
         torch.where(
-            torch.eq(x_idx, K), torch.tensor(K - 2, device=x.device), cand_start_idx,
+            torch.eq(x_idx, K),
+            torch.tensor(K - 2, device=x.device),
+            cand_start_idx,
         ),
     )
-    end_idx = torch.where(torch.eq(start_idx, cand_start_idx), start_idx + 2, start_idx + 1)
+    end_idx = torch.where(
+        torch.eq(start_idx, cand_start_idx), start_idx + 2, start_idx + 1
+    )
     start_x = torch.gather(sorted_all_x, dim=2, index=start_idx.unsqueeze(2)).squeeze(2)
     end_x = torch.gather(sorted_all_x, dim=2, index=end_idx.unsqueeze(2)).squeeze(2)
     start_idx2 = torch.where(
         torch.eq(x_idx, 0),
         torch.tensor(0, device=x.device),
         torch.where(
-            torch.eq(x_idx, K), torch.tensor(K - 2, device=x.device), cand_start_idx,
+            torch.eq(x_idx, K),
+            torch.tensor(K - 2, device=x.device),
+            cand_start_idx,
         ),
     )
     y_positions_expanded = yp.unsqueeze(0).expand(N, -1, -1)
-    start_y = torch.gather(y_positions_expanded, dim=2, index=start_idx2.unsqueeze(2)).squeeze(2)
-    end_y = torch.gather(y_positions_expanded, dim=2, index=(start_idx2 + 1).unsqueeze(2)).squeeze(2)
+    start_y = torch.gather(
+        y_positions_expanded, dim=2, index=start_idx2.unsqueeze(2)
+    ).squeeze(2)
+    end_y = torch.gather(
+        y_positions_expanded, dim=2, index=(start_idx2 + 1).unsqueeze(2)
+    ).squeeze(2)
     cand = start_y + (x - start_x) * (end_y - start_y) / (end_x - start_x)
     return cand
 
@@ -860,4 +1022,4 @@ def expand_dims(v, dims):
     Returns:
         a PyTorch tensor with shape [N, 1, 1, ..., 1] and the total dimension is `dims`.
     """
-    return v[(...,) + (None,)*(dims - 1)]
+    return v[(...,) + (None,) * (dims - 1)]

--- a/modules/models/sd3/mmdit.py
+++ b/modules/models/sd3/mmdit.py
@@ -10,25 +10,28 @@ from modules.models.sd3.other_impls import attention, Mlp
 
 
 class PatchEmbed(nn.Module):
-    """ 2D Image to Patch Embedding"""
+    """2D Image to Patch Embedding"""
+
     def __init__(
-            self,
-            img_size: Optional[int] = 224,
-            patch_size: int = 16,
-            in_chans: int = 3,
-            embed_dim: int = 768,
-            flatten: bool = True,
-            bias: bool = True,
-            strict_img_size: bool = True,
-            dynamic_img_pad: bool = False,
-            dtype=None,
-            device=None,
+        self,
+        img_size: Optional[int] = 224,
+        patch_size: int = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        flatten: bool = True,
+        bias: bool = True,
+        strict_img_size: bool = True,
+        dynamic_img_pad: bool = False,
+        dtype=None,
+        device=None,
     ):
         super().__init__()
         self.patch_size = (patch_size, patch_size)
         if img_size is not None:
             self.img_size = (img_size, img_size)
-            self.grid_size = tuple([s // p for s, p in zip(self.img_size, self.patch_size)])
+            self.grid_size = tuple(
+                [s // p for s, p in zip(self.img_size, self.patch_size)]
+            )
             self.num_patches = self.grid_size[0] * self.grid_size[1]
         else:
             self.img_size = None
@@ -40,7 +43,15 @@ class PatchEmbed(nn.Module):
         self.strict_img_size = strict_img_size
         self.dynamic_img_pad = dynamic_img_pad
 
-        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_size, stride=patch_size, bias=bias, dtype=dtype, device=device)
+        self.proj = nn.Conv2d(
+            in_chans,
+            embed_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+            bias=bias,
+            dtype=dtype,
+            device=device,
+        )
 
     def forward(self, x):
         B, C, H, W = x.shape
@@ -61,7 +72,14 @@ def modulate(x, shift, scale):
 #################################################################################
 
 
-def get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False, extra_tokens=0, scaling_factor=None, offset=None):
+def get_2d_sincos_pos_embed(
+    embed_dim,
+    grid_size,
+    cls_token=False,
+    extra_tokens=0,
+    scaling_factor=None,
+    offset=None,
+):
     """
     grid_size: int of the grid height and width
     return:
@@ -78,7 +96,9 @@ def get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False, extra_tokens=
     grid = grid.reshape([2, 1, grid_size, grid_size])
     pos_embed = get_2d_sincos_pos_embed_from_grid(embed_dim, grid)
     if cls_token and extra_tokens > 0:
-        pos_embed = np.concatenate([np.zeros([extra_tokens, embed_dim]), pos_embed], axis=0)
+        pos_embed = np.concatenate(
+            [np.zeros([extra_tokens, embed_dim]), pos_embed], axis=0
+        )
     return pos_embed
 
 
@@ -116,10 +136,18 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
 class TimestepEmbedder(nn.Module):
     """Embeds scalar timesteps into vector representations."""
 
-    def __init__(self, hidden_size, frequency_embedding_size=256, dtype=None, device=None):
+    def __init__(
+        self, hidden_size, frequency_embedding_size=256, dtype=None, device=None
+    ):
         super().__init__()
         self.mlp = nn.Sequential(
-            nn.Linear(frequency_embedding_size, hidden_size, bias=True, dtype=dtype, device=device),
+            nn.Linear(
+                frequency_embedding_size,
+                hidden_size,
+                bias=True,
+                dtype=dtype,
+                device=device,
+            ),
             nn.SiLU(),
             nn.Linear(hidden_size, hidden_size, bias=True, dtype=dtype, device=device),
         )
@@ -144,7 +172,9 @@ class TimestepEmbedder(nn.Module):
         args = t[:, None].float() * freqs[None]
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
         if dim % 2:
-            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
         if torch.is_floating_point(t):
             embedding = embedding.to(dtype=t.dtype)
         return embedding
@@ -178,12 +208,15 @@ class VectorEmbedder(nn.Module):
 class QkvLinear(torch.nn.Linear):
     pass
 
+
 def split_qkv(qkv, head_dim):
     qkv = qkv.reshape(qkv.shape[0], qkv.shape[1], 3, -1, head_dim).movedim(2, 0)
     return qkv[0], qkv[1], qkv[2]
 
+
 def optimized_attention(qkv, num_heads):
     return attention(qkv[0], qkv[1], qkv[2], num_heads)
+
 
 class SelfAttention(nn.Module):
     ATTENTION_MODES = ("xformers", "torch", "torch-hb", "math", "debug")
@@ -213,11 +246,35 @@ class SelfAttention(nn.Module):
         self.pre_only = pre_only
 
         if qk_norm == "rms":
-            self.ln_q = RMSNorm(self.head_dim, elementwise_affine=True, eps=1.0e-6, dtype=dtype, device=device)
-            self.ln_k = RMSNorm(self.head_dim, elementwise_affine=True, eps=1.0e-6, dtype=dtype, device=device)
+            self.ln_q = RMSNorm(
+                self.head_dim,
+                elementwise_affine=True,
+                eps=1.0e-6,
+                dtype=dtype,
+                device=device,
+            )
+            self.ln_k = RMSNorm(
+                self.head_dim,
+                elementwise_affine=True,
+                eps=1.0e-6,
+                dtype=dtype,
+                device=device,
+            )
         elif qk_norm == "ln":
-            self.ln_q = nn.LayerNorm(self.head_dim, elementwise_affine=True, eps=1.0e-6, dtype=dtype, device=device)
-            self.ln_k = nn.LayerNorm(self.head_dim, elementwise_affine=True, eps=1.0e-6, dtype=dtype, device=device)
+            self.ln_q = nn.LayerNorm(
+                self.head_dim,
+                elementwise_affine=True,
+                eps=1.0e-6,
+                dtype=dtype,
+                device=device,
+            )
+            self.ln_k = nn.LayerNorm(
+                self.head_dim,
+                elementwise_affine=True,
+                eps=1.0e-6,
+                dtype=dtype,
+                device=device,
+            )
         elif qk_norm is None:
             self.ln_q = nn.Identity()
             self.ln_k = nn.Identity()
@@ -246,7 +303,12 @@ class SelfAttention(nn.Module):
 
 class RMSNorm(torch.nn.Module):
     def __init__(
-        self, dim: int, elementwise_affine: bool = False, eps: float = 1e-6, device=None, dtype=None
+        self,
+        dim: int,
+        elementwise_affine: bool = False,
+        eps: float = 1e-6,
+        device=None,
+        dtype=None,
     ):
         """
         Initialize the RMSNorm normalization layer.
@@ -352,38 +414,77 @@ class DismantledBlock(nn.Module):
         super().__init__()
         assert attn_mode in self.ATTENTION_MODES
         if not rmsnorm:
-            self.norm1 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
+            self.norm1 = nn.LayerNorm(
+                hidden_size,
+                elementwise_affine=False,
+                eps=1e-6,
+                dtype=dtype,
+                device=device,
+            )
         else:
             self.norm1 = RMSNorm(hidden_size, elementwise_affine=False, eps=1e-6)
-        self.attn = SelfAttention(dim=hidden_size, num_heads=num_heads, qkv_bias=qkv_bias, attn_mode=attn_mode, pre_only=pre_only, qk_norm=qk_norm, rmsnorm=rmsnorm, dtype=dtype, device=device)
+        self.attn = SelfAttention(
+            dim=hidden_size,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_mode=attn_mode,
+            pre_only=pre_only,
+            qk_norm=qk_norm,
+            rmsnorm=rmsnorm,
+            dtype=dtype,
+            device=device,
+        )
         if not pre_only:
             if not rmsnorm:
-                self.norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
+                self.norm2 = nn.LayerNorm(
+                    hidden_size,
+                    elementwise_affine=False,
+                    eps=1e-6,
+                    dtype=dtype,
+                    device=device,
+                )
             else:
                 self.norm2 = RMSNorm(hidden_size, elementwise_affine=False, eps=1e-6)
         mlp_hidden_dim = int(hidden_size * mlp_ratio)
         if not pre_only:
             if not swiglu:
-                self.mlp = Mlp(in_features=hidden_size, hidden_features=mlp_hidden_dim, act_layer=nn.GELU(approximate="tanh"), dtype=dtype, device=device)
+                self.mlp = Mlp(
+                    in_features=hidden_size,
+                    hidden_features=mlp_hidden_dim,
+                    act_layer=nn.GELU(approximate="tanh"),
+                    dtype=dtype,
+                    device=device,
+                )
             else:
-                self.mlp = SwiGLUFeedForward(dim=hidden_size, hidden_dim=mlp_hidden_dim, multiple_of=256)
+                self.mlp = SwiGLUFeedForward(
+                    dim=hidden_size, hidden_dim=mlp_hidden_dim, multiple_of=256
+                )
         self.scale_mod_only = scale_mod_only
         if not scale_mod_only:
             n_mods = 6 if not pre_only else 2
         else:
             n_mods = 4 if not pre_only else 1
-        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(hidden_size, n_mods * hidden_size, bias=True, dtype=dtype, device=device))
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(
+                hidden_size, n_mods * hidden_size, bias=True, dtype=dtype, device=device
+            ),
+        )
         self.pre_only = pre_only
 
     def pre_attention(self, x: torch.Tensor, c: torch.Tensor):
         assert x is not None, "pre_attention called with None input"
         if not self.pre_only:
             if not self.scale_mod_only:
-                shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaLN_modulation(c).chunk(6, dim=1)
+                shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+                    self.adaLN_modulation(c).chunk(6, dim=1)
+                )
             else:
                 shift_msa = None
                 shift_mlp = None
-                scale_msa, gate_msa, scale_mlp, gate_mlp = self.adaLN_modulation(c).chunk(4, dim=1)
+                scale_msa, gate_msa, scale_mlp, gate_mlp = self.adaLN_modulation(
+                    c
+                ).chunk(4, dim=1)
             qkv = self.attn.pre_attention(modulate(self.norm1(x), shift_msa, scale_msa))
             return qkv, (x, gate_msa, shift_mlp, scale_mlp, gate_mlp)
         else:
@@ -398,7 +499,9 @@ class DismantledBlock(nn.Module):
     def post_attention(self, attn, x, gate_msa, shift_mlp, scale_mlp, gate_mlp):
         assert not self.pre_only
         x = x + gate_msa.unsqueeze(1) * self.attn.post_attention(attn)
-        x = x + gate_mlp.unsqueeze(1) * self.mlp(modulate(self.norm2(x), shift_mlp, scale_mlp))
+        x = x + gate_mlp.unsqueeze(1) * self.mlp(
+            modulate(self.norm2(x), shift_mlp, scale_mlp)
+        )
         return x
 
     def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
@@ -420,7 +523,10 @@ def block_mixing(context, x, context_block, x_block, c):
     q, k, v = tuple(o)
 
     attn = attention(q, k, v, x_block.attn.num_heads)
-    context_attn, x_attn = (attn[:, : context_qkv[0].shape[1]], attn[:, context_qkv[0].shape[1] :])
+    context_attn, x_attn = (
+        attn[:, : context_qkv[0].shape[1]],
+        attn[:, context_qkv[0].shape[1] :],
+    )
 
     if not context_block.pre_only:
         context = context_block.post_attention(context_attn, *context_intermediates)
@@ -437,11 +543,15 @@ class JointBlock(nn.Module):
         super().__init__()
         pre_only = kwargs.pop("pre_only")
         qk_norm = kwargs.pop("qk_norm", None)
-        self.context_block = DismantledBlock(*args, pre_only=pre_only, qk_norm=qk_norm, **kwargs)
+        self.context_block = DismantledBlock(
+            *args, pre_only=pre_only, qk_norm=qk_norm, **kwargs
+        )
         self.x_block = DismantledBlock(*args, pre_only=False, qk_norm=qk_norm, **kwargs)
 
     def forward(self, *args, **kwargs):
-        return block_mixing(*args, context_block=self.context_block, x_block=self.x_block, **kwargs)
+        return block_mixing(
+            *args, context_block=self.context_block, x_block=self.x_block, **kwargs
+        )
 
 
 class FinalLayer(nn.Module):
@@ -449,15 +559,38 @@ class FinalLayer(nn.Module):
     The final layer of DiT.
     """
 
-    def __init__(self, hidden_size: int, patch_size: int, out_channels: int, total_out_channels: Optional[int] = None, dtype=None, device=None):
+    def __init__(
+        self,
+        hidden_size: int,
+        patch_size: int,
+        out_channels: int,
+        total_out_channels: Optional[int] = None,
+        dtype=None,
+        device=None,
+    ):
         super().__init__()
-        self.norm_final = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.linear = (
-            nn.Linear(hidden_size, patch_size * patch_size * out_channels, bias=True, dtype=dtype, device=device)
-            if (total_out_channels is None)
-            else nn.Linear(hidden_size, total_out_channels, bias=True, dtype=dtype, device=device)
+        self.norm_final = nn.LayerNorm(
+            hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device
         )
-        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(hidden_size, 2 * hidden_size, bias=True, dtype=dtype, device=device))
+        self.linear = (
+            nn.Linear(
+                hidden_size,
+                patch_size * patch_size * out_channels,
+                bias=True,
+                dtype=dtype,
+                device=device,
+            )
+            if (total_out_channels is None)
+            else nn.Linear(
+                hidden_size, total_out_channels, bias=True, dtype=dtype, device=device
+            )
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(
+                hidden_size, 2 * hidden_size, bias=True, dtype=dtype, device=device
+            ),
+        )
 
     def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
         shift, scale = self.adaLN_modulation(c).chunk(2, dim=1)
@@ -488,18 +621,20 @@ class MMDiT(nn.Module):
         pos_embed_scaling_factor: Optional[float] = None,
         pos_embed_offset: Optional[float] = None,
         pos_embed_max_size: Optional[int] = None,
-        num_patches = None,
+        num_patches=None,
         qk_norm: Optional[str] = None,
         qkv_bias: bool = True,
-        dtype = None,
-        device = None,
+        dtype=None,
+        device=None,
     ):
         super().__init__()
         self.dtype = dtype
         self.learn_sigma = learn_sigma
         self.in_channels = in_channels
         default_out_channels = in_channels * 2 if learn_sigma else in_channels
-        self.out_channels = out_channels if out_channels is not None else default_out_channels
+        self.out_channels = (
+            out_channels if out_channels is not None else default_out_channels
+        )
         self.patch_size = patch_size
         self.pos_embed_scaling_factor = pos_embed_scaling_factor
         self.pos_embed_offset = pos_embed_offset
@@ -511,21 +646,36 @@ class MMDiT(nn.Module):
 
         self.num_heads = num_heads
 
-        self.x_embedder = PatchEmbed(input_size, patch_size, in_channels, hidden_size, bias=True, strict_img_size=self.pos_embed_max_size is None, dtype=dtype, device=device)
+        self.x_embedder = PatchEmbed(
+            input_size,
+            patch_size,
+            in_channels,
+            hidden_size,
+            bias=True,
+            strict_img_size=self.pos_embed_max_size is None,
+            dtype=dtype,
+            device=device,
+        )
         self.t_embedder = TimestepEmbedder(hidden_size, dtype=dtype, device=device)
 
         if adm_in_channels is not None:
             assert isinstance(adm_in_channels, int)
-            self.y_embedder = VectorEmbedder(adm_in_channels, hidden_size, dtype=dtype, device=device)
+            self.y_embedder = VectorEmbedder(
+                adm_in_channels, hidden_size, dtype=dtype, device=device
+            )
 
         self.context_embedder = nn.Identity()
         if context_embedder_config is not None:
             if context_embedder_config["target"] == "torch.nn.Linear":
-                self.context_embedder = nn.Linear(**context_embedder_config["params"], dtype=dtype, device=device)
+                self.context_embedder = nn.Linear(
+                    **context_embedder_config["params"], dtype=dtype, device=device
+                )
 
         self.register_length = register_length
         if self.register_length > 0:
-            self.register = nn.Parameter(torch.randn(1, register_length, hidden_size, dtype=dtype, device=device))
+            self.register = nn.Parameter(
+                torch.randn(1, register_length, hidden_size, dtype=dtype, device=device)
+            )
 
         # num_patches = self.x_embedder.num_patches
         # Will use fixed sin-cos embedding:
@@ -540,12 +690,27 @@ class MMDiT(nn.Module):
 
         self.joint_blocks = nn.ModuleList(
             [
-                JointBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio, qkv_bias=qkv_bias, attn_mode=attn_mode, pre_only=i == depth - 1, rmsnorm=rmsnorm, scale_mod_only=scale_mod_only, swiglu=swiglu, qk_norm=qk_norm, dtype=dtype, device=device)
+                JointBlock(
+                    hidden_size,
+                    num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    attn_mode=attn_mode,
+                    pre_only=i == depth - 1,
+                    rmsnorm=rmsnorm,
+                    scale_mod_only=scale_mod_only,
+                    swiglu=swiglu,
+                    qk_norm=qk_norm,
+                    dtype=dtype,
+                    device=device,
+                )
                 for i in range(depth)
             ]
         )
 
-        self.final_layer = FinalLayer(hidden_size, patch_size, self.out_channels, dtype=dtype, device=device)
+        self.final_layer = FinalLayer(
+            hidden_size, patch_size, self.out_channels, dtype=dtype, device=device
+        )
 
     def cropped_pos_embed(self, hw):
         assert self.pos_embed_max_size is not None
@@ -588,9 +753,20 @@ class MMDiT(nn.Module):
         imgs = x.reshape(shape=(x.shape[0], c, h * p, w * p))
         return imgs
 
-    def forward_core_with_concat(self, x: torch.Tensor, c_mod: torch.Tensor, context: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward_core_with_concat(
+        self,
+        x: torch.Tensor,
+        c_mod: torch.Tensor,
+        context: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         if self.register_length > 0:
-            context = torch.cat((repeat(self.register, "1 ... -> b ...", b=x.shape[0]), context if context is not None else torch.Tensor([]).type_as(x)), 1)
+            context = torch.cat(
+                (
+                    repeat(self.register, "1 ... -> b ...", b=x.shape[0]),
+                    context if context is not None else torch.Tensor([]).type_as(x),
+                ),
+                1,
+            )
 
         # context is B, L', D
         # x is B, L, D
@@ -600,7 +776,13 @@ class MMDiT(nn.Module):
         x = self.final_layer(x, c_mod)  # (N, T, patch_size ** 2 * out_channels)
         return x
 
-    def forward(self, x: torch.Tensor, t: torch.Tensor, y: Optional[torch.Tensor] = None, context: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        y: Optional[torch.Tensor] = None,
+        context: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """
         Forward pass of DiT.
         x: (N, C, H, W) tensor of spatial inputs (images or latent representations of images)

--- a/modules/models/sd3/other_impls.py
+++ b/modules/models/sd3/other_impls.py
@@ -22,7 +22,11 @@ class AutocastLinear(nn.Linear):
     """
 
     def forward(self, x):
-        return torch.nn.functional.linear(x, self.weight.to(x.dtype), self.bias.to(x.dtype) if self.bias is not None else None)
+        return torch.nn.functional.linear(
+            x,
+            self.weight.to(x.dtype),
+            self.bias.to(x.dtype) if self.bias is not None else None,
+        )
 
 
 def attention(q, k, v, heads, mask=None):
@@ -30,20 +34,36 @@ def attention(q, k, v, heads, mask=None):
     b, _, dim_head = q.shape
     dim_head //= heads
     q, k, v = [t.view(b, -1, heads, dim_head).transpose(1, 2) for t in (q, k, v)]
-    out = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False
+    )
     return out.transpose(1, 2).reshape(b, -1, heads * dim_head)
 
 
 class Mlp(nn.Module):
-    """ MLP as used in Vision Transformer, MLP-Mixer and related networks"""
-    def __init__(self, in_features, hidden_features=None, out_features=None, act_layer=nn.GELU, bias=True, dtype=None, device=None):
+    """MLP as used in Vision Transformer, MLP-Mixer and related networks"""
+
+    def __init__(
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        bias=True,
+        dtype=None,
+        device=None,
+    ):
         super().__init__()
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
 
-        self.fc1 = nn.Linear(in_features, hidden_features, bias=bias, dtype=dtype, device=device)
+        self.fc1 = nn.Linear(
+            in_features, hidden_features, bias=bias, dtype=dtype, device=device
+        )
         self.act = act_layer
-        self.fc2 = nn.Linear(hidden_features, out_features, bias=bias, dtype=dtype, device=device)
+        self.fc2 = nn.Linear(
+            hidden_features, out_features, bias=bias, dtype=dtype, device=device
+        )
 
     def forward(self, x):
         x = self.fc1(x)
@@ -61,10 +81,18 @@ class CLIPAttention(torch.nn.Module):
     def __init__(self, embed_dim, heads, dtype, device):
         super().__init__()
         self.heads = heads
-        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=device)
-        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=device)
-        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=device)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True, dtype=dtype, device=device)
+        self.q_proj = nn.Linear(
+            embed_dim, embed_dim, bias=True, dtype=dtype, device=device
+        )
+        self.k_proj = nn.Linear(
+            embed_dim, embed_dim, bias=True, dtype=dtype, device=device
+        )
+        self.v_proj = nn.Linear(
+            embed_dim, embed_dim, bias=True, dtype=dtype, device=device
+        )
+        self.out_proj = nn.Linear(
+            embed_dim, embed_dim, bias=True, dtype=dtype, device=device
+        )
 
     def forward(self, x, mask=None):
         q = self.q_proj(x)
@@ -79,14 +107,30 @@ ACTIVATIONS = {
     "gelu": torch.nn.functional.gelu,
 }
 
+
 class CLIPLayer(torch.nn.Module):
-    def __init__(self, embed_dim, heads, intermediate_size, intermediate_activation, dtype, device):
+    def __init__(
+        self,
+        embed_dim,
+        heads,
+        intermediate_size,
+        intermediate_activation,
+        dtype,
+        device,
+    ):
         super().__init__()
         self.layer_norm1 = nn.LayerNorm(embed_dim, dtype=dtype, device=device)
         self.self_attn = CLIPAttention(embed_dim, heads, dtype, device)
         self.layer_norm2 = nn.LayerNorm(embed_dim, dtype=dtype, device=device)
-        #self.mlp = CLIPMLP(embed_dim, intermediate_size, intermediate_activation, dtype, device)
-        self.mlp = Mlp(embed_dim, intermediate_size, embed_dim, act_layer=ACTIVATIONS[intermediate_activation], dtype=dtype, device=device)
+        # self.mlp = CLIPMLP(embed_dim, intermediate_size, intermediate_activation, dtype, device)
+        self.mlp = Mlp(
+            embed_dim,
+            intermediate_size,
+            embed_dim,
+            act_layer=ACTIVATIONS[intermediate_activation],
+            dtype=dtype,
+            device=device,
+        )
 
     def forward(self, x, mask=None):
         x += self.self_attn(self.layer_norm1(x), mask)
@@ -95,9 +139,30 @@ class CLIPLayer(torch.nn.Module):
 
 
 class CLIPEncoder(torch.nn.Module):
-    def __init__(self, num_layers, embed_dim, heads, intermediate_size, intermediate_activation, dtype, device):
+    def __init__(
+        self,
+        num_layers,
+        embed_dim,
+        heads,
+        intermediate_size,
+        intermediate_activation,
+        dtype,
+        device,
+    ):
         super().__init__()
-        self.layers = torch.nn.ModuleList([CLIPLayer(embed_dim, heads, intermediate_size, intermediate_activation, dtype, device) for i in range(num_layers)])
+        self.layers = torch.nn.ModuleList(
+            [
+                CLIPLayer(
+                    embed_dim,
+                    heads,
+                    intermediate_size,
+                    intermediate_activation,
+                    dtype,
+                    device,
+                )
+                for i in range(num_layers)
+            ]
+        )
 
     def forward(self, x, mask=None, intermediate_output=None):
         if intermediate_output is not None:
@@ -112,10 +177,26 @@ class CLIPEncoder(torch.nn.Module):
 
 
 class CLIPEmbeddings(torch.nn.Module):
-    def __init__(self, embed_dim, vocab_size=49408, num_positions=77, dtype=None, device=None, textual_inversion_key="clip_l"):
+    def __init__(
+        self,
+        embed_dim,
+        vocab_size=49408,
+        num_positions=77,
+        dtype=None,
+        device=None,
+        textual_inversion_key="clip_l",
+    ):
         super().__init__()
-        self.token_embedding = sd_hijack.TextualInversionEmbeddings(vocab_size, embed_dim, dtype=dtype, device=device, textual_inversion_key=textual_inversion_key)
-        self.position_embedding = torch.nn.Embedding(num_positions, embed_dim, dtype=dtype, device=device)
+        self.token_embedding = sd_hijack.TextualInversionEmbeddings(
+            vocab_size,
+            embed_dim,
+            dtype=dtype,
+            device=device,
+            textual_inversion_key=textual_inversion_key,
+        )
+        self.position_embedding = torch.nn.Embedding(
+            num_positions, embed_dim, dtype=dtype, device=device
+        )
 
     def forward(self, input_tokens):
         return self.token_embedding(input_tokens) + self.position_embedding.weight
@@ -129,18 +210,42 @@ class CLIPTextModel_(torch.nn.Module):
         intermediate_size = config_dict["intermediate_size"]
         intermediate_activation = config_dict["hidden_act"]
         super().__init__()
-        self.embeddings = CLIPEmbeddings(embed_dim, dtype=torch.float32, device=device, textual_inversion_key=config_dict.get('textual_inversion_key', 'clip_l'))
-        self.encoder = CLIPEncoder(num_layers, embed_dim, heads, intermediate_size, intermediate_activation, dtype, device)
+        self.embeddings = CLIPEmbeddings(
+            embed_dim,
+            dtype=torch.float32,
+            device=device,
+            textual_inversion_key=config_dict.get("textual_inversion_key", "clip_l"),
+        )
+        self.encoder = CLIPEncoder(
+            num_layers,
+            embed_dim,
+            heads,
+            intermediate_size,
+            intermediate_activation,
+            dtype,
+            device,
+        )
         self.final_layer_norm = nn.LayerNorm(embed_dim, dtype=dtype, device=device)
 
-    def forward(self, input_tokens, intermediate_output=None, final_layer_norm_intermediate=True):
+    def forward(
+        self, input_tokens, intermediate_output=None, final_layer_norm_intermediate=True
+    ):
         x = self.embeddings(input_tokens)
-        causal_mask = torch.empty(x.shape[1], x.shape[1], dtype=x.dtype, device=x.device).fill_(float("-inf")).triu_(1)
-        x, i = self.encoder(x, mask=causal_mask, intermediate_output=intermediate_output)
+        causal_mask = (
+            torch.empty(x.shape[1], x.shape[1], dtype=x.dtype, device=x.device)
+            .fill_(float("-inf"))
+            .triu_(1)
+        )
+        x, i = self.encoder(
+            x, mask=causal_mask, intermediate_output=intermediate_output
+        )
         x = self.final_layer_norm(x)
         if i is not None and final_layer_norm_intermediate:
             i = self.final_layer_norm(i)
-        pooled_output = x[torch.arange(x.shape[0], device=x.device), input_tokens.to(dtype=torch.int, device=x.device).argmax(dim=-1),]
+        pooled_output = x[
+            torch.arange(x.shape[0], device=x.device),
+            input_tokens.to(dtype=torch.int, device=x.device).argmax(dim=-1),
+        ]
         return x, i, pooled_output
 
 
@@ -150,7 +255,9 @@ class CLIPTextModel(torch.nn.Module):
         self.num_layers = config_dict["num_hidden_layers"]
         self.text_model = CLIPTextModel_(config_dict, dtype, device)
         embed_dim = config_dict["hidden_size"]
-        self.text_projection = nn.Linear(embed_dim, embed_dim, bias=False, dtype=dtype, device=device)
+        self.text_projection = nn.Linear(
+            embed_dim, embed_dim, bias=False, dtype=dtype, device=device
+        )
         self.text_projection.weight.copy_(torch.eye(embed_dim))
         self.dtype = dtype
 
@@ -167,11 +274,19 @@ class CLIPTextModel(torch.nn.Module):
 
 
 class SDTokenizer:
-    def __init__(self, max_length=77, pad_with_end=True, tokenizer=None, has_start_token=True, pad_to_max_length=True, min_length=None):
+    def __init__(
+        self,
+        max_length=77,
+        pad_with_end=True,
+        tokenizer=None,
+        has_start_token=True,
+        pad_to_max_length=True,
+        min_length=None,
+    ):
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.min_length = min_length
-        empty = self.tokenizer('')["input_ids"]
+        empty = self.tokenizer("")["input_ids"]
         if has_start_token:
             self.tokens_start = 1
             self.start_token = empty[0]
@@ -186,8 +301,7 @@ class SDTokenizer:
         self.inv_vocab = {v: k for k, v in vocab.items()}
         self.max_word_length = 8
 
-
-    def tokenize_with_weights(self, text:str):
+    def tokenize_with_weights(self, text: str):
         """Tokenize the text, with weight values - presume 1.0 for all and ignore other features here. The details aren't relevant for a reference impl, and weights themselves has weak effect on SD3."""
         if self.pad_with_end:
             pad_token = self.end_token
@@ -196,10 +310,15 @@ class SDTokenizer:
         batch = []
         if self.start_token is not None:
             batch.append((self.start_token, 1.0))
-        to_tokenize = text.replace("\n", " ").split(' ')
+        to_tokenize = text.replace("\n", " ").split(" ")
         to_tokenize = [x for x in to_tokenize if x != ""]
         for word in to_tokenize:
-            batch.extend([(t, 1) for t in self.tokenizer(word)["input_ids"][self.tokens_start:-1]])
+            batch.extend(
+                [
+                    (t, 1)
+                    for t in self.tokenizer(word)["input_ids"][self.tokens_start : -1]
+                ]
+            )
         batch.append((self.end_token, 1.0))
         if self.pad_to_max_length:
             batch.extend([(pad_token, 1.0)] * (self.max_length - len(batch)))
@@ -220,7 +339,7 @@ class SD3Tokenizer:
         self.clip_g = SDXLClipGTokenizer(clip_tokenizer)
         self.t5xxl = T5XXLTokenizer()
 
-    def tokenize_with_weights(self, text:str):
+    def tokenize_with_weights(self, text: str):
         out = {}
         out["g"] = self.clip_g.tokenize_with_weights(text)
         out["l"] = self.clip_l.tokenize_with_weights(text)
@@ -242,9 +361,22 @@ class ClipTokenWeightEncoder:
 
 class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
     """Uses the CLIP transformer encoder for text (from huggingface)"""
+
     LAYERS = ["last", "pooled", "hidden"]
-    def __init__(self, device="cpu", max_length=77, layer="last", layer_idx=None, textmodel_json_config=None, dtype=None, model_class=CLIPTextModel,
-                 special_tokens=None, layer_norm_hidden_state=True, return_projected_pooled=True):
+
+    def __init__(
+        self,
+        device="cpu",
+        max_length=77,
+        layer="last",
+        layer_idx=None,
+        textmodel_json_config=None,
+        dtype=None,
+        model_class=CLIPTextModel,
+        special_tokens=None,
+        layer_norm_hidden_state=True,
+        return_projected_pooled=True,
+    ):
         super().__init__()
         assert layer in self.LAYERS
         self.transformer = model_class(textmodel_json_config, dtype, device)
@@ -255,7 +387,11 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
             param.requires_grad = False
         self.layer = layer
         self.layer_idx = None
-        self.special_tokens = special_tokens if special_tokens is not None else {"start": 49406, "end": 49407, "pad": 49407}
+        self.special_tokens = (
+            special_tokens
+            if special_tokens is not None
+            else {"start": 49406, "end": 49407, "pad": 49407}
+        )
         self.logit_scale = torch.nn.Parameter(torch.tensor(4.6055))
         self.layer_norm_hidden_state = layer_norm_hidden_state
         self.return_projected_pooled = return_projected_pooled
@@ -263,11 +399,17 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
             assert layer_idx is not None
             assert abs(layer_idx) < self.num_layers
             self.set_clip_options({"layer": layer_idx})
-        self.options_default = (self.layer, self.layer_idx, self.return_projected_pooled)
+        self.options_default = (
+            self.layer,
+            self.layer_idx,
+            self.return_projected_pooled,
+        )
 
     def set_clip_options(self, options):
         layer_idx = options.get("layer", self.layer_idx)
-        self.return_projected_pooled = options.get("projected_pooled", self.return_projected_pooled)
+        self.return_projected_pooled = options.get(
+            "projected_pooled", self.return_projected_pooled
+        )
         if layer_idx is None or abs(layer_idx) > self.num_layers:
             self.layer = "last"
         else:
@@ -276,8 +418,14 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
 
     def forward(self, tokens):
         backup_embeds = self.transformer.get_input_embeddings()
-        tokens = torch.asarray(tokens, dtype=torch.int64, device=backup_embeds.weight.device)
-        outputs = self.transformer(tokens, intermediate_output=self.layer_idx, final_layer_norm_intermediate=self.layer_norm_hidden_state)
+        tokens = torch.asarray(
+            tokens, dtype=torch.int64, device=backup_embeds.weight.device
+        )
+        outputs = self.transformer(
+            tokens,
+            intermediate_output=self.layer_idx,
+            final_layer_norm_intermediate=self.layer_norm_hidden_state,
+        )
         self.transformer.set_input_embeddings(backup_embeds)
         if self.layer == "last":
             z = outputs[0]
@@ -285,7 +433,11 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
             z = outputs[1]
         pooled_output = None
         if len(outputs) >= 3:
-            if not self.return_projected_pooled and len(outputs) >= 4 and outputs[3] is not None:
+            if (
+                not self.return_projected_pooled
+                and len(outputs) >= 4
+                and outputs[3] is not None
+            ):
                 pooled_output = outputs[3].float()
             elif outputs[2] is not None:
                 pooled_output = outputs[2].float()
@@ -294,33 +446,64 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
 
 class SDXLClipG(SDClipModel):
     """Wraps the CLIP-G model into the SD-CLIP-Model interface"""
-    def __init__(self, config, device="cpu", layer="penultimate", layer_idx=None, dtype=None):
+
+    def __init__(
+        self, config, device="cpu", layer="penultimate", layer_idx=None, dtype=None
+    ):
         if layer == "penultimate":
-            layer="hidden"
-            layer_idx=-2
-        super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config=config, dtype=dtype, special_tokens={"start": 49406, "end": 49407, "pad": 0}, layer_norm_hidden_state=False)
+            layer = "hidden"
+            layer_idx = -2
+        super().__init__(
+            device=device,
+            layer=layer,
+            layer_idx=layer_idx,
+            textmodel_json_config=config,
+            dtype=dtype,
+            special_tokens={"start": 49406, "end": 49407, "pad": 0},
+            layer_norm_hidden_state=False,
+        )
 
 
 class T5XXLModel(SDClipModel):
     """Wraps the T5-XXL model into the SD-CLIP-Model interface for convenience"""
+
     def __init__(self, config, device="cpu", layer="last", layer_idx=None, dtype=None):
-        super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config=config, dtype=dtype, special_tokens={"end": 1, "pad": 0}, model_class=T5)
+        super().__init__(
+            device=device,
+            layer=layer,
+            layer_idx=layer_idx,
+            textmodel_json_config=config,
+            dtype=dtype,
+            special_tokens={"end": 1, "pad": 0},
+            model_class=T5,
+        )
 
 
 #################################################################################################
 ### T5 implementation, for the T5-XXL text encoder portion, largely pulled from upstream impl
 #################################################################################################
 
+
 class T5XXLTokenizer(SDTokenizer):
     """Wraps the T5 Tokenizer from HF into the SDTokenizer interface"""
+
     def __init__(self):
-        super().__init__(pad_with_end=False, tokenizer=T5TokenizerFast.from_pretrained("google/t5-v1_1-xxl"), has_start_token=False, pad_to_max_length=False, max_length=99999999, min_length=77)
+        super().__init__(
+            pad_with_end=False,
+            tokenizer=T5TokenizerFast.from_pretrained("google/t5-v1_1-xxl"),
+            has_start_token=False,
+            pad_to_max_length=False,
+            max_length=99999999,
+            min_length=77,
+        )
 
 
 class T5LayerNorm(torch.nn.Module):
     def __init__(self, hidden_size, eps=1e-6, dtype=None, device=None):
         super().__init__()
-        self.weight = torch.nn.Parameter(torch.ones(hidden_size, dtype=dtype, device=device))
+        self.weight = torch.nn.Parameter(
+            torch.ones(hidden_size, dtype=dtype, device=device)
+        )
         self.variance_epsilon = eps
 
     def forward(self, x):
@@ -332,9 +515,15 @@ class T5LayerNorm(torch.nn.Module):
 class T5DenseGatedActDense(torch.nn.Module):
     def __init__(self, model_dim, ff_dim, dtype, device):
         super().__init__()
-        self.wi_0 = AutocastLinear(model_dim, ff_dim, bias=False, dtype=dtype, device=device)
-        self.wi_1 = AutocastLinear(model_dim, ff_dim, bias=False, dtype=dtype, device=device)
-        self.wo = AutocastLinear(ff_dim, model_dim, bias=False, dtype=dtype, device=device)
+        self.wi_0 = AutocastLinear(
+            model_dim, ff_dim, bias=False, dtype=dtype, device=device
+        )
+        self.wi_1 = AutocastLinear(
+            model_dim, ff_dim, bias=False, dtype=dtype, device=device
+        )
+        self.wo = AutocastLinear(
+            ff_dim, model_dim, bias=False, dtype=dtype, device=device
+        )
 
     def forward(self, x):
         hidden_gelu = torch.nn.functional.gelu(self.wi_0(x), approximate="tanh")
@@ -358,22 +547,36 @@ class T5LayerFF(torch.nn.Module):
 
 
 class T5Attention(torch.nn.Module):
-    def __init__(self, model_dim, inner_dim, num_heads, relative_attention_bias, dtype, device):
+    def __init__(
+        self, model_dim, inner_dim, num_heads, relative_attention_bias, dtype, device
+    ):
         super().__init__()
         # Mesh TensorFlow initialization to avoid scaling before softmax
-        self.q = AutocastLinear(model_dim, inner_dim, bias=False, dtype=dtype, device=device)
-        self.k = AutocastLinear(model_dim, inner_dim, bias=False, dtype=dtype, device=device)
-        self.v = AutocastLinear(model_dim, inner_dim, bias=False, dtype=dtype, device=device)
-        self.o = AutocastLinear(inner_dim, model_dim, bias=False, dtype=dtype, device=device)
+        self.q = AutocastLinear(
+            model_dim, inner_dim, bias=False, dtype=dtype, device=device
+        )
+        self.k = AutocastLinear(
+            model_dim, inner_dim, bias=False, dtype=dtype, device=device
+        )
+        self.v = AutocastLinear(
+            model_dim, inner_dim, bias=False, dtype=dtype, device=device
+        )
+        self.o = AutocastLinear(
+            inner_dim, model_dim, bias=False, dtype=dtype, device=device
+        )
         self.num_heads = num_heads
         self.relative_attention_bias = None
         if relative_attention_bias:
             self.relative_attention_num_buckets = 32
             self.relative_attention_max_distance = 128
-            self.relative_attention_bias = torch.nn.Embedding(self.relative_attention_num_buckets, self.num_heads, device=device)
+            self.relative_attention_bias = torch.nn.Embedding(
+                self.relative_attention_num_buckets, self.num_heads, device=device
+            )
 
     @staticmethod
-    def _relative_position_bucket(relative_position, bidirectional=True, num_buckets=32, max_distance=128):
+    def _relative_position_bucket(
+        relative_position, bidirectional=True, num_buckets=32, max_distance=128
+    ):
         """
         Adapted from Mesh Tensorflow:
         https://github.com/tensorflow/mesh/blob/0cb87fe07da627bf0b7e60475d59f95ed6b5be3d/mesh_tensorflow/transformer/transformer_layers.py#L593
@@ -400,7 +603,9 @@ class T5Attention(torch.nn.Module):
             relative_buckets += (relative_position > 0).to(torch.long) * num_buckets
             relative_position = torch.abs(relative_position)
         else:
-            relative_position = -torch.min(relative_position, torch.zeros_like(relative_position))
+            relative_position = -torch.min(
+                relative_position, torch.zeros_like(relative_position)
+            )
         # now relative_position is in the range [0, inf)
         # half of the buckets are for exact increments in positions
         max_exact = num_buckets // 2
@@ -411,23 +616,38 @@ class T5Attention(torch.nn.Module):
             / math.log(max_distance / max_exact)
             * (num_buckets - max_exact)
         ).to(torch.long)
-        relative_position_if_large = torch.min(relative_position_if_large, torch.full_like(relative_position_if_large, num_buckets - 1))
-        relative_buckets += torch.where(is_small, relative_position, relative_position_if_large)
+        relative_position_if_large = torch.min(
+            relative_position_if_large,
+            torch.full_like(relative_position_if_large, num_buckets - 1),
+        )
+        relative_buckets += torch.where(
+            is_small, relative_position, relative_position_if_large
+        )
         return relative_buckets
 
     def compute_bias(self, query_length, key_length, device):
         """Compute binned relative position bias"""
-        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
-        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
-        relative_position = memory_position - context_position  # shape (query_length, key_length)
+        context_position = torch.arange(query_length, dtype=torch.long, device=device)[
+            :, None
+        ]
+        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[
+            None, :
+        ]
+        relative_position = (
+            memory_position - context_position
+        )  # shape (query_length, key_length)
         relative_position_bucket = self._relative_position_bucket(
             relative_position,  # shape (query_length, key_length)
             bidirectional=True,
             num_buckets=self.relative_attention_num_buckets,
             max_distance=self.relative_attention_max_distance,
         )
-        values = self.relative_attention_bias(relative_position_bucket)  # shape (query_length, key_length, num_heads)
-        values = values.permute([2, 0, 1]).unsqueeze(0)  # shape (1, num_heads, query_length, key_length)
+        values = self.relative_attention_bias(
+            relative_position_bucket
+        )  # shape (query_length, key_length, num_heads)
+        values = values.permute([2, 0, 1]).unsqueeze(
+            0
+        )  # shape (1, num_heads, query_length, key_length)
         return values
 
     def forward(self, x, past_bias=None):
@@ -442,15 +662,32 @@ class T5Attention(torch.nn.Module):
         else:
             mask = None
 
-        out = attention(q, k * ((k.shape[-1] / self.num_heads) ** 0.5), v, self.num_heads, mask.to(x.dtype) if mask is not None else None)
+        out = attention(
+            q,
+            k * ((k.shape[-1] / self.num_heads) ** 0.5),
+            v,
+            self.num_heads,
+            mask.to(x.dtype) if mask is not None else None,
+        )
 
         return self.o(out), past_bias
 
 
 class T5LayerSelfAttention(torch.nn.Module):
-    def __init__(self, model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias, dtype, device):
+    def __init__(
+        self,
+        model_dim,
+        inner_dim,
+        ff_dim,
+        num_heads,
+        relative_attention_bias,
+        dtype,
+        device,
+    ):
         super().__init__()
-        self.SelfAttention = T5Attention(model_dim, inner_dim, num_heads, relative_attention_bias, dtype, device)
+        self.SelfAttention = T5Attention(
+            model_dim, inner_dim, num_heads, relative_attention_bias, dtype, device
+        )
         self.layer_norm = T5LayerNorm(model_dim, dtype=dtype, device=device)
 
     def forward(self, x, past_bias=None):
@@ -460,10 +697,29 @@ class T5LayerSelfAttention(torch.nn.Module):
 
 
 class T5Block(torch.nn.Module):
-    def __init__(self, model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias, dtype, device):
+    def __init__(
+        self,
+        model_dim,
+        inner_dim,
+        ff_dim,
+        num_heads,
+        relative_attention_bias,
+        dtype,
+        device,
+    ):
         super().__init__()
         self.layer = torch.nn.ModuleList()
-        self.layer.append(T5LayerSelfAttention(model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias, dtype, device))
+        self.layer.append(
+            T5LayerSelfAttention(
+                model_dim,
+                inner_dim,
+                ff_dim,
+                num_heads,
+                relative_attention_bias,
+                dtype,
+                device,
+            )
+        )
         self.layer.append(T5LayerFF(model_dim, ff_dim, dtype, device))
 
     def forward(self, x, past_bias=None):
@@ -473,15 +729,42 @@ class T5Block(torch.nn.Module):
 
 
 class T5Stack(torch.nn.Module):
-    def __init__(self, num_layers, model_dim, inner_dim, ff_dim, num_heads, vocab_size, dtype, device):
+    def __init__(
+        self,
+        num_layers,
+        model_dim,
+        inner_dim,
+        ff_dim,
+        num_heads,
+        vocab_size,
+        dtype,
+        device,
+    ):
         super().__init__()
         self.embed_tokens = torch.nn.Embedding(vocab_size, model_dim, device=device)
-        self.block = torch.nn.ModuleList([T5Block(model_dim, inner_dim, ff_dim, num_heads, relative_attention_bias=(i == 0), dtype=dtype, device=device) for i in range(num_layers)])
+        self.block = torch.nn.ModuleList(
+            [
+                T5Block(
+                    model_dim,
+                    inner_dim,
+                    ff_dim,
+                    num_heads,
+                    relative_attention_bias=(i == 0),
+                    dtype=dtype,
+                    device=device,
+                )
+                for i in range(num_layers)
+            ]
+        )
         self.final_layer_norm = T5LayerNorm(model_dim, dtype=dtype, device=device)
 
-    def forward(self, input_ids, intermediate_output=None, final_layer_norm_intermediate=True):
+    def forward(
+        self, input_ids, intermediate_output=None, final_layer_norm_intermediate=True
+    ):
         intermediate = None
-        x = self.embed_tokens(input_ids).to(torch.float32)  # needs float32 or else T5 returns all zeroes
+        x = self.embed_tokens(input_ids).to(
+            torch.float32
+        )  # needs float32 or else T5 returns all zeroes
         past_bias = None
         for i, layer in enumerate(self.block):
             x, past_bias = layer(x, past_bias)
@@ -497,7 +780,16 @@ class T5(torch.nn.Module):
     def __init__(self, config_dict, dtype, device):
         super().__init__()
         self.num_layers = config_dict["num_layers"]
-        self.encoder = T5Stack(self.num_layers, config_dict["d_model"], config_dict["d_model"], config_dict["d_ff"], config_dict["num_heads"], config_dict["vocab_size"], dtype, device)
+        self.encoder = T5Stack(
+            self.num_layers,
+            config_dict["d_model"],
+            config_dict["d_model"],
+            config_dict["d_ff"],
+            config_dict["num_heads"],
+            config_dict["vocab_size"],
+            dtype,
+            device,
+        )
         self.dtype = dtype
 
     def get_input_embeddings(self):

--- a/modules/models/sd3/sd3_cond.py
+++ b/modules/models/sd3/sd3_cond.py
@@ -6,7 +6,12 @@ import typing
 from transformers import CLIPTokenizer, T5TokenizerFast
 
 from modules import shared, devices, modelloader, sd_hijack_clip, prompt_parser
-from modules.models.sd3.other_impls import SDClipModel, SDXLClipG, T5XXLModel, SD3Tokenizer
+from modules.models.sd3.other_impls import (
+    SDClipModel,
+    SDXLClipG,
+    T5XXLModel,
+    SD3Tokenizer,
+)
 
 
 class SafetensorsMapping(typing.Mapping):
@@ -62,7 +67,7 @@ class Sd3ClipLG(sd_hijack_clip.TextConditionalModel):
 
         self.tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
 
-        empty = self.tokenizer('')["input_ids"]
+        empty = self.tokenizer("")["input_ids"]
         self.id_start = empty[0]
         self.id_end = empty[1]
         self.id_pad = empty[1]
@@ -70,14 +75,16 @@ class Sd3ClipLG(sd_hijack_clip.TextConditionalModel):
         self.return_pooled = True
 
     def tokenize(self, texts):
-        return self.tokenizer(texts, truncation=False, add_special_tokens=False)["input_ids"]
+        return self.tokenizer(texts, truncation=False, add_special_tokens=False)[
+            "input_ids"
+        ]
 
     def encode_with_transformers(self, tokens):
         tokens_g = tokens.clone()
 
         for batch_pos in range(tokens_g.shape[0]):
             index = tokens_g[batch_pos].cpu().tolist().index(self.id_end)
-            tokens_g[batch_pos, index+1:tokens_g.shape[1]] = 0
+            tokens_g[batch_pos, index + 1 : tokens_g.shape[1]] = 0
 
         l_out, l_pooled = self.clip_l(tokens)
         g_out, g_pooled = self.clip_g(tokens_g)
@@ -91,7 +98,7 @@ class Sd3ClipLG(sd_hijack_clip.TextConditionalModel):
         return lg_out
 
     def encode_embedding_init_text(self, init_text, nvpt):
-        return torch.zeros((nvpt, 768+1280), device=devices.device) # XXX
+        return torch.zeros((nvpt, 768 + 1280), device=devices.device)  # XXX
 
 
 class Sd3T5(torch.nn.Module):
@@ -101,12 +108,14 @@ class Sd3T5(torch.nn.Module):
         self.t5xxl = t5xxl
         self.tokenizer = T5TokenizerFast.from_pretrained("google/t5-v1_1-xxl")
 
-        empty = self.tokenizer('', padding='max_length', max_length=2)["input_ids"]
+        empty = self.tokenizer("", padding="max_length", max_length=2)["input_ids"]
         self.id_end = empty[0]
         self.id_pad = empty[1]
 
     def tokenize(self, texts):
-        return self.tokenizer(texts, truncation=False, add_special_tokens=False)["input_ids"]
+        return self.tokenizer(texts, truncation=False, add_special_tokens=False)[
+            "input_ids"
+        ]
 
     def tokenize_line(self, line, *, target_token_count=None):
         if shared.opts.emphasis != "None":
@@ -120,7 +129,7 @@ class Sd3T5(torch.nn.Module):
         multipliers = []
 
         for text_tokens, (text, weight) in zip(tokenized, parsed):
-            if text == 'BREAK' and weight == -1:
+            if text == "BREAK" and weight == -1:
                 continue
 
             tokens += text_tokens
@@ -141,12 +150,18 @@ class Sd3T5(torch.nn.Module):
 
     def forward(self, texts, *, token_count):
         if not self.t5xxl or not shared.opts.sd3_enable_t5:
-            return torch.zeros((len(texts), token_count, 4096), device=devices.device, dtype=devices.dtype)
+            return torch.zeros(
+                (len(texts), token_count, 4096),
+                device=devices.device,
+                dtype=devices.dtype,
+            )
 
         tokens_batch = []
 
         for text in texts:
-            tokens, multipliers = self.tokenize_line(text, target_token_count=token_count)
+            tokens, multipliers = self.tokenize_line(
+                text, target_token_count=token_count
+            )
             tokens_batch.append(tokens)
 
         t5_out, t5_pooled = self.t5xxl(tokens_batch)
@@ -154,7 +169,7 @@ class Sd3T5(torch.nn.Module):
         return t5_out
 
     def encode_embedding_init_text(self, init_text, nvpt):
-        return torch.zeros((nvpt, 4096), device=devices.device) # XXX
+        return torch.zeros((nvpt, 4096), device=devices.device)  # XXX
 
 
 class SD3Cond(torch.nn.Module):
@@ -165,7 +180,15 @@ class SD3Cond(torch.nn.Module):
 
         with torch.no_grad():
             self.clip_g = SDXLClipG(CLIPG_CONFIG, device="cpu", dtype=devices.dtype)
-            self.clip_l = SDClipModel(layer="hidden", layer_idx=-2, device="cpu", dtype=devices.dtype, layer_norm_hidden_state=False, return_projected_pooled=False, textmodel_json_config=CLIPL_CONFIG)
+            self.clip_l = SDClipModel(
+                layer="hidden",
+                layer_idx=-2,
+                device="cpu",
+                dtype=devices.dtype,
+                layer_norm_hidden_state=False,
+                return_projected_pooled=False,
+                textmodel_json_config=CLIPL_CONFIG,
+            )
 
             if shared.opts.sd3_enable_t5:
                 self.t5xxl = T5XXLModel(T5_CONFIG, device="cpu", dtype=devices.dtype)
@@ -182,27 +205,47 @@ class SD3Cond(torch.nn.Module):
             lgt_out = torch.cat([lg_out, t5_out], dim=-2)
 
         return {
-            'crossattn': lgt_out,
-            'vector': vector_out,
+            "crossattn": lgt_out,
+            "vector": vector_out,
         }
 
     def before_load_weights(self, state_dict):
         clip_path = os.path.join(shared.models_path, "CLIP")
 
-        if 'text_encoders.clip_g.transformer.text_model.embeddings.position_embedding.weight' not in state_dict:
-            clip_g_file = modelloader.load_file_from_url(CLIPG_URL, model_dir=clip_path, file_name="clip_g.safetensors")
+        if (
+            "text_encoders.clip_g.transformer.text_model.embeddings.position_embedding.weight"
+            not in state_dict
+        ):
+            clip_g_file = modelloader.load_file_from_url(
+                CLIPG_URL, model_dir=clip_path, file_name="clip_g.safetensors"
+            )
             with safetensors.safe_open(clip_g_file, framework="pt") as file:
                 self.clip_g.transformer.load_state_dict(SafetensorsMapping(file))
 
-        if 'text_encoders.clip_l.transformer.text_model.embeddings.position_embedding.weight' not in state_dict:
-            clip_l_file = modelloader.load_file_from_url(CLIPL_URL, model_dir=clip_path, file_name="clip_l.safetensors")
+        if (
+            "text_encoders.clip_l.transformer.text_model.embeddings.position_embedding.weight"
+            not in state_dict
+        ):
+            clip_l_file = modelloader.load_file_from_url(
+                CLIPL_URL, model_dir=clip_path, file_name="clip_l.safetensors"
+            )
             with safetensors.safe_open(clip_l_file, framework="pt") as file:
-                self.clip_l.transformer.load_state_dict(SafetensorsMapping(file), strict=False)
+                self.clip_l.transformer.load_state_dict(
+                    SafetensorsMapping(file), strict=False
+                )
 
-        if self.t5xxl and 'text_encoders.t5xxl.transformer.encoder.embed_tokens.weight' not in state_dict:
-            t5_file = modelloader.load_file_from_url(T5_URL, model_dir=clip_path, file_name="t5xxl_fp16.safetensors")
+        if (
+            self.t5xxl
+            and "text_encoders.t5xxl.transformer.encoder.embed_tokens.weight"
+            not in state_dict
+        ):
+            t5_file = modelloader.load_file_from_url(
+                T5_URL, model_dir=clip_path, file_name="t5xxl_fp16.safetensors"
+            )
             with safetensors.safe_open(t5_file, framework="pt") as file:
-                self.t5xxl.transformer.load_state_dict(SafetensorsMapping(file), strict=False)
+                self.t5xxl.transformer.load_state_dict(
+                    SafetensorsMapping(file), strict=False
+                )
 
     def encode_embedding_init_text(self, init_text, nvpt):
         return self.model_lg.encode_embedding_init_text(init_text, nvpt)

--- a/modules/models/sd3/sd3_impls.py
+++ b/modules/models/sd3/sd3_impls.py
@@ -14,12 +14,13 @@ from PIL import Image
 
 class ModelSamplingDiscreteFlow(torch.nn.Module):
     """Helper for sampler scheduling (ie timestep/sigma calculations) for Discrete Flow models"""
+
     def __init__(self, shift=1.0):
         super().__init__()
         self.shift = shift
         timesteps = 1000
         ts = self.sigma(torch.arange(1, timesteps + 1, 1))
-        self.register_buffer('sigmas', ts)
+        self.register_buffer("sigmas", ts)
 
     @property
     def sigma_min(self):
@@ -48,7 +49,10 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
 
 class BaseModel(torch.nn.Module):
     """Wrapper around the core MM-DiT model"""
-    def __init__(self, shift=1.0, device=None, dtype=torch.float32, state_dict=None, prefix=""):
+
+    def __init__(
+        self, shift=1.0, device=None, dtype=torch.float32, state_dict=None, prefix=""
+    ):
         super().__init__()
         # Important configuration values can be quickly determined by checking shapes in the source file
         # Some of these will vary between models (eg 2B vs 8B primarily differ in their depth, but also other details change)
@@ -62,17 +66,32 @@ class BaseModel(torch.nn.Module):
             "target": "torch.nn.Linear",
             "params": {
                 "in_features": context_shape[1],
-                "out_features": context_shape[0]
-            }
+                "out_features": context_shape[0],
+            },
         }
-        self.diffusion_model = MMDiT(input_size=None, pos_embed_scaling_factor=None, pos_embed_offset=None, pos_embed_max_size=pos_embed_max_size, patch_size=patch_size, in_channels=16, depth=depth, num_patches=num_patches, adm_in_channels=adm_in_channels, context_embedder_config=context_embedder_config, device=device, dtype=dtype)
+        self.diffusion_model = MMDiT(
+            input_size=None,
+            pos_embed_scaling_factor=None,
+            pos_embed_offset=None,
+            pos_embed_max_size=pos_embed_max_size,
+            patch_size=patch_size,
+            in_channels=16,
+            depth=depth,
+            num_patches=num_patches,
+            adm_in_channels=adm_in_channels,
+            context_embedder_config=context_embedder_config,
+            device=device,
+            dtype=dtype,
+        )
         self.model_sampling = ModelSamplingDiscreteFlow(shift=shift)
         self.depth = depth
 
     def apply_model(self, x, sigma, c_crossattn=None, y=None):
         dtype = self.get_dtype()
         timestep = self.model_sampling.timestep(sigma).float()
-        model_output = self.diffusion_model(x.to(dtype), timestep, context=c_crossattn.to(dtype), y=y.to(dtype)).float()
+        model_output = self.diffusion_model(
+            x.to(dtype), timestep, context=c_crossattn.to(dtype), y=y.to(dtype)
+        ).float()
         return self.model_sampling.calculate_denoised(sigma, model_output, x)
 
     def forward(self, *args, **kwargs):
@@ -84,13 +103,19 @@ class BaseModel(torch.nn.Module):
 
 class CFGDenoiser(torch.nn.Module):
     """Helper for applying CFG Scaling to diffusion outputs"""
+
     def __init__(self, model):
         super().__init__()
         self.model = model
 
     def forward(self, x, timestep, cond, uncond, cond_scale):
         # Run cond and uncond in a batch together
-        batched = self.model.apply_model(torch.cat([x, x]), torch.cat([timestep, timestep]), c_crossattn=torch.cat([cond["c_crossattn"], uncond["c_crossattn"]]), y=torch.cat([cond["y"], uncond["y"]]))
+        batched = self.model.apply_model(
+            torch.cat([x, x]),
+            torch.cat([timestep, timestep]),
+            c_crossattn=torch.cat([cond["c_crossattn"], uncond["c_crossattn"]]),
+            y=torch.cat([cond["y"], uncond["y"]]),
+        )
         # Then split and apply CFG Scaling
         pos_out, neg_out = batched.chunk(2)
         scaled = neg_out + (pos_out - neg_out) * cond_scale
@@ -99,6 +124,7 @@ class CFGDenoiser(torch.nn.Module):
 
 class SD3LatentFormat:
     """Latents are slightly shifted from center - this class must be called after VAE Decode to correct for the shift"""
+
     def __init__(self):
         self.scale_factor = 1.5305
         self.shift_factor = 0.0609
@@ -111,22 +137,35 @@ class SD3LatentFormat:
 
     def decode_latent_to_preview(self, x0):
         """Quick RGB approximate preview of sd3 latents"""
-        factors = torch.tensor([
-            [-0.0645,  0.0177,  0.1052], [ 0.0028,  0.0312,  0.0650],
-            [ 0.1848,  0.0762,  0.0360], [ 0.0944,  0.0360,  0.0889],
-            [ 0.0897,  0.0506, -0.0364], [-0.0020,  0.1203,  0.0284],
-            [ 0.0855,  0.0118,  0.0283], [-0.0539,  0.0658,  0.1047],
-            [-0.0057,  0.0116,  0.0700], [-0.0412,  0.0281, -0.0039],
-            [ 0.1106,  0.1171,  0.1220], [-0.0248,  0.0682, -0.0481],
-            [ 0.0815,  0.0846,  0.1207], [-0.0120, -0.0055, -0.0867],
-            [-0.0749, -0.0634, -0.0456], [-0.1418, -0.1457, -0.1259]
-        ], device="cpu")
+        factors = torch.tensor(
+            [
+                [-0.0645, 0.0177, 0.1052],
+                [0.0028, 0.0312, 0.0650],
+                [0.1848, 0.0762, 0.0360],
+                [0.0944, 0.0360, 0.0889],
+                [0.0897, 0.0506, -0.0364],
+                [-0.0020, 0.1203, 0.0284],
+                [0.0855, 0.0118, 0.0283],
+                [-0.0539, 0.0658, 0.1047],
+                [-0.0057, 0.0116, 0.0700],
+                [-0.0412, 0.0281, -0.0039],
+                [0.1106, 0.1171, 0.1220],
+                [-0.0248, 0.0682, -0.0481],
+                [0.0815, 0.0846, 0.1207],
+                [-0.0120, -0.0055, -0.0867],
+                [-0.0749, -0.0634, -0.0456],
+                [-0.1418, -0.1457, -0.1259],
+            ],
+            device="cpu",
+        )
         latent_image = x0[0].permute(1, 2, 0).cpu() @ factors
 
-        latents_ubyte = (((latent_image + 1) / 2)
-                            .clamp(0, 1)  # change scale from -1..1 to 0..1
-                            .mul(0xFF)  # to 0..255
-                            .byte()).cpu()
+        latents_ubyte = (
+            ((latent_image + 1) / 2)
+            .clamp(0, 1)  # change scale from -1..1 to 0..1
+            .mul(0xFF)  # to 0..255
+            .byte()
+        ).cpu()
 
         return Image.fromarray(latents_ubyte.numpy())
 
@@ -169,22 +208,55 @@ def sample_euler(model, x, sigmas, extra_args=None):
 
 
 def Normalize(in_channels, num_groups=32, dtype=torch.float32, device=None):
-    return torch.nn.GroupNorm(num_groups=num_groups, num_channels=in_channels, eps=1e-6, affine=True, dtype=dtype, device=device)
+    return torch.nn.GroupNorm(
+        num_groups=num_groups,
+        num_channels=in_channels,
+        eps=1e-6,
+        affine=True,
+        dtype=dtype,
+        device=device,
+    )
 
 
 class ResnetBlock(torch.nn.Module):
-    def __init__(self, *, in_channels, out_channels=None, dtype=torch.float32, device=None):
+    def __init__(
+        self, *, in_channels, out_channels=None, dtype=torch.float32, device=None
+    ):
         super().__init__()
         self.in_channels = in_channels
         out_channels = in_channels if out_channels is None else out_channels
         self.out_channels = out_channels
 
         self.norm1 = Normalize(in_channels, dtype=dtype, device=device)
-        self.conv1 = torch.nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv1 = torch.nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         self.norm2 = Normalize(out_channels, dtype=dtype, device=device)
-        self.conv2 = torch.nn.Conv2d(out_channels, out_channels, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv2 = torch.nn.Conv2d(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         if self.in_channels != self.out_channels:
-            self.nin_shortcut = torch.nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1, padding=0, dtype=dtype, device=device)
+            self.nin_shortcut = torch.nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                dtype=dtype,
+                device=device,
+            )
         else:
             self.nin_shortcut = None
         self.swish = torch.nn.SiLU(inplace=True)
@@ -206,10 +278,42 @@ class AttnBlock(torch.nn.Module):
     def __init__(self, in_channels, dtype=torch.float32, device=None):
         super().__init__()
         self.norm = Normalize(in_channels, dtype=dtype, device=device)
-        self.q = torch.nn.Conv2d(in_channels, in_channels, kernel_size=1, stride=1, padding=0, dtype=dtype, device=device)
-        self.k = torch.nn.Conv2d(in_channels, in_channels, kernel_size=1, stride=1, padding=0, dtype=dtype, device=device)
-        self.v = torch.nn.Conv2d(in_channels, in_channels, kernel_size=1, stride=1, padding=0, dtype=dtype, device=device)
-        self.proj_out = torch.nn.Conv2d(in_channels, in_channels, kernel_size=1, stride=1, padding=0, dtype=dtype, device=device)
+        self.q = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
+            device=device,
+        )
+        self.k = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
+            device=device,
+        )
+        self.v = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
+            device=device,
+        )
+        self.proj_out = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
+            device=device,
+        )
 
     def forward(self, x):
         hidden = self.norm(x)
@@ -217,8 +321,13 @@ class AttnBlock(torch.nn.Module):
         k = self.k(hidden)
         v = self.v(hidden)
         b, c, h, w = q.shape
-        q, k, v = [einops.rearrange(x, "b c h w -> b 1 (h w) c").contiguous() for x in (q, k, v)]
-        hidden = torch.nn.functional.scaled_dot_product_attention(q, k, v)  # scale is dim ** -0.5 per default
+        q, k, v = [
+            einops.rearrange(x, "b c h w -> b 1 (h w) c").contiguous()
+            for x in (q, k, v)
+        ]
+        hidden = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v
+        )  # scale is dim ** -0.5 per default
         hidden = einops.rearrange(hidden, "b 1 (h w) c -> b c h w", h=h, w=w, c=c, b=b)
         hidden = self.proj_out(hidden)
         return x + hidden
@@ -227,10 +336,18 @@ class AttnBlock(torch.nn.Module):
 class Downsample(torch.nn.Module):
     def __init__(self, in_channels, dtype=torch.float32, device=None):
         super().__init__()
-        self.conv = torch.nn.Conv2d(in_channels, in_channels, kernel_size=3, stride=2, padding=0, dtype=dtype, device=device)
+        self.conv = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+            dtype=dtype,
+            device=device,
+        )
 
     def forward(self, x):
-        pad = (0,1,0,1)
+        pad = (0, 1, 0, 1)
         x = torch.nn.functional.pad(x, pad, mode="constant", value=0)
         x = self.conv(x)
         return x
@@ -239,7 +356,15 @@ class Downsample(torch.nn.Module):
 class Upsample(torch.nn.Module):
     def __init__(self, in_channels, dtype=torch.float32, device=None):
         super().__init__()
-        self.conv = torch.nn.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv = torch.nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
 
     def forward(self, x):
         x = torch.nn.functional.interpolate(x, scale_factor=2.0, mode="nearest")
@@ -248,22 +373,46 @@ class Upsample(torch.nn.Module):
 
 
 class VAEEncoder(torch.nn.Module):
-    def __init__(self, ch=128, ch_mult=(1,2,4,4), num_res_blocks=2, in_channels=3, z_channels=16, dtype=torch.float32, device=None):
+    def __init__(
+        self,
+        ch=128,
+        ch_mult=(1, 2, 4, 4),
+        num_res_blocks=2,
+        in_channels=3,
+        z_channels=16,
+        dtype=torch.float32,
+        device=None,
+    ):
         super().__init__()
         self.num_resolutions = len(ch_mult)
         self.num_res_blocks = num_res_blocks
         # downsampling
-        self.conv_in = torch.nn.Conv2d(in_channels, ch, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv_in = torch.nn.Conv2d(
+            in_channels,
+            ch,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         in_ch_mult = (1,) + tuple(ch_mult)
         self.in_ch_mult = in_ch_mult
         self.down = torch.nn.ModuleList()
         for i_level in range(self.num_resolutions):
             block = torch.nn.ModuleList()
             attn = torch.nn.ModuleList()
-            block_in = ch*in_ch_mult[i_level]
-            block_out = ch*ch_mult[i_level]
+            block_in = ch * in_ch_mult[i_level]
+            block_out = ch * ch_mult[i_level]
             for _ in range(num_res_blocks):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out, dtype=dtype, device=device))
+                block.append(
+                    ResnetBlock(
+                        in_channels=block_in,
+                        out_channels=block_out,
+                        dtype=dtype,
+                        device=device,
+                    )
+                )
                 block_in = block_out
             down = torch.nn.Module()
             down.block = block
@@ -273,12 +422,24 @@ class VAEEncoder(torch.nn.Module):
             self.down.append(down)
         # middle
         self.mid = torch.nn.Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in, dtype=dtype, device=device)
+        self.mid.block_1 = ResnetBlock(
+            in_channels=block_in, out_channels=block_in, dtype=dtype, device=device
+        )
         self.mid.attn_1 = AttnBlock(block_in, dtype=dtype, device=device)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in, dtype=dtype, device=device)
+        self.mid.block_2 = ResnetBlock(
+            in_channels=block_in, out_channels=block_in, dtype=dtype, device=device
+        )
         # end
         self.norm_out = Normalize(block_in, dtype=dtype, device=device)
-        self.conv_out = torch.nn.Conv2d(block_in, 2 * z_channels, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv_out = torch.nn.Conv2d(
+            block_in,
+            2 * z_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         self.swish = torch.nn.SiLU(inplace=True)
 
     def forward(self, x):
@@ -288,7 +449,7 @@ class VAEEncoder(torch.nn.Module):
             for i_block in range(self.num_res_blocks):
                 h = self.down[i_level].block[i_block](hs[-1])
                 hs.append(h)
-            if i_level != self.num_resolutions-1:
+            if i_level != self.num_resolutions - 1:
                 hs.append(self.down[i_level].downsample(hs[-1]))
         # middle
         h = hs[-1]
@@ -303,36 +464,73 @@ class VAEEncoder(torch.nn.Module):
 
 
 class VAEDecoder(torch.nn.Module):
-    def __init__(self, ch=128, out_ch=3, ch_mult=(1, 2, 4, 4), num_res_blocks=2, resolution=256, z_channels=16, dtype=torch.float32, device=None):
+    def __init__(
+        self,
+        ch=128,
+        out_ch=3,
+        ch_mult=(1, 2, 4, 4),
+        num_res_blocks=2,
+        resolution=256,
+        z_channels=16,
+        dtype=torch.float32,
+        device=None,
+    ):
         super().__init__()
         self.num_resolutions = len(ch_mult)
         self.num_res_blocks = num_res_blocks
         block_in = ch * ch_mult[self.num_resolutions - 1]
         curr_res = resolution // 2 ** (self.num_resolutions - 1)
         # z to block_in
-        self.conv_in = torch.nn.Conv2d(z_channels, block_in, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv_in = torch.nn.Conv2d(
+            z_channels,
+            block_in,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         # middle
         self.mid = torch.nn.Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in, dtype=dtype, device=device)
+        self.mid.block_1 = ResnetBlock(
+            in_channels=block_in, out_channels=block_in, dtype=dtype, device=device
+        )
         self.mid.attn_1 = AttnBlock(block_in, dtype=dtype, device=device)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in, dtype=dtype, device=device)
+        self.mid.block_2 = ResnetBlock(
+            in_channels=block_in, out_channels=block_in, dtype=dtype, device=device
+        )
         # upsampling
         self.up = torch.nn.ModuleList()
         for i_level in reversed(range(self.num_resolutions)):
             block = torch.nn.ModuleList()
             block_out = ch * ch_mult[i_level]
             for _ in range(self.num_res_blocks + 1):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out, dtype=dtype, device=device))
+                block.append(
+                    ResnetBlock(
+                        in_channels=block_in,
+                        out_channels=block_out,
+                        dtype=dtype,
+                        device=device,
+                    )
+                )
                 block_in = block_out
             up = torch.nn.Module()
             up.block = block
             if i_level != 0:
                 up.upsample = Upsample(block_in, dtype=dtype, device=device)
                 curr_res = curr_res * 2
-            self.up.insert(0, up) # prepend to get consistent order
+            self.up.insert(0, up)  # prepend to get consistent order
         # end
         self.norm_out = Normalize(block_in, dtype=dtype, device=device)
-        self.conv_out = torch.nn.Conv2d(block_in, out_ch, kernel_size=3, stride=1, padding=1, dtype=dtype, device=device)
+        self.conv_out = torch.nn.Conv2d(
+            block_in,
+            out_ch,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+            device=device,
+        )
         self.swish = torch.nn.SiLU(inplace=True)
 
     def forward(self, z):

--- a/modules/models/sd3/sd3_model.py
+++ b/modules/models/sd3/sd3_model.py
@@ -25,14 +25,20 @@ class SD3Inferencer(torch.nn.Module):
         self.shift = shift
 
         with torch.no_grad():
-            self.model = BaseModel(shift=shift, state_dict=state_dict, prefix="model.diffusion_model.", device="cpu", dtype=devices.dtype)
+            self.model = BaseModel(
+                shift=shift,
+                state_dict=state_dict,
+                prefix="model.diffusion_model.",
+                device="cpu",
+                dtype=devices.dtype,
+            )
             self.first_stage_model = SDVAE(device="cpu", dtype=devices.dtype_vae)
             self.first_stage_model.dtype = self.model.diffusion_model.dtype
 
-        self.alphas_cumprod = 1 / (self.model.model_sampling.sigmas ** 2 + 1)
+        self.alphas_cumprod = 1 / (self.model.model_sampling.sigmas**2 + 1)
 
         self.text_encoders = SD3Cond()
-        self.cond_stage_key = 'txt'
+        self.cond_stage_key = "txt"
 
         self.parameterization = "eps"
         self.model.conditioning_key = "crossattn"
@@ -54,7 +60,7 @@ class SD3Inferencer(torch.nn.Module):
         return self.cond_stage_model(batch)
 
     def apply_model(self, x, t, cond):
-        return self.model(x, t, c_crossattn=cond['crossattn'], y=cond['vector'])
+        return self.model(x, t, c_crossattn=cond["crossattn"], y=cond["vector"])
 
     def decode_first_stage(self, latent):
         latent = self.latent_format.process_out(latent)
@@ -72,9 +78,9 @@ class SD3Inferencer(torch.nn.Module):
 
     def medvram_fields(self):
         return [
-            (self, 'first_stage_model'),
-            (self, 'text_encoders'),
-            (self, 'model'),
+            (self, "first_stage_model"),
+            (self, "text_encoders"),
+            (self, "model"),
         ]
 
     def add_noise_to_latent(self, x, noise, amount):
@@ -85,12 +91,36 @@ class SD3Inferencer(torch.nn.Module):
 
     def diffusers_weight_mapping(self):
         for i in range(self.model.depth):
-            yield f"transformer.transformer_blocks.{i}.attn.to_q", f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_q_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.to_k", f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_k_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.to_v", f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_v_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.to_out.0", f"diffusion_model_joint_blocks_{i}_x_block_attn_proj"
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.to_q",
+                f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_q_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.to_k",
+                f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_k_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.to_v",
+                f"diffusion_model_joint_blocks_{i}_x_block_attn_qkv_v_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.to_out.0",
+                f"diffusion_model_joint_blocks_{i}_x_block_attn_proj",
+            )
 
-            yield f"transformer.transformer_blocks.{i}.attn.add_q_proj", f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_q_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.add_k_proj", f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_k_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.add_v_proj", f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_v_proj"
-            yield f"transformer.transformer_blocks.{i}.attn.add_out_proj.0", f"diffusion_model_joint_blocks_{i}_context_block_attn_proj"
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.add_q_proj",
+                f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_q_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.add_k_proj",
+                f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_k_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.add_v_proj",
+                f"diffusion_model_joint_blocks_{i}_context_block.attn_qkv_v_proj",
+            )
+            yield (
+                f"transformer.transformer_blocks.{i}.attn.add_out_proj.0",
+                f"diffusion_model_joint_blocks_{i}_context_block_attn_proj",
+            )

--- a/modules/ngrok.py
+++ b/modules/ngrok.py
@@ -1,30 +1,34 @@
 import ngrok
 
+
 # Connect to ngrok for ingress
 def connect(token, port, options):
     account = None
     if token is None:
-        token = 'None'
+        token = "None"
     else:
-        if ':' in token:
+        if ":" in token:
             # token = authtoken:username:password
-            token, username, password = token.split(':', 2)
+            token, username, password = token.split(":", 2)
             account = f"{username}:{password}"
 
     # For all options see: https://github.com/ngrok/ngrok-py/blob/main/examples/ngrok-connect-full.py
-    if not options.get('authtoken_from_env'):
-        options['authtoken'] = token
+    if not options.get("authtoken_from_env"):
+        options["authtoken"] = token
     if account:
-        options['basic_auth'] = account
-    if not options.get('session_metadata'):
-        options['session_metadata'] = 'stable-diffusion-webui'
-
+        options["basic_auth"] = account
+    if not options.get("session_metadata"):
+        options["session_metadata"] = "stable-diffusion-webui"
 
     try:
         public_url = ngrok.connect(f"127.0.0.1:{port}", **options).url()
     except Exception as e:
-        print(f'Invalid ngrok authtoken? ngrok connection aborted due to: {e}\n'
-              f'Your token: {token}, get the right one on https://dashboard.ngrok.com/get-started/your-authtoken')
+        print(
+            f"Invalid ngrok authtoken? ngrok connection aborted due to: {e}\n"
+            f"Your token: {token}, get the right one on https://dashboard.ngrok.com/get-started/your-authtoken"
+        )
     else:
-        print(f'ngrok connected to localhost:{port}! URL: {public_url}\n'
-               'You can use this link after the launch is complete.')
+        print(
+            f"ngrok connected to localhost:{port}! URL: {public_url}\n"
+            "You can use this link after the launch is complete."
+        )

--- a/modules/options.py
+++ b/modules/options.py
@@ -11,7 +11,21 @@ from modules.paths_internal import script_path
 
 
 class OptionInfo:
-    def __init__(self, default=None, label="", component=None, component_args=None, onchange=None, section=None, refresh=None, comment_before='', comment_after='', infotext=None, restrict_api=False, category_id=None):
+    def __init__(
+        self,
+        default=None,
+        label="",
+        component=None,
+        component_args=None,
+        onchange=None,
+        section=None,
+        refresh=None,
+        comment_before="",
+        comment_after="",
+        infotext=None,
+        restrict_api=False,
+        category_id=None,
+    ):
         self.default = default
         self.label = label
         self.component = component
@@ -60,7 +74,11 @@ class OptionInfo:
 
 class OptionHTML(OptionInfo):
     def __init__(self, text):
-        super().__init__(str(text).strip(), label='', component=lambda **kwargs: gr.HTML(elem_classes="settings-info", **kwargs))
+        super().__init__(
+            str(text).strip(),
+            label="",
+            component=lambda **kwargs: gr.HTML(elem_classes="settings-info", **kwargs),
+        )
 
         self.do_not_save = True
 
@@ -84,7 +102,9 @@ class Options:
 
     def __init__(self, data_labels: dict[str, OptionInfo], restricted_opts):
         self.data_labels = data_labels
-        self.data = {k: v.default for k, v in self.data_labels.items() if not v.do_not_save}
+        self.data = {
+            k: v.default for k, v in self.data_labels.items() if not v.do_not_save
+        }
         self.restricted_opts = restricted_opts
 
     def __setattr__(self, key, value):
@@ -93,7 +113,6 @@ class Options:
 
         if self.data is not None:
             if key in self.data or key in self.data_labels:
-
                 # Check that settings aren't globally frozen
                 assert not cmd_opts.freeze_settings, "changing settings is disabled"
 
@@ -104,24 +123,39 @@ class Options:
 
                 # Restrict component arguments
                 comp_args = info.component_args if info else None
-                if isinstance(comp_args, dict) and comp_args.get('visible', True) is False:
-                    raise RuntimeError(f"not possible to set '{key}' because it is restricted")
+                if (
+                    isinstance(comp_args, dict)
+                    and comp_args.get("visible", True) is False
+                ):
+                    raise RuntimeError(
+                        f"not possible to set '{key}' because it is restricted"
+                    )
 
                 # Check that this section isn't frozen
                 if cmd_opts.freeze_settings_in_sections is not None:
-                    frozen_sections = list(map(str.strip, cmd_opts.freeze_settings_in_sections.split(','))) # Trim whitespace from section names
+                    frozen_sections = list(
+                        map(str.strip, cmd_opts.freeze_settings_in_sections.split(","))
+                    )  # Trim whitespace from section names
                     section_key = info.section[0]
                     section_name = info.section[1]
-                    assert section_key not in frozen_sections, f"not possible to set '{key}' because settings in section '{section_name}' ({section_key}) are frozen with --freeze-settings-in-sections"
+                    assert (
+                        section_key not in frozen_sections
+                    ), f"not possible to set '{key}' because settings in section '{section_name}' ({section_key}) are frozen with --freeze-settings-in-sections"
 
                 # Check that this section of the settings isn't frozen
                 if cmd_opts.freeze_specific_settings is not None:
-                    frozen_keys = list(map(str.strip, cmd_opts.freeze_specific_settings.split(','))) # Trim whitespace from setting keys
-                    assert key not in frozen_keys, f"not possible to set '{key}' because this setting is frozen with --freeze-specific-settings"
+                    frozen_keys = list(
+                        map(str.strip, cmd_opts.freeze_specific_settings.split(","))
+                    )  # Trim whitespace from setting keys
+                    assert (
+                        key not in frozen_keys
+                    ), f"not possible to set '{key}' because this setting is frozen with --freeze-specific-settings"
 
                 # Check shorthand option which disables editing options in "saving-paths"
                 if cmd_opts.hide_ui_dir_config and key in self.restricted_opts:
-                    raise RuntimeError(f"not possible to set '{key}' because it is restricted with --hide_ui_dir_config")
+                    raise RuntimeError(
+                        f"not possible to set '{key}' because it is restricted with --hide_ui_dir_config"
+                    )
 
                 self.data[key] = value
                 return
@@ -201,30 +235,56 @@ class Options:
         except FileNotFoundError:
             self.data = {}
         except Exception:
-            errors.report(f'\nCould not load settings\nThe config file "{filename}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n''', exc_info=True)
+            errors.report(
+                f'\nCould not load settings\nThe config file "{filename}" is likely corrupted\nIt has been moved to the "tmp/config.json"\nReverting config to default\n\n'
+                "",
+                exc_info=True,
+            )
             os.replace(filename, os.path.join(script_path, "tmp", "config.json"))
             self.data = {}
         # 1.6.0 VAE defaults
-        if self.data.get('sd_vae_as_default') is not None and self.data.get('sd_vae_overrides_per_model_preferences') is None:
-            self.data['sd_vae_overrides_per_model_preferences'] = not self.data.get('sd_vae_as_default')
+        if (
+            self.data.get("sd_vae_as_default") is not None
+            and self.data.get("sd_vae_overrides_per_model_preferences") is None
+        ):
+            self.data["sd_vae_overrides_per_model_preferences"] = not self.data.get(
+                "sd_vae_as_default"
+            )
 
         # 1.1.1 quicksettings list migration
-        if self.data.get('quicksettings') is not None and self.data.get('quicksettings_list') is None:
-            self.data['quicksettings_list'] = [i.strip() for i in self.data.get('quicksettings').split(',')]
+        if (
+            self.data.get("quicksettings") is not None
+            and self.data.get("quicksettings_list") is None
+        ):
+            self.data["quicksettings_list"] = [
+                i.strip() for i in self.data.get("quicksettings").split(",")
+            ]
 
         # 1.4.0 ui_reorder
-        if isinstance(self.data.get('ui_reorder'), str) and self.data.get('ui_reorder') and "ui_reorder_list" not in self.data:
-            self.data['ui_reorder_list'] = [i.strip() for i in self.data.get('ui_reorder').split(',')]
+        if (
+            isinstance(self.data.get("ui_reorder"), str)
+            and self.data.get("ui_reorder")
+            and "ui_reorder_list" not in self.data
+        ):
+            self.data["ui_reorder_list"] = [
+                i.strip() for i in self.data.get("ui_reorder").split(",")
+            ]
 
         bad_settings = 0
         for k, v in self.data.items():
             info = self.data_labels.get(k, None)
             if info is not None and not self.same_type(info.default, v):
-                print(f"Warning: bad setting value: {k}: {v} ({type(v).__name__}; expected {type(info.default).__name__})", file=sys.stderr)
+                print(
+                    f"Warning: bad setting value: {k}: {v} ({type(v).__name__}; expected {type(info.default).__name__})",
+                    file=sys.stderr,
+                )
                 bad_settings += 1
 
         if bad_settings > 0:
-            print(f"The program is likely to not work with bad settings.\nSettings file: {filename}\nEither fix the file, or delete it and restart.", file=sys.stderr)
+            print(
+                f"The program is likely to not work with bad settings.\nSettings file: {filename}\nEither fix the file, or delete it and restart.",
+                file=sys.stderr,
+            )
 
     def onchange(self, key, func, call=True):
         item = self.data_labels.get(key)
@@ -235,8 +295,16 @@ class Options:
 
     def dumpjson(self):
         d = {k: self.data.get(k, v.default) for k, v in self.data_labels.items()}
-        d["_comments_before"] = {k: v.comment_before for k, v in self.data_labels.items() if v.comment_before is not None}
-        d["_comments_after"] = {k: v.comment_after for k, v in self.data_labels.items() if v.comment_after is not None}
+        d["_comments_before"] = {
+            k: v.comment_before
+            for k, v in self.data_labels.items()
+            if v.comment_before is not None
+        }
+        d["_comments_after"] = {
+            k: v.comment_after
+            for k, v in self.data_labels.items()
+            if v.comment_after is not None
+        }
 
         item_categories = {}
         for item in self.data_labels.values():
@@ -249,7 +317,9 @@ class Options:
                 item_categories[category] = item.section[1]
 
         # _categories is a list of pairs: [section, category]. Each section (a setting page) will get a special heading above it with the category as text.
-        d["_categories"] = [[v, k] for k, v in item_categories.items()] + [["Defaults", "Other"]]
+        d["_categories"] = [[v, k] for k, v in item_categories.items()] + [
+            ["Defaults", "Other"]
+        ]
 
         return json.dumps(d)
 
@@ -321,6 +391,7 @@ class Options:
 class OptionsCategory:
     id: str
     label: str
+
 
 class OptionsCategories:
     def __init__(self):

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -1,6 +1,11 @@
 import os
 import sys
 from modules.paths_internal import (
+    cwd,
+    data_path,
+    extensions_builtin_dir,
+    extensions_dir,
+    models_path,
     script_path,
 )  # noqa: F401
 

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -11,6 +11,15 @@ from modules.paths_internal import (
 
 import modules.safe  # noqa: F401
 
+__all__ = [
+    "cwd",
+    "data_path",
+    "extensions_builtin_dir",
+    "extensions_dir",
+    "models_path",
+    "script_path",
+]
+
 
 def mute_sdxl_imports():
     """create fake modules that SDXL wants to import but doesn't actually use for our purposes"""

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -1,6 +1,8 @@
 import os
 import sys
-from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir, cwd  # noqa: F401
+from modules.paths_internal import (
+    script_path,
+)  # noqa: F401
 
 import modules.safe  # noqa: F401
 
@@ -13,11 +15,11 @@ def mute_sdxl_imports():
 
     module = Dummy()
     module.LPIPS = None
-    sys.modules['taming.modules.losses.lpips'] = module
+    sys.modules["taming.modules.losses.lpips"] = module
 
     module = Dummy()
     module.StableDataModuleFromConfig = None
-    sys.modules['sgm.data'] = module
+    sys.modules["sgm.data"] = module
 
 
 # data_path = cmd_opts_pre.data
@@ -25,21 +27,37 @@ sys.path.insert(0, script_path)
 
 # search for directory of stable diffusion in following places
 sd_path = None
-possible_sd_paths = [os.path.join(script_path, 'repositories/stable-diffusion-stability-ai'), '.', os.path.dirname(script_path)]
+possible_sd_paths = [
+    os.path.join(script_path, "repositories/stable-diffusion-stability-ai"),
+    ".",
+    os.path.dirname(script_path),
+]
 for possible_sd_path in possible_sd_paths:
-    if os.path.exists(os.path.join(possible_sd_path, 'ldm/models/diffusion/ddpm.py')):
+    if os.path.exists(os.path.join(possible_sd_path, "ldm/models/diffusion/ddpm.py")):
         sd_path = os.path.abspath(possible_sd_path)
         break
 
-assert sd_path is not None, f"Couldn't find Stable Diffusion in any of: {possible_sd_paths}"
+assert (
+    sd_path is not None
+), f"Couldn't find Stable Diffusion in any of: {possible_sd_paths}"
 
 mute_sdxl_imports()
 
 path_dirs = [
-    (sd_path, 'ldm', 'Stable Diffusion', []),
-    (os.path.join(sd_path, '../generative-models'), 'sgm', 'Stable Diffusion XL', ["sgm"]),
-    (os.path.join(sd_path, '../BLIP'), 'models/blip.py', 'BLIP', []),
-    (os.path.join(sd_path, '../k-diffusion'), 'k_diffusion/sampling.py', 'k_diffusion', ["atstart"]),
+    (sd_path, "ldm", "Stable Diffusion", []),
+    (
+        os.path.join(sd_path, "../generative-models"),
+        "sgm",
+        "Stable Diffusion XL",
+        ["sgm"],
+    ),
+    (os.path.join(sd_path, "../BLIP"), "models/blip.py", "BLIP", []),
+    (
+        os.path.join(sd_path, "../k-diffusion"),
+        "k_diffusion/sampling.py",
+        "k_diffusion",
+        ["atstart"],
+    ),
 ]
 
 paths = {}
@@ -58,6 +76,7 @@ for d, must_exist, what, options in path_dirs:
 
             sys.path.insert(0, d)
             import sgm  # noqa: F401
+
             sys.path.pop(0)
         else:
             sys.path.append(d)

--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 normalized_filepath = lambda filepath: str(Path(filepath).absolute())
 
-commandline_args = os.environ.get('COMMANDLINE_ARGS', "")
+commandline_args = os.environ.get("COMMANDLINE_ARGS", "")
 sys.argv += shlex.split(commandline_args)
 
 cwd = os.getcwd()
@@ -18,21 +18,35 @@ script_path = os.path.dirname(modules_path)
 
 sd_configs_path = os.path.join(script_path, "configs")
 sd_default_config = os.path.join(sd_configs_path, "v1-inference.yaml")
-sd_model_file = os.path.join(script_path, 'model.ckpt')
+sd_model_file = os.path.join(script_path, "model.ckpt")
 default_sd_model_file = sd_model_file
 
 # Parse the --data-dir flag first so we can use it as a base for our other argument default values
 parser_pre = argparse.ArgumentParser(add_help=False)
-parser_pre.add_argument("--data-dir", type=str, default=os.path.dirname(modules_path), help="base path where all user data is stored", )
-parser_pre.add_argument("--models-dir", type=str, default=None, help="base path where models are stored; overrides --data-dir", )
+parser_pre.add_argument(
+    "--data-dir",
+    type=str,
+    default=os.path.dirname(modules_path),
+    help="base path where all user data is stored",
+)
+parser_pre.add_argument(
+    "--models-dir",
+    type=str,
+    default=None,
+    help="base path where models are stored; overrides --data-dir",
+)
 cmd_opts_pre = parser_pre.parse_known_args()[0]
 
 data_path = cmd_opts_pre.data_dir
 
-models_path = cmd_opts_pre.models_dir if cmd_opts_pre.models_dir else os.path.join(data_path, "models")
+models_path = (
+    cmd_opts_pre.models_dir
+    if cmd_opts_pre.models_dir
+    else os.path.join(data_path, "models")
+)
 extensions_dir = os.path.join(data_path, "extensions")
 extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
 config_states_dir = os.path.join(script_path, "config_states")
 default_output_dir = os.path.join(data_path, "outputs")
 
-roboto_ttf_file = os.path.join(modules_path, 'Roboto-Regular.ttf')
+roboto_ttf_file = os.path.join(modules_path, "Roboto-Regular.ttf")

--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -2,11 +2,28 @@ import os
 
 from PIL import Image
 
-from modules import shared, images, devices, scripts, scripts_postprocessing, ui_common, infotext_utils
+from modules import (
+    shared,
+    images,
+    devices,
+    scripts,
+    scripts_postprocessing,
+    ui_common,
+    infotext_utils,
+)
 from modules.shared import opts
 
 
-def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, show_extras_results, *args, save_output: bool = True):
+def run_postprocessing(
+    extras_mode,
+    image,
+    image_folder,
+    input_dir,
+    output_dir,
+    show_extras_results,
+    *args,
+    save_output: bool = True,
+):
     devices.torch_gc()
 
     shared.state.begin(job="extras")
@@ -18,28 +35,30 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
             for img in image_folder:
                 if isinstance(img, Image.Image):
                     image = images.fix_image(img)
-                    fn = ''
+                    fn = ""
                 else:
                     image = images.read(os.path.abspath(img.name))
                     fn = os.path.splitext(img.orig_name)[0]
                 yield image, fn
         elif extras_mode == 2:
-            assert not shared.cmd_opts.hide_ui_dir_config, '--hide-ui-dir-config option must be disabled'
-            assert input_dir, 'input directory not selected'
+            assert (
+                not shared.cmd_opts.hide_ui_dir_config
+            ), "--hide-ui-dir-config option must be disabled"
+            assert input_dir, "input directory not selected"
 
             image_list = shared.listfiles(input_dir)
             for filename in image_list:
                 yield filename, filename
         else:
-            assert image, 'image not selected'
+            assert image, "image not selected"
             yield image, None
 
-    if extras_mode == 2 and output_dir != '':
+    if extras_mode == 2 and output_dir != "":
         outpath = output_dir
     else:
         outpath = opts.outdir_samples or opts.outdir_extras_samples
 
-    infotext = ''
+    infotext = ""
 
     data_to_process = list(get_images(extras_mode, image, image_folder, input_dir))
     shared.state.job_count = len(data_to_process)
@@ -62,7 +81,11 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
         else:
             image_data = image_placeholder
 
-        image_data = image_data if image_data.mode in ("RGBA", "RGB") else image_data.convert("RGB")
+        image_data = (
+            image_data
+            if image_data.mode in ("RGBA", "RGB")
+            else image_data.convert("RGB")
+        )
 
         parameters, existing_pnginfo = images.read_info_from_image(image_data)
         if parameters:
@@ -83,10 +106,16 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
                 basename = os.path.splitext(os.path.basename(name))[0]
                 forced_filename = basename + suffix
             else:
-                basename = ''
+                basename = ""
                 forced_filename = None
 
-            infotext = ", ".join([k if k == v else f'{k}: {infotext_utils.quote(v)}' for k, v in pp.info.items() if v is not None])
+            infotext = ", ".join(
+                [
+                    k if k == v else f"{k}: {infotext_utils.quote(v)}"
+                    for k, v in pp.info.items()
+                    if v is not None
+                ]
+            )
 
             if opts.enable_pnginfo:
                 pp.image.info = existing_pnginfo
@@ -95,7 +124,20 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
             shared.state.assign_current_image(pp.image)
 
             if save_output:
-                fullfn, _ = images.save_image(pp.image, path=outpath, basename=basename, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=forced_filename, suffix=suffix)
+                fullfn, _ = images.save_image(
+                    pp.image,
+                    path=outpath,
+                    basename=basename,
+                    extension=opts.samples_format,
+                    info=infotext,
+                    short_filename=True,
+                    no_prompt=True,
+                    grid=False,
+                    pnginfo_section_name="extras",
+                    existing_info=existing_pnginfo,
+                    forced_filename=forced_filename,
+                    suffix=suffix,
+                )
 
                 if pp.caption:
                     caption_filename = os.path.splitext(fullfn)[0] + ".txt"
@@ -107,11 +149,11 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
                         pass
 
                     action = shared.opts.postprocessing_existing_caption_action
-                    if action == 'Prepend' and existing_caption:
+                    if action == "Prepend" and existing_caption:
                         caption = f"{existing_caption} {pp.caption}"
-                    elif action == 'Append' and existing_caption:
+                    elif action == "Append" and existing_caption:
                         caption = f"{pp.caption} {existing_caption}"
-                    elif action == 'Keep' and existing_caption:
+                    elif action == "Keep" and existing_caption:
                         caption = existing_caption
                     else:
                         caption = pp.caption
@@ -126,38 +168,70 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
 
     devices.torch_gc()
     shared.state.end()
-    return outputs, ui_common.plaintext_to_html(infotext), ''
+    return outputs, ui_common.plaintext_to_html(infotext), ""
 
 
 def run_postprocessing_webui(id_task, *args, **kwargs):
     return run_postprocessing(*args, **kwargs)
 
 
-def run_extras(extras_mode, resize_mode, image, image_folder, input_dir, output_dir, show_extras_results, gfpgan_visibility, codeformer_visibility, codeformer_weight, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_first: bool, save_output: bool = True, max_side_length: int = 0):
+def run_extras(
+    extras_mode,
+    resize_mode,
+    image,
+    image_folder,
+    input_dir,
+    output_dir,
+    show_extras_results,
+    gfpgan_visibility,
+    codeformer_visibility,
+    codeformer_weight,
+    upscaling_resize,
+    upscaling_resize_w,
+    upscaling_resize_h,
+    upscaling_crop,
+    extras_upscaler_1,
+    extras_upscaler_2,
+    extras_upscaler_2_visibility,
+    upscale_first: bool,
+    save_output: bool = True,
+    max_side_length: int = 0,
+):
     """old handler for API"""
 
-    args = scripts.scripts_postproc.create_args_for_run({
-        "Upscale": {
-            "upscale_enabled": True,
-            "upscale_mode": resize_mode,
-            "upscale_by": upscaling_resize,
-            "max_side_length": max_side_length,
-            "upscale_to_width": upscaling_resize_w,
-            "upscale_to_height": upscaling_resize_h,
-            "upscale_crop": upscaling_crop,
-            "upscaler_1_name": extras_upscaler_1,
-            "upscaler_2_name": extras_upscaler_2,
-            "upscaler_2_visibility": extras_upscaler_2_visibility,
-        },
-        "GFPGAN": {
-            "enable": True,
-            "gfpgan_visibility": gfpgan_visibility,
-        },
-        "CodeFormer": {
-            "enable": True,
-            "codeformer_visibility": codeformer_visibility,
-            "codeformer_weight": codeformer_weight,
-        },
-    })
+    args = scripts.scripts_postproc.create_args_for_run(
+        {
+            "Upscale": {
+                "upscale_enabled": True,
+                "upscale_mode": resize_mode,
+                "upscale_by": upscaling_resize,
+                "max_side_length": max_side_length,
+                "upscale_to_width": upscaling_resize_w,
+                "upscale_to_height": upscaling_resize_h,
+                "upscale_crop": upscaling_crop,
+                "upscaler_1_name": extras_upscaler_1,
+                "upscaler_2_name": extras_upscaler_2,
+                "upscaler_2_visibility": extras_upscaler_2_visibility,
+            },
+            "GFPGAN": {
+                "enable": True,
+                "gfpgan_visibility": gfpgan_visibility,
+            },
+            "CodeFormer": {
+                "enable": True,
+                "codeformer_visibility": codeformer_visibility,
+                "codeformer_weight": codeformer_weight,
+            },
+        }
+    )
 
-    return run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, show_extras_results, *args, save_output=save_output)
+    return run_postprocessing(
+        extras_mode,
+        image,
+        image_folder,
+        input_dir,
+        output_dir,
+        show_extras_results,
+        *args,
+        save_output=save_output,
+    )

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -16,10 +16,29 @@ from skimage import exposure
 from typing import Any
 
 import modules.sd_hijack
-from modules import devices, prompt_parser, masking, sd_samplers, lowvram, infotext_utils, extra_networks, sd_vae_approx, scripts, sd_samplers_common, sd_unet, errors, rng, profiling
-from modules.rng import slerp # noqa: F401
+from modules import (
+    devices,
+    prompt_parser,
+    masking,
+    sd_samplers,
+    lowvram,
+    infotext_utils,
+    extra_networks,
+    sd_vae_approx,
+    scripts,
+    sd_samplers_common,
+    sd_unet,
+    errors,
+    rng,
+    profiling,
+)
+from modules.rng import slerp  # noqa: F401
 from modules.sd_hijack import model_hijack
-from modules.sd_samplers_common import images_tensor_to_samples, decode_first_stage, approximation_indexes
+from modules.sd_samplers_common import (
+    images_tensor_to_samples,
+    decode_first_stage,
+    approximation_indexes,
+)
 from modules.shared import opts, cmd_opts, state
 import modules.shared as shared
 import modules.paths as paths
@@ -48,23 +67,25 @@ def setup_color_correction(image):
 
 def apply_color_correction(correction, original_image):
     logging.info("Applying color correction.")
-    image = Image.fromarray(cv2.cvtColor(exposure.match_histograms(
+    image = Image.fromarray(
         cv2.cvtColor(
-            np.asarray(original_image),
-            cv2.COLOR_RGB2LAB
-        ),
-        correction,
-        channel_axis=2
-    ), cv2.COLOR_LAB2RGB).astype("uint8"))
+            exposure.match_histograms(
+                cv2.cvtColor(np.asarray(original_image), cv2.COLOR_RGB2LAB),
+                correction,
+                channel_axis=2,
+            ),
+            cv2.COLOR_LAB2RGB,
+        ).astype("uint8")
+    )
 
     image = blendLayers(image, original_image, BlendType.LUMINOSITY)
 
-    return image.convert('RGB')
+    return image.convert("RGB")
 
 
 def uncrop(image, dest_size, paste_loc):
     x, y, w, h = paste_loc
-    base_image = Image.new('RGBA', dest_size)
+    base_image = Image.new("RGBA", dest_size)
     image = images.resize_image(1, image, w, h)
     base_image.paste(image, (x, y))
     image = base_image
@@ -81,48 +102,66 @@ def apply_overlay(image, paste_loc, overlay):
 
     original_denoised_image = image.copy()
 
-    image = image.convert('RGBA')
+    image = image.convert("RGBA")
     image.alpha_composite(overlay)
-    image = image.convert('RGB')
+    image = image.convert("RGB")
 
     return image, original_denoised_image
 
+
 def create_binary_mask(image, round=True):
-    if image.mode == 'RGBA' and image.getextrema()[-1] != (255, 255):
+    if image.mode == "RGBA" and image.getextrema()[-1] != (255, 255):
         if round:
-            image = image.split()[-1].convert("L").point(lambda x: 255 if x > 128 else 0)
+            image = (
+                image.split()[-1].convert("L").point(lambda x: 255 if x > 128 else 0)
+            )
         else:
             image = image.split()[-1].convert("L")
     else:
-        image = image.convert('L')
+        image = image.convert("L")
     return image
 
-def txt2img_image_conditioning(sd_model, x, width, height):
-    if sd_model.model.conditioning_key in {'hybrid', 'concat'}: # Inpainting models
 
+def txt2img_image_conditioning(sd_model, x, width, height):
+    if sd_model.model.conditioning_key in {"hybrid", "concat"}:  # Inpainting models
         # The "masked-image" in this case will just be all 0.5 since the entire image is masked.
-        image_conditioning = torch.ones(x.shape[0], 3, height, width, device=x.device) * 0.5
-        image_conditioning = images_tensor_to_samples(image_conditioning, approximation_indexes.get(opts.sd_vae_encode_method))
+        image_conditioning = (
+            torch.ones(x.shape[0], 3, height, width, device=x.device) * 0.5
+        )
+        image_conditioning = images_tensor_to_samples(
+            image_conditioning, approximation_indexes.get(opts.sd_vae_encode_method)
+        )
 
         # Add the fake full 1s mask to the first dimension.
-        image_conditioning = torch.nn.functional.pad(image_conditioning, (0, 0, 0, 0, 1, 0), value=1.0)
+        image_conditioning = torch.nn.functional.pad(
+            image_conditioning, (0, 0, 0, 0, 1, 0), value=1.0
+        )
         image_conditioning = image_conditioning.to(x.dtype)
 
         return image_conditioning
 
-    elif sd_model.model.conditioning_key == "crossattn-adm": # UnCLIP models
-
-        return x.new_zeros(x.shape[0], 2*sd_model.noise_augmentor.time_embed.dim, dtype=x.dtype, device=x.device)
+    elif sd_model.model.conditioning_key == "crossattn-adm":  # UnCLIP models
+        return x.new_zeros(
+            x.shape[0],
+            2 * sd_model.noise_augmentor.time_embed.dim,
+            dtype=x.dtype,
+            device=x.device,
+        )
 
     else:
         if sd_model.is_sdxl_inpaint:
             # The "masked-image" in this case will just be all 0.5 since the entire image is masked.
-            image_conditioning = torch.ones(x.shape[0], 3, height, width, device=x.device) * 0.5
-            image_conditioning = images_tensor_to_samples(image_conditioning,
-                                                            approximation_indexes.get(opts.sd_vae_encode_method))
+            image_conditioning = (
+                torch.ones(x.shape[0], 3, height, width, device=x.device) * 0.5
+            )
+            image_conditioning = images_tensor_to_samples(
+                image_conditioning, approximation_indexes.get(opts.sd_vae_encode_method)
+            )
 
             # Add the fake full 1s mask to the first dimension.
-            image_conditioning = torch.nn.functional.pad(image_conditioning, (0, 0, 0, 0, 1, 0), value=1.0)
+            image_conditioning = torch.nn.functional.pad(
+                image_conditioning, (0, 0, 0, 0, 1, 0), value=1.0
+            )
             image_conditioning = image_conditioning.to(x.dtype)
 
             return image_conditioning
@@ -135,7 +174,6 @@ def txt2img_image_conditioning(sd_model, x, width, height):
 
 @dataclass(repr=False)
 class StableDiffusionProcessing:
-    sd_model: object = None
     outpath_samples: str = None
     outpath_grids: str = None
     prompt: str = ""
@@ -227,7 +265,10 @@ class StableDiffusionProcessing:
 
     def __post_init__(self):
         if self.sampler_index is not None:
-            print("sampler_index argument for StableDiffusionProcessing does not do anything; use sampler_name", file=sys.stderr)
+            print(
+                "sampler_index argument for StableDiffusionProcessing does not do anything; use sampler_name",
+                file=sys.stderr,
+            )
 
         self.comments = {}
 
@@ -252,10 +293,14 @@ class StableDiffusionProcessing:
         self.cached_c = StableDiffusionProcessing.cached_c
 
     def fill_fields_from_opts(self):
-        self.s_min_uncond = self.s_min_uncond if self.s_min_uncond is not None else opts.s_min_uncond
+        self.s_min_uncond = (
+            self.s_min_uncond if self.s_min_uncond is not None else opts.s_min_uncond
+        )
         self.s_churn = self.s_churn if self.s_churn is not None else opts.s_churn
         self.s_tmin = self.s_tmin if self.s_tmin is not None else opts.s_tmin
-        self.s_tmax = (self.s_tmax if self.s_tmax is not None else opts.s_tmax) or float('inf')
+        self.s_tmax = (
+            self.s_tmax if self.s_tmax is not None else opts.s_tmax
+        ) or float("inf")
         self.s_noise = self.s_noise if self.s_noise is not None else opts.s_noise
 
     @property
@@ -274,7 +319,11 @@ class StableDiffusionProcessing:
     def scripts(self, value):
         self.scripts_value = value
 
-        if self.scripts_value and self.script_args_value and not self.scripts_setup_complete:
+        if (
+            self.scripts_value
+            and self.script_args_value
+            and not self.scripts_setup_complete
+        ):
             self.setup_scripts()
 
     @property
@@ -285,7 +334,11 @@ class StableDiffusionProcessing:
     def script_args(self, value):
         self.script_args_value = value
 
-        if self.scripts_value and self.script_args_value and not self.scripts_setup_complete:
+        if (
+            self.scripts_value
+            and self.script_args_value
+            and not self.scripts_setup_complete
+        ):
             self.setup_scripts()
 
     def setup_scripts(self):
@@ -297,18 +350,27 @@ class StableDiffusionProcessing:
         self.comments[text] = 1
 
     def txt2img_image_conditioning(self, x, width=None, height=None):
-        self.is_using_inpainting_conditioning = self.sd_model.model.conditioning_key in {'hybrid', 'concat'}
+        self.is_using_inpainting_conditioning = (
+            self.sd_model.model.conditioning_key in {"hybrid", "concat"}
+        )
 
-        return txt2img_image_conditioning(self.sd_model, x, width or self.width, height or self.height)
+        return txt2img_image_conditioning(
+            self.sd_model, x, width or self.width, height or self.height
+        )
 
     def depth2img_image_conditioning(self, source_image):
         # Use the AddMiDaS helper to Format our source image to suit the MiDaS model
         transformer = AddMiDaS(model_type="dpt_hybrid")
         transformed = transformer({"jpg": rearrange(source_image[0], "c h w -> h w c")})
-        midas_in = torch.from_numpy(transformed["midas_in"][None, ...]).to(device=shared.device)
+        midas_in = torch.from_numpy(transformed["midas_in"][None, ...]).to(
+            device=shared.device
+        )
         midas_in = repeat(midas_in, "1 ... -> n ...", n=self.batch_size)
 
-        conditioning_image = images_tensor_to_samples(source_image*0.5+0.5, approximation_indexes.get(opts.sd_vae_encode_method))
+        conditioning_image = images_tensor_to_samples(
+            source_image * 0.5 + 0.5,
+            approximation_indexes.get(opts.sd_vae_encode_method),
+        )
         conditioning = torch.nn.functional.interpolate(
             self.sd_model.depth_model(midas_in),
             size=conditioning_image.shape[2:],
@@ -317,7 +379,7 @@ class StableDiffusionProcessing:
         )
 
         (depth_min, depth_max) = torch.aminmax(conditioning)
-        conditioning = 2. * (conditioning - depth_min) / (depth_max - depth_min) - 1.
+        conditioning = 2.0 * (conditioning - depth_min) / (depth_max - depth_min) - 1.0
         return conditioning
 
     def edit_image_conditioning(self, source_image):
@@ -328,12 +390,21 @@ class StableDiffusionProcessing:
     def unclip_image_conditioning(self, source_image):
         c_adm = self.sd_model.embedder(source_image)
         if self.sd_model.noise_augmentor is not None:
-            noise_level = 0 # TODO: Allow other noise levels?
-            c_adm, noise_level_emb = self.sd_model.noise_augmentor(c_adm, noise_level=repeat(torch.tensor([noise_level]).to(c_adm.device), '1 -> b', b=c_adm.shape[0]))
+            noise_level = 0  # TODO: Allow other noise levels?
+            c_adm, noise_level_emb = self.sd_model.noise_augmentor(
+                c_adm,
+                noise_level=repeat(
+                    torch.tensor([noise_level]).to(c_adm.device),
+                    "1 -> b",
+                    b=c_adm.shape[0],
+                ),
+            )
             c_adm = torch.cat((c_adm, noise_level_emb), 1)
         return c_adm
 
-    def inpainting_image_conditioning(self, source_image, latent_image, image_mask=None, round_image_mask=True):
+    def inpainting_image_conditioning(
+        self, source_image, latent_image, image_mask=None, round_image_mask=True
+    ):
         self.is_using_inpainting_conditioning = True
 
         # Handle the different mask inputs
@@ -354,25 +425,37 @@ class StableDiffusionProcessing:
 
         # Create another latent image, this time with a masked version of the original input.
         # Smoothly interpolate between the masked and unmasked latent conditioning image using a parameter.
-        conditioning_mask = conditioning_mask.to(device=source_image.device, dtype=source_image.dtype)
+        conditioning_mask = conditioning_mask.to(
+            device=source_image.device, dtype=source_image.dtype
+        )
         conditioning_image = torch.lerp(
             source_image,
             source_image * (1.0 - conditioning_mask),
-            getattr(self, "inpainting_mask_weight", shared.opts.inpainting_mask_weight)
+            getattr(self, "inpainting_mask_weight", shared.opts.inpainting_mask_weight),
         )
 
         # Encode the new masked image using first stage of network.
-        conditioning_image = self.sd_model.get_first_stage_encoding(self.sd_model.encode_first_stage(conditioning_image))
+        conditioning_image = self.sd_model.get_first_stage_encoding(
+            self.sd_model.encode_first_stage(conditioning_image)
+        )
 
         # Create the concatenated conditioning tensor to be fed to `c_concat`
-        conditioning_mask = torch.nn.functional.interpolate(conditioning_mask, size=latent_image.shape[-2:])
-        conditioning_mask = conditioning_mask.expand(conditioning_image.shape[0], -1, -1, -1)
+        conditioning_mask = torch.nn.functional.interpolate(
+            conditioning_mask, size=latent_image.shape[-2:]
+        )
+        conditioning_mask = conditioning_mask.expand(
+            conditioning_image.shape[0], -1, -1, -1
+        )
         image_conditioning = torch.cat([conditioning_mask, conditioning_image], dim=1)
-        image_conditioning = image_conditioning.to(shared.device).type(self.sd_model.dtype)
+        image_conditioning = image_conditioning.to(shared.device).type(
+            self.sd_model.dtype
+        )
 
         return image_conditioning
 
-    def img2img_image_conditioning(self, source_image, latent_image, image_mask=None, round_image_mask=True):
+    def img2img_image_conditioning(
+        self, source_image, latent_image, image_mask=None, round_image_mask=True
+    ):
         source_image = devices.cond_cast_float(source_image)
 
         # HACK: Using introspection as the Depth2Image model doesn't appear to uniquely
@@ -383,14 +466,21 @@ class StableDiffusionProcessing:
         if self.sd_model.cond_stage_key == "edit":
             return self.edit_image_conditioning(source_image)
 
-        if self.sampler.conditioning_key in {'hybrid', 'concat'}:
-            return self.inpainting_image_conditioning(source_image, latent_image, image_mask=image_mask, round_image_mask=round_image_mask)
+        if self.sampler.conditioning_key in {"hybrid", "concat"}:
+            return self.inpainting_image_conditioning(
+                source_image,
+                latent_image,
+                image_mask=image_mask,
+                round_image_mask=round_image_mask,
+            )
 
         if self.sampler.conditioning_key == "crossattn-adm":
             return self.unclip_image_conditioning(source_image)
 
         if self.sampler.model_wrap.inner_model.is_sdxl_inpaint:
-            return self.inpainting_image_conditioning(source_image, latent_image, image_mask=image_mask)
+            return self.inpainting_image_conditioning(
+                source_image, latent_image, image_mask=image_mask
+            )
 
         # Dummy zero conditioning if we're not using inpainting or depth model.
         return latent_image.new_zeros(latent_image.shape[0], 5, 1, 1)
@@ -398,7 +488,15 @@ class StableDiffusionProcessing:
     def init(self, all_prompts, all_seeds, all_subseeds):
         pass
 
-    def sample(self, conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
+    def sample(
+        self,
+        conditioning,
+        unconditional_conditioning,
+        seeds,
+        subseeds,
+        subseed_strength,
+        prompts,
+    ):
         raise NotImplementedError()
 
     def close(self):
@@ -411,12 +509,17 @@ class StableDiffusionProcessing:
 
     def get_token_merging_ratio(self, for_hr=False):
         if for_hr:
-            return self.token_merging_ratio_hr or opts.token_merging_ratio_hr or self.token_merging_ratio or opts.token_merging_ratio
+            return (
+                self.token_merging_ratio_hr
+                or opts.token_merging_ratio_hr
+                or self.token_merging_ratio
+                or opts.token_merging_ratio
+            )
 
         return self.token_merging_ratio or opts.token_merging_ratio
 
     def setup_prompts(self):
-        if isinstance(self.prompt,list):
+        if isinstance(self.prompt, list):
             self.all_prompts = self.prompt
         elif isinstance(self.negative_prompt, list):
             self.all_prompts = [self.prompt] * len(self.negative_prompt)
@@ -429,15 +532,30 @@ class StableDiffusionProcessing:
             self.all_negative_prompts = [self.negative_prompt] * len(self.all_prompts)
 
         if len(self.all_prompts) != len(self.all_negative_prompts):
-            raise RuntimeError(f"Received a different number of prompts ({len(self.all_prompts)}) and negative prompts ({len(self.all_negative_prompts)})")
+            raise RuntimeError(
+                f"Received a different number of prompts ({len(self.all_prompts)}) and negative prompts ({len(self.all_negative_prompts)})"
+            )
 
-        self.all_prompts = [shared.prompt_styles.apply_styles_to_prompt(x, self.styles) for x in self.all_prompts]
-        self.all_negative_prompts = [shared.prompt_styles.apply_negative_styles_to_prompt(x, self.styles) for x in self.all_negative_prompts]
+        self.all_prompts = [
+            shared.prompt_styles.apply_styles_to_prompt(x, self.styles)
+            for x in self.all_prompts
+        ]
+        self.all_negative_prompts = [
+            shared.prompt_styles.apply_negative_styles_to_prompt(x, self.styles)
+            for x in self.all_negative_prompts
+        ]
 
         self.main_prompt = self.all_prompts[0]
         self.main_negative_prompt = self.all_negative_prompts[0]
 
-    def cached_params(self, required_prompts, steps, extra_network_data, hires_steps=None, use_old_scheduling=False):
+    def cached_params(
+        self,
+        required_prompts,
+        steps,
+        extra_network_data,
+        hires_steps=None,
+        use_old_scheduling=False,
+    ):
         """Returns parameters that invalidate the cond cache if changed"""
 
         return (
@@ -457,7 +575,15 @@ class StableDiffusionProcessing:
             opts.emphasis,
         )
 
-    def get_conds_with_caching(self, function, required_prompts, steps, caches, extra_network_data, hires_steps=None):
+    def get_conds_with_caching(
+        self,
+        function,
+        required_prompts,
+        steps,
+        caches,
+        extra_network_data,
+        hires_steps=None,
+    ):
         """
         Returns the result of calling function(shared.sd_model, required_prompts, steps)
         using a cache to store the result if the same arguments have been used before.
@@ -471,12 +597,22 @@ class StableDiffusionProcessing:
         """
 
         if shared.opts.use_old_scheduling:
-            old_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(required_prompts, steps, hires_steps, False)
-            new_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(required_prompts, steps, hires_steps, True)
+            old_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(
+                required_prompts, steps, hires_steps, False
+            )
+            new_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(
+                required_prompts, steps, hires_steps, True
+            )
             if old_schedules != new_schedules:
                 self.extra_generation_params["Old prompt editing timelines"] = True
 
-        cached_params = self.cached_params(required_prompts, steps, extra_network_data, hires_steps, shared.opts.use_old_scheduling)
+        cached_params = self.cached_params(
+            required_prompts,
+            steps,
+            extra_network_data,
+            hires_steps,
+            shared.opts.use_old_scheduling,
+        )
 
         for cache in caches:
             if cache[0] is not None and cached_params == cache[0]:
@@ -485,36 +621,87 @@ class StableDiffusionProcessing:
         cache = caches[0]
 
         with devices.autocast():
-            cache[1] = function(shared.sd_model, required_prompts, steps, hires_steps, shared.opts.use_old_scheduling)
+            cache[1] = function(
+                shared.sd_model,
+                required_prompts,
+                steps,
+                hires_steps,
+                shared.opts.use_old_scheduling,
+            )
 
         cache[0] = cached_params
         return cache[1]
 
     def setup_conds(self):
-        prompts = prompt_parser.SdConditioning(self.prompts, width=self.width, height=self.height)
-        negative_prompts = prompt_parser.SdConditioning(self.negative_prompts, width=self.width, height=self.height, is_negative_prompt=True)
+        prompts = prompt_parser.SdConditioning(
+            self.prompts, width=self.width, height=self.height
+        )
+        negative_prompts = prompt_parser.SdConditioning(
+            self.negative_prompts,
+            width=self.width,
+            height=self.height,
+            is_negative_prompt=True,
+        )
 
         sampler_config = sd_samplers.find_sampler_config(self.sampler_name)
-        total_steps = sampler_config.total_steps(self.steps) if sampler_config else self.steps
+        total_steps = (
+            sampler_config.total_steps(self.steps) if sampler_config else self.steps
+        )
         self.step_multiplier = total_steps // self.steps
         self.firstpass_steps = total_steps
 
-        self.uc = self.get_conds_with_caching(prompt_parser.get_learned_conditioning, negative_prompts, total_steps, [self.cached_uc], self.extra_network_data)
-        self.c = self.get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, prompts, total_steps, [self.cached_c], self.extra_network_data)
+        self.uc = self.get_conds_with_caching(
+            prompt_parser.get_learned_conditioning,
+            negative_prompts,
+            total_steps,
+            [self.cached_uc],
+            self.extra_network_data,
+        )
+        self.c = self.get_conds_with_caching(
+            prompt_parser.get_multicond_learned_conditioning,
+            prompts,
+            total_steps,
+            [self.cached_c],
+            self.extra_network_data,
+        )
 
     def get_conds(self):
         return self.c, self.uc
 
     def parse_extra_network_prompts(self):
-        self.prompts, self.extra_network_data = extra_networks.parse_prompts(self.prompts)
+        self.prompts, self.extra_network_data = extra_networks.parse_prompts(
+            self.prompts
+        )
 
     def save_samples(self) -> bool:
         """Returns whether generated images need to be written to disk"""
-        return opts.samples_save and not self.do_not_save_samples and (opts.save_incomplete_images or not state.interrupted and not state.skipped)
+        return (
+            opts.samples_save
+            and not self.do_not_save_samples
+            and (
+                opts.save_incomplete_images
+                or not state.interrupted
+                and not state.skipped
+            )
+        )
 
 
 class Processed:
-    def __init__(self, p: StableDiffusionProcessing, images_list, seed=-1, info="", subseed=None, all_prompts=None, all_negative_prompts=None, all_seeds=None, all_subseeds=None, index_of_first_image=0, infotexts=None, comments=""):
+    def __init__(
+        self,
+        p: StableDiffusionProcessing,
+        images_list,
+        seed=-1,
+        info="",
+        subseed=None,
+        all_prompts=None,
+        all_negative_prompts=None,
+        all_seeds=None,
+        all_subseeds=None,
+        index_of_first_image=0,
+        infotexts=None,
+        comments="",
+    ):
         self.images = images_list
         self.prompt = p.prompt
         self.negative_prompt = p.negative_prompt
@@ -527,18 +714,20 @@ class Processed:
         self.height = p.height
         self.sampler_name = p.sampler_name
         self.cfg_scale = p.cfg_scale
-        self.image_cfg_scale = getattr(p, 'image_cfg_scale', None)
+        self.image_cfg_scale = getattr(p, "image_cfg_scale", None)
         self.steps = p.steps
         self.batch_size = p.batch_size
         self.restore_faces = p.restore_faces
-        self.face_restoration_model = opts.face_restoration_model if p.restore_faces else None
+        self.face_restoration_model = (
+            opts.face_restoration_model if p.restore_faces else None
+        )
         self.sd_model_name = p.sd_model_name
         self.sd_model_hash = p.sd_model_hash
         self.sd_vae_name = p.sd_vae_name
         self.sd_vae_hash = p.sd_vae_hash
         self.seed_resize_from_w = p.seed_resize_from_w
         self.seed_resize_from_h = p.seed_resize_from_h
-        self.denoising_strength = getattr(p, 'denoising_strength', None)
+        self.denoising_strength = getattr(p, "denoising_strength", None)
         self.extra_generation_params = p.extra_generation_params
         self.index_of_first_image = index_of_first_image
         self.styles = p.styles
@@ -555,14 +744,30 @@ class Processed:
         self.s_noise = p.s_noise
         self.s_min_uncond = p.s_min_uncond
         self.sampler_noise_scheduler_override = p.sampler_noise_scheduler_override
-        self.prompt = self.prompt if not isinstance(self.prompt, list) else self.prompt[0]
-        self.negative_prompt = self.negative_prompt if not isinstance(self.negative_prompt, list) else self.negative_prompt[0]
-        self.seed = int(self.seed if not isinstance(self.seed, list) else self.seed[0]) if self.seed is not None else -1
-        self.subseed = int(self.subseed if not isinstance(self.subseed, list) else self.subseed[0]) if self.subseed is not None else -1
+        self.prompt = (
+            self.prompt if not isinstance(self.prompt, list) else self.prompt[0]
+        )
+        self.negative_prompt = (
+            self.negative_prompt
+            if not isinstance(self.negative_prompt, list)
+            else self.negative_prompt[0]
+        )
+        self.seed = (
+            int(self.seed if not isinstance(self.seed, list) else self.seed[0])
+            if self.seed is not None
+            else -1
+        )
+        self.subseed = (
+            int(self.subseed if not isinstance(self.subseed, list) else self.subseed[0])
+            if self.subseed is not None
+            else -1
+        )
         self.is_using_inpainting_conditioning = p.is_using_inpainting_conditioning
 
         self.all_prompts = all_prompts or p.all_prompts or [self.prompt]
-        self.all_negative_prompts = all_negative_prompts or p.all_negative_prompts or [self.negative_prompt]
+        self.all_negative_prompts = (
+            all_negative_prompts or p.all_negative_prompts or [self.negative_prompt]
+        )
         self.all_seeds = all_seeds or p.all_seeds or [self.seed]
         self.all_subseeds = all_subseeds or p.all_subseeds or [self.subseed]
         self.infotexts = infotexts or [info] * len(images_list)
@@ -607,14 +812,37 @@ class Processed:
         return json.dumps(obj, default=lambda o: None)
 
     def infotext(self, p: StableDiffusionProcessing, index):
-        return create_infotext(p, self.all_prompts, self.all_seeds, self.all_subseeds, comments=[], position_in_batch=index % self.batch_size, iteration=index // self.batch_size)
+        return create_infotext(
+            p,
+            self.all_prompts,
+            self.all_seeds,
+            self.all_subseeds,
+            comments=[],
+            position_in_batch=index % self.batch_size,
+            iteration=index // self.batch_size,
+        )
 
     def get_token_merging_ratio(self, for_hr=False):
         return self.token_merging_ratio_hr if for_hr else self.token_merging_ratio
 
 
-def create_random_tensors(shape, seeds, subseeds=None, subseed_strength=0.0, seed_resize_from_h=0, seed_resize_from_w=0, p=None):
-    g = rng.ImageRNG(shape, seeds, subseeds=subseeds, subseed_strength=subseed_strength, seed_resize_from_h=seed_resize_from_h, seed_resize_from_w=seed_resize_from_w)
+def create_random_tensors(
+    shape,
+    seeds,
+    subseeds=None,
+    subseed_strength=0.0,
+    seed_resize_from_h=0,
+    seed_resize_from_w=0,
+    p=None,
+):
+    g = rng.ImageRNG(
+        shape,
+        seeds,
+        subseeds=subseeds,
+        subseed_strength=subseed_strength,
+        seed_resize_from_h=seed_resize_from_h,
+        seed_resize_from_w=seed_resize_from_w,
+    )
     return g.next()
 
 
@@ -629,10 +857,9 @@ def decode_latent_batch(model, batch, target_device=None, check_for_nans=False):
         devices.test_for_nans(batch, "unet")
 
     for i in range(batch.shape[0]):
-        sample = decode_first_stage(model, batch[i:i + 1])[0]
+        sample = decode_first_stage(model, batch[i : i + 1])[0]
 
         if check_for_nans:
-
             try:
                 devices.test_for_nans(sample, "vae")
             except devices.NansException as e:
@@ -662,7 +889,7 @@ def decode_latent_batch(model, batch, target_device=None, check_for_nans=False):
                 model.first_stage_model.to(devices.dtype_vae)
                 batch = batch.to(devices.dtype_vae)
 
-                sample = decode_first_stage(model, batch[i:i + 1])[0]
+                sample = decode_first_stage(model, batch[i : i + 1])[0]
 
         if target_device is not None:
             sample = sample.to(target_device)
@@ -673,7 +900,7 @@ def decode_latent_batch(model, batch, target_device=None, check_for_nans=False):
 
 
 def get_fixed_seed(seed):
-    if seed == '' or seed is None:
+    if seed == "" or seed is None:
         seed = -1
     elif isinstance(seed, str):
         try:
@@ -702,7 +929,18 @@ def program_version():
     return res
 
 
-def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iteration=0, position_in_batch=0, use_main_prompt=False, index=None, all_negative_prompts=None):
+def create_infotext(
+    p,
+    all_prompts,
+    all_seeds,
+    all_subseeds,
+    comments=None,
+    iteration=0,
+    position_in_batch=0,
+    use_main_prompt=False,
+    index=None,
+    all_negative_prompts=None,
+):
     """
     this function is used to generate the infotext that is stored in the generated images, it's contains the parameters that are required to generate the imagee
     Args:
@@ -755,13 +993,15 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
     if all_negative_prompts is None:
         all_negative_prompts = p.all_negative_prompts
 
-    clip_skip = getattr(p, 'clip_skip', opts.CLIP_stop_at_last_layers)
-    enable_hr = getattr(p, 'enable_hr', False)
+    clip_skip = getattr(p, "clip_skip", opts.CLIP_stop_at_last_layers)
+    enable_hr = getattr(p, "enable_hr", False)
     token_merging_ratio = p.get_token_merging_ratio()
     token_merging_ratio_hr = p.get_token_merging_ratio(for_hr=True)
 
     prompt_text = p.main_prompt if use_main_prompt else all_prompts[index]
-    negative_prompt = p.main_negative_prompt if use_main_prompt else all_negative_prompts[index]
+    negative_prompt = (
+        p.main_negative_prompt if use_main_prompt else all_negative_prompts[index]
+    )
 
     uses_ensd = opts.eta_noise_seed_delta != 0
     if uses_ensd:
@@ -772,7 +1012,7 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
         "Sampler": p.sampler_name,
         "Schedule type": p.scheduler,
         "CFG scale": p.cfg_scale,
-        "Image CFG scale": getattr(p, 'image_cfg_scale', None),
+        "Image CFG scale": getattr(p, "image_cfg_scale", None),
         "Seed": p.all_seeds[0] if use_main_prompt else all_seeds[index],
         "Face restoration": opts.face_restoration_model if p.restore_faces else None,
         "Size": f"{p.width}x{p.height}",
@@ -782,16 +1022,34 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
         "Cache FP16 weight for LoRA": opts.cache_fp16_weight if devices.fp8 else None,
         "VAE hash": p.sd_vae_hash if opts.add_vae_hash_to_info else None,
         "VAE": p.sd_vae_name if opts.add_vae_name_to_info else None,
-        "Variation seed": (None if p.subseed_strength == 0 else (p.all_subseeds[0] if use_main_prompt else all_subseeds[index])),
-        "Variation seed strength": (None if p.subseed_strength == 0 else p.subseed_strength),
-        "Seed resize from": (None if p.seed_resize_from_w <= 0 or p.seed_resize_from_h <= 0 else f"{p.seed_resize_from_w}x{p.seed_resize_from_h}"),
+        "Variation seed": (
+            None
+            if p.subseed_strength == 0
+            else (p.all_subseeds[0] if use_main_prompt else all_subseeds[index])
+        ),
+        "Variation seed strength": (
+            None if p.subseed_strength == 0 else p.subseed_strength
+        ),
+        "Seed resize from": (
+            None
+            if p.seed_resize_from_w <= 0 or p.seed_resize_from_h <= 0
+            else f"{p.seed_resize_from_w}x{p.seed_resize_from_h}"
+        ),
         "Denoising strength": p.extra_generation_params.get("Denoising strength"),
-        "Conditional mask weight": getattr(p, "inpainting_mask_weight", shared.opts.inpainting_mask_weight) if p.is_using_inpainting_conditioning else None,
+        "Conditional mask weight": getattr(
+            p, "inpainting_mask_weight", shared.opts.inpainting_mask_weight
+        )
+        if p.is_using_inpainting_conditioning
+        else None,
         "Clip skip": None if clip_skip <= 1 else clip_skip,
         "ENSD": opts.eta_noise_seed_delta if uses_ensd else None,
-        "Token merging ratio": None if token_merging_ratio == 0 else token_merging_ratio,
-        "Token merging ratio hr": None if not enable_hr or token_merging_ratio_hr == 0 else token_merging_ratio_hr,
-        "Init image hash": getattr(p, 'init_img_hash', None),
+        "Token merging ratio": None
+        if token_merging_ratio == 0
+        else token_merging_ratio,
+        "Token merging ratio hr": None
+        if not enable_hr or token_merging_ratio_hr == 0
+        else token_merging_ratio_hr,
+        "Init image hash": getattr(p, "init_img_hash", None),
         "RNG": opts.randn_source if opts.randn_source != "GPU" else None,
         "Tiling": "True" if p.tiling else None,
         **p.extra_generation_params,
@@ -809,9 +1067,17 @@ def create_infotext(p, all_prompts, all_seeds, all_subseeds, comments=None, iter
             errors.report(f'Error creating infotext for key "{key}"', exc_info=True)
             generation_params[key] = None
 
-    generation_params_text = ", ".join([k if k == v else f'{k}: {infotext_utils.quote(v)}' for k, v in generation_params.items() if v is not None])
+    generation_params_text = ", ".join(
+        [
+            k if k == v else f"{k}: {infotext_utils.quote(v)}"
+            for k, v in generation_params.items()
+            if v is not None
+        ]
+    )
 
-    negative_prompt_text = f"\nNegative prompt: {negative_prompt}" if negative_prompt else ""
+    negative_prompt_text = (
+        f"\nNegative prompt: {negative_prompt}" if negative_prompt else ""
+    )
 
     return f"{prompt_text}{negative_prompt_text}\n{generation_params_text}".strip()
 
@@ -820,22 +1086,31 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     if p.scripts is not None:
         p.scripts.before_process(p)
 
-    stored_opts = {k: opts.data[k] if k in opts.data else opts.get_default(k) for k in p.override_settings.keys() if k in opts.data}
+    stored_opts = {
+        k: opts.data[k] if k in opts.data else opts.get_default(k)
+        for k in p.override_settings.keys()
+        if k in opts.data
+    }
 
     try:
         # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint
         # and if after running refiner, the refiner model is not unloaded - webui swaps back to main model here, if model over is present it will be reloaded afterwards
-        if sd_models.checkpoint_aliases.get(p.override_settings.get('sd_model_checkpoint')) is None:
-            p.override_settings.pop('sd_model_checkpoint', None)
+        if (
+            sd_models.checkpoint_aliases.get(
+                p.override_settings.get("sd_model_checkpoint")
+            )
+            is None
+        ):
+            p.override_settings.pop("sd_model_checkpoint", None)
             sd_models.reload_model_weights()
 
         for k, v in p.override_settings.items():
             opts.set(k, v, is_api=True, run_callbacks=False)
 
-            if k == 'sd_model_checkpoint':
+            if k == "sd_model_checkpoint":
                 sd_models.reload_model_weights()
 
-            if k == 'sd_vae':
+            if k == "sd_vae":
                 sd_vae.reload_vae_weights()
 
         sd_models.apply_token_merging(p.sd_model, p.get_token_merging_ratio())
@@ -854,7 +1129,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
             for k, v in stored_opts.items():
                 setattr(opts, k, v)
 
-                if k == 'sd_vae':
+                if k == "sd_vae":
                     sd_vae.reload_vae_weights()
 
     return res
@@ -864,7 +1139,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     """this is the main loop that both txt2img and img2img use; it calls func_init once inside all the scopes and func_sample once per batch"""
 
     if isinstance(p.prompt, list):
-        assert(len(p.prompt) > 0)
+        assert len(p.prompt) > 0
     else:
         assert p.prompt is not None
 
@@ -880,11 +1155,15 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         p.tiling = opts.tiling
 
     if p.refiner_checkpoint not in (None, "", "None", "none"):
-        p.refiner_checkpoint_info = sd_models.get_closet_checkpoint_match(p.refiner_checkpoint)
+        p.refiner_checkpoint_info = sd_models.get_closet_checkpoint_match(
+            p.refiner_checkpoint
+        )
         if p.refiner_checkpoint_info is None:
-            raise Exception(f'Could not find checkpoint with name {p.refiner_checkpoint}')
+            raise Exception(
+                f"Could not find checkpoint with name {p.refiner_checkpoint}"
+            )
 
-    if hasattr(shared.sd_model, 'fix_dimensions'):
+    if hasattr(shared.sd_model, "fix_dimensions"):
         p.width, p.height = shared.sd_model.fix_dimensions(p.width, p.height)
 
     p.sd_model_name = shared.sd_model.sd_checkpoint_info.name_for_extra
@@ -901,7 +1180,10 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     if isinstance(seed, list):
         p.all_seeds = seed
     else:
-        p.all_seeds = [int(seed) + (x if p.subseed_strength == 0 else 0) for x in range(len(p.all_prompts))]
+        p.all_seeds = [
+            int(seed) + (x if p.subseed_strength == 0 else 0)
+            for x in range(len(p.all_prompts))
+        ]
 
     if isinstance(subseed, list):
         p.all_subseeds = subseed
@@ -921,7 +1203,10 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             p.init(p.all_prompts, p.all_seeds, p.all_subseeds)
 
             # for OSX, loading the model during sampling changes the generated picture, so it is loaded here
-            if shared.opts.live_previews_enable and opts.show_progress_type == "Approx NN":
+            if (
+                shared.opts.live_previews_enable
+                and opts.show_progress_type == "Approx NN"
+            ):
                 sd_vae_approx.model()
 
             sd_unet.apply_unet()
@@ -940,16 +1225,31 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             sd_models.reload_model_weights()  # model can be changed for example by refiner
 
-            p.prompts = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
-            p.negative_prompts = p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size]
-            p.seeds = p.all_seeds[n * p.batch_size:(n + 1) * p.batch_size]
-            p.subseeds = p.all_subseeds[n * p.batch_size:(n + 1) * p.batch_size]
+            p.prompts = p.all_prompts[n * p.batch_size : (n + 1) * p.batch_size]
+            p.negative_prompts = p.all_negative_prompts[
+                n * p.batch_size : (n + 1) * p.batch_size
+            ]
+            p.seeds = p.all_seeds[n * p.batch_size : (n + 1) * p.batch_size]
+            p.subseeds = p.all_subseeds[n * p.batch_size : (n + 1) * p.batch_size]
 
-            latent_channels = getattr(shared.sd_model, 'latent_channels', opt_C)
-            p.rng = rng.ImageRNG((latent_channels, p.height // opt_f, p.width // opt_f), p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, seed_resize_from_h=p.seed_resize_from_h, seed_resize_from_w=p.seed_resize_from_w)
+            latent_channels = getattr(shared.sd_model, "latent_channels", opt_C)
+            p.rng = rng.ImageRNG(
+                (latent_channels, p.height // opt_f, p.width // opt_f),
+                p.seeds,
+                subseeds=p.subseeds,
+                subseed_strength=p.subseed_strength,
+                seed_resize_from_h=p.seed_resize_from_h,
+                seed_resize_from_w=p.seed_resize_from_w,
+            )
 
             if p.scripts is not None:
-                p.scripts.before_process_batch(p, batch_number=n, prompts=p.prompts, seeds=p.seeds, subseeds=p.subseeds)
+                p.scripts.before_process_batch(
+                    p,
+                    batch_number=n,
+                    prompts=p.prompts,
+                    seeds=p.seeds,
+                    subseeds=p.subseeds,
+                )
 
             if len(p.prompts) == 0:
                 break
@@ -961,7 +1261,13 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     extra_networks.activate(p, p.extra_network_data)
 
             if p.scripts is not None:
-                p.scripts.process_batch(p, batch_number=n, prompts=p.prompts, seeds=p.seeds, subseeds=p.subseeds)
+                p.scripts.process_batch(
+                    p,
+                    batch_number=n,
+                    prompts=p.prompts,
+                    seeds=p.seeds,
+                    subseeds=p.subseeds,
+                )
 
             p.setup_conds()
 
@@ -972,7 +1278,9 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             # Example: a wildcard processed by process_batch sets an extra model
             # strength, which is saved as "Model Strength: 1.0" in the infotext
             if n == 0 and not cmd_opts.no_prompt_history:
-                with open(os.path.join(paths.data_path, "params.txt"), "w", encoding="utf8") as file:
+                with open(
+                    os.path.join(paths.data_path, "params.txt"), "w", encoding="utf8"
+                ) as file:
                     processed = Processed(p, [])
                     file.write(processed.infotext(p, 0))
 
@@ -984,22 +1292,38 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             sd_models.apply_alpha_schedule_override(p.sd_model, p)
 
-            with devices.without_autocast() if devices.unet_needs_upcast else devices.autocast():
-                samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
+            with (
+                devices.without_autocast()
+                if devices.unet_needs_upcast
+                else devices.autocast()
+            ):
+                samples_ddim = p.sample(
+                    conditioning=p.c,
+                    unconditional_conditioning=p.uc,
+                    seeds=p.seeds,
+                    subseeds=p.subseeds,
+                    subseed_strength=p.subseed_strength,
+                    prompts=p.prompts,
+                )
 
             if p.scripts is not None:
                 ps = scripts.PostSampleArgs(samples_ddim)
                 p.scripts.post_sample(p, ps)
                 samples_ddim = ps.samples
 
-            if getattr(samples_ddim, 'already_decoded', False):
+            if getattr(samples_ddim, "already_decoded", False):
                 x_samples_ddim = samples_ddim
             else:
                 devices.test_for_nans(samples_ddim, "unet")
 
-                if opts.sd_vae_decode_method != 'Full':
-                    p.extra_generation_params['VAE Decoder'] = opts.sd_vae_decode_method
-                x_samples_ddim = decode_latent_batch(p.sd_model, samples_ddim, target_device=devices.cpu, check_for_nans=True)
+                if opts.sd_vae_decode_method != "Full":
+                    p.extra_generation_params["VAE Decoder"] = opts.sd_vae_decode_method
+                x_samples_ddim = decode_latent_batch(
+                    p.sd_model,
+                    samples_ddim,
+                    target_device=devices.cpu,
+                    check_for_nans=True,
+                )
 
             x_samples_ddim = torch.stack(x_samples_ddim).float()
             x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
@@ -1016,27 +1340,47 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if p.scripts is not None:
                 p.scripts.postprocess_batch(p, x_samples_ddim, batch_number=n)
 
-                p.prompts = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]
-                p.negative_prompts = p.all_negative_prompts[n * p.batch_size:(n + 1) * p.batch_size]
+                p.prompts = p.all_prompts[n * p.batch_size : (n + 1) * p.batch_size]
+                p.negative_prompts = p.all_negative_prompts[
+                    n * p.batch_size : (n + 1) * p.batch_size
+                ]
 
                 batch_params = scripts.PostprocessBatchListArgs(list(x_samples_ddim))
                 p.scripts.postprocess_batch_list(p, batch_params, batch_number=n)
                 x_samples_ddim = batch_params.images
 
             def infotext(index=0, use_main_prompt=False):
-                return create_infotext(p, p.prompts, p.seeds, p.subseeds, use_main_prompt=use_main_prompt, index=index, all_negative_prompts=p.negative_prompts)
+                return create_infotext(
+                    p,
+                    p.prompts,
+                    p.seeds,
+                    p.subseeds,
+                    use_main_prompt=use_main_prompt,
+                    index=index,
+                    all_negative_prompts=p.negative_prompts,
+                )
 
             save_samples = p.save_samples()
 
             for i, x_sample in enumerate(x_samples_ddim):
                 p.batch_index = i
 
-                x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
+                x_sample = 255.0 * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
                 x_sample = x_sample.astype(np.uint8)
 
                 if p.restore_faces:
                     if save_samples and opts.save_images_before_face_restoration:
-                        images.save_image(Image.fromarray(x_sample), p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p, suffix="-before-face-restoration")
+                        images.save_image(
+                            Image.fromarray(x_sample),
+                            p.outpath_samples,
+                            "",
+                            p.seeds[i],
+                            p.prompts[i],
+                            opts.samples_format,
+                            info=infotext(i),
+                            p=p,
+                            suffix="-before-face-restoration",
+                        )
 
                     devices.torch_gc()
 
@@ -1054,27 +1398,48 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                 if not shared.opts.overlay_inpaint:
                     overlay_image = None
-                elif getattr(p, "overlay_images", None) is not None and i < len(p.overlay_images):
+                elif getattr(p, "overlay_images", None) is not None and i < len(
+                    p.overlay_images
+                ):
                     overlay_image = p.overlay_images[i]
                 else:
                     overlay_image = None
 
                 if p.scripts is not None:
-                    ppmo = scripts.PostProcessMaskOverlayArgs(i, mask_for_overlay, overlay_image)
+                    ppmo = scripts.PostProcessMaskOverlayArgs(
+                        i, mask_for_overlay, overlay_image
+                    )
                     p.scripts.postprocess_maskoverlay(p, ppmo)
-                    mask_for_overlay, overlay_image = ppmo.mask_for_overlay, ppmo.overlay_image
+                    mask_for_overlay, overlay_image = (
+                        ppmo.mask_for_overlay,
+                        ppmo.overlay_image,
+                    )
 
                 if p.color_corrections is not None and i < len(p.color_corrections):
                     if save_samples and opts.save_images_before_color_correction:
-                        image_without_cc, _ = apply_overlay(image, p.paste_to, overlay_image)
-                        images.save_image(image_without_cc, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p, suffix="-before-color-correction")
+                        image_without_cc, _ = apply_overlay(
+                            image, p.paste_to, overlay_image
+                        )
+                        images.save_image(
+                            image_without_cc,
+                            p.outpath_samples,
+                            "",
+                            p.seeds[i],
+                            p.prompts[i],
+                            opts.samples_format,
+                            info=infotext(i),
+                            p=p,
+                            suffix="-before-color-correction",
+                        )
                     image = apply_color_correction(p.color_corrections[i], image)
 
                 # If the intention is to show the output from the model
                 # that is being composited over the original image,
                 # we need to keep the original image around
                 # and use it in the composite step.
-                image, original_denoised_image = apply_overlay(image, p.paste_to, overlay_image)
+                image, original_denoised_image = apply_overlay(
+                    image, p.paste_to, overlay_image
+                )
 
                 if p.scripts is not None:
                     pp = scripts.PostprocessImageArgs(image)
@@ -1082,7 +1447,16 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                     image = pp.image
 
                 if save_samples:
-                    images.save_image(image, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p)
+                    images.save_image(
+                        image,
+                        p.outpath_samples,
+                        "",
+                        p.seeds[i],
+                        p.prompts[i],
+                        opts.samples_format,
+                        info=infotext(i),
+                        p=p,
+                    )
 
                 text = infotext(i)
                 infotexts.append(text)
@@ -1092,16 +1466,42 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
                 if mask_for_overlay is not None:
                     if opts.return_mask or opts.save_mask:
-                        image_mask = mask_for_overlay.convert('RGB')
+                        image_mask = mask_for_overlay.convert("RGB")
                         if save_samples and opts.save_mask:
-                            images.save_image(image_mask, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p, suffix="-mask")
+                            images.save_image(
+                                image_mask,
+                                p.outpath_samples,
+                                "",
+                                p.seeds[i],
+                                p.prompts[i],
+                                opts.samples_format,
+                                info=infotext(i),
+                                p=p,
+                                suffix="-mask",
+                            )
                         if opts.return_mask:
                             output_images.append(image_mask)
 
                     if opts.return_mask_composite or opts.save_mask_composite:
-                        image_mask_composite = Image.composite(original_denoised_image.convert('RGBA').convert('RGBa'), Image.new('RGBa', image.size), images.resize_image(2, mask_for_overlay, image.width, image.height).convert('L')).convert('RGBA')
+                        image_mask_composite = Image.composite(
+                            original_denoised_image.convert("RGBA").convert("RGBa"),
+                            Image.new("RGBa", image.size),
+                            images.resize_image(
+                                2, mask_for_overlay, image.width, image.height
+                            ).convert("L"),
+                        ).convert("RGBA")
                         if save_samples and opts.save_mask_composite:
-                            images.save_image(image_mask_composite, p.outpath_samples, "", p.seeds[i], p.prompts[i], opts.samples_format, info=infotext(i), p=p, suffix="-mask-composite")
+                            images.save_image(
+                                image_mask_composite,
+                                p.outpath_samples,
+                                "",
+                                p.seeds[i],
+                                p.prompts[i],
+                                opts.samples_format,
+                                info=infotext(i),
+                                p=p,
+                                suffix="-mask-composite",
+                            )
                         if opts.return_mask_composite:
                             output_images.append(image_mask_composite)
 
@@ -1115,8 +1515,14 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
         p.color_corrections = None
 
         index_of_first_image = 0
-        unwanted_grid_because_of_img_count = len(output_images) < 2 and opts.grid_only_if_multiple
-        if (opts.return_grid or opts.grid_save) and not p.do_not_save_grid and not unwanted_grid_because_of_img_count:
+        unwanted_grid_because_of_img_count = (
+            len(output_images) < 2 and opts.grid_only_if_multiple
+        )
+        if (
+            (opts.return_grid or opts.grid_save)
+            and not p.do_not_save_grid
+            and not unwanted_grid_because_of_img_count
+        ):
             grid = images.image_grid(output_images, p.batch_size)
 
             if opts.return_grid:
@@ -1127,7 +1533,18 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 output_images.insert(0, grid)
                 index_of_first_image = 1
             if opts.grid_save:
-                images.save_image(grid, p.outpath_grids, "grid", p.all_seeds[0], p.all_prompts[0], opts.grid_format, info=infotext(use_main_prompt=True), short_filename=not opts.grid_extended_filename, p=p, grid=True)
+                images.save_image(
+                    grid,
+                    p.outpath_grids,
+                    "grid",
+                    p.all_seeds[0],
+                    p.all_prompts[0],
+                    opts.grid_format,
+                    info=infotext(use_main_prompt=True),
+                    short_filename=not opts.grid_extended_filename,
+                    p=p,
+                    grid=True,
+                )
 
     if not p.disable_extra_networks and p.extra_network_data:
         extra_networks.deactivate(p, p.extra_network_data)
@@ -1176,8 +1593,8 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
     hr_checkpoint_name: str = None
     hr_sampler_name: str = None
     hr_scheduler: str = None
-    hr_prompt: str = ''
-    hr_negative_prompt: str = ''
+    hr_prompt: str = ""
+    hr_negative_prompt: str = ""
     force_task_id: str = None
 
     cached_hr_uc = [None, None]
@@ -1211,13 +1628,18 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         self.cached_hr_c = StableDiffusionProcessingTxt2Img.cached_hr_c
 
     def calculate_target_resolution(self):
-        if opts.use_old_hires_fix_width_height and self.applied_old_hires_behavior_to != (self.width, self.height):
+        if (
+            opts.use_old_hires_fix_width_height
+            and self.applied_old_hires_behavior_to != (self.width, self.height)
+        ):
             self.hr_resize_x = self.width
             self.hr_resize_y = self.height
             self.hr_upscale_to_x = self.width
             self.hr_upscale_to_y = self.height
 
-            self.width, self.height = old_hires_fix_first_pass_dimensions(self.width, self.height)
+            self.width, self.height = old_hires_fix_first_pass_dimensions(
+                self.width, self.height
+            )
             self.applied_old_hires_behavior_to = (self.width, self.height)
 
         if self.hr_resize_x == 0 and self.hr_resize_y == 0:
@@ -1225,7 +1647,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             self.hr_upscale_to_x = int(self.width * self.hr_scale)
             self.hr_upscale_to_y = int(self.height * self.hr_scale)
         else:
-            self.extra_generation_params["Hires resize"] = f"{self.hr_resize_x}x{self.hr_resize_y}"
+            self.extra_generation_params["Hires resize"] = (
+                f"{self.hr_resize_x}x{self.hr_resize_y}"
+            )
 
             if self.hr_resize_y == 0:
                 self.hr_upscale_to_x = self.hr_resize_x
@@ -1253,15 +1677,27 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         if self.enable_hr:
             self.extra_generation_params["Denoising strength"] = self.denoising_strength
 
-            if self.hr_checkpoint_name and self.hr_checkpoint_name != 'Use same checkpoint':
-                self.hr_checkpoint_info = sd_models.get_closet_checkpoint_match(self.hr_checkpoint_name)
+            if (
+                self.hr_checkpoint_name
+                and self.hr_checkpoint_name != "Use same checkpoint"
+            ):
+                self.hr_checkpoint_info = sd_models.get_closet_checkpoint_match(
+                    self.hr_checkpoint_name
+                )
 
                 if self.hr_checkpoint_info is None:
-                    raise Exception(f'Could not find checkpoint with name {self.hr_checkpoint_name}')
+                    raise Exception(
+                        f"Could not find checkpoint with name {self.hr_checkpoint_name}"
+                    )
 
-                self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
+                self.extra_generation_params["Hires checkpoint"] = (
+                    self.hr_checkpoint_info.short_title
+                )
 
-            if self.hr_sampler_name is not None and self.hr_sampler_name != self.sampler_name:
+            if (
+                self.hr_sampler_name is not None
+                and self.hr_sampler_name != self.sampler_name
+            ):
                 self.extra_generation_params["Hires sampler"] = self.hr_sampler_name
 
             def get_hr_prompt(p, index, prompt_text, **kwargs):
@@ -1270,17 +1706,31 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
             def get_hr_negative_prompt(p, index, negative_prompt, **kwargs):
                 hr_negative_prompt = p.all_hr_negative_prompts[index]
-                return hr_negative_prompt if hr_negative_prompt != negative_prompt else None
+                return (
+                    hr_negative_prompt
+                    if hr_negative_prompt != negative_prompt
+                    else None
+                )
 
             self.extra_generation_params["Hires prompt"] = get_hr_prompt
-            self.extra_generation_params["Hires negative prompt"] = get_hr_negative_prompt
+            self.extra_generation_params["Hires negative prompt"] = (
+                get_hr_negative_prompt
+            )
 
-            self.extra_generation_params["Hires schedule type"] = None  # to be set in sd_samplers_kdiffusion.py
+            self.extra_generation_params["Hires schedule type"] = (
+                None  # to be set in sd_samplers_kdiffusion.py
+            )
 
             if self.hr_scheduler is None:
                 self.hr_scheduler = self.scheduler
 
-            self.latent_scale_mode = shared.latent_upscale_modes.get(self.hr_upscaler, None) if self.hr_upscaler is not None else shared.latent_upscale_modes.get(shared.latent_upscale_default_mode, "nearest")
+            self.latent_scale_mode = (
+                shared.latent_upscale_modes.get(self.hr_upscaler, None)
+                if self.hr_upscaler is not None
+                else shared.latent_upscale_modes.get(
+                    shared.latent_upscale_default_mode, "nearest"
+                )
+            )
             if self.enable_hr and self.latent_scale_mode is None:
                 if not any(x.name == self.hr_upscaler for x in shared.sd_upscalers):
                     raise Exception(f"could not find upscaler named {self.hr_upscaler}")
@@ -1290,10 +1740,14 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             if not state.processing_has_refined_job_count:
                 if state.job_count == -1:
                     state.job_count = self.n_iter
-                if getattr(self, 'txt2img_upscale', False):
-                    total_steps = (self.hr_second_pass_steps or self.steps) * state.job_count
+                if getattr(self, "txt2img_upscale", False):
+                    total_steps = (
+                        self.hr_second_pass_steps or self.steps
+                    ) * state.job_count
                 else:
-                    total_steps = (self.steps + (self.hr_second_pass_steps or self.steps)) * state.job_count
+                    total_steps = (
+                        self.steps + (self.hr_second_pass_steps or self.steps)
+                    ) * state.job_count
                 shared.total_tqdm.updateTotal(total_steps)
                 state.job_count = state.job_count * 2
                 state.processing_has_refined_job_count = True
@@ -1304,14 +1758,25 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             if self.hr_upscaler is not None:
                 self.extra_generation_params["Hires upscaler"] = self.hr_upscaler
 
-    def sample(self, conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
+    def sample(
+        self,
+        conditioning,
+        unconditional_conditioning,
+        seeds,
+        subseeds,
+        subseed_strength,
+        prompts,
+    ):
         self.sampler = sd_samplers.create_sampler(self.sampler_name, self.sd_model)
 
         if self.firstpass_image is not None and self.enable_hr:
             # here we don't need to generate image, we just take self.firstpass_image and prepare it for hires fix
 
             if self.latent_scale_mode is None:
-                image = np.array(self.firstpass_image).astype(np.float32) / 255.0 * 2.0 - 1.0
+                image = (
+                    np.array(self.firstpass_image).astype(np.float32) / 255.0 * 2.0
+                    - 1.0
+                )
                 image = np.moveaxis(image, 2, 0)
 
                 samples = None
@@ -1323,10 +1788,16 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 image = torch.from_numpy(np.expand_dims(image, axis=0))
                 image = image.to(shared.device, dtype=devices.dtype_vae)
 
-                if opts.sd_vae_encode_method != 'Full':
-                    self.extra_generation_params['VAE Encoder'] = opts.sd_vae_encode_method
+                if opts.sd_vae_encode_method != "Full":
+                    self.extra_generation_params["VAE Encoder"] = (
+                        opts.sd_vae_encode_method
+                    )
 
-                samples = images_tensor_to_samples(image, approximation_indexes.get(opts.sd_vae_encode_method), self.sd_model)
+                samples = images_tensor_to_samples(
+                    image,
+                    approximation_indexes.get(opts.sd_vae_encode_method),
+                    self.sd_model,
+                )
                 decoded_samples = None
                 devices.torch_gc()
 
@@ -1336,14 +1807,16 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             x = self.rng.next()
             if self.scripts is not None:
                 self.scripts.process_before_every_sampling(
-                    p=self,
-                    x=x,
-                    noise=x,
-                    c=conditioning,
-                    uc=unconditional_conditioning
+                    p=self, x=x, noise=x, c=conditioning, uc=unconditional_conditioning
                 )
 
-            samples = self.sampler.sample(self, x, conditioning, unconditional_conditioning, image_conditioning=self.txt2img_image_conditioning(x))
+            samples = self.sampler.sample(
+                self,
+                x,
+                conditioning,
+                unconditional_conditioning,
+                image_conditioning=self.txt2img_image_conditioning(x),
+            )
             del x
 
             if not self.enable_hr:
@@ -1352,16 +1825,27 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             devices.torch_gc()
 
             if self.latent_scale_mode is None:
-                decoded_samples = torch.stack(decode_latent_batch(self.sd_model, samples, target_device=devices.cpu, check_for_nans=True)).to(dtype=torch.float32)
+                decoded_samples = torch.stack(
+                    decode_latent_batch(
+                        self.sd_model,
+                        samples,
+                        target_device=devices.cpu,
+                        check_for_nans=True,
+                    )
+                ).to(dtype=torch.float32)
             else:
                 decoded_samples = None
 
         with sd_models.SkipWritingToConfig():
             sd_models.reload_model_weights(info=self.hr_checkpoint_info)
 
-        return self.sample_hr_pass(samples, decoded_samples, seeds, subseeds, subseed_strength, prompts)
+        return self.sample_hr_pass(
+            samples, decoded_samples, seeds, subseeds, subseed_strength, prompts
+        )
 
-    def sample_hr_pass(self, samples, decoded_samples, seeds, subseeds, subseed_strength, prompts):
+    def sample_hr_pass(
+        self, samples, decoded_samples, seeds, subseeds, subseed_strength, prompts
+    ):
         if shared.state.interrupted:
             return samples
 
@@ -1378,8 +1862,26 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             if not isinstance(image, Image.Image):
                 image = sd_samplers.sample_to_image(image, index, approximation=0)
 
-            info = create_infotext(self, self.all_prompts, self.all_seeds, self.all_subseeds, [], iteration=self.iteration, position_in_batch=index)
-            images.save_image(image, self.outpath_samples, "", seeds[index], prompts[index], opts.samples_format, info=info, p=self, suffix="-before-highres-fix")
+            info = create_infotext(
+                self,
+                self.all_prompts,
+                self.all_seeds,
+                self.all_subseeds,
+                [],
+                iteration=self.iteration,
+                position_in_batch=index,
+            )
+            images.save_image(
+                image,
+                self.outpath_samples,
+                "",
+                seeds[index],
+                prompts[index],
+                opts.samples_format,
+                info=info,
+                p=self,
+                suffix="-before-highres-fix",
+            )
 
         img2img_sampler_name = self.hr_sampler_name or self.sampler_name
 
@@ -1389,26 +1891,46 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             for i in range(samples.shape[0]):
                 save_intermediate(samples, i)
 
-            samples = torch.nn.functional.interpolate(samples, size=(target_height // opt_f, target_width // opt_f), mode=self.latent_scale_mode["mode"], antialias=self.latent_scale_mode["antialias"])
+            samples = torch.nn.functional.interpolate(
+                samples,
+                size=(target_height // opt_f, target_width // opt_f),
+                mode=self.latent_scale_mode["mode"],
+                antialias=self.latent_scale_mode["antialias"],
+            )
 
             # Avoid making the inpainting conditioning unless necessary as
             # this does need some extra compute to decode / encode the image again.
-            if getattr(self, "inpainting_mask_weight", shared.opts.inpainting_mask_weight) < 1.0:
-                image_conditioning = self.img2img_image_conditioning(decode_first_stage(self.sd_model, samples), samples)
+            if (
+                getattr(
+                    self, "inpainting_mask_weight", shared.opts.inpainting_mask_weight
+                )
+                < 1.0
+            ):
+                image_conditioning = self.img2img_image_conditioning(
+                    decode_first_stage(self.sd_model, samples), samples
+                )
             else:
                 image_conditioning = self.txt2img_image_conditioning(samples)
         else:
-            lowres_samples = torch.clamp((decoded_samples + 1.0) / 2.0, min=0.0, max=1.0)
+            lowres_samples = torch.clamp(
+                (decoded_samples + 1.0) / 2.0, min=0.0, max=1.0
+            )
 
             batch_images = []
             for i, x_sample in enumerate(lowres_samples):
-                x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
+                x_sample = 255.0 * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
                 x_sample = x_sample.astype(np.uint8)
                 image = Image.fromarray(x_sample)
 
                 save_intermediate(image, i)
 
-                image = images.resize_image(0, image, target_width, target_height, upscaler_name=self.hr_upscaler)
+                image = images.resize_image(
+                    0,
+                    image,
+                    target_width,
+                    target_height,
+                    upscaler_name=self.hr_upscaler,
+                )
                 image = np.array(image).astype(np.float32) / 255.0
                 image = np.moveaxis(image, 2, 0)
                 batch_images.append(image)
@@ -1416,17 +1938,33 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             decoded_samples = torch.from_numpy(np.array(batch_images))
             decoded_samples = decoded_samples.to(shared.device, dtype=devices.dtype_vae)
 
-            if opts.sd_vae_encode_method != 'Full':
-                self.extra_generation_params['VAE Encoder'] = opts.sd_vae_encode_method
-            samples = images_tensor_to_samples(decoded_samples, approximation_indexes.get(opts.sd_vae_encode_method))
+            if opts.sd_vae_encode_method != "Full":
+                self.extra_generation_params["VAE Encoder"] = opts.sd_vae_encode_method
+            samples = images_tensor_to_samples(
+                decoded_samples, approximation_indexes.get(opts.sd_vae_encode_method)
+            )
 
-            image_conditioning = self.img2img_image_conditioning(decoded_samples, samples)
+            image_conditioning = self.img2img_image_conditioning(
+                decoded_samples, samples
+            )
 
         shared.state.nextjob()
 
-        samples = samples[:, :, self.truncate_y//2:samples.shape[2]-(self.truncate_y+1)//2, self.truncate_x//2:samples.shape[3]-(self.truncate_x+1)//2]
+        samples = samples[
+            :,
+            :,
+            self.truncate_y // 2 : samples.shape[2] - (self.truncate_y + 1) // 2,
+            self.truncate_x // 2 : samples.shape[3] - (self.truncate_x + 1) // 2,
+        ]
 
-        self.rng = rng.ImageRNG(samples.shape[1:], self.seeds, subseeds=self.subseeds, subseed_strength=self.subseed_strength, seed_resize_from_h=self.seed_resize_from_h, seed_resize_from_w=self.seed_resize_from_w)
+        self.rng = rng.ImageRNG(
+            samples.shape[1:],
+            self.seeds,
+            subseeds=self.subseeds,
+            subseed_strength=self.subseed_strength,
+            seed_resize_from_h=self.seed_resize_from_h,
+            seed_resize_from_w=self.seed_resize_from_w,
+        )
         noise = self.rng.next()
 
         # GC now before running the next img2img to prevent running out of memory
@@ -1439,7 +1977,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         with devices.autocast():
             self.calculate_hr_conds()
 
-        sd_models.apply_token_merging(self.sd_model, self.get_token_merging_ratio(for_hr=True))
+        sd_models.apply_token_merging(
+            self.sd_model, self.get_token_merging_ratio(for_hr=True)
+        )
 
         if self.scripts is not None:
             self.scripts.before_hr(self)
@@ -1451,14 +1991,24 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 uc=self.hr_uc,
             )
 
-        samples = self.sampler.sample_img2img(self, samples, noise, self.hr_c, self.hr_uc, steps=self.hr_second_pass_steps or self.steps, image_conditioning=image_conditioning)
+        samples = self.sampler.sample_img2img(
+            self,
+            samples,
+            noise,
+            self.hr_c,
+            self.hr_uc,
+            steps=self.hr_second_pass_steps or self.steps,
+            image_conditioning=image_conditioning,
+        )
 
         sd_models.apply_token_merging(self.sd_model, self.get_token_merging_ratio())
 
         self.sampler = None
         devices.torch_gc()
 
-        decoded_samples = decode_latent_batch(self.sd_model, samples, target_device=devices.cpu, check_for_nans=True)
+        decoded_samples = decode_latent_batch(
+            self.sd_model, samples, target_device=devices.cpu, check_for_nans=True
+        )
 
         self.is_hr_pass = False
         return decoded_samples
@@ -1477,10 +2027,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         if not self.enable_hr:
             return
 
-        if self.hr_prompt == '':
+        if self.hr_prompt == "":
             self.hr_prompt = self.prompt
 
-        if self.hr_negative_prompt == '':
+        if self.hr_negative_prompt == "":
             self.hr_negative_prompt = self.negative_prompt
 
         if isinstance(self.hr_prompt, list):
@@ -1491,24 +2041,55 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         if isinstance(self.hr_negative_prompt, list):
             self.all_hr_negative_prompts = self.hr_negative_prompt
         else:
-            self.all_hr_negative_prompts = self.batch_size * self.n_iter * [self.hr_negative_prompt]
+            self.all_hr_negative_prompts = (
+                self.batch_size * self.n_iter * [self.hr_negative_prompt]
+            )
 
-        self.all_hr_prompts = [shared.prompt_styles.apply_styles_to_prompt(x, self.styles) for x in self.all_hr_prompts]
-        self.all_hr_negative_prompts = [shared.prompt_styles.apply_negative_styles_to_prompt(x, self.styles) for x in self.all_hr_negative_prompts]
+        self.all_hr_prompts = [
+            shared.prompt_styles.apply_styles_to_prompt(x, self.styles)
+            for x in self.all_hr_prompts
+        ]
+        self.all_hr_negative_prompts = [
+            shared.prompt_styles.apply_negative_styles_to_prompt(x, self.styles)
+            for x in self.all_hr_negative_prompts
+        ]
 
     def calculate_hr_conds(self):
         if self.hr_c is not None:
             return
 
-        hr_prompts = prompt_parser.SdConditioning(self.hr_prompts, width=self.hr_upscale_to_x, height=self.hr_upscale_to_y)
-        hr_negative_prompts = prompt_parser.SdConditioning(self.hr_negative_prompts, width=self.hr_upscale_to_x, height=self.hr_upscale_to_y, is_negative_prompt=True)
+        hr_prompts = prompt_parser.SdConditioning(
+            self.hr_prompts, width=self.hr_upscale_to_x, height=self.hr_upscale_to_y
+        )
+        hr_negative_prompts = prompt_parser.SdConditioning(
+            self.hr_negative_prompts,
+            width=self.hr_upscale_to_x,
+            height=self.hr_upscale_to_y,
+            is_negative_prompt=True,
+        )
 
-        sampler_config = sd_samplers.find_sampler_config(self.hr_sampler_name or self.sampler_name)
+        sampler_config = sd_samplers.find_sampler_config(
+            self.hr_sampler_name or self.sampler_name
+        )
         steps = self.hr_second_pass_steps or self.steps
         total_steps = sampler_config.total_steps(steps) if sampler_config else steps
 
-        self.hr_uc = self.get_conds_with_caching(prompt_parser.get_learned_conditioning, hr_negative_prompts, self.firstpass_steps, [self.cached_hr_uc, self.cached_uc], self.hr_extra_network_data, total_steps)
-        self.hr_c = self.get_conds_with_caching(prompt_parser.get_multicond_learned_conditioning, hr_prompts, self.firstpass_steps, [self.cached_hr_c, self.cached_c], self.hr_extra_network_data, total_steps)
+        self.hr_uc = self.get_conds_with_caching(
+            prompt_parser.get_learned_conditioning,
+            hr_negative_prompts,
+            self.firstpass_steps,
+            [self.cached_hr_uc, self.cached_uc],
+            self.hr_extra_network_data,
+            total_steps,
+        )
+        self.hr_c = self.get_conds_with_caching(
+            prompt_parser.get_multicond_learned_conditioning,
+            hr_prompts,
+            self.firstpass_steps,
+            [self.cached_hr_c, self.cached_c],
+            self.hr_extra_network_data,
+            total_steps,
+        )
 
     def setup_conds(self):
         if self.is_hr_pass:
@@ -1526,7 +2107,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             if shared.opts.hires_fix_use_firstpass_conds:
                 self.calculate_hr_conds()
 
-            elif lowvram.is_enabled(shared.sd_model) and shared.sd_model.sd_checkpoint_info == sd_models.select_checkpoint():  # if in lowvram mode, we need to calculate conds right away, before the cond NN is unloaded
+            elif (
+                lowvram.is_enabled(shared.sd_model)
+                and shared.sd_model.sd_checkpoint_info == sd_models.select_checkpoint()
+            ):  # if in lowvram mode, we need to calculate conds right away, before the cond NN is unloaded
                 with devices.autocast():
                     extra_networks.activate(self, self.hr_extra_network_data)
 
@@ -1545,10 +2129,18 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         res = super().parse_extra_network_prompts()
 
         if self.enable_hr:
-            self.hr_prompts = self.all_hr_prompts[self.iteration * self.batch_size:(self.iteration + 1) * self.batch_size]
-            self.hr_negative_prompts = self.all_hr_negative_prompts[self.iteration * self.batch_size:(self.iteration + 1) * self.batch_size]
+            self.hr_prompts = self.all_hr_prompts[
+                self.iteration * self.batch_size : (self.iteration + 1)
+                * self.batch_size
+            ]
+            self.hr_negative_prompts = self.all_hr_negative_prompts[
+                self.iteration * self.batch_size : (self.iteration + 1)
+                * self.batch_size
+            ]
 
-            self.hr_prompts, self.hr_extra_network_data = extra_networks.parse_prompts(self.hr_prompts)
+            self.hr_prompts, self.hr_extra_network_data = extra_networks.parse_prompts(
+                self.hr_prompts
+            )
 
         return res
 
@@ -1562,7 +2154,6 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     mask: Any = None
     mask_blur_x: int = 4
     mask_blur_y: int = 4
-    mask_blur: int = None
     mask_round: bool = True
     inpainting_fill: int = 0
     inpaint_full_res: bool = True
@@ -1585,7 +2176,11 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
         self.image_mask = self.mask
         self.mask = None
-        self.initial_noise_multiplier = opts.initial_noise_multiplier if self.initial_noise_multiplier is None else self.initial_noise_multiplier
+        self.initial_noise_multiplier = (
+            opts.initial_noise_multiplier
+            if self.initial_noise_multiplier is None
+            else self.initial_noise_multiplier
+        )
 
     @property
     def mask_blur(self):
@@ -1602,7 +2197,9 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
     def init(self, all_prompts, all_seeds, all_subseeds):
         self.extra_generation_params["Denoising strength"] = self.denoising_strength
 
-        self.image_cfg_scale: float = self.image_cfg_scale if shared.sd_model.cond_stage_key == "edit" else None
+        self.image_cfg_scale: float = (
+            self.image_cfg_scale if shared.sd_model.cond_stage_key == "edit" else None
+        )
 
         self.sampler = sd_samplers.create_sampler(self.sampler_name, self.sd_model)
         crop_region = None
@@ -1635,16 +2232,22 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
             if self.inpaint_full_res:
                 self.mask_for_overlay = image_mask
-                mask = image_mask.convert('L')
-                crop_region = masking.get_crop_region_v2(mask, self.inpaint_full_res_padding)
+                mask = image_mask.convert("L")
+                crop_region = masking.get_crop_region_v2(
+                    mask, self.inpaint_full_res_padding
+                )
                 if crop_region:
-                    crop_region = masking.expand_crop_region(crop_region, self.width, self.height, mask.width, mask.height)
+                    crop_region = masking.expand_crop_region(
+                        crop_region, self.width, self.height, mask.width, mask.height
+                    )
                     x1, y1, x2, y2 = crop_region
                     mask = mask.crop(crop_region)
                     image_mask = images.resize_image(2, mask, self.width, self.height)
-                    self.paste_to = (x1, y1, x2-x1, y2-y1)
+                    self.paste_to = (x1, y1, x2 - x1, y2 - y1)
                     self.extra_generation_params["Inpaint area"] = "Only masked"
-                    self.extra_generation_params["Masked area padding"] = self.inpaint_full_res_padding
+                    self.extra_generation_params["Masked area padding"] = (
+                        self.inpaint_full_res_padding
+                    )
                 else:
                     crop_region = None
                     image_mask = None
@@ -1654,38 +2257,60 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                     model_hijack.comments.append(massage)
                     logging.info(massage)
             else:
-                image_mask = images.resize_image(self.resize_mode, image_mask, self.width, self.height)
+                image_mask = images.resize_image(
+                    self.resize_mode, image_mask, self.width, self.height
+                )
                 np_mask = np.array(image_mask)
-                np_mask = np.clip((np_mask.astype(np.float32)) * 2, 0, 255).astype(np.uint8)
+                np_mask = np.clip((np_mask.astype(np.float32)) * 2, 0, 255).astype(
+                    np.uint8
+                )
                 self.mask_for_overlay = Image.fromarray(np_mask)
 
             self.overlay_images = []
 
         latent_mask = self.latent_mask if self.latent_mask is not None else image_mask
 
-        add_color_corrections = opts.img2img_color_correction and self.color_corrections is None
+        add_color_corrections = (
+            opts.img2img_color_correction and self.color_corrections is None
+        )
         if add_color_corrections:
             self.color_corrections = []
         imgs = []
         for img in self.init_images:
-
             # Save init image
             if opts.save_init_img:
                 self.init_img_hash = hashlib.md5(img.tobytes()).hexdigest()
-                images.save_image(img, path=opts.outdir_init_images, basename=None, forced_filename=self.init_img_hash, save_to_dirs=False, existing_info=img.info)
+                images.save_image(
+                    img,
+                    path=opts.outdir_init_images,
+                    basename=None,
+                    forced_filename=self.init_img_hash,
+                    save_to_dirs=False,
+                    existing_info=img.info,
+                )
 
             image = images.flatten(img, opts.img2img_background_color)
 
             if crop_region is None and self.resize_mode != 3:
-                image = images.resize_image(self.resize_mode, image, self.width, self.height)
+                image = images.resize_image(
+                    self.resize_mode, image, self.width, self.height
+                )
 
             if image_mask is not None:
                 if self.mask_for_overlay.size != (image.width, image.height):
-                    self.mask_for_overlay = images.resize_image(self.resize_mode, self.mask_for_overlay, image.width, image.height)
-                image_masked = Image.new('RGBa', (image.width, image.height))
-                image_masked.paste(image.convert("RGBA").convert("RGBa"), mask=ImageOps.invert(self.mask_for_overlay.convert('L')))
+                    self.mask_for_overlay = images.resize_image(
+                        self.resize_mode,
+                        self.mask_for_overlay,
+                        image.width,
+                        image.height,
+                    )
+                image_masked = Image.new("RGBa", (image.width, image.height))
+                image_masked.paste(
+                    image.convert("RGBA").convert("RGBa"),
+                    mask=ImageOps.invert(self.mask_for_overlay.convert("L")),
+                )
 
-                self.overlay_images.append(image_masked.convert('RGBA'))
+                self.overlay_images.append(image_masked.convert("RGBA"))
 
             # crop_region is not None if we are doing inpaint full res
             if crop_region is not None:
@@ -1697,7 +2322,7 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                     image = masking.fill(image, latent_mask)
 
                     if self.inpainting_fill == 0:
-                        self.extra_generation_params["Masked content"] = 'fill'
+                        self.extra_generation_params["Masked content"] = "fill"
 
             if add_color_corrections:
                 self.color_corrections.append(setup_color_correction(image))
@@ -1708,7 +2333,9 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             imgs.append(image)
 
         if len(imgs) == 1:
-            batch_images = np.expand_dims(imgs[0], axis=0).repeat(self.batch_size, axis=0)
+            batch_images = np.expand_dims(imgs[0], axis=0).repeat(
+                self.batch_size, axis=0
+            )
             if self.overlay_images is not None:
                 self.overlay_images = self.overlay_images * self.batch_size
 
@@ -1719,48 +2346,79 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
             self.batch_size = len(imgs)
             batch_images = np.array(imgs)
         else:
-            raise RuntimeError(f"bad number of images passed: {len(imgs)}; expecting {self.batch_size} or less")
+            raise RuntimeError(
+                f"bad number of images passed: {len(imgs)}; expecting {self.batch_size} or less"
+            )
 
         image = torch.from_numpy(batch_images)
         image = image.to(shared.device, dtype=devices.dtype_vae)
 
-        if opts.sd_vae_encode_method != 'Full':
-            self.extra_generation_params['VAE Encoder'] = opts.sd_vae_encode_method
+        if opts.sd_vae_encode_method != "Full":
+            self.extra_generation_params["VAE Encoder"] = opts.sd_vae_encode_method
 
-        self.init_latent = images_tensor_to_samples(image, approximation_indexes.get(opts.sd_vae_encode_method), self.sd_model)
+        self.init_latent = images_tensor_to_samples(
+            image, approximation_indexes.get(opts.sd_vae_encode_method), self.sd_model
+        )
         devices.torch_gc()
 
         if self.resize_mode == 3:
-            self.init_latent = torch.nn.functional.interpolate(self.init_latent, size=(self.height // opt_f, self.width // opt_f), mode="bilinear")
+            self.init_latent = torch.nn.functional.interpolate(
+                self.init_latent,
+                size=(self.height // opt_f, self.width // opt_f),
+                mode="bilinear",
+            )
 
         if image_mask is not None:
             init_mask = latent_mask
-            latmask = init_mask.convert('RGB').resize((self.init_latent.shape[3], self.init_latent.shape[2]))
+            latmask = init_mask.convert("RGB").resize(
+                (self.init_latent.shape[3], self.init_latent.shape[2])
+            )
             latmask = np.moveaxis(np.array(latmask, dtype=np.float32), 2, 0) / 255
             latmask = latmask[0]
             if self.mask_round:
                 latmask = np.around(latmask)
             latmask = np.tile(latmask[None], (self.init_latent.shape[1], 1, 1))
 
-            self.mask = torch.asarray(1.0 - latmask).to(shared.device).type(devices.dtype)
+            self.mask = (
+                torch.asarray(1.0 - latmask).to(shared.device).type(devices.dtype)
+            )
             self.nmask = torch.asarray(latmask).to(shared.device).type(devices.dtype)
 
             # this needs to be fixed to be done in sample() using actual seeds for batches
             if self.inpainting_fill == 2:
-                self.init_latent = self.init_latent * self.mask + create_random_tensors(self.init_latent.shape[1:], all_seeds[0:self.init_latent.shape[0]]) * self.nmask
-                self.extra_generation_params["Masked content"] = 'latent noise'
+                self.init_latent = (
+                    self.init_latent * self.mask
+                    + create_random_tensors(
+                        self.init_latent.shape[1:],
+                        all_seeds[0 : self.init_latent.shape[0]],
+                    )
+                    * self.nmask
+                )
+                self.extra_generation_params["Masked content"] = "latent noise"
 
             elif self.inpainting_fill == 3:
                 self.init_latent = self.init_latent * self.mask
-                self.extra_generation_params["Masked content"] = 'latent nothing'
+                self.extra_generation_params["Masked content"] = "latent nothing"
 
-        self.image_conditioning = self.img2img_image_conditioning(image * 2 - 1, self.init_latent, image_mask, self.mask_round)
+        self.image_conditioning = self.img2img_image_conditioning(
+            image * 2 - 1, self.init_latent, image_mask, self.mask_round
+        )
 
-    def sample(self, conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
+    def sample(
+        self,
+        conditioning,
+        unconditional_conditioning,
+        seeds,
+        subseeds,
+        subseed_strength,
+        prompts,
+    ):
         x = self.rng.next()
 
         if self.initial_noise_multiplier != 1.0:
-            self.extra_generation_params["Noise multiplier"] = self.initial_noise_multiplier
+            self.extra_generation_params["Noise multiplier"] = (
+                self.initial_noise_multiplier
+            )
             x *= self.initial_noise_multiplier
 
         if self.scripts is not None:
@@ -1769,15 +2427,24 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
                 x=self.init_latent,
                 noise=x,
                 c=conditioning,
-                uc=unconditional_conditioning
+                uc=unconditional_conditioning,
             )
-        samples = self.sampler.sample_img2img(self, self.init_latent, x, conditioning, unconditional_conditioning, image_conditioning=self.image_conditioning)
+        samples = self.sampler.sample_img2img(
+            self,
+            self.init_latent,
+            x,
+            conditioning,
+            unconditional_conditioning,
+            image_conditioning=self.image_conditioning,
+        )
 
         if self.mask is not None:
             blended_samples = samples * self.nmask + self.init_latent * self.mask
 
             if self.scripts is not None:
-                mba = scripts.MaskBlendArgs(samples, self.nmask, self.init_latent, self.mask, blended_samples)
+                mba = scripts.MaskBlendArgs(
+                    samples, self.nmask, self.init_latent, self.mask, blended_samples
+                )
                 self.scripts.on_mask_blend(self, mba)
                 blended_samples = mba.blended_latent
 
@@ -1789,4 +2456,12 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         return samples
 
     def get_token_merging_ratio(self, for_hr=False):
-        return self.token_merging_ratio or ("token_merging_ratio" in self.override_settings and opts.token_merging_ratio) or opts.token_merging_ratio_img2img or opts.token_merging_ratio
+        return (
+            self.token_merging_ratio
+            or (
+                "token_merging_ratio" in self.override_settings
+                and opts.token_merging_ratio
+            )
+            or opts.token_merging_ratio_img2img
+            or opts.token_merging_ratio
+        )

--- a/modules/processing_scripts/comments.py
+++ b/modules/processing_scripts/comments.py
@@ -3,8 +3,8 @@ import re
 
 
 def strip_comments(text):
-    text = re.sub('(^|\n)#[^\n]*(\n|$)', '\n', text)  # while line comment
-    text = re.sub('#[^\n]*(\n|$)', '\n', text)  # in the middle of the line comment
+    text = re.sub("(^|\n)#[^\n]*(\n|$)", "\n", text)  # while line comment
+    text = re.sub("#[^\n]*(\n|$)", "\n", text)  # in the middle of the line comment
 
     return text
 
@@ -26,9 +26,11 @@ class ScriptStripComments(scripts.Script):
         p.main_prompt = strip_comments(p.main_prompt)
         p.main_negative_prompt = strip_comments(p.main_negative_prompt)
 
-        if getattr(p, 'enable_hr', False):
+        if getattr(p, "enable_hr", False):
             p.all_hr_prompts = [strip_comments(x) for x in p.all_hr_prompts]
-            p.all_hr_negative_prompts = [strip_comments(x) for x in p.all_hr_negative_prompts]
+            p.all_hr_negative_prompts = [
+                strip_comments(x) for x in p.all_hr_negative_prompts
+            ]
 
             p.hr_prompt = strip_comments(p.hr_prompt)
             p.hr_negative_prompt = strip_comments(p.hr_negative_prompt)
@@ -44,6 +46,13 @@ def before_token_counter(params: script_callbacks.BeforeTokenCounterParams):
 script_callbacks.on_before_token_counter(before_token_counter)
 
 
-shared.options_templates.update(shared.options_section(('sd', "Stable Diffusion", "sd"), {
-    "enable_prompt_comments": shared.OptionInfo(True, "Enable comments").info("Use # anywhere in the prompt to hide the text between # and the end of the line from the generation."),
-}))
+shared.options_templates.update(
+    shared.options_section(
+        ("sd", "Stable Diffusion", "sd"),
+        {
+            "enable_prompt_comments": shared.OptionInfo(True, "Enable comments").info(
+                "Use # anywhere in the prompt to hide the text between # and the end of the line from the generation."
+            ),
+        },
+    )
+)

--- a/modules/processing_scripts/refiner.py
+++ b/modules/processing_scripts/refiner.py
@@ -20,21 +20,46 @@ class ScriptRefiner(scripts.ScriptBuiltinUI):
         return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
-        with InputAccordion(False, label="Refiner", elem_id=self.elem_id("enable")) as enable_refiner:
+        with InputAccordion(
+            False, label="Refiner", elem_id=self.elem_id("enable")
+        ) as enable_refiner:
             with gr.Row():
-                refiner_checkpoint = gr.Dropdown(label='Checkpoint', elem_id=self.elem_id("checkpoint"), choices=sd_models.checkpoint_tiles(), value='', tooltip="switch to another model in the middle of generation")
-                create_refresh_button(refiner_checkpoint, sd_models.list_models, lambda: {"choices": sd_models.checkpoint_tiles()}, self.elem_id("checkpoint_refresh"))
+                refiner_checkpoint = gr.Dropdown(
+                    label="Checkpoint",
+                    elem_id=self.elem_id("checkpoint"),
+                    choices=sd_models.checkpoint_tiles(),
+                    value="",
+                    tooltip="switch to another model in the middle of generation",
+                )
+                create_refresh_button(
+                    refiner_checkpoint,
+                    sd_models.list_models,
+                    lambda: {"choices": sd_models.checkpoint_tiles()},
+                    self.elem_id("checkpoint_refresh"),
+                )
 
-                refiner_switch_at = gr.Slider(value=0.8, label="Switch at", minimum=0.01, maximum=1.0, step=0.01, elem_id=self.elem_id("switch_at"), tooltip="fraction of sampling steps when the switch to refiner model should happen; 1=never, 0.5=switch in the middle of generation")
+                refiner_switch_at = gr.Slider(
+                    value=0.8,
+                    label="Switch at",
+                    minimum=0.01,
+                    maximum=1.0,
+                    step=0.01,
+                    elem_id=self.elem_id("switch_at"),
+                    tooltip="fraction of sampling steps when the switch to refiner model should happen; 1=never, 0.5=switch in the middle of generation",
+                )
 
         def lookup_checkpoint(title):
             info = sd_models.get_closet_checkpoint_match(title)
             return None if info is None else info.title
 
         self.infotext_fields = [
-            PasteField(enable_refiner, lambda d: 'Refiner' in d),
-            PasteField(refiner_checkpoint, lambda d: lookup_checkpoint(d.get('Refiner')), api="refiner_checkpoint"),
-            PasteField(refiner_switch_at, 'Refiner switch at', api="refiner_switch_at"),
+            PasteField(enable_refiner, lambda d: "Refiner" in d),
+            PasteField(
+                refiner_checkpoint,
+                lambda d: lookup_checkpoint(d.get("Refiner")),
+                api="refiner_checkpoint",
+            ),
+            PasteField(refiner_switch_at, "Refiner switch at", api="refiner_switch_at"),
         ]
 
         return enable_refiner, refiner_checkpoint, refiner_switch_at

--- a/modules/processing_scripts/sampler.py
+++ b/modules/processing_scripts/sampler.py
@@ -22,19 +22,59 @@ class ScriptSampler(scripts.ScriptBuiltinUI):
 
         if shared.opts.samplers_in_dropdown:
             with FormRow(elem_id=f"sampler_selection_{self.tabname}"):
-                self.sampler_name = gr.Dropdown(label='Sampling method', elem_id=f"{self.tabname}_sampling", choices=sampler_names, value=sampler_names[0])
-                self.scheduler = gr.Dropdown(label='Schedule type', elem_id=f"{self.tabname}_scheduler", choices=scheduler_names, value=scheduler_names[0])
-                self.steps = gr.Slider(minimum=1, maximum=150, step=1, elem_id=f"{self.tabname}_steps", label="Sampling steps", value=20)
+                self.sampler_name = gr.Dropdown(
+                    label="Sampling method",
+                    elem_id=f"{self.tabname}_sampling",
+                    choices=sampler_names,
+                    value=sampler_names[0],
+                )
+                self.scheduler = gr.Dropdown(
+                    label="Schedule type",
+                    elem_id=f"{self.tabname}_scheduler",
+                    choices=scheduler_names,
+                    value=scheduler_names[0],
+                )
+                self.steps = gr.Slider(
+                    minimum=1,
+                    maximum=150,
+                    step=1,
+                    elem_id=f"{self.tabname}_steps",
+                    label="Sampling steps",
+                    value=20,
+                )
         else:
             with FormGroup(elem_id=f"sampler_selection_{self.tabname}"):
-                self.steps = gr.Slider(minimum=1, maximum=150, step=1, elem_id=f"{self.tabname}_steps", label="Sampling steps", value=20)
-                self.sampler_name = gr.Radio(label='Sampling method', elem_id=f"{self.tabname}_sampling", choices=sampler_names, value=sampler_names[0])
-                self.scheduler = gr.Dropdown(label='Schedule type', elem_id=f"{self.tabname}_scheduler", choices=scheduler_names, value=scheduler_names[0])
+                self.steps = gr.Slider(
+                    minimum=1,
+                    maximum=150,
+                    step=1,
+                    elem_id=f"{self.tabname}_steps",
+                    label="Sampling steps",
+                    value=20,
+                )
+                self.sampler_name = gr.Radio(
+                    label="Sampling method",
+                    elem_id=f"{self.tabname}_sampling",
+                    choices=sampler_names,
+                    value=sampler_names[0],
+                )
+                self.scheduler = gr.Dropdown(
+                    label="Schedule type",
+                    elem_id=f"{self.tabname}_scheduler",
+                    choices=scheduler_names,
+                    value=scheduler_names[0],
+                )
 
         self.infotext_fields = [
             PasteField(self.steps, "Steps", api="steps"),
-            PasteField(self.sampler_name, sd_samplers.get_sampler_from_infotext, api="sampler_name"),
-            PasteField(self.scheduler, sd_samplers.get_scheduler_from_infotext, api="scheduler"),
+            PasteField(
+                self.sampler_name,
+                sd_samplers.get_sampler_from_infotext,
+                api="sampler_name",
+            ),
+            PasteField(
+                self.scheduler, sd_samplers.get_scheduler_from_infotext, api="scheduler"
+            ),
         ]
 
         return self.steps, self.sampler_name, self.scheduler

--- a/modules/processing_scripts/seed.py
+++ b/modules/processing_scripts/seed.py
@@ -27,46 +27,144 @@ class ScriptSeed(scripts.ScriptBuiltinUI):
     def ui(self, is_img2img):
         with gr.Row(elem_id=self.elem_id("seed_row")):
             if cmd_opts.use_textbox_seed:
-                self.seed = gr.Textbox(label='Seed', value="", elem_id=self.elem_id("seed"), min_width=100)
+                self.seed = gr.Textbox(
+                    label="Seed", value="", elem_id=self.elem_id("seed"), min_width=100
+                )
             else:
-                self.seed = gr.Number(label='Seed', value=-1, elem_id=self.elem_id("seed"), min_width=100, precision=0)
+                self.seed = gr.Number(
+                    label="Seed",
+                    value=-1,
+                    elem_id=self.elem_id("seed"),
+                    min_width=100,
+                    precision=0,
+                )
 
-            random_seed = ToolButton(ui.random_symbol, elem_id=self.elem_id("random_seed"), tooltip="Set seed to -1, which will cause a new random number to be used every time")
-            reuse_seed = ToolButton(ui.reuse_symbol, elem_id=self.elem_id("reuse_seed"), tooltip="Reuse seed from last generation, mostly useful if it was randomized")
+            random_seed = ToolButton(
+                ui.random_symbol,
+                elem_id=self.elem_id("random_seed"),
+                tooltip="Set seed to -1, which will cause a new random number to be used every time",
+            )
+            reuse_seed = ToolButton(
+                ui.reuse_symbol,
+                elem_id=self.elem_id("reuse_seed"),
+                tooltip="Reuse seed from last generation, mostly useful if it was randomized",
+            )
 
-            seed_checkbox = gr.Checkbox(label='Extra', elem_id=self.elem_id("subseed_show"), value=False)
+            seed_checkbox = gr.Checkbox(
+                label="Extra", elem_id=self.elem_id("subseed_show"), value=False
+            )
 
-        with gr.Group(visible=False, elem_id=self.elem_id("seed_extras")) as seed_extras:
+        with gr.Group(
+            visible=False, elem_id=self.elem_id("seed_extras")
+        ) as seed_extras:
             with gr.Row(elem_id=self.elem_id("subseed_row")):
-                subseed = gr.Number(label='Variation seed', value=-1, elem_id=self.elem_id("subseed"), precision=0)
-                random_subseed = ToolButton(ui.random_symbol, elem_id=self.elem_id("random_subseed"))
-                reuse_subseed = ToolButton(ui.reuse_symbol, elem_id=self.elem_id("reuse_subseed"))
-                subseed_strength = gr.Slider(label='Variation strength', value=0.0, minimum=0, maximum=1, step=0.01, elem_id=self.elem_id("subseed_strength"))
+                subseed = gr.Number(
+                    label="Variation seed",
+                    value=-1,
+                    elem_id=self.elem_id("subseed"),
+                    precision=0,
+                )
+                random_subseed = ToolButton(
+                    ui.random_symbol, elem_id=self.elem_id("random_subseed")
+                )
+                reuse_subseed = ToolButton(
+                    ui.reuse_symbol, elem_id=self.elem_id("reuse_subseed")
+                )
+                subseed_strength = gr.Slider(
+                    label="Variation strength",
+                    value=0.0,
+                    minimum=0,
+                    maximum=1,
+                    step=0.01,
+                    elem_id=self.elem_id("subseed_strength"),
+                )
 
             with gr.Row(elem_id=self.elem_id("seed_resize_from_row")):
-                seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize seed from width", value=0, elem_id=self.elem_id("seed_resize_from_w"))
-                seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize seed from height", value=0, elem_id=self.elem_id("seed_resize_from_h"))
+                seed_resize_from_w = gr.Slider(
+                    minimum=0,
+                    maximum=2048,
+                    step=8,
+                    label="Resize seed from width",
+                    value=0,
+                    elem_id=self.elem_id("seed_resize_from_w"),
+                )
+                seed_resize_from_h = gr.Slider(
+                    minimum=0,
+                    maximum=2048,
+                    step=8,
+                    label="Resize seed from height",
+                    value=0,
+                    elem_id=self.elem_id("seed_resize_from_h"),
+                )
 
-        random_seed.click(fn=None, _js="function(){setRandomSeed('" + self.elem_id("seed") + "')}", show_progress=False, inputs=[], outputs=[])
-        random_subseed.click(fn=None, _js="function(){setRandomSeed('" + self.elem_id("subseed") + "')}", show_progress=False, inputs=[], outputs=[])
+        random_seed.click(
+            fn=None,
+            _js="function(){setRandomSeed('" + self.elem_id("seed") + "')}",
+            show_progress=False,
+            inputs=[],
+            outputs=[],
+        )
+        random_subseed.click(
+            fn=None,
+            _js="function(){setRandomSeed('" + self.elem_id("subseed") + "')}",
+            show_progress=False,
+            inputs=[],
+            outputs=[],
+        )
 
-        seed_checkbox.change(lambda x: gr.update(visible=x), show_progress=False, inputs=[seed_checkbox], outputs=[seed_extras])
+        seed_checkbox.change(
+            lambda x: gr.update(visible=x),
+            show_progress=False,
+            inputs=[seed_checkbox],
+            outputs=[seed_extras],
+        )
 
         self.infotext_fields = [
             PasteField(self.seed, "Seed", api="seed"),
-            PasteField(seed_checkbox, lambda d: "Variation seed" in d or "Seed resize from-1" in d),
+            PasteField(
+                seed_checkbox,
+                lambda d: "Variation seed" in d or "Seed resize from-1" in d,
+            ),
             PasteField(subseed, "Variation seed", api="subseed"),
-            PasteField(subseed_strength, "Variation seed strength", api="subseed_strength"),
-            PasteField(seed_resize_from_w, "Seed resize from-1", api="seed_resize_from_h"),
-            PasteField(seed_resize_from_h, "Seed resize from-2", api="seed_resize_from_w"),
+            PasteField(
+                subseed_strength, "Variation seed strength", api="subseed_strength"
+            ),
+            PasteField(
+                seed_resize_from_w, "Seed resize from-1", api="seed_resize_from_h"
+            ),
+            PasteField(
+                seed_resize_from_h, "Seed resize from-2", api="seed_resize_from_w"
+            ),
         ]
 
-        self.on_after_component(lambda x: connect_reuse_seed(self.seed, reuse_seed, x.component, False), elem_id=f'generation_info_{self.tabname}')
-        self.on_after_component(lambda x: connect_reuse_seed(subseed, reuse_subseed, x.component, True), elem_id=f'generation_info_{self.tabname}')
+        self.on_after_component(
+            lambda x: connect_reuse_seed(self.seed, reuse_seed, x.component, False),
+            elem_id=f"generation_info_{self.tabname}",
+        )
+        self.on_after_component(
+            lambda x: connect_reuse_seed(subseed, reuse_subseed, x.component, True),
+            elem_id=f"generation_info_{self.tabname}",
+        )
 
-        return self.seed, seed_checkbox, subseed, subseed_strength, seed_resize_from_w, seed_resize_from_h
+        return (
+            self.seed,
+            seed_checkbox,
+            subseed,
+            subseed_strength,
+            seed_resize_from_w,
+            seed_resize_from_h,
+        )
 
-    def setup(self, p, seed, seed_checkbox, subseed, subseed_strength, seed_resize_from_w, seed_resize_from_h):
+    def setup(
+        self,
+        p,
+        seed,
+        seed_checkbox,
+        subseed,
+        subseed_strength,
+        seed_resize_from_w,
+        seed_resize_from_h,
+    ):
         p.seed = seed
 
         if seed_checkbox and subseed_strength > 0:
@@ -78,21 +176,28 @@ class ScriptSeed(scripts.ScriptBuiltinUI):
             p.seed_resize_from_h = seed_resize_from_h
 
 
-def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: gr.Textbox, is_subseed):
-    """ Connects a 'reuse (sub)seed' button's click event so that it copies last used
-        (sub)seed value from generation info the to the seed field. If copying subseed and subseed strength
-        was 0, i.e. no variation seed was used, it copies the normal seed value instead."""
+def connect_reuse_seed(
+    seed: gr.Number, reuse_seed: gr.Button, generation_info: gr.Textbox, is_subseed
+):
+    """Connects a 'reuse (sub)seed' button's click event so that it copies last used
+    (sub)seed value from generation info the to the seed field. If copying subseed and subseed strength
+    was 0, i.e. no variation seed was used, it copies the normal seed value instead."""
 
     def copy_seed(gen_info_string: str, index):
         res = -1
         try:
             gen_info = json.loads(gen_info_string)
-            infotext = gen_info.get('infotexts')[index]
+            infotext = gen_info.get("infotexts")[index]
             gen_parameters = infotext_utils.parse_generation_parameters(infotext, [])
-            res = int(gen_parameters.get('Variation seed' if is_subseed else 'Seed', -1))
+            res = int(
+                gen_parameters.get("Variation seed" if is_subseed else "Seed", -1)
+            )
         except Exception:
             if gen_info_string:
-                errors.report(f"Error retrieving seed from generation info: {gen_info_string}", exc_info=True)
+                errors.report(
+                    f"Error retrieving seed from generation info: {gen_info_string}",
+                    exc_info=True,
+                )
 
         return [res, gr.update()]
 
@@ -101,5 +206,5 @@ def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: 
         _js="(x, y) => [x, selected_gallery_index()]",
         show_progress=False,
         inputs=[generation_info, seed],
-        outputs=[seed, seed]
+        outputs=[seed, seed],
     )

--- a/modules/profiling.py
+++ b/modules/profiling.py
@@ -23,7 +23,7 @@ class Profiler:
             activities=activities,
             record_shapes=shared.opts.profiling_record_shapes,
             profile_memory=shared.opts.profiling_profile_memory,
-            with_stack=shared.opts.profiling_with_stack
+            with_stack=shared.opts.profiling_with_stack,
         )
 
     def __enter__(self):
@@ -43,4 +43,3 @@ class Profiler:
 
 def webpath():
     return ui_gradio_extensions.webpath(shared.opts.profiling_filename)
-

--- a/modules/progress.py
+++ b/modules/progress.py
@@ -37,11 +37,12 @@ def finish_task(id_task):
     if len(finished_tasks) > 16:
         finished_tasks.pop(0)
 
+
 def create_task_id(task_type):
     N = 7
-    res = ''.join(random.choices(string.ascii_uppercase +
-    string.digits, k=N))
+    res = "".join(random.choices(string.ascii_uppercase + string.digits, k=N))
     return f"task({task_type}-{res})"
+
 
 def record_results(id_task, res):
     recorded_results.append((id_task, res))
@@ -52,30 +53,61 @@ def record_results(id_task, res):
 def add_task_to_queue(id_job):
     pending_tasks[id_job] = time.time()
 
+
 class PendingTasksResponse(BaseModel):
     size: int = Field(title="Pending task size")
     tasks: List[str] = Field(title="Pending task ids")
 
+
 class ProgressRequest(BaseModel):
-    id_task: str = Field(default=None, title="Task ID", description="id of the task to get progress for")
-    id_live_preview: int = Field(default=-1, title="Live preview image ID", description="id of last received last preview image")
-    live_preview: bool = Field(default=True, title="Include live preview", description="boolean flag indicating whether to include the live preview image")
+    id_task: str = Field(
+        default=None, title="Task ID", description="id of the task to get progress for"
+    )
+    id_live_preview: int = Field(
+        default=-1,
+        title="Live preview image ID",
+        description="id of last received last preview image",
+    )
+    live_preview: bool = Field(
+        default=True,
+        title="Include live preview",
+        description="boolean flag indicating whether to include the live preview image",
+    )
 
 
 class ProgressResponse(BaseModel):
     active: bool = Field(title="Whether the task is being worked on right now")
     queued: bool = Field(title="Whether the task is in queue")
     completed: bool = Field(title="Whether the task has already finished")
-    progress: float = Field(default=None, title="Progress", description="The progress with a range of 0 to 1")
+    progress: float = Field(
+        default=None,
+        title="Progress",
+        description="The progress with a range of 0 to 1",
+    )
     eta: float = Field(default=None, title="ETA in secs")
-    live_preview: str = Field(default=None, title="Live preview image", description="Current live preview; a data: uri")
-    id_live_preview: int = Field(default=None, title="Live preview image ID", description="Send this together with next request to prevent receiving same image")
-    textinfo: str = Field(default=None, title="Info text", description="Info text used by WebUI.")
+    live_preview: str = Field(
+        default=None,
+        title="Live preview image",
+        description="Current live preview; a data: uri",
+    )
+    id_live_preview: int = Field(
+        default=None,
+        title="Live preview image ID",
+        description="Send this together with next request to prevent receiving same image",
+    )
+    textinfo: str = Field(
+        default=None, title="Info text", description="Info text used by WebUI."
+    )
 
 
 def setup_progress_api(app):
     app.add_api_route("/internal/pending-tasks", get_pending_tasks, methods=["GET"])
-    return app.add_api_route("/internal/progress", progressapi, methods=["POST"], response_model=ProgressResponse)
+    return app.add_api_route(
+        "/internal/progress",
+        progressapi,
+        methods=["POST"],
+        response_model=ProgressResponse,
+    )
 
 
 def get_pending_tasks():
@@ -95,12 +127,21 @@ def progressapi(req: ProgressRequest):
             sorted_queued = sorted(pending_tasks.keys(), key=lambda x: pending_tasks[x])
             queue_index = sorted_queued.index(req.id_task)
             textinfo = "In queue: {}/{}".format(queue_index + 1, len(sorted_queued))
-        return ProgressResponse(active=active, queued=queued, completed=completed, id_live_preview=-1, textinfo=textinfo)
+        return ProgressResponse(
+            active=active,
+            queued=queued,
+            completed=completed,
+            id_live_preview=-1,
+            textinfo=textinfo,
+        )
 
     progress = 0
 
     job_count, job_no = shared.state.job_count, shared.state.job_no
-    sampling_steps, sampling_step = shared.state.sampling_steps, shared.state.sampling_step
+    sampling_steps, sampling_step = (
+        shared.state.sampling_steps,
+        shared.state.sampling_step,
+    )
 
     if job_count > 0:
         progress += job_no / job_count
@@ -111,7 +152,11 @@ def progressapi(req: ProgressRequest):
 
     elapsed_since_start = time.time() - shared.state.time_start
     predicted_duration = elapsed_since_start / progress if progress > 0 else None
-    eta = predicted_duration - elapsed_since_start if predicted_duration is not None else None
+    eta = (
+        predicted_duration - elapsed_since_start
+        if predicted_duration is not None
+        else None
+    )
 
     live_preview = None
     id_live_preview = req.id_live_preview
@@ -133,12 +178,23 @@ def progressapi(req: ProgressRequest):
                 else:
                     save_kwargs = {}
 
-                image.save(buffered, format=opts.live_previews_image_format, **save_kwargs)
-                base64_image = base64.b64encode(buffered.getvalue()).decode('ascii')
+                image.save(
+                    buffered, format=opts.live_previews_image_format, **save_kwargs
+                )
+                base64_image = base64.b64encode(buffered.getvalue()).decode("ascii")
                 live_preview = f"data:image/{opts.live_previews_image_format};base64,{base64_image}"
                 id_live_preview = shared.state.id_live_preview
 
-    return ProgressResponse(active=active, queued=queued, completed=completed, progress=progress, eta=eta, live_preview=live_preview, id_live_preview=id_live_preview, textinfo=shared.state.textinfo)
+    return ProgressResponse(
+        active=active,
+        queued=queued,
+        completed=completed,
+        progress=progress,
+        eta=eta,
+        live_preview=live_preview,
+        id_live_preview=id_live_preview,
+        textinfo=shared.state.textinfo,
+    )
 
 
 def restore_progress(id_task):
@@ -149,4 +205,9 @@ def restore_progress(id_task):
     if res is not None:
         return res
 
-    return gr.update(), gr.update(), gr.update(), f"Couldn't restore progress for {id_task}: results either have been discarded or never were obtained"
+    return (
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        f"Couldn't restore progress for {id_task}: results either have been discarded or never were obtained",
+    )

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -25,7 +25,10 @@ plain: /([^\\\[\]():|]|\\.)+/
 %import common.SIGNED_NUMBER -> NUMBER
 """)
 
-def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=None, use_old_scheduling=False):
+
+def get_learned_conditioning_prompt_schedules(
+    prompts, base_steps, hires_steps=None, use_old_scheduling=False
+):
     """
     >>> g = lambda p: get_learned_conditioning_prompt_schedules([p], 10)[0]
     >>> g("test")
@@ -80,18 +83,18 @@ def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=N
                 s = tree.children[-2]
                 v = float(s)
                 if use_old_scheduling:
-                    v = v*steps if v<1 else v
+                    v = v * steps if v < 1 else v
                 else:
                     if "." in s:
                         v = (v - flt_offset) * steps
                     else:
-                        v = (v - int_offset)
+                        v = v - int_offset
                 tree.children[-2] = min(steps, int(v))
                 if tree.children[-2] >= 1:
                     res.append(tree.children[-2])
 
             def alternate(self, tree):
-                res.extend(range(1, steps+1))
+                res.extend(range(1, steps + 1))
 
         CollectSteps().visit(tree)
         return sorted(set(res))
@@ -101,9 +104,11 @@ def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=N
             def scheduled(self, args):
                 before, after, _, when, _ = args
                 yield before or () if step <= when else after
+
             def alternate(self, args):
                 args = ["" if not arg else arg for arg in args]
                 yield args[(step - 1) % len(args)]
+
             def start(self, args):
                 def flatten(x):
                     if isinstance(x, str):
@@ -111,12 +116,16 @@ def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=N
                     else:
                         for gen in x:
                             yield from flatten(gen)
-                return ''.join(flatten(args))
+
+                return "".join(flatten(args))
+
             def plain(self, args):
                 yield args[0].value
+
             def __default__(self, data, children, meta):
                 for child in children:
                     yield child
+
         return AtStep().transform(tree)
 
     def get_schedule(prompt):
@@ -125,6 +134,7 @@ def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=N
         except lark.exceptions.LarkError:
             if 0:
                 import traceback
+
                 traceback.print_exc()
             return [[steps, prompt]]
         return [[t, at_step(t, tree)] for t in collect_steps(steps, tree)]
@@ -133,7 +143,9 @@ def get_learned_conditioning_prompt_schedules(prompts, base_steps, hires_steps=N
     return [promptdict[prompt] for prompt in prompts]
 
 
-ScheduledPromptConditioning = namedtuple("ScheduledPromptConditioning", ["end_at_step", "cond"])
+ScheduledPromptConditioning = namedtuple(
+    "ScheduledPromptConditioning", ["end_at_step", "cond"]
+)
 
 
 class SdConditioning(list):
@@ -141,20 +153,30 @@ class SdConditioning(list):
     A list with prompts for stable diffusion's conditioner model.
     Can also specify width and height of created image - SDXL needs it.
     """
-    def __init__(self, prompts, is_negative_prompt=False, width=None, height=None, copy_from=None):
+
+    def __init__(
+        self, prompts, is_negative_prompt=False, width=None, height=None, copy_from=None
+    ):
         super().__init__()
         self.extend(prompts)
 
         if copy_from is None:
             copy_from = prompts
 
-        self.is_negative_prompt = is_negative_prompt or getattr(copy_from, 'is_negative_prompt', False)
-        self.width = width or getattr(copy_from, 'width', None)
-        self.height = height or getattr(copy_from, 'height', None)
+        self.is_negative_prompt = is_negative_prompt or getattr(
+            copy_from, "is_negative_prompt", False
+        )
+        self.width = width or getattr(copy_from, "width", None)
+        self.height = height or getattr(copy_from, "height", None)
 
 
-
-def get_learned_conditioning(model, prompts: SdConditioning | list[str], steps, hires_steps=None, use_old_scheduling=False):
+def get_learned_conditioning(
+    model,
+    prompts: SdConditioning | list[str],
+    steps,
+    hires_steps=None,
+    use_old_scheduling=False,
+):
     """converts a list of prompts into a list of prompt schedules - each schedule is a list of ScheduledPromptConditioning, specifying the comdition (cond),
     and the sampling step at which this condition is to be replaced by the next one.
 
@@ -174,11 +196,12 @@ def get_learned_conditioning(model, prompts: SdConditioning | list[str], steps, 
     """
     res = []
 
-    prompt_schedules = get_learned_conditioning_prompt_schedules(prompts, steps, hires_steps, use_old_scheduling)
+    prompt_schedules = get_learned_conditioning_prompt_schedules(
+        prompts, steps, hires_steps, use_old_scheduling
+    )
     cache = {}
 
     for prompt, prompt_schedule in zip(prompts, prompt_schedules):
-
         cached = cache.get(prompt, None)
         if cached is not None:
             res.append(cached)
@@ -245,11 +268,15 @@ class ComposableScheduledPromptConditioning:
 
 class MulticondLearnedConditioning:
     def __init__(self, shape, batch):
-        self.shape: tuple = shape  # the shape field is needed to send this object to DDIM/PLMS
+        self.shape: tuple = (
+            shape  # the shape field is needed to send this object to DDIM/PLMS
+        )
         self.batch: list[list[ComposableScheduledPromptConditioning]] = batch
 
 
-def get_multicond_learned_conditioning(model, prompts, steps, hires_steps=None, use_old_scheduling=False) -> MulticondLearnedConditioning:
+def get_multicond_learned_conditioning(
+    model, prompts, steps, hires_steps=None, use_old_scheduling=False
+) -> MulticondLearnedConditioning:
     """same as get_learned_conditioning, but returns a list of ScheduledPromptConditioning along with the weight objects for each prompt.
     For each prompt, the list is obtained by splitting the prompt using the AND separator.
 
@@ -258,11 +285,18 @@ def get_multicond_learned_conditioning(model, prompts, steps, hires_steps=None, 
 
     res_indexes, prompt_flat_list, prompt_indexes = get_multicond_prompt_list(prompts)
 
-    learned_conditioning = get_learned_conditioning(model, prompt_flat_list, steps, hires_steps, use_old_scheduling)
+    learned_conditioning = get_learned_conditioning(
+        model, prompt_flat_list, steps, hires_steps, use_old_scheduling
+    )
 
     res = []
     for indexes in res_indexes:
-        res.append([ComposableScheduledPromptConditioning(learned_conditioning[i], weight) for i, weight in indexes])
+        res.append(
+            [
+                ComposableScheduledPromptConditioning(learned_conditioning[i], weight)
+                for i, weight in indexes
+            ]
+        )
 
     return MulticondLearnedConditioning(shape=(len(prompts),), batch=res)
 
@@ -283,10 +317,17 @@ def reconstruct_cond_batch(c: list[list[ScheduledPromptConditioning]], current_s
 
     if is_dict:
         dict_cond = param
-        res = {k: torch.zeros((len(c),) + param.shape, device=param.device, dtype=param.dtype) for k, param in dict_cond.items()}
-        res = DictWithShape(res, (len(c),) + dict_cond['crossattn'].shape)
+        res = {
+            k: torch.zeros(
+                (len(c),) + param.shape, device=param.device, dtype=param.dtype
+            )
+            for k, param in dict_cond.items()
+        }
+        res = DictWithShape(res, (len(c),) + dict_cond["crossattn"].shape)
     else:
-        res = torch.zeros((len(c),) + param.shape, device=param.device, dtype=param.dtype)
+        res = torch.zeros(
+            (len(c),) + param.shape, device=param.device, dtype=param.dtype
+        )
 
     for i, cond_schedule in enumerate(c):
         target_index = 0
@@ -311,11 +352,12 @@ def stack_conds(tensors):
     for i in range(len(tensors)):
         if tensors[i].shape[0] != token_count:
             last_vector = tensors[i][-1:]
-            last_vector_repeated = last_vector.repeat([token_count - tensors[i].shape[0], 1])
+            last_vector_repeated = last_vector.repeat(
+                [token_count - tensors[i].shape[0], 1]
+            )
             tensors[i] = torch.vstack([tensors[i], last_vector_repeated])
 
     return torch.stack(tensors)
-
 
 
 def reconstruct_multicond_batch(c: MulticondLearnedConditioning, current_step):
@@ -342,14 +384,15 @@ def reconstruct_multicond_batch(c: MulticondLearnedConditioning, current_step):
     if isinstance(tensors[0], dict):
         keys = list(tensors[0].keys())
         stacked = {k: stack_conds([x[k] for x in tensors]) for k in keys}
-        stacked = DictWithShape(stacked, stacked['crossattn'].shape)
+        stacked = DictWithShape(stacked, stacked["crossattn"].shape)
     else:
         stacked = stack_conds(tensors).to(device=param.device, dtype=param.dtype)
 
     return conds_list, stacked
 
 
-re_attention = re.compile(r"""
+re_attention = re.compile(
+    r"""
 \\\(|
 \\\)|
 \\\[|
@@ -363,9 +406,12 @@ re_attention = re.compile(r"""
 ]|
 [^\\()\[\]:]+|
 :
-""", re.X)
+""",
+    re.X,
+)
 
 re_break = re.compile(r"\s*\bBREAK\b\s*", re.S)
+
 
 def parse_prompt_attention(text):
     """
@@ -418,17 +464,17 @@ def parse_prompt_attention(text):
         text = m.group(0)
         weight = m.group(1)
 
-        if text.startswith('\\'):
+        if text.startswith("\\"):
             res.append([text[1:], 1.0])
-        elif text == '(':
+        elif text == "(":
             round_brackets.append(len(res))
-        elif text == '[':
+        elif text == "[":
             square_brackets.append(len(res))
         elif weight is not None and round_brackets:
             multiply_range(round_brackets.pop(), float(weight))
-        elif text == ')' and round_brackets:
+        elif text == ")" and round_brackets:
             multiply_range(round_brackets.pop(), round_bracket_multiplier)
-        elif text == ']' and square_brackets:
+        elif text == "]" and square_brackets:
             multiply_range(square_brackets.pop(), square_bracket_multiplier)
         else:
             parts = re.split(re_break, text)
@@ -457,8 +503,10 @@ def parse_prompt_attention(text):
 
     return res
 
+
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 else:
     import torch  # doctest faster

--- a/modules/realesrgan_model.py
+++ b/modules/realesrgan_model.py
@@ -19,7 +19,11 @@ class UpscalerRealESRGAN(Upscaler):
         for scaler in scalers:
             if scaler.local_data_path.startswith("http"):
                 filename = modelloader.friendly_name(scaler.local_data_path)
-                local_model_candidates = [local_model for local_model in local_model_paths if local_model.endswith(f"{filename}.pth")]
+                local_model_candidates = [
+                    local_model
+                    for local_model in local_model_paths
+                    if local_model.endswith(f"{filename}.pth")
+                ]
                 if local_model_candidates:
                     scaler.local_data_path = local_model_candidates[0]
 
@@ -59,7 +63,9 @@ class UpscalerRealESRGAN(Upscaler):
                         model_dir=self.model_download_path,
                     )
                 if not os.path.exists(scaler.local_data_path):
-                    raise FileNotFoundError(f"RealESRGAN data missing: {scaler.local_data_path}")
+                    raise FileNotFoundError(
+                        f"RealESRGAN data missing: {scaler.local_data_path}"
+                    )
                 return scaler
         raise ValueError(f"Unable to find model info: {path}")
 

--- a/modules/restart.py
+++ b/modules/restart.py
@@ -8,7 +8,7 @@ def is_restartable() -> bool:
     """
     Return True if the webui is restartable (i.e. there is something watching to restart it with)
     """
-    return bool(os.environ.get('SD_WEBUI_RESTART'))
+    return bool(os.environ.get("SD_WEBUI_RESTART"))
 
 
 def restart_program() -> None:

--- a/modules/rng.py
+++ b/modules/rng.py
@@ -13,8 +13,10 @@ def randn(seed, shape, generator=None):
     if shared.opts.randn_source == "NV":
         return torch.asarray((generator or nv_rng).randn(shape), device=devices.device)
 
-    if shared.opts.randn_source == "CPU" or devices.device.type == 'mps':
-        return torch.randn(shape, device=devices.cpu, generator=generator).to(devices.device)
+    if shared.opts.randn_source == "CPU" or devices.device.type == "mps":
+        return torch.randn(shape, device=devices.cpu, generator=generator).to(
+            devices.device
+        )
 
     return torch.randn(shape, device=devices.device, generator=generator)
 
@@ -28,9 +30,15 @@ def randn_local(seed, shape):
         rng = rng_philox.Generator(seed)
         return torch.asarray(rng.randn(shape), device=devices.device)
 
-    local_device = devices.cpu if shared.opts.randn_source == "CPU" or devices.device.type == 'mps' else devices.device
+    local_device = (
+        devices.cpu
+        if shared.opts.randn_source == "CPU" or devices.device.type == "mps"
+        else devices.device
+    )
     local_generator = torch.Generator(local_device).manual_seed(int(seed))
-    return torch.randn(shape, device=local_device, generator=local_generator).to(devices.device)
+    return torch.randn(shape, device=local_device, generator=local_generator).to(
+        devices.device
+    )
 
 
 def randn_like(x):
@@ -41,7 +49,7 @@ def randn_like(x):
     if shared.opts.randn_source == "NV":
         return torch.asarray(nv_rng.randn(x.shape), device=x.device, dtype=x.dtype)
 
-    if shared.opts.randn_source == "CPU" or x.device.type == 'mps':
+    if shared.opts.randn_source == "CPU" or x.device.type == "mps":
         return torch.randn_like(x, device=devices.cpu).to(x.device)
 
     return torch.randn_like(x)
@@ -55,8 +63,10 @@ def randn_without_seed(shape, generator=None):
     if shared.opts.randn_source == "NV":
         return torch.asarray((generator or nv_rng).randn(shape), device=devices.device)
 
-    if shared.opts.randn_source == "CPU" or devices.device.type == 'mps':
-        return torch.randn(shape, device=devices.cpu, generator=generator).to(devices.device)
+    if shared.opts.randn_source == "CPU" or devices.device.type == "mps":
+        return torch.randn(shape, device=devices.cpu, generator=generator).to(
+            devices.device
+        )
 
     return torch.randn(shape, device=devices.device, generator=generator)
 
@@ -76,28 +86,42 @@ def create_generator(seed):
     if shared.opts.randn_source == "NV":
         return rng_philox.Generator(seed)
 
-    device = devices.cpu if shared.opts.randn_source == "CPU" or devices.device.type == 'mps' else devices.device
+    device = (
+        devices.cpu
+        if shared.opts.randn_source == "CPU" or devices.device.type == "mps"
+        else devices.device
+    )
     generator = torch.Generator(device).manual_seed(int(seed))
     return generator
 
 
 # from https://discuss.pytorch.org/t/help-regarding-slerp-function-for-generative-model-sampling/32475/3
 def slerp(val, low, high):
-    low_norm = low/torch.norm(low, dim=1, keepdim=True)
-    high_norm = high/torch.norm(high, dim=1, keepdim=True)
-    dot = (low_norm*high_norm).sum(1)
+    low_norm = low / torch.norm(low, dim=1, keepdim=True)
+    high_norm = high / torch.norm(high, dim=1, keepdim=True)
+    dot = (low_norm * high_norm).sum(1)
 
     if dot.mean() > 0.9995:
         return low * val + high * (1 - val)
 
     omega = torch.acos(dot)
     so = torch.sin(omega)
-    res = (torch.sin((1.0-val)*omega)/so).unsqueeze(1)*low + (torch.sin(val*omega)/so).unsqueeze(1) * high
+    res = (torch.sin((1.0 - val) * omega) / so).unsqueeze(1) * low + (
+        torch.sin(val * omega) / so
+    ).unsqueeze(1) * high
     return res
 
 
 class ImageRNG:
-    def __init__(self, shape, seeds, subseeds=None, subseed_strength=0.0, seed_resize_from_h=0, seed_resize_from_w=0):
+    def __init__(
+        self,
+        shape,
+        seeds,
+        subseeds=None,
+        subseed_strength=0.0,
+        seed_resize_from_h=0,
+        seed_resize_from_w=0,
+    ):
         self.shape = tuple(map(int, shape))
         self.seeds = seeds
         self.subseeds = subseeds
@@ -110,7 +134,15 @@ class ImageRNG:
         self.is_first = True
 
     def first(self):
-        noise_shape = self.shape if self.seed_resize_from_h <= 0 or self.seed_resize_from_w <= 0 else (self.shape[0], int(self.seed_resize_from_h) // 8, int(self.seed_resize_from_w // 8))
+        noise_shape = (
+            self.shape
+            if self.seed_resize_from_h <= 0 or self.seed_resize_from_w <= 0
+            else (
+                self.shape[0],
+                int(self.seed_resize_from_h) // 8,
+                int(self.seed_resize_from_w // 8),
+            )
+        )
 
         xs = []
 
@@ -139,14 +171,16 @@ class ImageRNG:
                 dx = max(-dx, 0)
                 dy = max(-dy, 0)
 
-                x[:, ty:ty + h, tx:tx + w] = noise[:, dy:dy + h, dx:dx + w]
+                x[:, ty : ty + h, tx : tx + w] = noise[:, dy : dy + h, dx : dx + w]
                 noise = x
 
             xs.append(noise)
 
         eta_noise_seed_delta = shared.opts.eta_noise_seed_delta or 0
         if eta_noise_seed_delta:
-            self.generators = [create_generator(seed + eta_noise_seed_delta) for seed in self.seeds]
+            self.generators = [
+                create_generator(seed + eta_noise_seed_delta) for seed in self.seeds
+            ]
 
         return torch.stack(xs).to(shared.device)
 

--- a/modules/rng_philox.py
+++ b/modules/rng_philox.py
@@ -90,7 +90,9 @@ class Generator:
 
         counter = np.zeros((4, n), dtype=np.uint32)
         counter[0] = self.offset
-        counter[2] = np.arange(n, dtype=np.uint32)  # up to 2^32 numbers can be generated - if you want more you'd need to spill into counter[3]
+        counter[2] = np.arange(
+            n, dtype=np.uint32
+        )  # up to 2^32 numbers can be generated - if you want more you'd need to spill into counter[3]
         self.offset += 1
 
         key = np.empty(n, dtype=np.uint64)

--- a/modules/safe.py
+++ b/modules/safe.py
@@ -13,7 +13,12 @@ import re
 # PyTorch 1.13 and later have _TypedStorage renamed to TypedStorage
 from modules import errors
 
-TypedStorage = torch.storage.TypedStorage if hasattr(torch.storage, 'TypedStorage') else torch.storage._TypedStorage
+TypedStorage = (
+    torch.storage.TypedStorage
+    if hasattr(torch.storage, "TypedStorage")
+    else torch.storage._TypedStorage
+)
+
 
 def encode(*args):
     out = _codecs.encode(*args)
@@ -24,12 +29,14 @@ class RestrictedUnpickler(pickle.Unpickler):
     extra_handler = None
 
     def persistent_load(self, saved_id):
-        assert saved_id[0] == 'storage'
+        assert saved_id[0] == "storage"
 
         try:
             return TypedStorage(_internal=True)
         except TypeError:
-            return TypedStorage()  # PyTorch before 2.0 does not have the _internal argument
+            return (
+                TypedStorage()
+            )  # PyTorch before 2.0 does not have the _internal argument
 
     def find_class(self, module, name):
         if self.extra_handler is not None:
@@ -37,27 +44,45 @@ class RestrictedUnpickler(pickle.Unpickler):
             if res is not None:
                 return res
 
-        if module == 'collections' and name == 'OrderedDict':
+        if module == "collections" and name == "OrderedDict":
             return getattr(collections, name)
-        if module == 'torch._utils' and name in ['_rebuild_tensor_v2', '_rebuild_parameter', '_rebuild_device_tensor_from_numpy']:
+        if module == "torch._utils" and name in [
+            "_rebuild_tensor_v2",
+            "_rebuild_parameter",
+            "_rebuild_device_tensor_from_numpy",
+        ]:
             return getattr(torch._utils, name)
-        if module == 'torch' and name in ['FloatStorage', 'HalfStorage', 'IntStorage', 'LongStorage', 'DoubleStorage', 'ByteStorage', 'float32', 'BFloat16Storage']:
+        if module == "torch" and name in [
+            "FloatStorage",
+            "HalfStorage",
+            "IntStorage",
+            "LongStorage",
+            "DoubleStorage",
+            "ByteStorage",
+            "float32",
+            "BFloat16Storage",
+        ]:
             return getattr(torch, name)
-        if module == 'torch.nn.modules.container' and name in ['ParameterDict']:
+        if module == "torch.nn.modules.container" and name in ["ParameterDict"]:
             return getattr(torch.nn.modules.container, name)
-        if module == 'numpy.core.multiarray' and name in ['scalar', '_reconstruct']:
+        if module == "numpy.core.multiarray" and name in ["scalar", "_reconstruct"]:
             return getattr(numpy.core.multiarray, name)
-        if module == 'numpy' and name in ['dtype', 'ndarray']:
+        if module == "numpy" and name in ["dtype", "ndarray"]:
             return getattr(numpy, name)
-        if module == '_codecs' and name == 'encode':
+        if module == "_codecs" and name == "encode":
             return encode
-        if module == "pytorch_lightning.callbacks" and name == 'model_checkpoint':
+        if module == "pytorch_lightning.callbacks" and name == "model_checkpoint":
             import pytorch_lightning.callbacks
+
             return pytorch_lightning.callbacks.model_checkpoint
-        if module == "pytorch_lightning.callbacks.model_checkpoint" and name == 'ModelCheckpoint':
+        if (
+            module == "pytorch_lightning.callbacks.model_checkpoint"
+            and name == "ModelCheckpoint"
+        ):
             import pytorch_lightning.callbacks.model_checkpoint
+
             return pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint
-        if module == "__builtin__" and name == 'set':
+        if module == "__builtin__" and name == "set":
             return set
 
         # Forbid everything else.
@@ -65,8 +90,11 @@ class RestrictedUnpickler(pickle.Unpickler):
 
 
 # Regular expression that accepts 'dirname/version', 'dirname/byteorder', 'dirname/data.pkl', '.data/serialization_id', and 'dirname/data/<number>'
-allowed_zip_names_re = re.compile(r"^([^/]+)/((data/\d+)|version|byteorder|.data/serialization_id|(data\.pkl))$")
+allowed_zip_names_re = re.compile(
+    r"^([^/]+)/((data/\d+)|version|byteorder|.data/serialization_id|(data\.pkl))$"
+)
 data_pkl_re = re.compile(r"^([^/]+)/data\.pkl$")
+
 
 def check_zip_filenames(filename, names):
     for name in names:
@@ -78,7 +106,6 @@ def check_zip_filenames(filename, names):
 
 def check_pt(filename, extra_handler):
     try:
-
         # new pytorch format is a zip file
         with zipfile.ZipFile(filename) as z:
             check_zip_filenames(filename, z.namelist())
@@ -95,7 +122,6 @@ def check_pt(filename, extra_handler):
                 unpickler.load()
 
     except zipfile.BadZipfile:
-
         # if it's not a zip file, it's an old pytorch format, with five objects written to pickle
         with open(filename, "rb") as file:
             unpickler = RestrictedUnpickler(file)
@@ -105,7 +131,9 @@ def check_pt(filename, extra_handler):
 
 
 def load(filename, *args, **kwargs):
-    return load_with_extra(filename, *args, extra_handler=global_extra_handler, **kwargs)
+    return load_with_extra(
+        filename, *args, extra_handler=global_extra_handler, **kwargs
+    )
 
 
 def load_with_extra(filename, extra_handler=None, *args, **kwargs):
@@ -158,22 +186,22 @@ def load_with_extra(filename, extra_handler=None, *args, **kwargs):
 
 class Extra:
     """
-    A class for temporarily setting the global handler for when you can't explicitly call load_with_extra
-    (because it's not your code making the torch.load call). The intended use is like this:
+        A class for temporarily setting the global handler for when you can't explicitly call load_with_extra
+        (because it's not your code making the torch.load call). The intended use is like this:
 
-```
-import torch
-from modules import safe
+    ```
+    import torch
+    from modules import safe
 
-def handler(module, name):
-    if module == 'torch' and name in ['float64', 'float16']:
-        return getattr(torch, name)
+    def handler(module, name):
+        if module == 'torch' and name in ['float64', 'float16']:
+            return getattr(torch, name)
 
-    return None
+        return None
 
-with safe.Extra(handler):
-    x = torch.load('model.pt')
-```
+    with safe.Extra(handler):
+        x = torch.load('model.pt')
+    ```
     """
 
     def __init__(self, handler):
@@ -182,7 +210,7 @@ with safe.Extra(handler):
     def __enter__(self):
         global global_extra_handler
 
-        assert global_extra_handler is None, 'already inside an Extra() block'
+        assert global_extra_handler is None, "already inside an Extra() block"
         global_extra_handler = self.handler
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -43,7 +43,17 @@ class ExtraNoiseParams:
 
 
 class CFGDenoiserParams:
-    def __init__(self, x, image_cond, sigma, sampling_step, total_sampling_steps, text_cond, text_uncond, denoiser=None):
+    def __init__(
+        self,
+        x,
+        image_cond,
+        sigma,
+        sampling_step,
+        total_sampling_steps,
+        text_cond,
+        text_uncond,
+        denoiser=None,
+    ):
         self.x = x
         """Latent image representation in the process of being denoised"""
 
@@ -124,17 +134,17 @@ class ScriptCallback:
     name: str = "unnamed"
 
 
-def add_callback(callbacks, fun, *, name=None, category='unknown', filename=None):
+def add_callback(callbacks, fun, *, name=None, category="unknown", filename=None):
     if filename is None:
         stack = [x for x in inspect.stack() if x.filename != __file__]
-        filename = stack[0].filename if stack else 'unknown file'
+        filename = stack[0].filename if stack else "unknown file"
 
     extension = extensions.find_extension(filename)
-    extension_name = extension.canonical_name if extension else 'base'
+    extension_name = extension.canonical_name if extension else "base"
 
     callback_name = f"{extension_name}/{os.path.basename(filename)}/{category}"
     if name is not None:
-        callback_name += f'/{name}'
+        callback_name += f"/{name}"
 
     unique_callback_name = callback_name
     for index in range(1000):
@@ -142,7 +152,7 @@ def add_callback(callbacks, fun, *, name=None, category='unknown', filename=None
         if not existing:
             break
 
-        unique_callback_name = f'{callback_name}-{index+1}'
+        unique_callback_name = f"{callback_name}-{index+1}"
 
     callbacks.append(ScriptCallback(filename, fun, unique_callback_name))
 
@@ -183,8 +193,13 @@ def sort_callbacks(category, unordered_callbacks, *, enable_user_sort=True):
         callbacks = [callback_lookup[x] for x in sorted_names]
 
     if enable_user_sort:
-        for name in reversed(getattr(shared.opts, 'prioritized_callbacks_' + category, [])):
-            index = next((i for i, callback in enumerate(callbacks) if callback.name == name), None)
+        for name in reversed(
+            getattr(shared.opts, "prioritized_callbacks_" + category, [])
+        ):
+            index = next(
+                (i for i, callback in enumerate(callbacks) if callback.name == name),
+                None,
+            )
             if index is not None:
                 callbacks.insert(0, callbacks.pop(index))
 
@@ -193,7 +208,7 @@ def sort_callbacks(category, unordered_callbacks, *, enable_user_sort=True):
 
 def ordered_callbacks(category, unordered_callbacks=None, *, enable_user_sort=True):
     if unordered_callbacks is None:
-        unordered_callbacks = callback_map.get('callbacks_' + category, [])
+        unordered_callbacks = callback_map.get("callbacks_" + category, [])
 
     if not enable_user_sort:
         return sort_callbacks(category, unordered_callbacks, enable_user_sort=False)
@@ -210,7 +225,7 @@ def ordered_callbacks(category, unordered_callbacks=None, *, enable_user_sort=Tr
 
 def enumerate_callbacks():
     for category, callbacks in callback_map.items():
-        if category.startswith('callbacks_'):
+        if category.startswith("callbacks_"):
             category = category[10:]
 
         yield category, callbacks
@@ -251,162 +266,162 @@ def clear_callbacks():
 
 
 def app_started_callback(demo: Optional[Blocks], app: FastAPI):
-    for c in ordered_callbacks('app_started'):
+    for c in ordered_callbacks("app_started"):
         try:
             c.callback(demo, app)
             timer.startup_timer.record(os.path.basename(c.script))
         except Exception:
-            report_exception(c, 'app_started_callback')
+            report_exception(c, "app_started_callback")
 
 
 def app_reload_callback():
-    for c in ordered_callbacks('on_reload'):
+    for c in ordered_callbacks("on_reload"):
         try:
             c.callback()
         except Exception:
-            report_exception(c, 'callbacks_on_reload')
+            report_exception(c, "callbacks_on_reload")
 
 
 def model_loaded_callback(sd_model):
-    for c in ordered_callbacks('model_loaded'):
+    for c in ordered_callbacks("model_loaded"):
         try:
             c.callback(sd_model)
         except Exception:
-            report_exception(c, 'model_loaded_callback')
+            report_exception(c, "model_loaded_callback")
 
 
 def ui_tabs_callback():
     res = []
 
-    for c in ordered_callbacks('ui_tabs'):
+    for c in ordered_callbacks("ui_tabs"):
         try:
             res += c.callback() or []
         except Exception:
-            report_exception(c, 'ui_tabs_callback')
+            report_exception(c, "ui_tabs_callback")
 
     return res
 
 
 def ui_train_tabs_callback(params: UiTrainTabParams):
-    for c in ordered_callbacks('ui_train_tabs'):
+    for c in ordered_callbacks("ui_train_tabs"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'callbacks_ui_train_tabs')
+            report_exception(c, "callbacks_ui_train_tabs")
 
 
 def ui_settings_callback():
-    for c in ordered_callbacks('ui_settings'):
+    for c in ordered_callbacks("ui_settings"):
         try:
             c.callback()
         except Exception:
-            report_exception(c, 'ui_settings_callback')
+            report_exception(c, "ui_settings_callback")
 
 
 def before_image_saved_callback(params: ImageSaveParams):
-    for c in ordered_callbacks('before_image_saved'):
+    for c in ordered_callbacks("before_image_saved"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'before_image_saved_callback')
+            report_exception(c, "before_image_saved_callback")
 
 
 def image_saved_callback(params: ImageSaveParams):
-    for c in ordered_callbacks('image_saved'):
+    for c in ordered_callbacks("image_saved"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'image_saved_callback')
+            report_exception(c, "image_saved_callback")
 
 
 def extra_noise_callback(params: ExtraNoiseParams):
-    for c in ordered_callbacks('extra_noise'):
+    for c in ordered_callbacks("extra_noise"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'callbacks_extra_noise')
+            report_exception(c, "callbacks_extra_noise")
 
 
 def cfg_denoiser_callback(params: CFGDenoiserParams):
-    for c in ordered_callbacks('cfg_denoiser'):
+    for c in ordered_callbacks("cfg_denoiser"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'cfg_denoiser_callback')
+            report_exception(c, "cfg_denoiser_callback")
 
 
 def cfg_denoised_callback(params: CFGDenoisedParams):
-    for c in ordered_callbacks('cfg_denoised'):
+    for c in ordered_callbacks("cfg_denoised"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'cfg_denoised_callback')
+            report_exception(c, "cfg_denoised_callback")
 
 
 def cfg_after_cfg_callback(params: AfterCFGCallbackParams):
-    for c in ordered_callbacks('cfg_after_cfg'):
+    for c in ordered_callbacks("cfg_after_cfg"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'cfg_after_cfg_callback')
+            report_exception(c, "cfg_after_cfg_callback")
 
 
 def before_component_callback(component, **kwargs):
-    for c in ordered_callbacks('before_component'):
+    for c in ordered_callbacks("before_component"):
         try:
             c.callback(component, **kwargs)
         except Exception:
-            report_exception(c, 'before_component_callback')
+            report_exception(c, "before_component_callback")
 
 
 def after_component_callback(component, **kwargs):
-    for c in ordered_callbacks('after_component'):
+    for c in ordered_callbacks("after_component"):
         try:
             c.callback(component, **kwargs)
         except Exception:
-            report_exception(c, 'after_component_callback')
+            report_exception(c, "after_component_callback")
 
 
 def image_grid_callback(params: ImageGridLoopParams):
-    for c in ordered_callbacks('image_grid'):
+    for c in ordered_callbacks("image_grid"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'image_grid')
+            report_exception(c, "image_grid")
 
 
 def infotext_pasted_callback(infotext: str, params: dict[str, Any]):
-    for c in ordered_callbacks('infotext_pasted'):
+    for c in ordered_callbacks("infotext_pasted"):
         try:
             c.callback(infotext, params)
         except Exception:
-            report_exception(c, 'infotext_pasted')
+            report_exception(c, "infotext_pasted")
 
 
 def script_unloaded_callback():
-    for c in reversed(ordered_callbacks('script_unloaded')):
+    for c in reversed(ordered_callbacks("script_unloaded")):
         try:
             c.callback()
         except Exception:
-            report_exception(c, 'script_unloaded')
+            report_exception(c, "script_unloaded")
 
 
 def before_ui_callback():
-    for c in reversed(ordered_callbacks('before_ui')):
+    for c in reversed(ordered_callbacks("before_ui")):
         try:
             c.callback()
         except Exception:
-            report_exception(c, 'before_ui')
+            report_exception(c, "before_ui")
 
 
 def list_optimizers_callback():
     res = []
 
-    for c in ordered_callbacks('list_optimizers'):
+    for c in ordered_callbacks("list_optimizers"):
         try:
             c.callback(res)
         except Exception:
-            report_exception(c, 'list_optimizers')
+            report_exception(c, "list_optimizers")
 
     return res
 
@@ -414,60 +429,78 @@ def list_optimizers_callback():
 def list_unets_callback():
     res = []
 
-    for c in ordered_callbacks('list_unets'):
+    for c in ordered_callbacks("list_unets"):
         try:
             c.callback(res)
         except Exception:
-            report_exception(c, 'list_unets')
+            report_exception(c, "list_unets")
 
     return res
 
 
 def before_token_counter_callback(params: BeforeTokenCounterParams):
-    for c in ordered_callbacks('before_token_counter'):
+    for c in ordered_callbacks("before_token_counter"):
         try:
             c.callback(params)
         except Exception:
-            report_exception(c, 'before_token_counter')
+            report_exception(c, "before_token_counter")
 
 
 def remove_current_script_callbacks():
     stack = [x for x in inspect.stack() if x.filename != __file__]
-    filename = stack[0].filename if stack else 'unknown file'
-    if filename == 'unknown file':
+    filename = stack[0].filename if stack else "unknown file"
+    if filename == "unknown file":
         return
     for callback_list in callback_map.values():
         for callback_to_remove in [cb for cb in callback_list if cb.script == filename]:
             callback_list.remove(callback_to_remove)
     for ordered_callbacks_list in ordered_callbacks_map.values():
-        for callback_to_remove in [cb for cb in ordered_callbacks_list if cb.script == filename]:
+        for callback_to_remove in [
+            cb for cb in ordered_callbacks_list if cb.script == filename
+        ]:
             ordered_callbacks_list.remove(callback_to_remove)
 
 
 def remove_callbacks_for_function(callback_func):
     for callback_list in callback_map.values():
-        for callback_to_remove in [cb for cb in callback_list if cb.callback == callback_func]:
+        for callback_to_remove in [
+            cb for cb in callback_list if cb.callback == callback_func
+        ]:
             callback_list.remove(callback_to_remove)
     for ordered_callback_list in ordered_callbacks_map.values():
-        for callback_to_remove in [cb for cb in ordered_callback_list if cb.callback == callback_func]:
+        for callback_to_remove in [
+            cb for cb in ordered_callback_list if cb.callback == callback_func
+        ]:
             ordered_callback_list.remove(callback_to_remove)
 
 
 def on_app_started(callback, *, name=None):
     """register a function to be called when the webui started, the gradio `Block` component and
     fastapi `FastAPI` object are passed as the arguments"""
-    add_callback(callback_map['callbacks_app_started'], callback, name=name, category='app_started')
+    add_callback(
+        callback_map["callbacks_app_started"],
+        callback,
+        name=name,
+        category="app_started",
+    )
 
 
 def on_before_reload(callback, *, name=None):
     """register a function to be called just before the server reloads."""
-    add_callback(callback_map['callbacks_on_reload'], callback, name=name, category='on_reload')
+    add_callback(
+        callback_map["callbacks_on_reload"], callback, name=name, category="on_reload"
+    )
 
 
 def on_model_loaded(callback, *, name=None):
     """register a function to be called when the stable diffusion model is created; the model is
-    passed as an argument; this function is also called when the script is reloaded. """
-    add_callback(callback_map['callbacks_model_loaded'], callback, name=name, category='model_loaded')
+    passed as an argument; this function is also called when the script is reloaded."""
+    add_callback(
+        callback_map["callbacks_model_loaded"],
+        callback,
+        name=name,
+        category="model_loaded",
+    )
 
 
 def on_ui_tabs(callback, *, name=None):
@@ -480,20 +513,32 @@ def on_ui_tabs(callback, *, name=None):
     title is tab text displayed to user in the UI
     elem_id is HTML id for the tab
     """
-    add_callback(callback_map['callbacks_ui_tabs'], callback, name=name, category='ui_tabs')
+    add_callback(
+        callback_map["callbacks_ui_tabs"], callback, name=name, category="ui_tabs"
+    )
 
 
 def on_ui_train_tabs(callback, *, name=None):
     """register a function to be called when the UI is creating new tabs for the train tab.
     Create your new tabs with gr.Tab.
     """
-    add_callback(callback_map['callbacks_ui_train_tabs'], callback, name=name, category='ui_train_tabs')
+    add_callback(
+        callback_map["callbacks_ui_train_tabs"],
+        callback,
+        name=name,
+        category="ui_train_tabs",
+    )
 
 
 def on_ui_settings(callback, *, name=None):
     """register a function to be called before UI settings are populated; add your settings
-    by using shared.opts.add_option(shared.OptionInfo(...)) """
-    add_callback(callback_map['callbacks_ui_settings'], callback, name=name, category='ui_settings')
+    by using shared.opts.add_option(shared.OptionInfo(...))"""
+    add_callback(
+        callback_map["callbacks_ui_settings"],
+        callback,
+        name=name,
+        category="ui_settings",
+    )
 
 
 def on_before_image_saved(callback, *, name=None):
@@ -501,7 +546,12 @@ def on_before_image_saved(callback, *, name=None):
     The callback is called with one argument:
         - params: ImageSaveParams - parameters the image is to be saved with. You can change fields in this object.
     """
-    add_callback(callback_map['callbacks_before_image_saved'], callback, name=name, category='before_image_saved')
+    add_callback(
+        callback_map["callbacks_before_image_saved"],
+        callback,
+        name=name,
+        category="before_image_saved",
+    )
 
 
 def on_image_saved(callback, *, name=None):
@@ -509,7 +559,12 @@ def on_image_saved(callback, *, name=None):
     The callback is called with one argument:
         - params: ImageSaveParams - parameters the image was saved with. Changing fields in this object does nothing.
     """
-    add_callback(callback_map['callbacks_image_saved'], callback, name=name, category='image_saved')
+    add_callback(
+        callback_map["callbacks_image_saved"],
+        callback,
+        name=name,
+        category="image_saved",
+    )
 
 
 def on_extra_noise(callback, *, name=None):
@@ -517,7 +572,12 @@ def on_extra_noise(callback, *, name=None):
     The callback is called with one argument:
         - params: ExtraNoiseParams - contains noise determined by seed and latent representation of image
     """
-    add_callback(callback_map['callbacks_extra_noise'], callback, name=name, category='extra_noise')
+    add_callback(
+        callback_map["callbacks_extra_noise"],
+        callback,
+        name=name,
+        category="extra_noise",
+    )
 
 
 def on_cfg_denoiser(callback, *, name=None):
@@ -525,7 +585,12 @@ def on_cfg_denoiser(callback, *, name=None):
     The callback is called with one argument:
         - params: CFGDenoiserParams - parameters to be passed to the inner model and sampling state details.
     """
-    add_callback(callback_map['callbacks_cfg_denoiser'], callback, name=name, category='cfg_denoiser')
+    add_callback(
+        callback_map["callbacks_cfg_denoiser"],
+        callback,
+        name=name,
+        category="cfg_denoiser",
+    )
 
 
 def on_cfg_denoised(callback, *, name=None):
@@ -533,7 +598,12 @@ def on_cfg_denoised(callback, *, name=None):
     The callback is called with one argument:
         - params: CFGDenoisedParams - parameters to be passed to the inner model and sampling state details.
     """
-    add_callback(callback_map['callbacks_cfg_denoised'], callback, name=name, category='cfg_denoised')
+    add_callback(
+        callback_map["callbacks_cfg_denoised"],
+        callback,
+        name=name,
+        category="cfg_denoised",
+    )
 
 
 def on_cfg_after_cfg(callback, *, name=None):
@@ -541,7 +611,12 @@ def on_cfg_after_cfg(callback, *, name=None):
     The callback is called with one argument:
         - params: AfterCFGCallbackParams - parameters to be passed to the script for post-processing after cfg calculation.
     """
-    add_callback(callback_map['callbacks_cfg_after_cfg'], callback, name=name, category='cfg_after_cfg')
+    add_callback(
+        callback_map["callbacks_cfg_after_cfg"],
+        callback,
+        name=name,
+        category="cfg_after_cfg",
+    )
 
 
 def on_before_component(callback, *, name=None):
@@ -553,12 +628,22 @@ def on_before_component(callback, *, name=None):
     Use elem_id/label fields of kwargs to figure out which component it is.
     This can be useful to inject your own components somewhere in the middle of vanilla UI.
     """
-    add_callback(callback_map['callbacks_before_component'], callback, name=name, category='before_component')
+    add_callback(
+        callback_map["callbacks_before_component"],
+        callback,
+        name=name,
+        category="before_component",
+    )
 
 
 def on_after_component(callback, *, name=None):
     """register a function to be called after a component is created. See on_before_component for more."""
-    add_callback(callback_map['callbacks_after_component'], callback, name=name, category='after_component')
+    add_callback(
+        callback_map["callbacks_after_component"],
+        callback,
+        name=name,
+        category="after_component",
+    )
 
 
 def on_image_grid(callback, *, name=None):
@@ -566,7 +651,9 @@ def on_image_grid(callback, *, name=None):
     The callback is called with one argument:
        - params: ImageGridLoopParams - parameters to be used for grid creation. Can be modified.
     """
-    add_callback(callback_map['callbacks_image_grid'], callback, name=name, category='image_grid')
+    add_callback(
+        callback_map["callbacks_image_grid"], callback, name=name, category="image_grid"
+    )
 
 
 def on_infotext_pasted(callback, *, name=None):
@@ -575,20 +662,32 @@ def on_infotext_pasted(callback, *, name=None):
        - infotext: str - raw infotext.
        - result: dict[str, any] - parsed infotext parameters.
     """
-    add_callback(callback_map['callbacks_infotext_pasted'], callback, name=name, category='infotext_pasted')
+    add_callback(
+        callback_map["callbacks_infotext_pasted"],
+        callback,
+        name=name,
+        category="infotext_pasted",
+    )
 
 
 def on_script_unloaded(callback, *, name=None):
     """register a function to be called before the script is unloaded. Any hooks/hijacks/monkeying about that
     the script did should be reverted here"""
 
-    add_callback(callback_map['callbacks_script_unloaded'], callback, name=name, category='script_unloaded')
+    add_callback(
+        callback_map["callbacks_script_unloaded"],
+        callback,
+        name=name,
+        category="script_unloaded",
+    )
 
 
 def on_before_ui(callback, *, name=None):
     """register a function to be called before the UI is created."""
 
-    add_callback(callback_map['callbacks_before_ui'], callback, name=name, category='before_ui')
+    add_callback(
+        callback_map["callbacks_before_ui"], callback, name=name, category="before_ui"
+    )
 
 
 def on_list_optimizers(callback, *, name=None):
@@ -596,18 +695,30 @@ def on_list_optimizers(callback, *, name=None):
     The function will be called with one argument, a list, and shall add objects of type modules.sd_hijack_optimizations.SdOptimization
     to it."""
 
-    add_callback(callback_map['callbacks_list_optimizers'], callback, name=name, category='list_optimizers')
+    add_callback(
+        callback_map["callbacks_list_optimizers"],
+        callback,
+        name=name,
+        category="list_optimizers",
+    )
 
 
 def on_list_unets(callback, *, name=None):
     """register a function to be called when UI is making a list of alternative options for unet.
     The function will be called with one argument, a list, and shall add objects of type modules.sd_unet.SdUnetOption to it."""
 
-    add_callback(callback_map['callbacks_list_unets'], callback, name=name, category='list_unets')
+    add_callback(
+        callback_map["callbacks_list_unets"], callback, name=name, category="list_unets"
+    )
 
 
 def on_before_token_counter(callback, *, name=None):
     """register a function to be called when UI is counting tokens for a prompt.
     The function will be called with one argument of type BeforeTokenCounterParams, and should modify its fields if necessary."""
 
-    add_callback(callback_map['callbacks_before_token_counter'], callback, name=name, category='before_token_counter')
+    add_callback(
+        callback_map["callbacks_before_token_counter"],
+        callback,
+        name=name,
+        category="before_token_counter",
+    )

--- a/modules/script_loading.py
+++ b/modules/script_loading.py
@@ -20,7 +20,9 @@ def preload_extensions(extensions_dir, parser, extension_list=None):
     if not os.path.isdir(extensions_dir):
         return
 
-    extensions = extension_list if extension_list is not None else os.listdir(extensions_dir)
+    extensions = (
+        extension_list if extension_list is not None else os.listdir(extensions_dir)
+    )
     for dirname in sorted(extensions):
         preload_script = os.path.join(extensions_dir, dirname, "preload.py")
         if not os.path.isfile(preload_script):
@@ -28,8 +30,10 @@ def preload_extensions(extensions_dir, parser, extension_list=None):
 
         try:
             module = load_module(preload_script)
-            if hasattr(module, 'preload'):
+            if hasattr(module, "preload"):
                 module.preload(parser)
 
         except Exception:
-            errors.report(f"Error running preload() for {preload_script}", exc_info=True)
+            errors.report(
+                f"Error running preload() for {preload_script}", exc_info=True
+            )

--- a/modules/scripts.py
+++ b/modules/scripts.py
@@ -7,14 +7,34 @@ from dataclasses import dataclass
 
 import gradio as gr
 
-from modules import shared, paths, script_callbacks, extensions, script_loading, scripts_postprocessing, errors, timer, util
+from modules import (
+    shared,
+    paths,
+    script_callbacks,
+    extensions,
+    script_loading,
+    scripts_postprocessing,
+    errors,
+    timer,
+    util,
+)
 
 topological_sort = util.topological_sort
 
 AlwaysVisible = object()
 
+
 class MaskBlendArgs:
-    def __init__(self, current_latent, nmask, init_latent, mask, blended_latent, denoiser=None, sigma=None):
+    def __init__(
+        self,
+        current_latent,
+        nmask,
+        init_latent,
+        mask,
+        blended_latent,
+        denoiser=None,
+        sigma=None,
+    ):
         self.current_latent = current_latent
         self.nmask = nmask
         self.init_latent = init_latent
@@ -25,19 +45,23 @@ class MaskBlendArgs:
         self.is_final_blend = denoiser is None
         self.sigma = sigma
 
+
 class PostSampleArgs:
     def __init__(self, samples):
         self.samples = samples
 
+
 class PostprocessImageArgs:
     def __init__(self, image):
         self.image = image
+
 
 class PostProcessMaskOverlayArgs:
     def __init__(self, index, mask_for_overlay, overlay_image):
         self.index = index
         self.mask_for_overlay = mask_for_overlay
         self.overlay_image = overlay_image
+
 
 class PostprocessBatchListArgs:
     def __init__(self, images):
@@ -117,7 +141,7 @@ class Script:
          - False if the script should not be shown in UI at all
          - True if the script should be shown in UI if it's selected in the scripts dropdown
          - script.AlwaysVisible if the script should be shown in UI at all times
-         """
+        """
 
         return True
 
@@ -335,11 +359,11 @@ class Script:
         """helper function to generate id for a HTML element, constructs final id out of script name, tab and user-supplied item_id"""
 
         need_tabname = self.show(True) == self.show(False)
-        tabkind = 'img2img' if self.is_img2img else 'txt2img'
+        tabkind = "img2img" if self.is_img2img else "txt2img"
         tabname = f"{tabkind}_" if need_tabname else ""
-        title = re.sub(r'[^a-z_0-9]', '', re.sub(r'\s', '_', self.title().lower()))
+        title = re.sub(r"[^a-z_0-9]", "", re.sub(r"\s", "_", self.title().lower()))
 
-        return f'script_{tabname}{title}_{item_id}'
+        return f"script_{tabname}{title}_{item_id}"
 
     def before_hr(self, p, *args):
         """
@@ -355,9 +379,11 @@ class ScriptBuiltinUI(Script):
         """helper function to generate id for a HTML element, constructs final id out of tab and user-supplied item_id"""
 
         need_tabname = self.show(True) == self.show(False)
-        tabname = ('img2img' if self.is_img2img else 'txt2img') + "_" if need_tabname else ""
+        tabname = (
+            ("img2img" if self.is_img2img else "txt2img") + "_" if need_tabname else ""
+        )
 
-        return f'{tabname}{item_id}'
+        return f"{tabname}{item_id}"
 
     def show(self, is_img2img):
         return AlwaysVisible
@@ -378,7 +404,9 @@ ScriptFile = namedtuple("ScriptFile", ["basedir", "filename", "path"])
 
 scripts_data = []
 postprocessing_scripts_data = []
-ScriptClassData = namedtuple("ScriptClassData", ["script_class", "path", "basedir", "module"])
+ScriptClassData = namedtuple(
+    "ScriptClassData", ["script_class", "path", "basedir", "module"]
+)
 
 
 @dataclass
@@ -406,8 +434,12 @@ def list_scripts(scriptdirname, extension, *, include_extensions=True):
             if os.path.splitext(filename)[1].lower() != extension:
                 continue
 
-            script_file = ScriptFile(paths.script_path, filename, os.path.join(root_script_basedir, filename))
-            scripts[filename] = ScriptWithDependencies(filename, script_file, [], [], [])
+            script_file = ScriptFile(
+                paths.script_path, filename, os.path.join(root_script_basedir, filename)
+            )
+            scripts[filename] = ScriptWithDependencies(
+                filename, script_file, [], [], []
+            )
 
     if include_extensions:
         for ext in extensions.active():
@@ -416,15 +448,26 @@ def list_scripts(scriptdirname, extension, *, include_extensions=True):
                 if not os.path.isfile(extension_script.path):
                     continue
 
-                script_canonical_name = ("builtin/" if ext.is_builtin else "") + ext.canonical_name + "/" + extension_script.filename
+                script_canonical_name = (
+                    ("builtin/" if ext.is_builtin else "")
+                    + ext.canonical_name
+                    + "/"
+                    + extension_script.filename
+                )
                 relative_path = scriptdirname + "/" + extension_script.filename
 
                 script = ScriptWithDependencies(
                     script_canonical_name=script_canonical_name,
                     file=extension_script,
-                    requires=ext.metadata.get_script_requirements("Requires", relative_path, scriptdirname),
-                    load_before=ext.metadata.get_script_requirements("Before", relative_path, scriptdirname),
-                    load_after=ext.metadata.get_script_requirements("After", relative_path, scriptdirname),
+                    requires=ext.metadata.get_script_requirements(
+                        "Requires", relative_path, scriptdirname
+                    ),
+                    load_before=ext.metadata.get_script_requirements(
+                        "Before", relative_path, scriptdirname
+                    ),
+                    load_after=ext.metadata.get_script_requirements(
+                        "After", relative_path, scriptdirname
+                    ),
                 )
 
                 scripts[script_canonical_name] = script
@@ -457,13 +500,21 @@ def list_scripts(scriptdirname, extension, *, include_extensions=True):
 
     for script_canonical_name, script in scripts.items():
         for required_script in script.requires:
-            if required_script not in scripts and required_script not in loaded_extensions:
-                errors.report(f'Script "{script_canonical_name}" requires "{required_script}" to be loaded, but it is not.', exc_info=False)
+            if (
+                required_script not in scripts
+                and required_script not in loaded_extensions
+            ):
+                errors.report(
+                    f'Script "{script_canonical_name}" requires "{required_script}" to be loaded, but it is not.',
+                    exc_info=False,
+                )
 
         dependencies[script_canonical_name] = script.load_after
 
     ordered_scripts = topological_sort(dependencies)
-    scripts_list = [scripts[script_canonical_name].file for script_canonical_name in ordered_scripts]
+    scripts_list = [
+        scripts[script_canonical_name].file for script_canonical_name in ordered_scripts
+    ]
 
     return scripts_list
 
@@ -490,7 +541,9 @@ def load_scripts():
     postprocessing_scripts_data.clear()
     script_callbacks.clear_callbacks()
 
-    scripts_list = list_scripts("scripts", ".py") + list_scripts("modules/processing_scripts", ".py", include_extensions=False)
+    scripts_list = list_scripts("scripts", ".py") + list_scripts(
+        "modules/processing_scripts", ".py", include_extensions=False
+    )
 
     syspath = sys.path
 
@@ -500,9 +553,17 @@ def load_scripts():
                 continue
 
             if issubclass(script_class, Script):
-                scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir, module))
+                scripts_data.append(
+                    ScriptClassData(
+                        script_class, scriptfile.path, scriptfile.basedir, module
+                    )
+                )
             elif issubclass(script_class, scripts_postprocessing.ScriptPostprocessing):
-                postprocessing_scripts_data.append(ScriptClassData(script_class, scriptfile.path, scriptfile.basedir, module))
+                postprocessing_scripts_data.append(
+                    ScriptClassData(
+                        script_class, scriptfile.path, scriptfile.basedir, module
+                    )
+                )
 
     # here the scripts_list is already ordered
     # processing_script is not considered though
@@ -552,21 +613,21 @@ class ScriptRunner:
 
         self.callback_map = {}
         self.callback_names = [
-            'before_process',
-            'process',
-            'before_process_batch',
-            'after_extra_networks_activate',
-            'process_batch',
-            'postprocess',
-            'postprocess_batch',
-            'postprocess_batch_list',
-            'post_sample',
-            'on_mask_blend',
-            'postprocess_image',
-            'postprocess_maskoverlay',
-            'postprocess_image_after_composite',
-            'before_component',
-            'after_component',
+            "before_process",
+            "process",
+            "before_process_batch",
+            "after_extra_networks_activate",
+            "process_batch",
+            "postprocess",
+            "postprocess_batch",
+            "postprocess_batch_list",
+            "post_sample",
+            "on_mask_blend",
+            "postprocess_image",
+            "postprocess_maskoverlay",
+            "postprocess_image_after_composite",
+            "before_component",
+            "after_component",
         ]
 
         self.on_before_component_elem_id = {}
@@ -582,13 +643,18 @@ class ScriptRunner:
         self.alwayson_scripts.clear()
         self.selectable_scripts.clear()
 
-        auto_processing_scripts = scripts_auto_postprocessing.create_auto_preprocessing_script_data()
+        auto_processing_scripts = (
+            scripts_auto_postprocessing.create_auto_preprocessing_script_data()
+        )
 
         for script_data in auto_processing_scripts + scripts_data:
             try:
                 script = script_data.script_class()
             except Exception:
-                errors.report(f"Error # failed to initialize Script {script_data.module}: ", exc_info=True)
+                errors.report(
+                    f"Error # failed to initialize Script {script_data.module}: ",
+                    exc_info=True,
+                )
                 continue
 
             script.filename = script_data.path
@@ -632,7 +698,6 @@ class ScriptRunner:
             on_after.clear()
 
     def create_script_ui(self, script):
-
         script.args_from = len(self.inputs)
         script.args_to = len(self.inputs)
 
@@ -650,7 +715,9 @@ class ScriptRunner:
         if controls is None:
             return
 
-        script.name = wrap_call(script.title, script.filename, "title", default=script.filename).lower()
+        script.name = wrap_call(
+            script.title, script.filename, "title", default=script.filename
+        ).lower()
 
         api_args = []
 
@@ -664,9 +731,13 @@ class ScriptRunner:
                 if v is not None:
                     setattr(arg_info, field, v)
 
-            choices = getattr(control, 'choices', None)  # as of gradio 3.41, some items in choices are strings, and some are tuples where the first elem is the string
+            choices = getattr(
+                control, "choices", None
+            )  # as of gradio 3.41, some items in choices are strings, and some are tuples where the first elem is the string
             if choices is not None:
-                arg_info.choices = [x[0] if isinstance(x, tuple) else x for x in choices]
+                arg_info.choices = [
+                    x[0] if isinstance(x, tuple) else x for x in choices
+                ]
 
             api_args.append(arg_info)
 
@@ -706,13 +777,28 @@ class ScriptRunner:
         self.inputs = [None]
 
     def setup_ui(self):
-        all_titles = [wrap_call(script.title, script.filename, "title") or script.filename for script in self.scripts]
-        self.title_map = {title.lower(): script for title, script in zip(all_titles, self.scripts)}
-        self.titles = [wrap_call(script.title, script.filename, "title") or f"{script.filename} [error]" for script in self.selectable_scripts]
+        all_titles = [
+            wrap_call(script.title, script.filename, "title") or script.filename
+            for script in self.scripts
+        ]
+        self.title_map = {
+            title.lower(): script for title, script in zip(all_titles, self.scripts)
+        }
+        self.titles = [
+            wrap_call(script.title, script.filename, "title")
+            or f"{script.filename} [error]"
+            for script in self.selectable_scripts
+        ]
 
         self.setup_ui_for_section(None)
 
-        dropdown = gr.Dropdown(label="Script", elem_id="script_list", choices=["None"] + self.titles, value="None", type="index")
+        dropdown = gr.Dropdown(
+            label="Script",
+            elem_id="script_list",
+            choices=["None"] + self.titles,
+            value="None",
+            type="index",
+        )
         self.inputs[0] = dropdown
 
         self.setup_ui_for_section(None, self.selectable_scripts)
@@ -720,14 +806,18 @@ class ScriptRunner:
         def select_script(script_index):
             if script_index is None:
                 script_index = 0
-            selected_script = self.selectable_scripts[script_index - 1] if script_index>0 else None
+            selected_script = (
+                self.selectable_scripts[script_index - 1] if script_index > 0 else None
+            )
 
-            return [gr.update(visible=selected_script == s) for s in self.selectable_scripts]
+            return [
+                gr.update(visible=selected_script == s) for s in self.selectable_scripts
+            ]
 
         def init_field(title):
             """called when an initial value is set from ui-config.json to show script's UI components"""
 
-            if title == 'None':
+            if title == "None":
                 return
 
             script_index = self.titles.index(title)
@@ -738,13 +828,13 @@ class ScriptRunner:
         dropdown.change(
             fn=select_script,
             inputs=[dropdown],
-            outputs=[script.group for script in self.selectable_scripts]
+            outputs=[script.group for script in self.selectable_scripts],
         )
 
         self.script_load_ctr = 0
 
         def onload_script_visibility(params):
-            title = params.get('Script', None)
+            title = params.get("Script", None)
             if title:
                 try:
                     title_index = self.titles.index(title)
@@ -752,14 +842,21 @@ class ScriptRunner:
                     self.script_load_ctr = (self.script_load_ctr + 1) % len(self.titles)
                     return gr.update(visible=visibility)
                 except ValueError:
-                    params['Script'] = None
+                    params["Script"] = None
                     massage = f'Cannot find Script: "{title}"'
                     print(massage)
                     gr.Warning(massage)
             return gr.update(visible=False)
 
-        self.infotext_fields.append((dropdown, lambda x: gr.update(value=x.get('Script', 'None'))))
-        self.infotext_fields.extend([(script.group, onload_script_visibility) for script in self.selectable_scripts])
+        self.infotext_fields.append(
+            (dropdown, lambda x: gr.update(value=x.get("Script", "None")))
+        )
+        self.infotext_fields.extend(
+            [
+                (script.group, onload_script_visibility)
+                for script in self.selectable_scripts
+            ]
+        )
 
         self.apply_on_before_component_callbacks()
 
@@ -771,12 +868,12 @@ class ScriptRunner:
         if script_index == 0 or script_index is None:
             return None
 
-        script = self.selectable_scripts[script_index-1]
+        script = self.selectable_scripts[script_index - 1]
 
         if script is None:
             return None
 
-        script_args = args[script.args_from:script.args_to]
+        script_args = args[script.args_from : script.args_to]
         processed = script.run(p, *script_args)
 
         shared.total_tqdm.clear()
@@ -784,32 +881,44 @@ class ScriptRunner:
         return processed
 
     def list_scripts_for_method(self, method_name):
-        if method_name in ('before_component', 'after_component'):
+        if method_name in ("before_component", "after_component"):
             return self.scripts
         else:
             return self.alwayson_scripts
 
-    def create_ordered_callbacks_list(self,  method_name, *, enable_user_sort=True):
+    def create_ordered_callbacks_list(self, method_name, *, enable_user_sort=True):
         script_list = self.list_scripts_for_method(method_name)
-        category = f'script_{method_name}'
+        category = f"script_{method_name}"
         callbacks = []
 
         for script in script_list:
-            if getattr(script.__class__, method_name, None) == getattr(Script, method_name, None):
+            if getattr(script.__class__, method_name, None) == getattr(
+                Script, method_name, None
+            ):
                 continue
 
-            script_callbacks.add_callback(callbacks, script, category=category, name=script.__class__.__name__, filename=script.filename)
+            script_callbacks.add_callback(
+                callbacks,
+                script,
+                category=category,
+                name=script.__class__.__name__,
+                filename=script.filename,
+            )
 
-        return script_callbacks.sort_callbacks(category, callbacks, enable_user_sort=enable_user_sort)
+        return script_callbacks.sort_callbacks(
+            category, callbacks, enable_user_sort=enable_user_sort
+        )
 
     def ordered_callbacks(self, method_name, *, enable_user_sort=True):
         script_list = self.list_scripts_for_method(method_name)
-        category = f'script_{method_name}'
+        category = f"script_{method_name}"
 
         scrpts_len, callbacks = self.callback_map.get(category, (-1, None))
 
         if callbacks is None or scrpts_len != len(script_list):
-            callbacks = self.create_ordered_callbacks_list(method_name, enable_user_sort=enable_user_sort)
+            callbacks = self.create_ordered_callbacks_list(
+                method_name, enable_user_sort=enable_user_sort
+            )
             self.callback_map[category] = len(script_list), callbacks
 
         return callbacks
@@ -818,142 +927,189 @@ class ScriptRunner:
         return [x.callback for x in self.ordered_callbacks(method_name)]
 
     def before_process(self, p):
-        for script in self.ordered_scripts('before_process'):
+        for script in self.ordered_scripts("before_process"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.before_process(p, *script_args)
             except Exception:
-                errors.report(f"Error running before_process: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running before_process: {script.filename}", exc_info=True
+                )
 
     def process(self, p):
-        for script in self.ordered_scripts('process'):
+        for script in self.ordered_scripts("process"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.process(p, *script_args)
             except Exception:
-                errors.report(f"Error running process: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running process: {script.filename}", exc_info=True
+                )
 
     def process_before_every_sampling(self, p, **kwargs):
-        for script in self.ordered_scripts('process_before_every_sampling'):
+        for script in self.ordered_scripts("process_before_every_sampling"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.process_before_every_sampling(p, *script_args, **kwargs)
             except Exception:
-                errors.report(f"Error running process_before_every_sampling: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running process_before_every_sampling: {script.filename}",
+                    exc_info=True,
+                )
 
     def before_process_batch(self, p, **kwargs):
-        for script in self.ordered_scripts('before_process_batch'):
+        for script in self.ordered_scripts("before_process_batch"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.before_process_batch(p, *script_args, **kwargs)
             except Exception:
-                errors.report(f"Error running before_process_batch: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running before_process_batch: {script.filename}",
+                    exc_info=True,
+                )
 
     def after_extra_networks_activate(self, p, **kwargs):
-        for script in self.ordered_scripts('after_extra_networks_activate'):
+        for script in self.ordered_scripts("after_extra_networks_activate"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.after_extra_networks_activate(p, *script_args, **kwargs)
             except Exception:
-                errors.report(f"Error running after_extra_networks_activate: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running after_extra_networks_activate: {script.filename}",
+                    exc_info=True,
+                )
 
     def process_batch(self, p, **kwargs):
-        for script in self.ordered_scripts('process_batch'):
+        for script in self.ordered_scripts("process_batch"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.process_batch(p, *script_args, **kwargs)
             except Exception:
-                errors.report(f"Error running process_batch: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running process_batch: {script.filename}", exc_info=True
+                )
 
     def postprocess(self, p, processed):
-        for script in self.ordered_scripts('postprocess'):
+        for script in self.ordered_scripts("postprocess"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess(p, processed, *script_args)
             except Exception:
-                errors.report(f"Error running postprocess: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess: {script.filename}", exc_info=True
+                )
 
     def postprocess_batch(self, p, images, **kwargs):
-        for script in self.ordered_scripts('postprocess_batch'):
+        for script in self.ordered_scripts("postprocess_batch"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess_batch(p, *script_args, images=images, **kwargs)
             except Exception:
-                errors.report(f"Error running postprocess_batch: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess_batch: {script.filename}", exc_info=True
+                )
 
     def postprocess_batch_list(self, p, pp: PostprocessBatchListArgs, **kwargs):
-        for script in self.ordered_scripts('postprocess_batch_list'):
+        for script in self.ordered_scripts("postprocess_batch_list"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess_batch_list(p, pp, *script_args, **kwargs)
             except Exception:
-                errors.report(f"Error running postprocess_batch_list: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess_batch_list: {script.filename}",
+                    exc_info=True,
+                )
 
     def post_sample(self, p, ps: PostSampleArgs):
-        for script in self.ordered_scripts('post_sample'):
+        for script in self.ordered_scripts("post_sample"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.post_sample(p, ps, *script_args)
             except Exception:
-                errors.report(f"Error running post_sample: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running post_sample: {script.filename}", exc_info=True
+                )
 
     def on_mask_blend(self, p, mba: MaskBlendArgs):
-        for script in self.ordered_scripts('on_mask_blend'):
+        for script in self.ordered_scripts("on_mask_blend"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.on_mask_blend(p, mba, *script_args)
             except Exception:
-                errors.report(f"Error running post_sample: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running post_sample: {script.filename}", exc_info=True
+                )
 
     def postprocess_image(self, p, pp: PostprocessImageArgs):
-        for script in self.ordered_scripts('postprocess_image'):
+        for script in self.ordered_scripts("postprocess_image"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess_image(p, pp, *script_args)
             except Exception:
-                errors.report(f"Error running postprocess_image: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess_image: {script.filename}", exc_info=True
+                )
 
     def postprocess_maskoverlay(self, p, ppmo: PostProcessMaskOverlayArgs):
-        for script in self.ordered_scripts('postprocess_maskoverlay'):
+        for script in self.ordered_scripts("postprocess_maskoverlay"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess_maskoverlay(p, ppmo, *script_args)
             except Exception:
-                errors.report(f"Error running postprocess_image: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess_image: {script.filename}", exc_info=True
+                )
 
     def postprocess_image_after_composite(self, p, pp: PostprocessImageArgs):
-        for script in self.ordered_scripts('postprocess_image_after_composite'):
+        for script in self.ordered_scripts("postprocess_image_after_composite"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.postprocess_image_after_composite(p, pp, *script_args)
             except Exception:
-                errors.report(f"Error running postprocess_image_after_composite: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running postprocess_image_after_composite: {script.filename}",
+                    exc_info=True,
+                )
 
     def before_component(self, component, **kwargs):
-        for callback, script in self.on_before_component_elem_id.get(kwargs.get("elem_id"), []):
+        for callback, script in self.on_before_component_elem_id.get(
+            kwargs.get("elem_id"), []
+        ):
             try:
                 callback(OnComponent(component=component))
             except Exception:
-                errors.report(f"Error running on_before_component: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running on_before_component: {script.filename}",
+                    exc_info=True,
+                )
 
-        for script in self.ordered_scripts('before_component'):
+        for script in self.ordered_scripts("before_component"):
             try:
                 script.before_component(component, **kwargs)
             except Exception:
-                errors.report(f"Error running before_component: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running before_component: {script.filename}", exc_info=True
+                )
 
     def after_component(self, component, **kwargs):
-        for callback, script in self.on_after_component_elem_id.get(component.elem_id, []):
+        for callback, script in self.on_after_component_elem_id.get(
+            component.elem_id, []
+        ):
             try:
                 callback(OnComponent(component=component))
             except Exception:
-                errors.report(f"Error running on_after_component: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running on_after_component: {script.filename}",
+                    exc_info=True,
+                )
 
-        for script in self.ordered_scripts('after_component'):
+        for script in self.ordered_scripts("after_component"):
             try:
                 script.after_component(component, **kwargs)
             except Exception:
-                errors.report(f"Error running after_component: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running after_component: {script.filename}", exc_info=True
+                )
 
     def script(self, title):
         return self.title_map.get(title.lower())
@@ -977,20 +1133,22 @@ class ScriptRunner:
                     self.scripts[si].args_to = args_to
 
     def before_hr(self, p):
-        for script in self.ordered_scripts('before_hr'):
+        for script in self.ordered_scripts("before_hr"):
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.before_hr(p, *script_args)
             except Exception:
-                errors.report(f"Error running before_hr: {script.filename}", exc_info=True)
+                errors.report(
+                    f"Error running before_hr: {script.filename}", exc_info=True
+                )
 
     def setup_scrips(self, p, *, is_ui=True):
-        for script in self.ordered_scripts('setup'):
+        for script in self.ordered_scripts("setup"):
             if not is_ui and script.setup_for_ui_only:
                 continue
 
             try:
-                script_args = p.script_args[script.args_from:script.args_to]
+                script_args = p.script_args[script.args_from : script.args_to]
                 script.setup(p, *script_args)
             except Exception:
                 errors.report(f"Error running setup: {script.filename}", exc_info=True)
@@ -1012,17 +1170,23 @@ class ScriptRunner:
             raise RuntimeError(f"script {script_name} not found")
 
         for i, control in enumerate(script.controls):
-            if arg_elem_id in control.elem_id if fuzzy else arg_elem_id == control.elem_id:
+            if (
+                arg_elem_id in control.elem_id
+                if fuzzy
+                else arg_elem_id == control.elem_id
+            ):
                 index = script.args_from + i
 
                 if isinstance(args, tuple):
-                    return args[:index] + (value,) + args[index + 1:]
+                    return args[:index] + (value,) + args[index + 1 :]
                 elif isinstance(args, list):
                     args[index] = value
                     return args
                 else:
                     raise RuntimeError(f"args is not a list or tuple, but {type(args)}")
-        raise RuntimeError(f"arg_elem_id {arg_elem_id} not found in script {script_name}")
+        raise RuntimeError(
+            f"arg_elem_id {arg_elem_id} not found in script {script_name}"
+        )
 
 
 scripts_txt2img: ScriptRunner = None

--- a/modules/scripts_auto_postprocessing.py
+++ b/modules/scripts_auto_postprocessing.py
@@ -32,11 +32,27 @@ def create_auto_preprocessing_script_data():
     res = []
 
     for name in shared.opts.postprocessing_enable_in_main_ui:
-        script = next(iter([x for x in scripts.postprocessing_scripts_data if x.script_class.name == name]), None)
+        script = next(
+            iter(
+                [
+                    x
+                    for x in scripts.postprocessing_scripts_data
+                    if x.script_class.name == name
+                ]
+            ),
+            None,
+        )
         if script is None:
             continue
 
         constructor = lambda s=script: ScriptPostprocessingForMainUI(s.script_class())
-        res.append(scripts.ScriptClassData(script_class=constructor, path=script.path, basedir=script.basedir, module=script.module))
+        res.append(
+            scripts.ScriptClassData(
+                script_class=constructor,
+                path=script.path,
+                basedir=script.basedir,
+                module=script.module,
+            )
+        )
 
     return res

--- a/modules/scripts_postprocessing.py
+++ b/modules/scripts_postprocessing.py
@@ -140,6 +140,7 @@ class ScriptPostprocessingRunner:
     def scripts_in_preferred_order(self):
         if self.scripts is None:
             import modules.scripts
+
             self.initialize_scripts(modules.scripts.postprocessing_scripts_data)
 
         scripts_order = shared.opts.postprocessing_operation_order
@@ -152,8 +153,18 @@ class ScriptPostprocessingRunner:
 
             return len(self.scripts)
 
-        filtered_scripts = [script for script in self.scripts if script.name not in scripts_filter_out]
-        script_scores = {script.name: (script_score(script.name), script.order, script.name, original_index) for original_index, script in enumerate(filtered_scripts)}
+        filtered_scripts = [
+            script for script in self.scripts if script.name not in scripts_filter_out
+        ]
+        script_scores = {
+            script.name: (
+                script_score(script.name),
+                script.order,
+                script.name,
+                original_index,
+            )
+            for original_index, script in enumerate(filtered_scripts)
+        }
 
         return sorted(filtered_scripts, key=lambda x: script_scores[x.name])
 
@@ -173,7 +184,7 @@ class ScriptPostprocessingRunner:
         scripts = []
 
         for script in self.scripts_in_preferred_order():
-            script_args = args[script.args_from:script.args_to]
+            script_args = args[script.args_from : script.args_to]
 
             process_args = {}
             for (name, _component), value in zip(script.controls.items(), script_args):
@@ -193,7 +204,6 @@ class ScriptPostprocessingRunner:
             shared.state.job = script.name
 
             for single_image in all_images.copy():
-
                 if not single_image.disable_processing:
                     script.process(single_image, **process_args)
 
@@ -218,7 +228,6 @@ class ScriptPostprocessingRunner:
         for script in scripts:
             script_args_dict = scripts_args.get(script.name, None)
             if script_args_dict is not None:
-
                 for i, name in enumerate(script.controls):
                     args[script.args_from + i] = script_args_dict.get(name, None)
 
@@ -227,4 +236,3 @@ class ScriptPostprocessingRunner:
     def image_changed(self):
         for script in self.scripts_in_preferred_order():
             script.image_changed()
-

--- a/modules/sd_disable_initialization.py
+++ b/modules/sd_disable_initialization.py
@@ -61,22 +61,40 @@ class DisableInitialization(ReplaceHelper):
         def do_nothing(*args, **kwargs):
             pass
 
-        def create_model_and_transforms_without_pretrained(*args, pretrained=None, **kwargs):
+        def create_model_and_transforms_without_pretrained(
+            *args, pretrained=None, **kwargs
+        ):
             return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
 
-        def CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs):
-            res = self.CLIPTextModel_from_pretrained(None, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
+        def CLIPTextModel_from_pretrained(
+            pretrained_model_name_or_path, *model_args, **kwargs
+        ):
+            res = self.CLIPTextModel_from_pretrained(
+                None,
+                *model_args,
+                config=pretrained_model_name_or_path,
+                state_dict={},
+                **kwargs,
+            )
             res.name_or_path = pretrained_model_name_or_path
             return res
 
         def transformers_modeling_utils_load_pretrained_model(*args, **kwargs):
-            args = args[0:3] + ('/', ) + args[4:]  # resolved_archive_file; must set it to something to prevent what seems to be a bug
-            return self.transformers_modeling_utils_load_pretrained_model(*args, **kwargs)
+            args = (
+                args[0:3] + ("/",) + args[4:]
+            )  # resolved_archive_file; must set it to something to prevent what seems to be a bug
+            return self.transformers_modeling_utils_load_pretrained_model(
+                *args, **kwargs
+            )
 
         def transformers_utils_hub_get_file_from_cache(original, url, *args, **kwargs):
-
             # this file is always 404, prevent making request
-            if url == 'https://huggingface.co/openai/clip-vit-large-patch14/resolve/main/added_tokens.json' or url == 'openai/clip-vit-large-patch14' and args[0] == 'added_tokens.json':
+            if (
+                url
+                == "https://huggingface.co/openai/clip-vit-large-patch14/resolve/main/added_tokens.json"
+                or url == "openai/clip-vit-large-patch14"
+                and args[0] == "added_tokens.json"
+            ):
                 return None
 
             try:
@@ -87,26 +105,65 @@ class DisableInitialization(ReplaceHelper):
             except Exception:
                 return original(url, *args, local_files_only=False, **kwargs)
 
-        def transformers_utils_hub_get_from_cache(url, *args, local_files_only=False, **kwargs):
-            return transformers_utils_hub_get_file_from_cache(self.transformers_utils_hub_get_from_cache, url, *args, **kwargs)
+        def transformers_utils_hub_get_from_cache(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_utils_hub_get_from_cache, url, *args, **kwargs
+            )
 
-        def transformers_tokenization_utils_base_cached_file(url, *args, local_files_only=False, **kwargs):
-            return transformers_utils_hub_get_file_from_cache(self.transformers_tokenization_utils_base_cached_file, url, *args, **kwargs)
+        def transformers_tokenization_utils_base_cached_file(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_tokenization_utils_base_cached_file,
+                url,
+                *args,
+                **kwargs,
+            )
 
-        def transformers_configuration_utils_cached_file(url, *args, local_files_only=False, **kwargs):
-            return transformers_utils_hub_get_file_from_cache(self.transformers_configuration_utils_cached_file, url, *args, **kwargs)
+        def transformers_configuration_utils_cached_file(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_configuration_utils_cached_file, url, *args, **kwargs
+            )
 
-        self.replace(torch.nn.init, 'kaiming_uniform_', do_nothing)
-        self.replace(torch.nn.init, '_no_grad_normal_', do_nothing)
-        self.replace(torch.nn.init, '_no_grad_uniform_', do_nothing)
+        self.replace(torch.nn.init, "kaiming_uniform_", do_nothing)
+        self.replace(torch.nn.init, "_no_grad_normal_", do_nothing)
+        self.replace(torch.nn.init, "_no_grad_uniform_", do_nothing)
 
         if self.disable_clip:
-            self.create_model_and_transforms = self.replace(open_clip, 'create_model_and_transforms', create_model_and_transforms_without_pretrained)
-            self.CLIPTextModel_from_pretrained = self.replace(ldm.modules.encoders.modules.CLIPTextModel, 'from_pretrained', CLIPTextModel_from_pretrained)
-            self.transformers_modeling_utils_load_pretrained_model = self.replace(transformers.modeling_utils.PreTrainedModel, '_load_pretrained_model', transformers_modeling_utils_load_pretrained_model)
-            self.transformers_tokenization_utils_base_cached_file = self.replace(transformers.tokenization_utils_base, 'cached_file', transformers_tokenization_utils_base_cached_file)
-            self.transformers_configuration_utils_cached_file = self.replace(transformers.configuration_utils, 'cached_file', transformers_configuration_utils_cached_file)
-            self.transformers_utils_hub_get_from_cache = self.replace(transformers.utils.hub, 'get_from_cache', transformers_utils_hub_get_from_cache)
+            self.create_model_and_transforms = self.replace(
+                open_clip,
+                "create_model_and_transforms",
+                create_model_and_transforms_without_pretrained,
+            )
+            self.CLIPTextModel_from_pretrained = self.replace(
+                ldm.modules.encoders.modules.CLIPTextModel,
+                "from_pretrained",
+                CLIPTextModel_from_pretrained,
+            )
+            self.transformers_modeling_utils_load_pretrained_model = self.replace(
+                transformers.modeling_utils.PreTrainedModel,
+                "_load_pretrained_model",
+                transformers_modeling_utils_load_pretrained_model,
+            )
+            self.transformers_tokenization_utils_base_cached_file = self.replace(
+                transformers.tokenization_utils_base,
+                "cached_file",
+                transformers_tokenization_utils_base_cached_file,
+            )
+            self.transformers_configuration_utils_cached_file = self.replace(
+                transformers.configuration_utils,
+                "cached_file",
+                transformers_configuration_utils_cached_file,
+            )
+            self.transformers_utils_hub_get_from_cache = self.replace(
+                transformers.utils.hub,
+                "get_from_cache",
+                transformers_utils_hub_get_from_cache,
+            )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.restore()
@@ -133,10 +190,22 @@ class InitializeOnMeta(ReplaceHelper):
             x["device"] = "meta"
             return x
 
-        linear_init = self.replace(torch.nn.Linear, '__init__', lambda *args, **kwargs: linear_init(*args, **set_device(kwargs)))
-        conv2d_init = self.replace(torch.nn.Conv2d, '__init__', lambda *args, **kwargs: conv2d_init(*args, **set_device(kwargs)))
-        mha_init = self.replace(torch.nn.MultiheadAttention, '__init__', lambda *args, **kwargs: mha_init(*args, **set_device(kwargs)))
-        self.replace(torch.nn.Module, 'to', lambda *args, **kwargs: None)
+        linear_init = self.replace(
+            torch.nn.Linear,
+            "__init__",
+            lambda *args, **kwargs: linear_init(*args, **set_device(kwargs)),
+        )
+        conv2d_init = self.replace(
+            torch.nn.Conv2d,
+            "__init__",
+            lambda *args, **kwargs: conv2d_init(*args, **set_device(kwargs)),
+        )
+        mha_init = self.replace(
+            torch.nn.MultiheadAttention,
+            "__init__",
+            lambda *args, **kwargs: mha_init(*args, **set_device(kwargs)),
+        )
+        self.replace(torch.nn.Module, "to", lambda *args, **kwargs: None)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.restore()
@@ -160,10 +229,10 @@ class LoadStateDictOnMeta(ReplaceHelper):
         self.state_dict = state_dict
         self.device = device
         self.weight_dtype_conversion = weight_dtype_conversion or {}
-        self.default_dtype = self.weight_dtype_conversion.get('')
+        self.default_dtype = self.weight_dtype_conversion.get("")
 
     def get_weight_dtype(self, key):
-        key_first_term, _ = key.split('.', 1)
+        key_first_term, _ = key.split(".", 1)
         return self.weight_dtype_conversion.get(key_first_term, self.default_dtype)
 
     def __enter__(self):
@@ -188,7 +257,10 @@ class LoadStateDictOnMeta(ReplaceHelper):
 
                 if param.is_meta:
                     dtype = sd_param.dtype if sd_param is not None else param.dtype
-                    module._parameters[name] = torch.nn.parameter.Parameter(torch.zeros_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
+                    module._parameters[name] = torch.nn.parameter.Parameter(
+                        torch.zeros_like(param, device=device, dtype=dtype),
+                        requires_grad=param.requires_grad,
+                    )
 
             for name in module._buffers:
                 key = prefix + name
@@ -216,17 +288,61 @@ class LoadStateDictOnMeta(ReplaceHelper):
             """
 
             if state_dict is sd:
-                state_dict = {k: v.to(device="meta", dtype=v.dtype) for k, v in state_dict.items()}
+                state_dict = {
+                    k: v.to(device="meta", dtype=v.dtype) for k, v in state_dict.items()
+                }
 
             original(module, state_dict, strict=strict)
 
-        module_load_state_dict = self.replace(torch.nn.Module, 'load_state_dict', lambda *args, **kwargs: load_state_dict(module_load_state_dict, *args, **kwargs))
-        module_load_from_state_dict = self.replace(torch.nn.Module, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(module_load_from_state_dict, *args, **kwargs))
-        linear_load_from_state_dict = self.replace(torch.nn.Linear, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(linear_load_from_state_dict, *args, **kwargs))
-        conv2d_load_from_state_dict = self.replace(torch.nn.Conv2d, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(conv2d_load_from_state_dict, *args, **kwargs))
-        mha_load_from_state_dict = self.replace(torch.nn.MultiheadAttention, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(mha_load_from_state_dict, *args, **kwargs))
-        layer_norm_load_from_state_dict = self.replace(torch.nn.LayerNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(layer_norm_load_from_state_dict, *args, **kwargs))
-        group_norm_load_from_state_dict = self.replace(torch.nn.GroupNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(group_norm_load_from_state_dict, *args, **kwargs))
+        module_load_state_dict = self.replace(
+            torch.nn.Module,
+            "load_state_dict",
+            lambda *args, **kwargs: load_state_dict(
+                module_load_state_dict, *args, **kwargs
+            ),
+        )
+        module_load_from_state_dict = self.replace(
+            torch.nn.Module,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                module_load_from_state_dict, *args, **kwargs
+            ),
+        )
+        linear_load_from_state_dict = self.replace(
+            torch.nn.Linear,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                linear_load_from_state_dict, *args, **kwargs
+            ),
+        )
+        conv2d_load_from_state_dict = self.replace(
+            torch.nn.Conv2d,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                conv2d_load_from_state_dict, *args, **kwargs
+            ),
+        )
+        mha_load_from_state_dict = self.replace(
+            torch.nn.MultiheadAttention,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                mha_load_from_state_dict, *args, **kwargs
+            ),
+        )
+        layer_norm_load_from_state_dict = self.replace(
+            torch.nn.LayerNorm,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                layer_norm_load_from_state_dict, *args, **kwargs
+            ),
+        )
+        group_norm_load_from_state_dict = self.replace(
+            torch.nn.GroupNorm,
+            "_load_from_state_dict",
+            lambda *args, **kwargs: load_from_state_dict(
+                group_norm_load_from_state_dict, *args, **kwargs
+            ),
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.restore()

--- a/modules/sd_emphasis.py
+++ b/modules/sd_emphasis.py
@@ -25,7 +25,9 @@ class Emphasis:
 
 class EmphasisNone(Emphasis):
     name = "None"
-    description = "disable the mechanism entirely and treat (:.1.1) as literal characters"
+    description = (
+        "disable the mechanism entirely and treat (:.1.1) as literal characters"
+    )
 
 
 class EmphasisIgnore(Emphasis):
@@ -39,7 +41,9 @@ class EmphasisOriginal(Emphasis):
 
     def after_transformers(self):
         original_mean = self.z.mean()
-        self.z = self.z * self.multipliers.reshape(self.multipliers.shape + (1,)).expand(self.z.shape)
+        self.z = self.z * self.multipliers.reshape(
+            self.multipliers.shape + (1,)
+        ).expand(self.z.shape)
 
         # restoring original mean is likely not correct, but it seems to work well to prevent artifacts that happen otherwise
         new_mean = self.z.mean()
@@ -48,14 +52,20 @@ class EmphasisOriginal(Emphasis):
 
 class EmphasisOriginalNoNorm(EmphasisOriginal):
     name = "No norm"
-    description = "same as original, but without normalization (seems to work better for SDXL)"
+    description = (
+        "same as original, but without normalization (seems to work better for SDXL)"
+    )
 
     def after_transformers(self):
-        self.z = self.z * self.multipliers.reshape(self.multipliers.shape + (1,)).expand(self.z.shape)
+        self.z = self.z * self.multipliers.reshape(
+            self.multipliers.shape + (1,)
+        ).expand(self.z.shape)
 
 
 def get_current_option(emphasis_option_name):
-    return next(iter([x for x in options if x.name == emphasis_option_name]), EmphasisOriginal)
+    return next(
+        iter([x for x in options if x.name == emphasis_option_name]), EmphasisOriginal
+    )
 
 
 def get_options_descriptions():

--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -2,10 +2,25 @@ import torch
 from torch.nn.functional import silu
 from types import MethodType
 
-from modules import devices, sd_hijack_optimizations, shared, script_callbacks, errors, sd_unet, patches
+from modules import (
+    devices,
+    sd_hijack_optimizations,
+    shared,
+    script_callbacks,
+    errors,
+    sd_unet,
+    patches,
+)
 from modules.hypernetworks import hypernetwork
 from modules.shared import cmd_opts
-from modules import sd_hijack_clip, sd_hijack_open_clip, sd_hijack_unet, sd_hijack_xlmr, xlmr, xlmr_m18
+from modules import (
+    sd_hijack_clip,
+    sd_hijack_open_clip,
+    sd_hijack_unet,
+    sd_hijack_xlmr,
+    xlmr,
+    xlmr_m18,
+)
 
 import ldm.modules.attention
 import ldm.modules.diffusionmodules.model
@@ -22,12 +37,18 @@ import sgm.modules.encoders.modules
 
 attention_CrossAttention_forward = ldm.modules.attention.CrossAttention.forward
 diffusionmodules_model_nonlinearity = ldm.modules.diffusionmodules.model.nonlinearity
-diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.AttnBlock.forward
+diffusionmodules_model_AttnBlock_forward = (
+    ldm.modules.diffusionmodules.model.AttnBlock.forward
+)
 
 # new memory efficient cross attention blocks do not support hypernets and we already
 # have memory efficient cross attention anyway, so this disables SD2.0's memory efficient cross attention
-ldm.modules.attention.MemoryEfficientCrossAttention = ldm.modules.attention.CrossAttention
-ldm.modules.attention.BasicTransformerBlock.ATTENTION_MODES["softmax-xformers"] = ldm.modules.attention.CrossAttention
+ldm.modules.attention.MemoryEfficientCrossAttention = (
+    ldm.modules.attention.CrossAttention
+)
+ldm.modules.attention.BasicTransformerBlock.ATTENTION_MODES["softmax-xformers"] = (
+    ldm.modules.attention.CrossAttention
+)
 
 # silence new console spam from SD2
 ldm.modules.attention.print = shared.ldm_print
@@ -38,11 +59,25 @@ ldm.models.diffusion.ddpm.print = shared.ldm_print
 optimizers = []
 current_optimizer: sd_hijack_optimizations.SdOptimization = None
 
-ldm_patched_forward = sd_unet.create_unet_forward(ldm.modules.diffusionmodules.openaimodel.UNetModel.forward)
-ldm_original_forward = patches.patch(__file__, ldm.modules.diffusionmodules.openaimodel.UNetModel, "forward", ldm_patched_forward)
+ldm_patched_forward = sd_unet.create_unet_forward(
+    ldm.modules.diffusionmodules.openaimodel.UNetModel.forward
+)
+ldm_original_forward = patches.patch(
+    __file__,
+    ldm.modules.diffusionmodules.openaimodel.UNetModel,
+    "forward",
+    ldm_patched_forward,
+)
 
-sgm_patched_forward = sd_unet.create_unet_forward(sgm.modules.diffusionmodules.openaimodel.UNetModel.forward)
-sgm_original_forward = patches.patch(__file__, sgm.modules.diffusionmodules.openaimodel.UNetModel, "forward", sgm_patched_forward)
+sgm_patched_forward = sd_unet.create_unet_forward(
+    sgm.modules.diffusionmodules.openaimodel.UNetModel.forward
+)
+sgm_original_forward = patches.patch(
+    __file__,
+    sgm.modules.diffusionmodules.openaimodel.UNetModel,
+    "forward",
+    sgm_patched_forward,
+)
 
 
 def list_optimizers():
@@ -64,7 +99,7 @@ def apply_optimizations(option=None):
     if len(optimizers) == 0:
         # a script can access the model very early, and optimizations would not be filled by then
         current_optimizer = None
-        return ''
+        return ""
 
     ldm.modules.diffusionmodules.model.nonlinearity = silu
     ldm.modules.diffusionmodules.openaimodel.th = sd_hijack_unet.th
@@ -78,9 +113,20 @@ def apply_optimizations(option=None):
 
     selection = option or shared.opts.cross_attention_optimization
     if selection == "Automatic" and len(optimizers) > 0:
-        matching_optimizer = next(iter([x for x in optimizers if x.cmd_opt and getattr(shared.cmd_opts, x.cmd_opt, False)]), optimizers[0])
+        matching_optimizer = next(
+            iter(
+                [
+                    x
+                    for x in optimizers
+                    if x.cmd_opt and getattr(shared.cmd_opts, x.cmd_opt, False)
+                ]
+            ),
+            optimizers[0],
+        )
     else:
-        matching_optimizer = next(iter([x for x in optimizers if x.title() == selection]), None)
+        matching_optimizer = next(
+            iter([x for x in optimizers if x.title() == selection]), None
+        )
 
     if selection == "None":
         matching_optimizer = None
@@ -90,24 +136,36 @@ def apply_optimizations(option=None):
         matching_optimizer = optimizers[0]
 
     if matching_optimizer is not None:
-        print(f"Applying attention optimization: {matching_optimizer.name}... ", end='')
+        print(f"Applying attention optimization: {matching_optimizer.name}... ", end="")
         matching_optimizer.apply()
         print("done.")
         current_optimizer = matching_optimizer
         return current_optimizer.name
     else:
         print("Disabling attention optimization")
-        return ''
+        return ""
 
 
 def undo_optimizations():
-    ldm.modules.diffusionmodules.model.nonlinearity = diffusionmodules_model_nonlinearity
-    ldm.modules.attention.CrossAttention.forward = hypernetwork.attention_CrossAttention_forward
-    ldm.modules.diffusionmodules.model.AttnBlock.forward = diffusionmodules_model_AttnBlock_forward
+    ldm.modules.diffusionmodules.model.nonlinearity = (
+        diffusionmodules_model_nonlinearity
+    )
+    ldm.modules.attention.CrossAttention.forward = (
+        hypernetwork.attention_CrossAttention_forward
+    )
+    ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+        diffusionmodules_model_AttnBlock_forward
+    )
 
-    sgm.modules.diffusionmodules.model.nonlinearity = diffusionmodules_model_nonlinearity
-    sgm.modules.attention.CrossAttention.forward = hypernetwork.attention_CrossAttention_forward
-    sgm.modules.diffusionmodules.model.AttnBlock.forward = diffusionmodules_model_AttnBlock_forward
+    sgm.modules.diffusionmodules.model.nonlinearity = (
+        diffusionmodules_model_nonlinearity
+    )
+    sgm.modules.attention.CrossAttention.forward = (
+        hypernetwork.attention_CrossAttention_forward
+    )
+    sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+        diffusionmodules_model_AttnBlock_forward
+    )
 
 
 def fix_checkpoint():
@@ -118,45 +176,48 @@ def fix_checkpoint():
 
 
 def weighted_loss(sd_model, pred, target, mean=True):
-    #Calculate the weight normally, but ignore the mean
+    # Calculate the weight normally, but ignore the mean
     loss = sd_model._old_get_loss(pred, target, mean=False)
 
-    #Check if we have weights available
-    weight = getattr(sd_model, '_custom_loss_weight', None)
+    # Check if we have weights available
+    weight = getattr(sd_model, "_custom_loss_weight", None)
     if weight is not None:
         loss *= weight
 
-    #Return the loss, as mean if specified
+    # Return the loss, as mean if specified
     return loss.mean() if mean else loss
+
 
 def weighted_forward(sd_model, x, c, w, *args, **kwargs):
     try:
-        #Temporarily append weights to a place accessible during loss calc
+        # Temporarily append weights to a place accessible during loss calc
         sd_model._custom_loss_weight = w
 
-        #Replace 'get_loss' with a weight-aware one. Otherwise we need to reimplement 'forward' completely
-        #Keep 'get_loss', but don't overwrite the previous old_get_loss if it's already set
-        if not hasattr(sd_model, '_old_get_loss'):
+        # Replace 'get_loss' with a weight-aware one. Otherwise we need to reimplement 'forward' completely
+        # Keep 'get_loss', but don't overwrite the previous old_get_loss if it's already set
+        if not hasattr(sd_model, "_old_get_loss"):
             sd_model._old_get_loss = sd_model.get_loss
         sd_model.get_loss = MethodType(weighted_loss, sd_model)
 
-        #Run the standard forward function, but with the patched 'get_loss'
+        # Run the standard forward function, but with the patched 'get_loss'
         return sd_model.forward(x, c, *args, **kwargs)
     finally:
         try:
-            #Delete temporary weights if appended
+            # Delete temporary weights if appended
             del sd_model._custom_loss_weight
         except AttributeError:
             pass
 
-        #If we have an old loss function, reset the loss function to the original one
-        if hasattr(sd_model, '_old_get_loss'):
+        # If we have an old loss function, reset the loss function to the original one
+        if hasattr(sd_model, "_old_get_loss"):
             sd_model.get_loss = sd_model._old_get_loss
             del sd_model._old_get_loss
 
+
 def apply_weighted_forward(sd_model):
-    #Add new function 'weighted_forward' that can be called to calc weighted loss
+    # Add new function 'weighted_forward' that can be called to calc weighted loss
     sd_model.weighted_forward = MethodType(weighted_forward, sd_model)
+
 
 def undo_weighted_forward(sd_model):
     try:
@@ -178,7 +239,9 @@ class StableDiffusionModelHijack:
         self.extra_generation_params = {}
         self.comments = []
 
-        self.embedding_db = modules.textual_inversion.textual_inversion.EmbeddingDatabase()
+        self.embedding_db = (
+            modules.textual_inversion.textual_inversion.EmbeddingDatabase()
+        )
         self.embedding_db.add_embedding_dir(cmd_opts.embeddings_dir)
 
     def apply_optimizations(self, option=None):
@@ -191,37 +254,57 @@ class StableDiffusionModelHijack:
     def convert_sdxl_to_ssd(self, m):
         """Converts an SDXL model to a Segmind Stable Diffusion model (see https://huggingface.co/segmind/SSD-1B)"""
 
-        delattr(m.model.diffusion_model.middle_block, '1')
-        delattr(m.model.diffusion_model.middle_block, '2')
-        for i in ['9', '8', '7', '6', '5', '4']:
+        delattr(m.model.diffusion_model.middle_block, "1")
+        delattr(m.model.diffusion_model.middle_block, "2")
+        for i in ["9", "8", "7", "6", "5", "4"]:
             delattr(m.model.diffusion_model.input_blocks[7][1].transformer_blocks, i)
             delattr(m.model.diffusion_model.input_blocks[8][1].transformer_blocks, i)
             delattr(m.model.diffusion_model.output_blocks[0][1].transformer_blocks, i)
             delattr(m.model.diffusion_model.output_blocks[1][1].transformer_blocks, i)
-        delattr(m.model.diffusion_model.output_blocks[4][1].transformer_blocks, '1')
-        delattr(m.model.diffusion_model.output_blocks[5][1].transformer_blocks, '1')
+        delattr(m.model.diffusion_model.output_blocks[4][1].transformer_blocks, "1")
+        delattr(m.model.diffusion_model.output_blocks[5][1].transformer_blocks, "1")
         devices.torch_gc()
 
     def hijack(self, m):
-        conditioner = getattr(m, 'conditioner', None)
+        conditioner = getattr(m, "conditioner", None)
         if conditioner:
             text_cond_models = []
 
             for i in range(len(conditioner.embedders)):
                 embedder = conditioner.embedders[i]
                 typename = type(embedder).__name__
-                if typename == 'FrozenOpenCLIPEmbedder':
-                    embedder.model.token_embedding = EmbeddingsWithFixes(embedder.model.token_embedding, self)
-                    conditioner.embedders[i] = sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(embedder, self)
+                if typename == "FrozenOpenCLIPEmbedder":
+                    embedder.model.token_embedding = EmbeddingsWithFixes(
+                        embedder.model.token_embedding, self
+                    )
+                    conditioner.embedders[i] = (
+                        sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(
+                            embedder, self
+                        )
+                    )
                     text_cond_models.append(conditioner.embedders[i])
-                if typename == 'FrozenCLIPEmbedder':
+                if typename == "FrozenCLIPEmbedder":
                     model_embeddings = embedder.transformer.text_model.embeddings
-                    model_embeddings.token_embedding = EmbeddingsWithFixes(model_embeddings.token_embedding, self)
-                    conditioner.embedders[i] = sd_hijack_clip.FrozenCLIPEmbedderForSDXLWithCustomWords(embedder, self)
+                    model_embeddings.token_embedding = EmbeddingsWithFixes(
+                        model_embeddings.token_embedding, self
+                    )
+                    conditioner.embedders[i] = (
+                        sd_hijack_clip.FrozenCLIPEmbedderForSDXLWithCustomWords(
+                            embedder, self
+                        )
+                    )
                     text_cond_models.append(conditioner.embedders[i])
-                if typename == 'FrozenOpenCLIPEmbedder2':
-                    embedder.model.token_embedding = EmbeddingsWithFixes(embedder.model.token_embedding, self, textual_inversion_key='clip_g')
-                    conditioner.embedders[i] = sd_hijack_open_clip.FrozenOpenCLIPEmbedder2WithCustomWords(embedder, self)
+                if typename == "FrozenOpenCLIPEmbedder2":
+                    embedder.model.token_embedding = EmbeddingsWithFixes(
+                        embedder.model.token_embedding,
+                        self,
+                        textual_inversion_key="clip_g",
+                    )
+                    conditioner.embedders[i] = (
+                        sd_hijack_open_clip.FrozenOpenCLIPEmbedder2WithCustomWords(
+                            embedder, self
+                        )
+                    )
                     text_cond_models.append(conditioner.embedders[i])
 
             if len(text_cond_models) == 1:
@@ -229,19 +312,41 @@ class StableDiffusionModelHijack:
             else:
                 m.cond_stage_model = conditioner
 
-        if type(m.cond_stage_model) == xlmr.BertSeriesModelWithTransformation or type(m.cond_stage_model) == xlmr_m18.BertSeriesModelWithTransformation:
+        if (
+            type(m.cond_stage_model) == xlmr.BertSeriesModelWithTransformation
+            or type(m.cond_stage_model) == xlmr_m18.BertSeriesModelWithTransformation
+        ):
             model_embeddings = m.cond_stage_model.roberta.embeddings
-            model_embeddings.token_embedding = EmbeddingsWithFixes(model_embeddings.word_embeddings, self)
-            m.cond_stage_model = sd_hijack_xlmr.FrozenXLMREmbedderWithCustomWords(m.cond_stage_model, self)
+            model_embeddings.token_embedding = EmbeddingsWithFixes(
+                model_embeddings.word_embeddings, self
+            )
+            m.cond_stage_model = sd_hijack_xlmr.FrozenXLMREmbedderWithCustomWords(
+                m.cond_stage_model, self
+            )
 
-        elif type(m.cond_stage_model) == ldm.modules.encoders.modules.FrozenCLIPEmbedder:
+        elif (
+            type(m.cond_stage_model) == ldm.modules.encoders.modules.FrozenCLIPEmbedder
+        ):
             model_embeddings = m.cond_stage_model.transformer.text_model.embeddings
-            model_embeddings.token_embedding = EmbeddingsWithFixes(model_embeddings.token_embedding, self)
-            m.cond_stage_model = sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords(m.cond_stage_model, self)
+            model_embeddings.token_embedding = EmbeddingsWithFixes(
+                model_embeddings.token_embedding, self
+            )
+            m.cond_stage_model = sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords(
+                m.cond_stage_model, self
+            )
 
-        elif type(m.cond_stage_model) == ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder:
-            m.cond_stage_model.model.token_embedding = EmbeddingsWithFixes(m.cond_stage_model.model.token_embedding, self)
-            m.cond_stage_model = sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(m.cond_stage_model, self)
+        elif (
+            type(m.cond_stage_model)
+            == ldm.modules.encoders.modules.FrozenOpenCLIPEmbedder
+        ):
+            m.cond_stage_model.model.token_embedding = EmbeddingsWithFixes(
+                m.cond_stage_model.model.token_embedding, self
+            )
+            m.cond_stage_model = (
+                sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords(
+                    m.cond_stage_model, self
+                )
+            )
 
         apply_weighted_forward(m)
         if m.cond_stage_key == "edit":
@@ -271,33 +376,53 @@ class StableDiffusionModelHijack:
         else:
             sd_unet.original_forward = None
 
-
     def undo_hijack(self, m):
-        conditioner = getattr(m, 'conditioner', None)
+        conditioner = getattr(m, "conditioner", None)
         if conditioner:
             for i in range(len(conditioner.embedders)):
                 embedder = conditioner.embedders[i]
-                if isinstance(embedder, (sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords, sd_hijack_open_clip.FrozenOpenCLIPEmbedder2WithCustomWords)):
-                    embedder.wrapped.model.token_embedding = embedder.wrapped.model.token_embedding.wrapped
+                if isinstance(
+                    embedder,
+                    (
+                        sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords,
+                        sd_hijack_open_clip.FrozenOpenCLIPEmbedder2WithCustomWords,
+                    ),
+                ):
+                    embedder.wrapped.model.token_embedding = (
+                        embedder.wrapped.model.token_embedding.wrapped
+                    )
                     conditioner.embedders[i] = embedder.wrapped
-                if isinstance(embedder, sd_hijack_clip.FrozenCLIPEmbedderForSDXLWithCustomWords):
+                if isinstance(
+                    embedder, sd_hijack_clip.FrozenCLIPEmbedderForSDXLWithCustomWords
+                ):
                     embedder.wrapped.transformer.text_model.embeddings.token_embedding = embedder.wrapped.transformer.text_model.embeddings.token_embedding.wrapped
                     conditioner.embedders[i] = embedder.wrapped
 
-            if hasattr(m, 'cond_stage_model'):
-                delattr(m, 'cond_stage_model')
+            if hasattr(m, "cond_stage_model"):
+                delattr(m, "cond_stage_model")
 
-        elif type(m.cond_stage_model) == sd_hijack_xlmr.FrozenXLMREmbedderWithCustomWords:
+        elif (
+            type(m.cond_stage_model) == sd_hijack_xlmr.FrozenXLMREmbedderWithCustomWords
+        ):
             m.cond_stage_model = m.cond_stage_model.wrapped
 
-        elif type(m.cond_stage_model) == sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords:
+        elif (
+            type(m.cond_stage_model) == sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords
+        ):
             m.cond_stage_model = m.cond_stage_model.wrapped
 
             model_embeddings = m.cond_stage_model.transformer.text_model.embeddings
             if type(model_embeddings.token_embedding) == EmbeddingsWithFixes:
-                model_embeddings.token_embedding = model_embeddings.token_embedding.wrapped
-        elif type(m.cond_stage_model) == sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords:
-            m.cond_stage_model.wrapped.model.token_embedding = m.cond_stage_model.wrapped.model.token_embedding.wrapped
+                model_embeddings.token_embedding = (
+                    model_embeddings.token_embedding.wrapped
+                )
+        elif (
+            type(m.cond_stage_model)
+            == sd_hijack_open_clip.FrozenOpenCLIPEmbedderWithCustomWords
+        ):
+            m.cond_stage_model.wrapped.model.token_embedding = (
+                m.cond_stage_model.wrapped.model.token_embedding.wrapped
+            )
             m.cond_stage_model = m.cond_stage_model.wrapped
 
         undo_optimizations()
@@ -307,7 +432,6 @@ class StableDiffusionModelHijack:
         self.layers = None
         self.clip = None
 
-
     def apply_circular(self, enable):
         if self.circular_enabled == enable:
             return
@@ -315,7 +439,7 @@ class StableDiffusionModelHijack:
         self.circular_enabled = enable
 
         for layer in [layer for layer in self.layers if type(layer) == torch.nn.Conv2d]:
-            layer.padding_mode = 'circular' if enable else 'zeros'
+            layer.padding_mode = "circular" if enable else "zeros"
 
     def clear_comments(self):
         self.comments = []
@@ -325,7 +449,7 @@ class StableDiffusionModelHijack:
         if self.clip is None:
             return "-", "-"
 
-        if hasattr(self.clip, 'get_token_count'):
+        if hasattr(self.clip, "get_token_count"):
             token_count = self.clip.get_token_count(text)
         else:
             _, token_count = self.clip.process_texts([text])
@@ -338,7 +462,7 @@ class StableDiffusionModelHijack:
 
 
 class EmbeddingsWithFixes(torch.nn.Module):
-    def __init__(self, wrapped, embeddings, textual_inversion_key='clip_l'):
+    def __init__(self, wrapped, embeddings, textual_inversion_key="clip_l"):
         super().__init__()
         self.wrapped = wrapped
         self.embeddings = embeddings
@@ -350,16 +474,30 @@ class EmbeddingsWithFixes(torch.nn.Module):
 
         inputs_embeds = self.wrapped(input_ids)
 
-        if batch_fixes is None or len(batch_fixes) == 0 or max([len(x) for x in batch_fixes]) == 0:
+        if (
+            batch_fixes is None
+            or len(batch_fixes) == 0
+            or max([len(x) for x in batch_fixes]) == 0
+        ):
             return inputs_embeds
 
         vecs = []
         for fixes, tensor in zip(batch_fixes, inputs_embeds):
             for offset, embedding in fixes:
-                vec = embedding.vec[self.textual_inversion_key] if isinstance(embedding.vec, dict) else embedding.vec
+                vec = (
+                    embedding.vec[self.textual_inversion_key]
+                    if isinstance(embedding.vec, dict)
+                    else embedding.vec
+                )
                 emb = devices.cond_cast_unet(vec)
                 emb_len = min(tensor.shape[0] - offset - 1, emb.shape[0])
-                tensor = torch.cat([tensor[0:offset + 1], emb[0:emb_len], tensor[offset + 1 + emb_len:]]).to(dtype=inputs_embeds.dtype)
+                tensor = torch.cat(
+                    [
+                        tensor[0 : offset + 1],
+                        emb[0:emb_len],
+                        tensor[offset + 1 + emb_len :],
+                    ]
+                ).to(dtype=inputs_embeds.dtype)
 
             vecs.append(tensor)
 
@@ -367,7 +505,13 @@ class EmbeddingsWithFixes(torch.nn.Module):
 
 
 class TextualInversionEmbeddings(torch.nn.Embedding):
-    def __init__(self, num_embeddings: int, embedding_dim: int, textual_inversion_key='clip_l', **kwargs):
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        textual_inversion_key="clip_l",
+        **kwargs,
+    ):
         super().__init__(num_embeddings, embedding_dim, **kwargs)
 
         self.embeddings = model_hijack
@@ -385,7 +529,7 @@ def add_circular_option_to_conv_2d():
     conv2d_constructor = torch.nn.Conv2d.__init__
 
     def conv2d_constructor_circular(self, *args, **kwargs):
-        return conv2d_constructor(self, *args, padding_mode='circular', **kwargs)
+        return conv2d_constructor(self, *args, padding_mode="circular", **kwargs)
 
     torch.nn.Conv2d.__init__ = conv2d_constructor_circular
 
@@ -400,7 +544,10 @@ def register_buffer(self, name, attr):
 
     if type(attr) == torch.Tensor:
         if attr.device != devices.device:
-            attr = attr.to(device=devices.device, dtype=(torch.float32 if devices.device.type == 'mps' else None))
+            attr = attr.to(
+                device=devices.device,
+                dtype=(torch.float32 if devices.device.type == "mps" else None),
+            )
 
     setattr(self, name, attr)
 

--- a/modules/sd_hijack_checkpoint.py
+++ b/modules/sd_hijack_checkpoint.py
@@ -23,15 +23,19 @@ def add():
     if len(stored) != 0:
         return
 
-    stored.extend([
-        ldm.modules.attention.BasicTransformerBlock.forward,
-        ldm.modules.diffusionmodules.openaimodel.ResBlock.forward,
-        ldm.modules.diffusionmodules.openaimodel.AttentionBlock.forward
-    ])
+    stored.extend(
+        [
+            ldm.modules.attention.BasicTransformerBlock.forward,
+            ldm.modules.diffusionmodules.openaimodel.ResBlock.forward,
+            ldm.modules.diffusionmodules.openaimodel.AttentionBlock.forward,
+        ]
+    )
 
     ldm.modules.attention.BasicTransformerBlock.forward = BasicTransformerBlock_forward
     ldm.modules.diffusionmodules.openaimodel.ResBlock.forward = ResBlock_forward
-    ldm.modules.diffusionmodules.openaimodel.AttentionBlock.forward = AttentionBlock_forward
+    ldm.modules.diffusionmodules.openaimodel.AttentionBlock.forward = (
+        AttentionBlock_forward
+    )
 
 
 def remove():
@@ -43,4 +47,3 @@ def remove():
     ldm.modules.diffusionmodules.openaimodel.AttentionBlock.forward = stored[2]
 
     stored.clear()
-

--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -21,7 +21,7 @@ class PromptChunk:
         self.fixes = []
 
 
-PromptChunkFix = namedtuple('PromptChunkFix', ['offset', 'embedding'])
+PromptChunkFix = namedtuple("PromptChunkFix", ["offset", "embedding"])
 """An object of this type is a marker showing that textual inversion embedding's vectors have to placed at offset in the prompt
 chunk. Those objects are found in PromptChunk.fixes and, are placed into FrozenCLIPEmbedderWithCustomWordsBase.hijack.fixes, and finally
 are applied by sd_hijack.EmbeddingsWithFixes's forward function."""
@@ -35,7 +35,7 @@ class TextConditionalModel(torch.nn.Module):
         self.chunk_length = 75
 
         self.is_trainable = False
-        self.input_key = 'txt'
+        self.input_key = "txt"
         self.return_pooled = False
 
         self.comma_token = None
@@ -122,7 +122,7 @@ class TextConditionalModel(torch.nn.Module):
             chunk = PromptChunk()
 
         for tokens, (text, weight) in zip(tokenized, parsed):
-            if text == 'BREAK' and weight == -1:
+            if text == "BREAK" and weight == -1:
                 next_chunk()
                 continue
 
@@ -135,7 +135,12 @@ class TextConditionalModel(torch.nn.Module):
 
                 # this is when we are at the end of allotted 75 tokens for the current chunk, and the current token is not a comma. opts.comma_padding_backtrack
                 # is a setting that specifies that if there is a comma nearby, the text after the comma should be moved out of this chunk and into the next.
-                elif opts.comma_padding_backtrack != 0 and len(chunk.tokens) == self.chunk_length and last_comma != -1 and len(chunk.tokens) - last_comma <= opts.comma_padding_backtrack:
+                elif (
+                    opts.comma_padding_backtrack != 0
+                    and len(chunk.tokens) == self.chunk_length
+                    and last_comma != -1
+                    and len(chunk.tokens) - last_comma <= opts.comma_padding_backtrack
+                ):
                     break_location = last_comma + 1
 
                     reloc_tokens = chunk.tokens[break_location:]
@@ -151,7 +156,11 @@ class TextConditionalModel(torch.nn.Module):
                 if len(chunk.tokens) == self.chunk_length:
                     next_chunk()
 
-                embedding, embedding_length_in_tokens = self.hijack.embedding_db.find_embedding_at_position(tokens, position)
+                embedding, embedding_length_in_tokens = (
+                    self.hijack.embedding_db.find_embedding_at_position(
+                        tokens, position
+                    )
+                )
                 if embedding is None:
                     chunk.tokens.append(token)
                     chunk.multipliers.append(weight)
@@ -214,7 +223,10 @@ class TextConditionalModel(torch.nn.Module):
 
         zs = []
         for i in range(chunk_count):
-            batch_chunk = [chunks[i] if i < len(chunks) else self.empty_chunk() for chunks in batch_chunks]
+            batch_chunk = [
+                chunks[i] if i < len(chunks) else self.empty_chunk()
+                for chunks in batch_chunks
+            ]
 
             tokens = [x.tokens for x in batch_chunk]
             multipliers = [x.multipliers for x in batch_chunk]
@@ -242,7 +254,10 @@ class TextConditionalModel(torch.nn.Module):
                     hashes.append(self.hijack.extra_generation_params.get("TI hashes"))
                 self.hijack.extra_generation_params["TI hashes"] = ", ".join(hashes)
 
-        if any(x for x in texts if "(" in x or "[" in x) and opts.emphasis != "Original":
+        if (
+            any(x for x in texts if "(" in x or "[" in x)
+            and opts.emphasis != "Original"
+        ):
             self.hijack.extra_generation_params["Emphasis"] = opts.emphasis
 
         if self.return_pooled:
@@ -264,11 +279,11 @@ class TextConditionalModel(torch.nn.Module):
         if self.id_end != self.id_pad:
             for batch_pos in range(len(remade_batch_tokens)):
                 index = remade_batch_tokens[batch_pos].index(self.id_end)
-                tokens[batch_pos, index+1:tokens.shape[1]] = self.id_pad
+                tokens[batch_pos, index + 1 : tokens.shape[1]] = self.id_pad
 
         z = self.encode_with_transformers(tokens)
 
-        pooled = getattr(z, 'pooled', None)
+        pooled = getattr(z, "pooled", None)
 
         emphasis = sd_emphasis.get_current_option(opts.emphasis)()
         emphasis.tokens = remade_batch_tokens
@@ -299,15 +314,16 @@ class FrozenCLIPEmbedderWithCustomWordsBase(TextConditionalModel):
         """Original FrozenCLIPEmbedder module; can also be FrozenOpenCLIPEmbedder or xlmr.BertSeriesModelWithTransformation,
         depending on model."""
 
-        self.is_trainable = getattr(wrapped, 'is_trainable', False)
-        self.input_key = getattr(wrapped, 'input_key', 'txt')
-        self.return_pooled = getattr(self.wrapped, 'return_pooled', False)
+        self.is_trainable = getattr(wrapped, "is_trainable", False)
+        self.input_key = getattr(wrapped, "input_key", "txt")
+        self.return_pooled = getattr(self.wrapped, "return_pooled", False)
 
         self.legacy_ucg_val = None  # for sgm codebase
 
     def forward(self, texts):
         if opts.use_old_emphasis_implementation:
             import modules.sd_hijack_clip_old
+
             return modules.sd_hijack_clip_old.forward_old(self, texts)
 
         return super().forward(texts)
@@ -320,20 +336,24 @@ class FrozenCLIPEmbedderWithCustomWords(FrozenCLIPEmbedderWithCustomWordsBase):
 
         vocab = self.tokenizer.get_vocab()
 
-        self.comma_token = vocab.get(',</w>', None)
+        self.comma_token = vocab.get(",</w>", None)
 
         self.token_mults = {}
-        tokens_with_parens = [(k, v) for k, v in vocab.items() if '(' in k or ')' in k or '[' in k or ']' in k]
+        tokens_with_parens = [
+            (k, v)
+            for k, v in vocab.items()
+            if "(" in k or ")" in k or "[" in k or "]" in k
+        ]
         for text, ident in tokens_with_parens:
             mult = 1.0
             for c in text:
-                if c == '[':
+                if c == "[":
                     mult /= 1.1
-                if c == ']':
+                if c == "]":
                     mult *= 1.1
-                if c == '(':
+                if c == "(":
                     mult *= 1.1
-                if c == ')':
+                if c == ")":
                     mult /= 1.1
 
             if mult != 1.0:
@@ -344,12 +364,16 @@ class FrozenCLIPEmbedderWithCustomWords(FrozenCLIPEmbedderWithCustomWordsBase):
         self.id_pad = self.id_end
 
     def tokenize(self, texts):
-        tokenized = self.wrapped.tokenizer(texts, truncation=False, add_special_tokens=False)["input_ids"]
+        tokenized = self.wrapped.tokenizer(
+            texts, truncation=False, add_special_tokens=False
+        )["input_ids"]
 
         return tokenized
 
     def encode_with_transformers(self, tokens):
-        outputs = self.wrapped.transformer(input_ids=tokens, output_hidden_states=-opts.CLIP_stop_at_last_layers)
+        outputs = self.wrapped.transformer(
+            input_ids=tokens, output_hidden_states=-opts.CLIP_stop_at_last_layers
+        )
 
         if opts.CLIP_stop_at_last_layers > 1:
             z = outputs.hidden_states[-opts.CLIP_stop_at_last_layers]
@@ -361,8 +385,12 @@ class FrozenCLIPEmbedderWithCustomWords(FrozenCLIPEmbedderWithCustomWordsBase):
 
     def encode_embedding_init_text(self, init_text, nvpt):
         embedding_layer = self.wrapped.transformer.text_model.embeddings
-        ids = self.wrapped.tokenizer(init_text, max_length=nvpt, return_tensors="pt", add_special_tokens=False)["input_ids"]
-        embedded = embedding_layer.token_embedding.wrapped(ids.to(embedding_layer.token_embedding.wrapped.weight.device)).squeeze(0)
+        ids = self.wrapped.tokenizer(
+            init_text, max_length=nvpt, return_tensors="pt", add_special_tokens=False
+        )["input_ids"]
+        embedded = embedding_layer.token_embedding.wrapped(
+            ids.to(embedding_layer.token_embedding.wrapped.weight.device)
+        ).squeeze(0)
 
         return embedded
 
@@ -372,7 +400,9 @@ class FrozenCLIPEmbedderForSDXLWithCustomWords(FrozenCLIPEmbedderWithCustomWords
         super().__init__(wrapped, hijack)
 
     def encode_with_transformers(self, tokens):
-        outputs = self.wrapped.transformer(input_ids=tokens, output_hidden_states=self.wrapped.layer == "hidden")
+        outputs = self.wrapped.transformer(
+            input_ids=tokens, output_hidden_states=self.wrapped.layer == "hidden"
+        )
 
         if opts.sdxl_clip_l_skip is True:
             z = outputs.hidden_states[-opts.CLIP_stop_at_last_layers]

--- a/modules/sd_hijack_clip_old.py
+++ b/modules/sd_hijack_clip_old.py
@@ -30,9 +30,15 @@ def process_text_old(self: sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase,
             while i < len(tokens):
                 token = tokens[i]
 
-                embedding, embedding_length_in_tokens = self.hijack.embedding_db.find_embedding_at_position(tokens, i)
+                embedding, embedding_length_in_tokens = (
+                    self.hijack.embedding_db.find_embedding_at_position(tokens, i)
+                )
 
-                mult_change = self.token_mults.get(token) if shared.opts.emphasis != "None" else None
+                mult_change = (
+                    self.token_mults.get(token)
+                    if shared.opts.emphasis != "None"
+                    else None
+                )
                 if mult_change is not None:
                     mult *= mult_change
                     i += 1
@@ -50,32 +56,52 @@ def process_text_old(self: sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase,
 
             if len(remade_tokens) > maxlen - 2:
                 vocab = {v: k for k, v in self.wrapped.tokenizer.get_vocab().items()}
-                ovf = remade_tokens[maxlen - 2:]
+                ovf = remade_tokens[maxlen - 2 :]
                 overflowing_words = [vocab.get(int(x), "") for x in ovf]
-                overflowing_text = self.wrapped.tokenizer.convert_tokens_to_string(''.join(overflowing_words))
-                hijack_comments.append(f"Warning: too many input tokens; some ({len(overflowing_words)}) have been truncated:\n{overflowing_text}\n")
+                overflowing_text = self.wrapped.tokenizer.convert_tokens_to_string(
+                    "".join(overflowing_words)
+                )
+                hijack_comments.append(
+                    f"Warning: too many input tokens; some ({len(overflowing_words)}) have been truncated:\n{overflowing_text}\n"
+                )
 
             token_count = len(remade_tokens)
             remade_tokens = remade_tokens + [id_end] * (maxlen - 2 - len(remade_tokens))
-            remade_tokens = [id_start] + remade_tokens[0:maxlen - 2] + [id_end]
+            remade_tokens = [id_start] + remade_tokens[0 : maxlen - 2] + [id_end]
             cache[tuple_tokens] = (remade_tokens, fixes, multipliers)
 
         multipliers = multipliers + [1.0] * (maxlen - 2 - len(multipliers))
-        multipliers = [1.0] + multipliers[0:maxlen - 2] + [1.0]
+        multipliers = [1.0] + multipliers[0 : maxlen - 2] + [1.0]
 
         remade_batch_tokens.append(remade_tokens)
         hijack_fixes.append(fixes)
         batch_multipliers.append(multipliers)
-    return batch_multipliers, remade_batch_tokens, used_custom_terms, hijack_comments, hijack_fixes, token_count
+    return (
+        batch_multipliers,
+        remade_batch_tokens,
+        used_custom_terms,
+        hijack_comments,
+        hijack_fixes,
+        token_count,
+    )
 
 
 def forward_old(self: sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase, texts):
-    batch_multipliers, remade_batch_tokens, used_custom_terms, hijack_comments, hijack_fixes, token_count = process_text_old(self, texts)
+    (
+        batch_multipliers,
+        remade_batch_tokens,
+        used_custom_terms,
+        hijack_comments,
+        hijack_fixes,
+        token_count,
+    ) = process_text_old(self, texts)
 
     self.hijack.comments += hijack_comments
 
     if used_custom_terms:
-        embedding_names = ", ".join(f"{word} [{checksum}]" for word, checksum in used_custom_terms)
+        embedding_names = ", ".join(
+            f"{word} [{checksum}]" for word, checksum in used_custom_terms
+        )
         self.hijack.comments.append(f"Used embeddings: {embedding_names}")
 
     self.hijack.fixes = hijack_fixes

--- a/modules/sd_hijack_ip2p.py
+++ b/modules/sd_hijack_ip2p.py
@@ -5,6 +5,8 @@ def should_hijack_ip2p(checkpoint_info):
     from modules import sd_models_config
 
     ckpt_basename = os.path.basename(checkpoint_info.filename).lower()
-    cfg_basename = os.path.basename(sd_models_config.find_checkpoint_config_near_filename(checkpoint_info)).lower()
+    cfg_basename = os.path.basename(
+        sd_models_config.find_checkpoint_config_near_filename(checkpoint_info)
+    ).lower()
 
     return "pix2pix" in ckpt_basename and "pix2pix" not in cfg_basename

--- a/modules/sd_hijack_open_clip.py
+++ b/modules/sd_hijack_open_clip.py
@@ -7,17 +7,21 @@ from modules.shared import opts
 tokenizer = open_clip.tokenizer._tokenizer
 
 
-class FrozenOpenCLIPEmbedderWithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase):
+class FrozenOpenCLIPEmbedderWithCustomWords(
+    sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase
+):
     def __init__(self, wrapped, hijack):
         super().__init__(wrapped, hijack)
 
-        self.comma_token = [v for k, v in tokenizer.encoder.items() if k == ',</w>'][0]
+        self.comma_token = [v for k, v in tokenizer.encoder.items() if k == ",</w>"][0]
         self.id_start = tokenizer.encoder["<start_of_text>"]
         self.id_end = tokenizer.encoder["<end_of_text>"]
         self.id_pad = 0
 
     def tokenize(self, texts):
-        assert not opts.use_old_emphasis_implementation, 'Old emphasis implementation not supported for Open Clip'
+        assert (
+            not opts.use_old_emphasis_implementation
+        ), "Old emphasis implementation not supported for Open Clip"
 
         tokenized = [tokenizer.encode(text) for text in texts]
 
@@ -37,17 +41,21 @@ class FrozenOpenCLIPEmbedderWithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWit
         return embedded
 
 
-class FrozenOpenCLIPEmbedder2WithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase):
+class FrozenOpenCLIPEmbedder2WithCustomWords(
+    sd_hijack_clip.FrozenCLIPEmbedderWithCustomWordsBase
+):
     def __init__(self, wrapped, hijack):
         super().__init__(wrapped, hijack)
 
-        self.comma_token = [v for k, v in tokenizer.encoder.items() if k == ',</w>'][0]
+        self.comma_token = [v for k, v in tokenizer.encoder.items() if k == ",</w>"][0]
         self.id_start = tokenizer.encoder["<start_of_text>"]
         self.id_end = tokenizer.encoder["<end_of_text>"]
         self.id_pad = 0
 
     def tokenize(self, texts):
-        assert not opts.use_old_emphasis_implementation, 'Old emphasis implementation not supported for Open Clip'
+        assert (
+            not opts.use_old_emphasis_implementation
+        ), "Old emphasis implementation not supported for Open Clip"
 
         tokenized = [tokenizer.encode(text) for text in texts]
 
@@ -66,6 +74,8 @@ class FrozenOpenCLIPEmbedder2WithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWi
     def encode_embedding_init_text(self, init_text, nvpt):
         ids = tokenizer.encode(init_text)
         ids = torch.asarray([ids], device=devices.device, dtype=torch.int)
-        embedded = self.wrapped.model.token_embedding.wrapped(ids.to(self.wrapped.model.token_embedding.wrapped.weight.device)).squeeze(0)
+        embedded = self.wrapped.model.token_embedding.wrapped(
+            ids.to(self.wrapped.model.token_embedding.wrapped.weight.device)
+        ).squeeze(0)
 
         return embedded

--- a/modules/sd_hijack_optimizations.py
+++ b/modules/sd_hijack_optimizations.py
@@ -18,8 +18,12 @@ import ldm.modules.diffusionmodules.model
 import sgm.modules.attention
 import sgm.modules.diffusionmodules.model
 
-diffusionmodules_model_AttnBlock_forward = ldm.modules.diffusionmodules.model.AttnBlock.forward
-sgm_diffusionmodules_model_AttnBlock_forward = sgm.modules.diffusionmodules.model.AttnBlock.forward
+diffusionmodules_model_AttnBlock_forward = (
+    ldm.modules.diffusionmodules.model.AttnBlock.forward
+)
+sgm_diffusionmodules_model_AttnBlock_forward = (
+    sgm.modules.diffusionmodules.model.AttnBlock.forward
+)
 
 
 class SdOptimization:
@@ -41,11 +45,19 @@ class SdOptimization:
         pass
 
     def undo(self):
-        ldm.modules.attention.CrossAttention.forward = hypernetwork.attention_CrossAttention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = diffusionmodules_model_AttnBlock_forward
+        ldm.modules.attention.CrossAttention.forward = (
+            hypernetwork.attention_CrossAttention_forward
+        )
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+            diffusionmodules_model_AttnBlock_forward
+        )
 
-        sgm.modules.attention.CrossAttention.forward = hypernetwork.attention_CrossAttention_forward
-        sgm.modules.diffusionmodules.model.AttnBlock.forward = sgm_diffusionmodules_model_AttnBlock_forward
+        sgm.modules.attention.CrossAttention.forward = (
+            hypernetwork.attention_CrossAttention_forward
+        )
+        sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+            sgm_diffusionmodules_model_AttnBlock_forward
+        )
 
 
 class SdOptimizationXformers(SdOptimization):
@@ -54,13 +66,21 @@ class SdOptimizationXformers(SdOptimization):
     priority = 100
 
     def is_available(self):
-        return shared.cmd_opts.force_enable_xformers or (shared.xformers_available and torch.cuda.is_available() and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0))
+        return shared.cmd_opts.force_enable_xformers or (
+            shared.xformers_available
+            and torch.cuda.is_available()
+            and (6, 0) <= torch.cuda.get_device_capability(shared.device) <= (9, 0)
+        )
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = xformers_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = xformers_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+            xformers_attnblock_forward
+        )
         sgm.modules.attention.CrossAttention.forward = xformers_attention_forward
-        sgm.modules.diffusionmodules.model.AttnBlock.forward = xformers_attnblock_forward
+        sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+            xformers_attnblock_forward
+        )
 
 
 class SdOptimizationSdpNoMem(SdOptimization):
@@ -70,13 +90,23 @@ class SdOptimizationSdpNoMem(SdOptimization):
     priority = 80
 
     def is_available(self):
-        return hasattr(torch.nn.functional, "scaled_dot_product_attention") and callable(torch.nn.functional.scaled_dot_product_attention)
+        return hasattr(
+            torch.nn.functional, "scaled_dot_product_attention"
+        ) and callable(torch.nn.functional.scaled_dot_product_attention)
 
     def apply(self):
-        ldm.modules.attention.CrossAttention.forward = scaled_dot_product_no_mem_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sdp_no_mem_attnblock_forward
-        sgm.modules.attention.CrossAttention.forward = scaled_dot_product_no_mem_attention_forward
-        sgm.modules.diffusionmodules.model.AttnBlock.forward = sdp_no_mem_attnblock_forward
+        ldm.modules.attention.CrossAttention.forward = (
+            scaled_dot_product_no_mem_attention_forward
+        )
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+            sdp_no_mem_attnblock_forward
+        )
+        sgm.modules.attention.CrossAttention.forward = (
+            scaled_dot_product_no_mem_attention_forward
+        )
+        sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+            sdp_no_mem_attnblock_forward
+        )
 
 
 class SdOptimizationSdp(SdOptimizationSdpNoMem):
@@ -86,9 +116,13 @@ class SdOptimizationSdp(SdOptimizationSdpNoMem):
     priority = 70
 
     def apply(self):
-        ldm.modules.attention.CrossAttention.forward = scaled_dot_product_attention_forward
+        ldm.modules.attention.CrossAttention.forward = (
+            scaled_dot_product_attention_forward
+        )
         ldm.modules.diffusionmodules.model.AttnBlock.forward = sdp_attnblock_forward
-        sgm.modules.attention.CrossAttention.forward = scaled_dot_product_attention_forward
+        sgm.modules.attention.CrossAttention.forward = (
+            scaled_dot_product_attention_forward
+        )
         sgm.modules.diffusionmodules.model.AttnBlock.forward = sdp_attnblock_forward
 
 
@@ -98,13 +132,17 @@ class SdOptimizationSubQuad(SdOptimization):
 
     @property
     def priority(self):
-        return 1000 if shared.device.type == 'mps' else 10
+        return 1000 if shared.device.type == "mps" else 10
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = sub_quad_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = sub_quad_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+            sub_quad_attnblock_forward
+        )
         sgm.modules.attention.CrossAttention.forward = sub_quad_attention_forward
-        sgm.modules.diffusionmodules.model.AttnBlock.forward = sub_quad_attnblock_forward
+        sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+            sub_quad_attnblock_forward
+        )
 
 
 class SdOptimizationV1(SdOptimization):
@@ -124,11 +162,19 @@ class SdOptimizationInvokeAI(SdOptimization):
 
     @property
     def priority(self):
-        return 1000 if shared.device.type != 'mps' and not torch.cuda.is_available() else 10
+        return (
+            1000
+            if shared.device.type != "mps" and not torch.cuda.is_available()
+            else 10
+        )
 
     def apply(self):
-        ldm.modules.attention.CrossAttention.forward = split_cross_attention_forward_invokeAI
-        sgm.modules.attention.CrossAttention.forward = split_cross_attention_forward_invokeAI
+        ldm.modules.attention.CrossAttention.forward = (
+            split_cross_attention_forward_invokeAI
+        )
+        sgm.modules.attention.CrossAttention.forward = (
+            split_cross_attention_forward_invokeAI
+        )
 
 
 class SdOptimizationDoggettx(SdOptimization):
@@ -138,36 +184,43 @@ class SdOptimizationDoggettx(SdOptimization):
 
     def apply(self):
         ldm.modules.attention.CrossAttention.forward = split_cross_attention_forward
-        ldm.modules.diffusionmodules.model.AttnBlock.forward = cross_attention_attnblock_forward
+        ldm.modules.diffusionmodules.model.AttnBlock.forward = (
+            cross_attention_attnblock_forward
+        )
         sgm.modules.attention.CrossAttention.forward = split_cross_attention_forward
-        sgm.modules.diffusionmodules.model.AttnBlock.forward = cross_attention_attnblock_forward
+        sgm.modules.diffusionmodules.model.AttnBlock.forward = (
+            cross_attention_attnblock_forward
+        )
 
 
 def list_optimizers(res):
-    res.extend([
-        SdOptimizationXformers(),
-        SdOptimizationSdpNoMem(),
-        SdOptimizationSdp(),
-        SdOptimizationSubQuad(),
-        SdOptimizationV1(),
-        SdOptimizationInvokeAI(),
-        SdOptimizationDoggettx(),
-    ])
+    res.extend(
+        [
+            SdOptimizationXformers(),
+            SdOptimizationSdpNoMem(),
+            SdOptimizationSdp(),
+            SdOptimizationSubQuad(),
+            SdOptimizationV1(),
+            SdOptimizationInvokeAI(),
+            SdOptimizationDoggettx(),
+        ]
+    )
 
 
 if shared.cmd_opts.xformers or shared.cmd_opts.force_enable_xformers:
     try:
         import xformers.ops
+
         shared.xformers_available = True
     except Exception:
         errors.report("Cannot import xformers", exc_info=True)
 
 
 def get_available_vram():
-    if shared.device.type == 'cuda':
+    if shared.device.type == "cuda":
         stats = torch.cuda.memory_stats(shared.device)
-        mem_active = stats['active_bytes.all.current']
-        mem_reserved = stats['reserved_bytes.all.current']
+        mem_active = stats["active_bytes.all.current"]
+        mem_reserved = stats["reserved_bytes.all.current"]
         mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
         mem_free_torch = mem_reserved - mem_active
         mem_free_total = mem_free_cuda + mem_free_torch
@@ -183,12 +236,14 @@ def split_cross_attention_forward_v1(self, x, context=None, mask=None, **kwargs)
     q_in = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k_in = self.to_k(context_k)
     v_in = self.to_v(context_v)
     del context, context_k, context_v, x
 
-    q, k, v = (rearrange(t, 'b n (h d) -> (b h) n d', h=h) for t in (q_in, k_in, v_in))
+    q, k, v = (rearrange(t, "b n (h d) -> (b h) n d", h=h) for t in (q_in, k_in, v_in))
     del q_in, k_in, v_in
 
     dtype = q.dtype
@@ -196,22 +251,24 @@ def split_cross_attention_forward_v1(self, x, context=None, mask=None, **kwargs)
         q, k, v = q.float(), k.float(), v.float()
 
     with devices.without_autocast(disable=not shared.opts.upcast_attn):
-        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
+        r1 = torch.zeros(
+            q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype
+        )
         for i in range(0, q.shape[0], 2):
             end = i + 2
-            s1 = einsum('b i d, b j d -> b i j', q[i:end], k[i:end])
+            s1 = einsum("b i d, b j d -> b i j", q[i:end], k[i:end])
             s1 *= self.scale
 
             s2 = s1.softmax(dim=-1)
             del s1
 
-            r1[i:end] = einsum('b i j, b j d -> b i d', s2, v[i:end])
+            r1[i:end] = einsum("b i j, b j d -> b i d", s2, v[i:end])
             del s2
         del q, k, v
 
     r1 = r1.to(dtype)
 
-    r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
+    r2 = rearrange(r1, "(b h) n d -> b n (h d)", h=h)
     del r1
 
     return self.to_out(r2)
@@ -224,27 +281,37 @@ def split_cross_attention_forward(self, x, context=None, mask=None, **kwargs):
     q_in = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k_in = self.to_k(context_k)
     v_in = self.to_v(context_v)
 
     dtype = q_in.dtype
     if shared.opts.upcast_attn:
-        q_in, k_in, v_in = q_in.float(), k_in.float(), v_in if v_in.device.type == 'mps' else v_in.float()
+        q_in, k_in, v_in = (
+            q_in.float(),
+            k_in.float(),
+            v_in if v_in.device.type == "mps" else v_in.float(),
+        )
 
     with devices.without_autocast(disable=not shared.opts.upcast_attn):
         k_in = k_in * self.scale
 
         del context, x
 
-        q, k, v = (rearrange(t, 'b n (h d) -> (b h) n d', h=h) for t in (q_in, k_in, v_in))
+        q, k, v = (
+            rearrange(t, "b n (h d) -> (b h) n d", h=h) for t in (q_in, k_in, v_in)
+        )
         del q_in, k_in, v_in
 
-        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
+        r1 = torch.zeros(
+            q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype
+        )
 
         mem_free_total = get_available_vram()
 
-        gb = 1024 ** 3
+        gb = 1024**3
         tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * q.element_size()
         modifier = 3 if q.element_size() == 2 else 2.5
         mem_required = tensor_size * modifier
@@ -257,25 +324,27 @@ def split_cross_attention_forward(self, x, context=None, mask=None, **kwargs):
 
         if steps > 64:
             max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                               f'Need: {mem_required / 64 / gb:0.1f}GB free, Have:{mem_free_total / gb:0.1f}GB free')
+            raise RuntimeError(
+                f"Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). "
+                f"Need: {mem_required / 64 / gb:0.1f}GB free, Have:{mem_free_total / gb:0.1f}GB free"
+            )
 
         slice_size = q.shape[1] // steps
         for i in range(0, q.shape[1], slice_size):
             end = min(i + slice_size, q.shape[1])
-            s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)
+            s1 = einsum("b i d, b j d -> b i j", q[:, i:end], k)
 
             s2 = s1.softmax(dim=-1, dtype=q.dtype)
             del s1
 
-            r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
+            r1[:, i:end] = einsum("b i j, b j d -> b i d", s2, v)
             del s2
 
         del q, k, v
 
     r1 = r1.to(dtype)
 
-    r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
+    r2 = rearrange(r1, "(b h) n d -> b n (h d)", h=h)
     del r1
 
     return self.to_out(r2)
@@ -286,9 +355,9 @@ mem_total_gb = psutil.virtual_memory().total // (1 << 30)
 
 
 def einsum_op_compvis(q, k, v):
-    s = einsum('b i d, b j d -> b i j', q, k)
+    s = einsum("b i d, b j d -> b i j", q, k)
     s = s.softmax(dim=-1, dtype=s.dtype)
-    return einsum('b i j, b j d -> b i d', s, v)
+    return einsum("b i j, b j d -> b i d", s, v)
 
 
 def einsum_op_slice_0(q, k, v, slice_size):
@@ -308,7 +377,7 @@ def einsum_op_slice_1(q, k, v, slice_size):
 
 
 def einsum_op_mps_v1(q, k, v):
-    if q.shape[0] * q.shape[1] <= 2**16: # (512x512) max q.shape[1]: 4096
+    if q.shape[0] * q.shape[1] <= 2**16:  # (512x512) max q.shape[1]: 4096
         return einsum_op_compvis(q, k, v)
     else:
         slice_size = math.floor(2**30 / (q.shape[0] * q.shape[1]))
@@ -336,8 +405,8 @@ def einsum_op_tensor_mem(q, k, v, max_tensor_mb):
 
 def einsum_op_cuda(q, k, v):
     stats = torch.cuda.memory_stats(q.device)
-    mem_active = stats['active_bytes.all.current']
-    mem_reserved = stats['reserved_bytes.all.current']
+    mem_active = stats["active_bytes.all.current"]
+    mem_reserved = stats["reserved_bytes.all.current"]
     mem_free_cuda, _ = torch.cuda.mem_get_info(q.device)
     mem_free_torch = mem_reserved - mem_active
     mem_free_total = mem_free_cuda + mem_free_torch
@@ -346,11 +415,15 @@ def einsum_op_cuda(q, k, v):
 
 
 def einsum_op(q, k, v):
-    if q.device.type == 'cuda':
+    if q.device.type == "cuda":
         return einsum_op_cuda(q, k, v)
 
-    if q.device.type == 'mps':
-        if mem_total_gb >= 32 and q.shape[0] % 32 != 0 and q.shape[0] * q.shape[1] < 2**18:
+    if q.device.type == "mps":
+        if (
+            mem_total_gb >= 32
+            and q.shape[0] % 32 != 0
+            and q.shape[0] * q.shape[1] < 2**18
+        ):
             return einsum_op_mps_v1(q, k, v)
         return einsum_op_mps_v2(q, k, v)
 
@@ -365,22 +438,25 @@ def split_cross_attention_forward_invokeAI(self, x, context=None, mask=None, **k
     q = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k = self.to_k(context_k)
     v = self.to_v(context_v)
     del context, context_k, context_v, x
 
     dtype = q.dtype
     if shared.opts.upcast_attn:
-        q, k, v = q.float(), k.float(), v if v.device.type == 'mps' else v.float()
+        q, k, v = q.float(), k.float(), v if v.device.type == "mps" else v.float()
 
     with devices.without_autocast(disable=not shared.opts.upcast_attn):
         k = k * self.scale
 
-        q, k, v = (rearrange(t, 'b n (h d) -> (b h) n d', h=h) for t in (q, k, v))
+        q, k, v = (rearrange(t, "b n (h d) -> (b h) n d", h=h) for t in (q, k, v))
         r = einsum_op(q, k, v)
     r = r.to(dtype)
-    return self.to_out(rearrange(r, '(b h) n d -> b n (h d)', h=h))
+    return self.to_out(rearrange(r, "(b h) n d -> b n (h d)", h=h))
+
 
 # -- End of code from https://github.com/invoke-ai/InvokeAI --
 
@@ -388,34 +464,46 @@ def split_cross_attention_forward_invokeAI(self, x, context=None, mask=None, **k
 # Based on Birch-san's modified implementation of sub-quadratic attention from https://github.com/Birch-san/diffusers/pull/1
 # The sub_quad_attention_forward function is under the MIT License listed under Memory Efficient Attention in the Licenses section of the web UI interface
 def sub_quad_attention_forward(self, x, context=None, mask=None, **kwargs):
-    assert mask is None, "attention-mask not currently implemented for SubQuadraticCrossAttnProcessor."
+    assert (
+        mask is None
+    ), "attention-mask not currently implemented for SubQuadraticCrossAttnProcessor."
 
     h = self.heads
 
     q = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k = self.to_k(context_k)
     v = self.to_v(context_v)
     del context, context_k, context_v, x
 
-    q = q.unflatten(-1, (h, -1)).transpose(1,2).flatten(end_dim=1)
-    k = k.unflatten(-1, (h, -1)).transpose(1,2).flatten(end_dim=1)
-    v = v.unflatten(-1, (h, -1)).transpose(1,2).flatten(end_dim=1)
+    q = q.unflatten(-1, (h, -1)).transpose(1, 2).flatten(end_dim=1)
+    k = k.unflatten(-1, (h, -1)).transpose(1, 2).flatten(end_dim=1)
+    v = v.unflatten(-1, (h, -1)).transpose(1, 2).flatten(end_dim=1)
 
-    if q.device.type == 'mps':
+    if q.device.type == "mps":
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
 
     dtype = q.dtype
     if shared.opts.upcast_attn:
         q, k = q.float(), k.float()
 
-    x = sub_quad_attention(q, k, v, q_chunk_size=shared.cmd_opts.sub_quad_q_chunk_size, kv_chunk_size=shared.cmd_opts.sub_quad_kv_chunk_size, chunk_threshold=shared.cmd_opts.sub_quad_chunk_threshold, use_checkpoint=self.training)
+    x = sub_quad_attention(
+        q,
+        k,
+        v,
+        q_chunk_size=shared.cmd_opts.sub_quad_q_chunk_size,
+        kv_chunk_size=shared.cmd_opts.sub_quad_kv_chunk_size,
+        chunk_threshold=shared.cmd_opts.sub_quad_chunk_threshold,
+        use_checkpoint=self.training,
+    )
 
     x = x.to(dtype)
 
-    x = x.unflatten(0, (-1, h)).transpose(1,2).flatten(start_dim=2)
+    x = x.unflatten(0, (-1, h)).transpose(1, 2).flatten(start_dim=2)
 
     out_proj, dropout = self.to_out
     x = out_proj(x)
@@ -424,15 +512,26 @@ def sub_quad_attention_forward(self, x, context=None, mask=None, **kwargs):
     return x
 
 
-def sub_quad_attention(q, k, v, q_chunk_size=1024, kv_chunk_size=None, kv_chunk_size_min=None, chunk_threshold=None, use_checkpoint=True):
-    bytes_per_token = torch.finfo(q.dtype).bits//8
+def sub_quad_attention(
+    q,
+    k,
+    v,
+    q_chunk_size=1024,
+    kv_chunk_size=None,
+    kv_chunk_size_min=None,
+    chunk_threshold=None,
+    use_checkpoint=True,
+):
+    bytes_per_token = torch.finfo(q.dtype).bits // 8
     batch_x_heads, q_tokens, _ = q.shape
     _, k_tokens, _ = k.shape
     qk_matmul_size_bytes = batch_x_heads * bytes_per_token * q_tokens * k_tokens
 
     if chunk_threshold is None:
-        if q.device.type == 'mps':
-            chunk_threshold_bytes = 268435456 * (2 if platform.processor() == 'i386' else bytes_per_token)
+        if q.device.type == "mps":
+            chunk_threshold_bytes = 268435456 * (
+                2 if platform.processor() == "i386" else bytes_per_token
+            )
         else:
             chunk_threshold_bytes = int(get_available_vram() * 0.7)
     elif chunk_threshold == 0:
@@ -441,11 +540,16 @@ def sub_quad_attention(q, k, v, q_chunk_size=1024, kv_chunk_size=None, kv_chunk_
         chunk_threshold_bytes = int(0.01 * chunk_threshold * get_available_vram())
 
     if kv_chunk_size_min is None and chunk_threshold_bytes is not None:
-        kv_chunk_size_min = chunk_threshold_bytes // (batch_x_heads * bytes_per_token * (k.shape[2] + v.shape[2]))
+        kv_chunk_size_min = chunk_threshold_bytes // (
+            batch_x_heads * bytes_per_token * (k.shape[2] + v.shape[2])
+        )
     elif kv_chunk_size_min == 0:
         kv_chunk_size_min = None
 
-    if chunk_threshold_bytes is not None and qk_matmul_size_bytes <= chunk_threshold_bytes:
+    if (
+        chunk_threshold_bytes is not None
+        and qk_matmul_size_bytes <= chunk_threshold_bytes
+    ):
         # the big matmul fits into our memory limit; do everything in 1 chunk,
         # i.e. send it down the unchunked fast-path
         kv_chunk_size = k_tokens
@@ -457,7 +561,7 @@ def sub_quad_attention(q, k, v, q_chunk_size=1024, kv_chunk_size=None, kv_chunk_
             v,
             query_chunk_size=q_chunk_size,
             kv_chunk_size=kv_chunk_size,
-            kv_chunk_size_min = kv_chunk_size_min,
+            kv_chunk_size_min=kv_chunk_size_min,
             use_checkpoint=use_checkpoint,
         )
 
@@ -469,7 +573,9 @@ def get_xformers_flash_attention_op(q, k, v):
     try:
         flash_attention_op = xformers.ops.MemoryEfficientAttentionFlashAttentionOp
         fw, bw = flash_attention_op
-        if fw.supports(xformers.ops.fmha.Inputs(query=q, key=k, value=v, attn_bias=None)):
+        if fw.supports(
+            xformers.ops.fmha.Inputs(query=q, key=k, value=v, attn_bias=None)
+        ):
             return flash_attention_op
     except Exception as e:
         errors.display_once(e, "enabling flash attention")
@@ -482,7 +588,9 @@ def xformers_attention_forward(self, x, context=None, mask=None, **kwargs):
     q_in = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k_in = self.to_k(context_k)
     v_in = self.to_v(context_v)
 
@@ -494,7 +602,9 @@ def xformers_attention_forward(self, x, context=None, mask=None, **kwargs):
     if shared.opts.upcast_attn:
         q, k, v = q.float(), k.float(), v.float()
 
-    out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None, op=get_xformers_flash_attention_op(q, k, v))
+    out = xformers.ops.memory_efficient_attention(
+        q, k, v, attn_bias=None, op=get_xformers_flash_attention_op(q, k, v)
+    )
 
     out = out.to(dtype)
 
@@ -516,7 +626,9 @@ def scaled_dot_product_attention_forward(self, x, context=None, mask=None, **kwa
     q_in = self.to_q(x)
     context = default(context, x)
 
-    context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+    context_k, context_v = hypernetwork.apply_hypernetworks(
+        shared.loaded_hypernetworks, context
+    )
     k_in = self.to_k(context_k)
     v_in = self.to_v(context_v)
 
@@ -546,68 +658,74 @@ def scaled_dot_product_attention_forward(self, x, context=None, mask=None, **kwa
     return hidden_states
 
 
-def scaled_dot_product_no_mem_attention_forward(self, x, context=None, mask=None, **kwargs):
-    with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=True, enable_mem_efficient=False):
+def scaled_dot_product_no_mem_attention_forward(
+    self, x, context=None, mask=None, **kwargs
+):
+    with torch.backends.cuda.sdp_kernel(
+        enable_flash=True, enable_math=True, enable_mem_efficient=False
+    ):
         return scaled_dot_product_attention_forward(self, x, context, mask)
 
 
 def cross_attention_attnblock_forward(self, x):
-        h_ = x
-        h_ = self.norm(h_)
-        q1 = self.q(h_)
-        k1 = self.k(h_)
-        v = self.v(h_)
+    h_ = x
+    h_ = self.norm(h_)
+    q1 = self.q(h_)
+    k1 = self.k(h_)
+    v = self.v(h_)
 
-        # compute attention
-        b, c, h, w = q1.shape
+    # compute attention
+    b, c, h, w = q1.shape
 
-        q2 = q1.reshape(b, c, h*w)
-        del q1
+    q2 = q1.reshape(b, c, h * w)
+    del q1
 
-        q = q2.permute(0, 2, 1)   # b,hw,c
-        del q2
+    q = q2.permute(0, 2, 1)  # b,hw,c
+    del q2
 
-        k = k1.reshape(b, c, h*w) # b,c,hw
-        del k1
+    k = k1.reshape(b, c, h * w)  # b,c,hw
+    del k1
 
-        h_ = torch.zeros_like(k, device=q.device)
+    h_ = torch.zeros_like(k, device=q.device)
 
-        mem_free_total = get_available_vram()
+    mem_free_total = get_available_vram()
 
-        tensor_size = q.shape[0] * q.shape[1] * k.shape[2] * q.element_size()
-        mem_required = tensor_size * 2.5
-        steps = 1
+    tensor_size = q.shape[0] * q.shape[1] * k.shape[2] * q.element_size()
+    mem_required = tensor_size * 2.5
+    steps = 1
 
-        if mem_required > mem_free_total:
-            steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
+    if mem_required > mem_free_total:
+        steps = 2 ** (math.ceil(math.log(mem_required / mem_free_total, 2)))
 
-        slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
-        for i in range(0, q.shape[1], slice_size):
-            end = i + slice_size
+    slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
+    for i in range(0, q.shape[1], slice_size):
+        end = i + slice_size
 
-            w1 = torch.bmm(q[:, i:end], k)     # b,hw,hw    w[b,i,j]=sum_c q[b,i,c]k[b,c,j]
-            w2 = w1 * (int(c)**(-0.5))
-            del w1
-            w3 = torch.nn.functional.softmax(w2, dim=2, dtype=q.dtype)
-            del w2
+        w1 = torch.bmm(q[:, i:end], k)  # b,hw,hw    w[b,i,j]=sum_c q[b,i,c]k[b,c,j]
+        w2 = w1 * (int(c) ** (-0.5))
+        del w1
+        w3 = torch.nn.functional.softmax(w2, dim=2, dtype=q.dtype)
+        del w2
 
-            # attend to values
-            v1 = v.reshape(b, c, h*w)
-            w4 = w3.permute(0, 2, 1)   # b,hw,hw (first hw of k, second of q)
-            del w3
+        # attend to values
+        v1 = v.reshape(b, c, h * w)
+        w4 = w3.permute(0, 2, 1)  # b,hw,hw (first hw of k, second of q)
+        del w3
 
-            h_[:, :, i:end] = torch.bmm(v1, w4)     # b, c,hw (hw of q) h_[b,c,j] = sum_i v[b,c,i] w_[b,i,j]
-            del v1, w4
+        h_[:, :, i:end] = torch.bmm(
+            v1, w4
+        )  # b, c,hw (hw of q) h_[b,c,j] = sum_i v[b,c,i] w_[b,i,j]
+        del v1, w4
 
-        h2 = h_.reshape(b, c, h, w)
-        del h_
+    h2 = h_.reshape(b, c, h, w)
+    del h_
 
-        h3 = self.proj_out(h2)
-        del h2
+    h3 = self.proj_out(h2)
+    del h2
 
-        h3 += x
+    h3 += x
 
-        return h3
+    return h3
 
 
 def xformers_attnblock_forward(self, x):
@@ -618,16 +736,18 @@ def xformers_attnblock_forward(self, x):
         k = self.k(h_)
         v = self.v(h_)
         b, c, h, w = q.shape
-        q, k, v = (rearrange(t, 'b c h w -> b (h w) c') for t in (q, k, v))
+        q, k, v = (rearrange(t, "b c h w -> b (h w) c") for t in (q, k, v))
         dtype = q.dtype
         if shared.opts.upcast_attn:
             q, k = q.float(), k.float()
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
-        out = xformers.ops.memory_efficient_attention(q, k, v, op=get_xformers_flash_attention_op(q, k, v))
+        out = xformers.ops.memory_efficient_attention(
+            q, k, v, op=get_xformers_flash_attention_op(q, k, v)
+        )
         out = out.to(dtype)
-        out = rearrange(out, 'b (h w) c -> b c h w', h=h)
+        out = rearrange(out, "b (h w) c -> b c h w", h=h)
         out = self.proj_out(out)
         return x + out
     except NotImplementedError:
@@ -641,22 +761,26 @@ def sdp_attnblock_forward(self, x):
     k = self.k(h_)
     v = self.v(h_)
     b, c, h, w = q.shape
-    q, k, v = (rearrange(t, 'b c h w -> b (h w) c') for t in (q, k, v))
+    q, k, v = (rearrange(t, "b c h w -> b (h w) c") for t in (q, k, v))
     dtype = q.dtype
     if shared.opts.upcast_attn:
         q, k, v = q.float(), k.float(), v.float()
     q = q.contiguous()
     k = k.contiguous()
     v = v.contiguous()
-    out = torch.nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=False)
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, dropout_p=0.0, is_causal=False
+    )
     out = out.to(dtype)
-    out = rearrange(out, 'b (h w) c -> b c h w', h=h)
+    out = rearrange(out, "b (h w) c -> b c h w", h=h)
     out = self.proj_out(out)
     return x + out
 
 
 def sdp_no_mem_attnblock_forward(self, x):
-    with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=True, enable_mem_efficient=False):
+    with torch.backends.cuda.sdp_kernel(
+        enable_flash=True, enable_math=True, enable_mem_efficient=False
+    ):
         return sdp_attnblock_forward(self, x)
 
 
@@ -667,11 +791,19 @@ def sub_quad_attnblock_forward(self, x):
     k = self.k(h_)
     v = self.v(h_)
     b, c, h, w = q.shape
-    q, k, v = (rearrange(t, 'b c h w -> b (h w) c') for t in (q, k, v))
+    q, k, v = (rearrange(t, "b c h w -> b (h w) c") for t in (q, k, v))
     q = q.contiguous()
     k = k.contiguous()
     v = v.contiguous()
-    out = sub_quad_attention(q, k, v, q_chunk_size=shared.cmd_opts.sub_quad_q_chunk_size, kv_chunk_size=shared.cmd_opts.sub_quad_kv_chunk_size, chunk_threshold=shared.cmd_opts.sub_quad_chunk_threshold, use_checkpoint=self.training)
-    out = rearrange(out, 'b (h w) c -> b c h w', h=h)
+    out = sub_quad_attention(
+        q,
+        k,
+        v,
+        q_chunk_size=shared.cmd_opts.sub_quad_q_chunk_size,
+        kv_chunk_size=shared.cmd_opts.sub_quad_kv_chunk_size,
+        chunk_threshold=shared.cmd_opts.sub_quad_chunk_threshold,
+        use_checkpoint=self.training,
+    )
+    out = rearrange(out, "b (h w) c -> b c h w", h=h)
     out = self.proj_out(out)
     return x + out

--- a/modules/sd_hijack_unet.py
+++ b/modules/sd_hijack_unet.py
@@ -14,13 +14,15 @@ class TorchHijackForUnet:
     """
 
     def __getattr__(self, item):
-        if item == 'cat':
+        if item == "cat":
             return self.cat
 
         if hasattr(torch, item):
             return getattr(torch, item)
 
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{item}'"
+        )
 
     def cat(self, tensors, *args, **kwargs):
         if len(tensors) == 2:
@@ -42,12 +44,25 @@ def apply_model(orig_func, self, x_noisy, t, cond, **kwargs):
     if isinstance(cond, dict):
         for y in cond.keys():
             if isinstance(cond[y], list):
-                cond[y] = [x.to(devices.dtype_unet) if isinstance(x, torch.Tensor) else x for x in cond[y]]
+                cond[y] = [
+                    x.to(devices.dtype_unet) if isinstance(x, torch.Tensor) else x
+                    for x in cond[y]
+                ]
             else:
-                cond[y] = cond[y].to(devices.dtype_unet) if isinstance(cond[y], torch.Tensor) else cond[y]
+                cond[y] = (
+                    cond[y].to(devices.dtype_unet)
+                    if isinstance(cond[y], torch.Tensor)
+                    else cond[y]
+                )
 
     with devices.autocast():
-        result = orig_func(self, x_noisy.to(devices.dtype_unet), t.to(devices.dtype_unet), cond, **kwargs)
+        result = orig_func(
+            self,
+            x_noisy.to(devices.dtype_unet),
+            t.to(devices.dtype_unet),
+            cond,
+            **kwargs,
+        )
         if devices.unet_needs_upcast:
             return result.float()
         else:
@@ -67,14 +82,20 @@ def timestep_embedding(_, timesteps, dim, max_period=10000, repeat_only=False):
     if not repeat_only:
         half = dim // 2
         freqs = torch.exp(
-            -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32, device=timesteps.device) / half
+            -math.log(max_period)
+            * torch.arange(
+                start=0, end=half, dtype=torch.float32, device=timesteps.device
+            )
+            / half
         )
         args = timesteps[:, None].float() * freqs[None]
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
         if dim % 2:
-            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
     else:
-        embedding = repeat(timesteps, 'b -> b d', d=dim)
+        embedding = repeat(timesteps, "b -> b d", d=dim)
     return embedding
 
 
@@ -105,6 +126,7 @@ def spatial_transformer_forward(_, self, x: torch.Tensor, context=None):
 class GELUHijack(torch.nn.GELU, torch.nn.Module):
     def __init__(self, *args, **kwargs):
         torch.nn.GELU.__init__(self, *args, **kwargs)
+
     def forward(self, x):
         if devices.unet_needs_upcast:
             return torch.nn.GELU.forward(self.float(), x.float()).to(devices.dtype_unet)
@@ -113,33 +135,99 @@ class GELUHijack(torch.nn.GELU, torch.nn.Module):
 
 
 ddpm_edit_hijack = None
+
+
 def hijack_ddpm_edit():
     global ddpm_edit_hijack
     if not ddpm_edit_hijack:
-        CondFunc('modules.models.diffusion.ddpm_edit.LatentDiffusion.decode_first_stage', first_stage_sub, first_stage_cond)
-        CondFunc('modules.models.diffusion.ddpm_edit.LatentDiffusion.encode_first_stage', first_stage_sub, first_stage_cond)
-        ddpm_edit_hijack = CondFunc('modules.models.diffusion.ddpm_edit.LatentDiffusion.apply_model', apply_model)
+        CondFunc(
+            "modules.models.diffusion.ddpm_edit.LatentDiffusion.decode_first_stage",
+            first_stage_sub,
+            first_stage_cond,
+        )
+        CondFunc(
+            "modules.models.diffusion.ddpm_edit.LatentDiffusion.encode_first_stage",
+            first_stage_sub,
+            first_stage_cond,
+        )
+        ddpm_edit_hijack = CondFunc(
+            "modules.models.diffusion.ddpm_edit.LatentDiffusion.apply_model",
+            apply_model,
+        )
 
 
 unet_needs_upcast = lambda *args, **kwargs: devices.unet_needs_upcast
-CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.apply_model', apply_model, unet_needs_upcast)
-CondFunc('ldm.modules.diffusionmodules.openaimodel.timestep_embedding', timestep_embedding)
-CondFunc('ldm.modules.attention.SpatialTransformer.forward', spatial_transformer_forward)
-CondFunc('ldm.modules.diffusionmodules.openaimodel.timestep_embedding', lambda orig_func, timesteps, *args, **kwargs: orig_func(timesteps, *args, **kwargs).to(torch.float32 if timesteps.dtype == torch.int64 else devices.dtype_unet), unet_needs_upcast)
+CondFunc(
+    "ldm.models.diffusion.ddpm.LatentDiffusion.apply_model",
+    apply_model,
+    unet_needs_upcast,
+)
+CondFunc(
+    "ldm.modules.diffusionmodules.openaimodel.timestep_embedding", timestep_embedding
+)
+CondFunc(
+    "ldm.modules.attention.SpatialTransformer.forward", spatial_transformer_forward
+)
+CondFunc(
+    "ldm.modules.diffusionmodules.openaimodel.timestep_embedding",
+    lambda orig_func, timesteps, *args, **kwargs: orig_func(
+        timesteps, *args, **kwargs
+    ).to(torch.float32 if timesteps.dtype == torch.int64 else devices.dtype_unet),
+    unet_needs_upcast,
+)
 
-if version.parse(torch.__version__) <= version.parse("1.13.2") or torch.cuda.is_available():
-    CondFunc('ldm.modules.diffusionmodules.util.GroupNorm32.forward', lambda orig_func, self, *args, **kwargs: orig_func(self.float(), *args, **kwargs), unet_needs_upcast)
-    CondFunc('ldm.modules.attention.GEGLU.forward', lambda orig_func, self, x: orig_func(self.float(), x.float()).to(devices.dtype_unet), unet_needs_upcast)
-    CondFunc('open_clip.transformer.ResidualAttentionBlock.__init__', lambda orig_func, *args, **kwargs: kwargs.update({'act_layer': GELUHijack}) and False or orig_func(*args, **kwargs), lambda _, *args, **kwargs: kwargs.get('act_layer') is None or kwargs['act_layer'] == torch.nn.GELU)
+if (
+    version.parse(torch.__version__) <= version.parse("1.13.2")
+    or torch.cuda.is_available()
+):
+    CondFunc(
+        "ldm.modules.diffusionmodules.util.GroupNorm32.forward",
+        lambda orig_func, self, *args, **kwargs: orig_func(
+            self.float(), *args, **kwargs
+        ),
+        unet_needs_upcast,
+    )
+    CondFunc(
+        "ldm.modules.attention.GEGLU.forward",
+        lambda orig_func, self, x: orig_func(self.float(), x.float()).to(
+            devices.dtype_unet
+        ),
+        unet_needs_upcast,
+    )
+    CondFunc(
+        "open_clip.transformer.ResidualAttentionBlock.__init__",
+        lambda orig_func, *args, **kwargs: kwargs.update({"act_layer": GELUHijack})
+        and False
+        or orig_func(*args, **kwargs),
+        lambda _, *args, **kwargs: kwargs.get("act_layer") is None
+        or kwargs["act_layer"] == torch.nn.GELU,
+    )
 
-first_stage_cond = lambda _, self, *args, **kwargs: devices.unet_needs_upcast and self.model.diffusion_model.dtype == torch.float16
-first_stage_sub = lambda orig_func, self, x, **kwargs: orig_func(self, x.to(devices.dtype_vae), **kwargs)
-CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.decode_first_stage', first_stage_sub, first_stage_cond)
-CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.encode_first_stage', first_stage_sub, first_stage_cond)
-CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.get_first_stage_encoding', lambda orig_func, *args, **kwargs: orig_func(*args, **kwargs).float(), first_stage_cond)
+first_stage_cond = (
+    lambda _, self, *args, **kwargs: devices.unet_needs_upcast
+    and self.model.diffusion_model.dtype == torch.float16
+)
+first_stage_sub = lambda orig_func, self, x, **kwargs: orig_func(
+    self, x.to(devices.dtype_vae), **kwargs
+)
+CondFunc(
+    "ldm.models.diffusion.ddpm.LatentDiffusion.decode_first_stage",
+    first_stage_sub,
+    first_stage_cond,
+)
+CondFunc(
+    "ldm.models.diffusion.ddpm.LatentDiffusion.encode_first_stage",
+    first_stage_sub,
+    first_stage_cond,
+)
+CondFunc(
+    "ldm.models.diffusion.ddpm.LatentDiffusion.get_first_stage_encoding",
+    lambda orig_func, *args, **kwargs: orig_func(*args, **kwargs).float(),
+    first_stage_cond,
+)
 
-CondFunc('ldm.models.diffusion.ddpm.LatentDiffusion.apply_model', apply_model)
-CondFunc('sgm.modules.diffusionmodules.wrappers.OpenAIWrapper.forward', apply_model)
+CondFunc("ldm.models.diffusion.ddpm.LatentDiffusion.apply_model", apply_model)
+CondFunc("sgm.modules.diffusionmodules.wrappers.OpenAIWrapper.forward", apply_model)
 
 
 def timestep_embedding_cast_result(orig_func, timesteps, *args, **kwargs):
@@ -150,5 +238,11 @@ def timestep_embedding_cast_result(orig_func, timesteps, *args, **kwargs):
     return orig_func(timesteps, *args, **kwargs).to(dtype=dtype)
 
 
-CondFunc('ldm.modules.diffusionmodules.openaimodel.timestep_embedding', timestep_embedding_cast_result)
-CondFunc('sgm.modules.diffusionmodules.openaimodel.timestep_embedding', timestep_embedding_cast_result)
+CondFunc(
+    "ldm.modules.diffusionmodules.openaimodel.timestep_embedding",
+    timestep_embedding_cast_result,
+)
+CondFunc(
+    "sgm.modules.diffusionmodules.openaimodel.timestep_embedding",
+    timestep_embedding_cast_result,
+)

--- a/modules/sd_hijack_utils.py
+++ b/modules/sd_hijack_utils.py
@@ -8,10 +8,10 @@ class CondFunc:
     def __new__(cls, orig_func, sub_func, cond_func=always_true_func):
         self = super(CondFunc, cls).__new__(cls)
         if isinstance(orig_func, str):
-            func_path = orig_func.split('.')
-            for i in range(len(func_path)-1, -1, -1):
+            func_path = orig_func.split(".")
+            for i in range(len(func_path) - 1, -1, -1):
                 try:
-                    resolved_obj = importlib.import_module('.'.join(func_path[:i]))
+                    resolved_obj = importlib.import_module(".".join(func_path[:i]))
                     break
                 except ImportError:
                     pass
@@ -19,16 +19,22 @@ class CondFunc:
                 for attr_name in func_path[i:-1]:
                     resolved_obj = getattr(resolved_obj, attr_name)
                 orig_func = getattr(resolved_obj, func_path[-1])
-                setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: self(*args, **kwargs))
+                setattr(
+                    resolved_obj,
+                    func_path[-1],
+                    lambda *args, **kwargs: self(*args, **kwargs),
+                )
             except AttributeError:
                 print(f"Warning: Failed to resolve {orig_func} for CondFunc hijack")
                 pass
         self.__init__(orig_func, sub_func, cond_func)
         return lambda *args, **kwargs: self(*args, **kwargs)
+
     def __init__(self, orig_func, sub_func, cond_func):
         self.__orig_func = orig_func
         self.__sub_func = sub_func
         self.__cond_func = cond_func
+
     def __call__(self, *args, **kwargs):
         if not self.__cond_func or self.__cond_func(self.__orig_func, *args, **kwargs):
             return self.__sub_func(self.__orig_func, *args, **kwargs)

--- a/modules/sd_hijack_xlmr.py
+++ b/modules/sd_hijack_xlmr.py
@@ -3,7 +3,9 @@ import torch
 from modules import sd_hijack_clip, devices
 
 
-class FrozenXLMREmbedderWithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords):
+class FrozenXLMREmbedderWithCustomWords(
+    sd_hijack_clip.FrozenCLIPEmbedderWithCustomWords
+):
     def __init__(self, wrapped, hijack):
         super().__init__(wrapped, hijack)
 
@@ -11,22 +13,30 @@ class FrozenXLMREmbedderWithCustomWords(sd_hijack_clip.FrozenCLIPEmbedderWithCus
         self.id_end = wrapped.config.eos_token_id
         self.id_pad = wrapped.config.pad_token_id
 
-        self.comma_token = self.tokenizer.get_vocab().get(',', None)  # alt diffusion doesn't have </w> bits for comma
+        self.comma_token = self.tokenizer.get_vocab().get(
+            ",", None
+        )  # alt diffusion doesn't have </w> bits for comma
 
     def encode_with_transformers(self, tokens):
         # there's no CLIP Skip here because all hidden layers have size of 1024 and the last one uses a
         # trained layer to transform those 1024 into 768 for unet; so you can't choose which transformer
         # layer to work with - you have to use the last
 
-        attention_mask = (tokens != self.id_pad).to(device=tokens.device, dtype=torch.int64)
+        attention_mask = (tokens != self.id_pad).to(
+            device=tokens.device, dtype=torch.int64
+        )
         features = self.wrapped(input_ids=tokens, attention_mask=attention_mask)
-        z = features['projection_state']
+        z = features["projection_state"]
 
         return z
 
     def encode_embedding_init_text(self, init_text, nvpt):
         embedding_layer = self.wrapped.roberta.embeddings
-        ids = self.wrapped.tokenizer(init_text, max_length=nvpt, return_tensors="pt", add_special_tokens=False)["input_ids"]
-        embedded = embedding_layer.token_embedding.wrapped(ids.to(devices.device)).squeeze(0)
+        ids = self.wrapped.tokenizer(
+            init_text, max_length=nvpt, return_tensors="pt", add_special_tokens=False
+        )["input_ids"]
+        embedded = embedding_layer.token_embedding.wrapped(
+            ids.to(devices.device)
+        ).squeeze(0)
 
         return embedded

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -12,7 +12,26 @@ from omegaconf import OmegaConf, ListConfig
 from urllib import request
 import ldm.modules.midas as midas
 
-from modules import paths, shared, modelloader, devices, script_callbacks, sd_vae, sd_disable_initialization, errors, hashes, sd_models_config, sd_unet, sd_models_xl, cache, extra_networks, processing, lowvram, sd_hijack, patches
+from modules import (
+    paths,
+    shared,
+    modelloader,
+    devices,
+    script_callbacks,
+    sd_vae,
+    sd_disable_initialization,
+    errors,
+    hashes,
+    sd_models_config,
+    sd_unet,
+    sd_models_xl,
+    cache,
+    extra_networks,
+    processing,
+    lowvram,
+    sd_hijack,
+    patches,
+)
 from modules.timer import Timer
 from modules.shared import opts
 import tomesd
@@ -57,14 +76,18 @@ class CheckpointInfo:
     def __init__(self, filename):
         self.filename = filename
         abspath = os.path.abspath(filename)
-        abs_ckpt_dir = os.path.abspath(shared.cmd_opts.ckpt_dir) if shared.cmd_opts.ckpt_dir is not None else None
+        abs_ckpt_dir = (
+            os.path.abspath(shared.cmd_opts.ckpt_dir)
+            if shared.cmd_opts.ckpt_dir is not None
+            else None
+        )
 
         self.is_safetensors = os.path.splitext(filename)[1].lower() == ".safetensors"
 
         if abs_ckpt_dir and abspath.startswith(abs_ckpt_dir):
-            name = abspath.replace(abs_ckpt_dir, '')
+            name = abspath.replace(abs_ckpt_dir, "")
         elif abspath.startswith(model_path):
-            name = abspath.replace(model_path, '')
+            name = abspath.replace(model_path, "")
         else:
             name = os.path.basename(filename)
 
@@ -73,14 +96,19 @@ class CheckpointInfo:
 
         def read_metadata():
             metadata = read_metadata_from_safetensors(filename)
-            self.modelspec_thumbnail = metadata.pop('modelspec.thumbnail', None)
+            self.modelspec_thumbnail = metadata.pop("modelspec.thumbnail", None)
 
             return metadata
 
         self.metadata = {}
         if self.is_safetensors:
             try:
-                self.metadata = cache.cached_data_for_file('safetensors-metadata', "checkpoint/" + name, filename, read_metadata)
+                self.metadata = cache.cached_data_for_file(
+                    "safetensors-metadata",
+                    "checkpoint/" + name,
+                    filename,
+                    read_metadata,
+                )
             except Exception as e:
                 errors.display(e, f"reading metadata for {filename}")
 
@@ -92,12 +120,28 @@ class CheckpointInfo:
         self.sha256 = hashes.sha256_from_cache(self.filename, f"checkpoint/{name}")
         self.shorthash = self.sha256[0:10] if self.sha256 else None
 
-        self.title = name if self.shorthash is None else f'{name} [{self.shorthash}]'
-        self.short_title = self.name_for_extra if self.shorthash is None else f'{self.name_for_extra} [{self.shorthash}]'
+        self.title = name if self.shorthash is None else f"{name} [{self.shorthash}]"
+        self.short_title = (
+            self.name_for_extra
+            if self.shorthash is None
+            else f"{self.name_for_extra} [{self.shorthash}]"
+        )
 
-        self.ids = [self.hash, self.model_name, self.title, name, self.name_for_extra, f'{name} [{self.hash}]']
+        self.ids = [
+            self.hash,
+            self.model_name,
+            self.title,
+            name,
+            self.name_for_extra,
+            f"{name} [{self.hash}]",
+        ]
         if self.shorthash:
-            self.ids += [self.shorthash, self.sha256, f'{self.name} [{self.shorthash}]', f'{self.name_for_extra} [{self.shorthash}]']
+            self.ids += [
+                self.shorthash,
+                self.sha256,
+                f"{self.name} [{self.shorthash}]",
+                f"{self.name_for_extra} [{self.shorthash}]",
+            ]
 
     def register(self):
         checkpoints_list[self.title] = self
@@ -116,11 +160,16 @@ class CheckpointInfo:
         self.shorthash = shorthash
 
         if self.shorthash not in self.ids:
-            self.ids += [self.shorthash, self.sha256, f'{self.name} [{self.shorthash}]', f'{self.name_for_extra} [{self.shorthash}]']
+            self.ids += [
+                self.shorthash,
+                self.sha256,
+                f"{self.name} [{self.shorthash}]",
+                f"{self.name_for_extra} [{self.shorthash}]",
+            ]
 
         old_title = self.title
-        self.title = f'{self.name} [{self.shorthash}]'
-        self.short_title = f'{self.name_for_extra} [{self.shorthash}]'
+        self.title = f"{self.name} [{self.shorthash}]"
+        self.short_title = f"{self.name_for_extra} [{self.shorthash}]"
 
         replace_key(checkpoints_list, old_title, self.title, self)
         self.register()
@@ -155,22 +204,39 @@ def list_models():
     checkpoint_aliases.clear()
 
     cmd_ckpt = shared.cmd_opts.ckpt
-    if shared.cmd_opts.no_download_sd_model or cmd_ckpt != shared.sd_model_file or os.path.exists(cmd_ckpt):
+    if (
+        shared.cmd_opts.no_download_sd_model
+        or cmd_ckpt != shared.sd_model_file
+        or os.path.exists(cmd_ckpt)
+    ):
         model_url = None
         expected_sha256 = None
     else:
         model_url = f"{shared.hf_endpoint}/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
-        expected_sha256 = '6ce0161689b3853acaa03779ec93eafe75a02f4ced659bee03f50797806fa2fa'
+        expected_sha256 = (
+            "6ce0161689b3853acaa03779ec93eafe75a02f4ced659bee03f50797806fa2fa"
+        )
 
-    model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.cmd_opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"], hash_prefix=expected_sha256)
+    model_list = modelloader.load_models(
+        model_path=model_path,
+        model_url=model_url,
+        command_path=shared.cmd_opts.ckpt_dir,
+        ext_filter=[".ckpt", ".safetensors"],
+        download_name="v1-5-pruned-emaonly.safetensors",
+        ext_blacklist=[".vae.ckpt", ".vae.safetensors"],
+        hash_prefix=expected_sha256,
+    )
 
     if os.path.exists(cmd_ckpt):
         checkpoint_info = CheckpointInfo(cmd_ckpt)
         checkpoint_info.register()
 
-        shared.opts.data['sd_model_checkpoint'] = checkpoint_info.title
+        shared.opts.data["sd_model_checkpoint"] = checkpoint_info.title
     elif cmd_ckpt is not None and cmd_ckpt != shared.default_sd_model_file:
-        print(f"Checkpoint in --ckpt argument not found (Possible it was moved to {model_path}: {cmd_ckpt}", file=sys.stderr)
+        print(
+            f"Checkpoint in --ckpt argument not found (Possible it was moved to {model_path}: {cmd_ckpt}",
+            file=sys.stderr,
+        )
 
     for filename in model_list:
         checkpoint_info = CheckpointInfo(filename)
@@ -188,12 +254,22 @@ def get_closet_checkpoint_match(search_string):
     if checkpoint_info is not None:
         return checkpoint_info
 
-    found = sorted([info for info in checkpoints_list.values() if search_string in info.title], key=lambda x: len(x.title))
+    found = sorted(
+        [info for info in checkpoints_list.values() if search_string in info.title],
+        key=lambda x: len(x.title),
+    )
     if found:
         return found[0]
 
-    search_string_without_checksum = re.sub(re_strip_checksum, '', search_string)
-    found = sorted([info for info in checkpoints_list.values() if search_string_without_checksum in info.title], key=lambda x: len(x.title))
+    search_string_without_checksum = re.sub(re_strip_checksum, "", search_string)
+    found = sorted(
+        [
+            info
+            for info in checkpoints_list.values()
+            if search_string_without_checksum in info.title
+        ],
+        key=lambda x: len(x.title),
+    )
     if found:
         return found[0]
 
@@ -206,13 +282,14 @@ def model_hash(filename):
     try:
         with open(filename, "rb") as file:
             import hashlib
+
             m = hashlib.sha256()
 
             file.seek(0x100000)
             m.update(file.read(0x10000))
             return m.hexdigest()[0:8]
     except FileNotFoundError:
-        return 'NOFILE'
+        return "NOFILE"
 
 
 def select_checkpoint():
@@ -224,37 +301,44 @@ def select_checkpoint():
         return checkpoint_info
 
     if len(checkpoints_list) == 0:
-        error_message = "No checkpoints found. When searching for checkpoints, looked at:"
+        error_message = (
+            "No checkpoints found. When searching for checkpoints, looked at:"
+        )
         if shared.cmd_opts.ckpt is not None:
             error_message += f"\n - file {os.path.abspath(shared.cmd_opts.ckpt)}"
         error_message += f"\n - directory {model_path}"
         if shared.cmd_opts.ckpt_dir is not None:
-            error_message += f"\n - directory {os.path.abspath(shared.cmd_opts.ckpt_dir)}"
+            error_message += (
+                f"\n - directory {os.path.abspath(shared.cmd_opts.ckpt_dir)}"
+            )
         error_message += "Can't run without a checkpoint. Find and place a .ckpt or .safetensors file into any of those locations."
         raise FileNotFoundError(error_message)
 
     checkpoint_info = next(iter(checkpoints_list.values()))
     if model_checkpoint is not None:
-        print(f"Checkpoint {model_checkpoint} not found; loading fallback {checkpoint_info.title}", file=sys.stderr)
+        print(
+            f"Checkpoint {model_checkpoint} not found; loading fallback {checkpoint_info.title}",
+            file=sys.stderr,
+        )
 
     return checkpoint_info
 
 
 checkpoint_dict_replacements_sd1 = {
-    'cond_stage_model.transformer.embeddings.': 'cond_stage_model.transformer.text_model.embeddings.',
-    'cond_stage_model.transformer.encoder.': 'cond_stage_model.transformer.text_model.encoder.',
-    'cond_stage_model.transformer.final_layer_norm.': 'cond_stage_model.transformer.text_model.final_layer_norm.',
+    "cond_stage_model.transformer.embeddings.": "cond_stage_model.transformer.text_model.embeddings.",
+    "cond_stage_model.transformer.encoder.": "cond_stage_model.transformer.text_model.encoder.",
+    "cond_stage_model.transformer.final_layer_norm.": "cond_stage_model.transformer.text_model.final_layer_norm.",
 }
 
-checkpoint_dict_replacements_sd2_turbo = { # Converts SD 2.1 Turbo from SGM to LDM format.
-    'conditioner.embedders.0.': 'cond_stage_model.',
+checkpoint_dict_replacements_sd2_turbo = {  # Converts SD 2.1 Turbo from SGM to LDM format.
+    "conditioner.embedders.0.": "cond_stage_model.",
 }
 
 
 def transform_checkpoint_dict_key(k, replacements):
     for text, replacement in replacements.items():
         if k.startswith(text):
-            k = replacement + k[len(text):]
+            k = replacement + k[len(text) :]
 
     return k
 
@@ -263,12 +347,17 @@ def get_state_dict_from_checkpoint(pl_sd):
     pl_sd = pl_sd.pop("state_dict", pl_sd)
     pl_sd.pop("state_dict", None)
 
-    is_sd2_turbo = 'conditioner.embedders.0.model.ln_final.weight' in pl_sd and pl_sd['conditioner.embedders.0.model.ln_final.weight'].size()[0] == 1024
+    is_sd2_turbo = (
+        "conditioner.embedders.0.model.ln_final.weight" in pl_sd
+        and pl_sd["conditioner.embedders.0.model.ln_final.weight"].size()[0] == 1024
+    )
 
     sd = {}
     for k, v in pl_sd.items():
         if is_sd2_turbo:
-            new_key = transform_checkpoint_dict_key(k, checkpoint_dict_replacements_sd2_turbo)
+            new_key = transform_checkpoint_dict_key(
+                k, checkpoint_dict_replacements_sd2_turbo
+            )
         else:
             new_key = transform_checkpoint_dict_key(k, checkpoint_dict_replacements_sd1)
 
@@ -289,22 +378,27 @@ def read_metadata_from_safetensors(filename):
         metadata_len = int.from_bytes(metadata_len, "little")
         json_start = file.read(2)
 
-        assert metadata_len > 2 and json_start in (b'{"', b"{'"), f"{filename} is not a safetensors file"
+        assert metadata_len > 2 and json_start in (
+            b'{"',
+            b"{'",
+        ), f"{filename} is not a safetensors file"
 
         res = {}
 
         try:
-            json_data = json_start + file.read(metadata_len-2)
+            json_data = json_start + file.read(metadata_len - 2)
             json_obj = json.loads(json_data)
             for k, v in json_obj.get("__metadata__", {}).items():
                 res[k] = v
-                if isinstance(v, str) and v[0:1] == '{':
+                if isinstance(v, str) and v[0:1] == "{":
                     try:
                         res[k] = json.loads(v)
                     except Exception:
                         pass
         except Exception:
-             errors.report(f"Error reading metadata from file: {filename}", exc_info=True)
+            errors.report(
+                f"Error reading metadata from file: {filename}", exc_info=True
+            )
 
         return res
 
@@ -312,15 +406,21 @@ def read_metadata_from_safetensors(filename):
 def read_state_dict(checkpoint_file, print_global_state=False, map_location=None):
     _, extension = os.path.splitext(checkpoint_file)
     if extension.lower() == ".safetensors":
-        device = map_location or shared.weight_load_location or devices.get_optimal_device_name()
+        device = (
+            map_location
+            or shared.weight_load_location
+            or devices.get_optimal_device_name()
+        )
 
         if not shared.opts.disable_mmap_load_safetensors:
             pl_sd = safetensors.torch.load_file(checkpoint_file, device=device)
         else:
-            pl_sd = safetensors.torch.load(open(checkpoint_file, 'rb').read())
+            pl_sd = safetensors.torch.load(open(checkpoint_file, "rb").read())
             pl_sd = {k: v.to(device) for k, v in pl_sd.items()}
     else:
-        pl_sd = torch.load(checkpoint_file, map_location=map_location or shared.weight_load_location)
+        pl_sd = torch.load(
+            checkpoint_file, map_location=map_location or shared.weight_load_location
+        )
 
     if print_global_state and "global_step" in pl_sd:
         print(f"Global Step: {pl_sd['global_step']}")
@@ -369,7 +469,10 @@ def check_fp8(model):
         enable_fp8 = False
     elif shared.opts.fp8_storage == "Enable":
         enable_fp8 = True
-    elif getattr(model, "is_sdxl", False) and shared.opts.fp8_storage == "Enable for SDXL":
+    elif (
+        getattr(model, "is_sdxl", False)
+        and shared.opts.fp8_storage == "Enable for SDXL"
+    ):
         enable_fp8 = True
     else:
         enable_fp8 = False
@@ -386,15 +489,18 @@ def set_model_type(model, state_dict):
     if "model.diffusion_model.x_embedder.proj.weight" in state_dict:
         model.is_sd3 = True
         model.model_type = ModelType.SD3
-    elif hasattr(model, 'conditioner'):
+    elif hasattr(model, "conditioner"):
         model.is_sdxl = True
 
-        if 'model.diffusion_model.middle_block.1.transformer_blocks.0.attn1.to_q.weight' not in state_dict.keys():
+        if (
+            "model.diffusion_model.middle_block.1.transformer_blocks.0.attn1.to_q.weight"
+            not in state_dict.keys()
+        ):
             model.is_ssd = True
             model.model_type = ModelType.SSD
         else:
             model.model_type = ModelType.SDXL
-    elif hasattr(model.cond_stage_model, 'model'):
+    elif hasattr(model.cond_stage_model, "model"):
         model.is_sd2 = True
         model.model_type = ModelType.SD2
     else:
@@ -403,7 +509,7 @@ def set_model_type(model, state_dict):
 
 
 def set_model_fields(model):
-    if not hasattr(model, 'latent_channels'):
+    if not hasattr(model, "latent_channels"):
         model.latent_channels = 4
 
 
@@ -450,12 +556,12 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
     # checkpoint state_dict does not contain the key
     # 'diffusion_model.input_blocks.0.0.weight'.
     diffusion_model_input = model.model.state_dict().get(
-        'diffusion_model.input_blocks.0.0.weight'
+        "diffusion_model.input_blocks.0.0.weight"
     )
     model.is_sdxl_inpaint = (
-        model.is_sdxl and
-        diffusion_model_input is not None and
-        diffusion_model_input.shape[1] == 9
+        model.is_sdxl
+        and diffusion_model_input is not None
+        and diffusion_model_input.shape[1] == 9
     )
 
     if shared.cmd_opts.opt_channelslast:
@@ -466,11 +572,13 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
         model.float()
         model.alphas_cumprod_original = model.alphas_cumprod
         devices.dtype_unet = torch.float32
-        assert shared.cmd_opts.precision != "half", "Cannot use --precision half with --no-half"
+        assert (
+            shared.cmd_opts.precision != "half"
+        ), "Cannot use --precision half with --no-half"
         timer.record("apply float()")
     else:
         vae = model.first_stage_model
-        depth_model = getattr(model, 'depth_model', None)
+        depth_model = getattr(model, "depth_model", None)
 
         # with --no-half-vae, remove VAE from model when doing half() to prevent its weights from being converted to float16
         if shared.cmd_opts.no_half_vae:
@@ -494,9 +602,9 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
     apply_alpha_schedule_override(model)
 
     for module in model.modules():
-        if hasattr(module, 'fp16_weight'):
+        if hasattr(module, "fp16_weight"):
             del module.fp16_weight
-        if hasattr(module, 'fp16_bias'):
+        if hasattr(module, "fp16_bias"):
             del module.fp16_bias
 
     if check_fp8(model):
@@ -515,7 +623,11 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
     else:
         devices.fp8 = False
 
-    devices.unet_needs_upcast = shared.cmd_opts.upcast_sampling and devices.dtype == torch.float16 and devices.dtype_unet == torch.float16
+    devices.unet_needs_upcast = (
+        shared.cmd_opts.upcast_sampling
+        and devices.dtype == torch.float16
+        and devices.dtype_unet == torch.float16
+    )
 
     model.first_stage_model.to(devices.dtype_vae)
     timer.record("apply dtype to VAE")
@@ -529,7 +641,7 @@ def load_model_weights(model, checkpoint_info: CheckpointInfo, state_dict, timer
     model.sd_checkpoint_info = checkpoint_info
     shared.opts.data["sd_checkpoint_hash"] = checkpoint_info.sha256
 
-    if hasattr(model, 'logvar'):
+    if hasattr(model, "logvar"):
         model.logvar = model.logvar.to(devices.device)  # fix for training
 
     sd_vae.delete_base_vae()
@@ -549,7 +661,7 @@ def enable_midas_autodownload():
     location automatically.
     """
 
-    midas_path = os.path.join(paths.models_path, 'midas')
+    midas_path = os.path.join(paths.models_path, "midas")
 
     # stable-diffusion-stability-ai hard-codes the midas model path to
     # a location that differs from where other scripts using this model look.
@@ -593,27 +705,48 @@ def patch_given_betas():
 
         original_register_schedule(*args, **kwargs)
 
-    original_register_schedule = patches.patch(__name__, ldm.models.diffusion.ddpm.DDPM, 'register_schedule', patched_register_schedule)
+    original_register_schedule = patches.patch(
+        __name__,
+        ldm.models.diffusion.ddpm.DDPM,
+        "register_schedule",
+        patched_register_schedule,
+    )
 
 
 def repair_config(sd_config, state_dict=None):
     if not hasattr(sd_config.model.params, "use_ema"):
         sd_config.model.params.use_ema = False
 
-    if hasattr(sd_config.model.params, 'unet_config'):
+    if hasattr(sd_config.model.params, "unet_config"):
         if shared.cmd_opts.no_half:
             sd_config.model.params.unet_config.params.use_fp16 = False
         elif shared.cmd_opts.upcast_sampling or shared.cmd_opts.precision == "half":
             sd_config.model.params.unet_config.params.use_fp16 = True
 
-    if hasattr(sd_config.model.params, 'first_stage_config'):
-        if getattr(sd_config.model.params.first_stage_config.params.ddconfig, "attn_type", None) == "vanilla-xformers" and not shared.xformers_available:
-            sd_config.model.params.first_stage_config.params.ddconfig.attn_type = "vanilla"
+    if hasattr(sd_config.model.params, "first_stage_config"):
+        if (
+            getattr(
+                sd_config.model.params.first_stage_config.params.ddconfig,
+                "attn_type",
+                None,
+            )
+            == "vanilla-xformers"
+            and not shared.xformers_available
+        ):
+            sd_config.model.params.first_stage_config.params.ddconfig.attn_type = (
+                "vanilla"
+            )
 
     # For UnCLIP-L, override the hardcoded karlo directory
-    if hasattr(sd_config.model.params, "noise_aug_config") and hasattr(sd_config.model.params.noise_aug_config.params, "clip_stats_path"):
-        karlo_path = os.path.join(paths.models_path, 'karlo')
-        sd_config.model.params.noise_aug_config.params.clip_stats_path = sd_config.model.params.noise_aug_config.params.clip_stats_path.replace("checkpoints/karlo_models", karlo_path)
+    if hasattr(sd_config.model.params, "noise_aug_config") and hasattr(
+        sd_config.model.params.noise_aug_config.params, "clip_stats_path"
+    ):
+        karlo_path = os.path.join(paths.models_path, "karlo")
+        sd_config.model.params.noise_aug_config.params.clip_stats_path = (
+            sd_config.model.params.noise_aug_config.params.clip_stats_path.replace(
+                "checkpoints/karlo_models", karlo_path
+            )
+        )
 
     # Do not use checkpoint for inference.
     # This helps prevent extra performance overhead on checking parameters.
@@ -624,7 +757,6 @@ def repair_config(sd_config, state_dict=None):
         sd_config.model.params.unet_config.params.use_checkpoint = False
 
 
-
 def rescale_zero_terminal_snr_abar(alphas_cumprod):
     alphas_bar_sqrt = alphas_cumprod.sqrt()
 
@@ -633,13 +765,13 @@ def rescale_zero_terminal_snr_abar(alphas_cumprod):
     alphas_bar_sqrt_T = alphas_bar_sqrt[-1].clone()
 
     # Shift so the last timestep is zero.
-    alphas_bar_sqrt -= (alphas_bar_sqrt_T)
+    alphas_bar_sqrt -= alphas_bar_sqrt_T
 
     # Scale so the first timestep is back to the old value.
     alphas_bar_sqrt *= alphas_bar_sqrt_0 / (alphas_bar_sqrt_0 - alphas_bar_sqrt_T)
 
     # Convert alphas_bar_sqrt to betas
-    alphas_bar = alphas_bar_sqrt ** 2  # Revert sqrt
+    alphas_bar = alphas_bar_sqrt**2  # Revert sqrt
     alphas_bar[-1] = 4.8973451890853435e-08
     return alphas_bar
 
@@ -651,26 +783,34 @@ def apply_alpha_schedule_override(sd_model, p=None):
     - rescales the alpha schedule to have zero terminal SNR
     """
 
-    if not hasattr(sd_model, 'alphas_cumprod') or not hasattr(sd_model, 'alphas_cumprod_original'):
+    if not hasattr(sd_model, "alphas_cumprod") or not hasattr(
+        sd_model, "alphas_cumprod_original"
+    ):
         return
 
     sd_model.alphas_cumprod = sd_model.alphas_cumprod_original.to(shared.device)
 
     if opts.use_downcasted_alpha_bar:
         if p is not None:
-            p.extra_generation_params['Downcast alphas_cumprod'] = opts.use_downcasted_alpha_bar
+            p.extra_generation_params["Downcast alphas_cumprod"] = (
+                opts.use_downcasted_alpha_bar
+            )
         sd_model.alphas_cumprod = sd_model.alphas_cumprod.half().to(shared.device)
 
     if opts.sd_noise_schedule == "Zero Terminal SNR":
         if p is not None:
-            p.extra_generation_params['Noise Schedule'] = opts.sd_noise_schedule
-        sd_model.alphas_cumprod = rescale_zero_terminal_snr_abar(sd_model.alphas_cumprod).to(shared.device)
+            p.extra_generation_params["Noise Schedule"] = opts.sd_noise_schedule
+        sd_model.alphas_cumprod = rescale_zero_terminal_snr_abar(
+            sd_model.alphas_cumprod
+        ).to(shared.device)
 
 
-sd1_clip_weight = 'cond_stage_model.transformer.text_model.embeddings.token_embedding.weight'
-sd2_clip_weight = 'cond_stage_model.model.transformer.resblocks.0.attn.in_proj_weight'
-sdxl_clip_weight = 'conditioner.embedders.1.model.ln_final.weight'
-sdxl_refiner_clip_weight = 'conditioner.embedders.0.model.ln_final.weight'
+sd1_clip_weight = (
+    "cond_stage_model.transformer.text_model.embeddings.token_embedding.weight"
+)
+sd2_clip_weight = "cond_stage_model.model.transformer.resblocks.0.attn.in_proj_weight"
+sdxl_clip_weight = "conditioner.embedders.1.model.ln_final.weight"
+sdxl_refiner_clip_weight = "conditioner.embedders.0.model.ln_final.weight"
 
 
 class SdModelData:
@@ -693,7 +833,9 @@ class SdModelData:
                     load_model()
 
                 except Exception as e:
-                    errors.display(e, "loading stable diffusion model", full_traceback=True)
+                    errors.display(
+                        e, "loading stable diffusion model", full_traceback=True
+                    )
                     print("", file=sys.stderr)
                     print("Stable diffusion model failed to load", file=sys.stderr)
                     self.sd_model = None
@@ -720,17 +862,16 @@ model_data = SdModelData()
 
 
 def get_empty_cond(sd_model):
-
     p = processing.StableDiffusionProcessingTxt2Img()
     extra_networks.activate(p, {})
 
-    if hasattr(sd_model, 'get_learned_conditioning'):
+    if hasattr(sd_model, "get_learned_conditioning"):
         d = sd_model.get_learned_conditioning([""])
     else:
         d = sd_model.cond_stage_model([""])
 
     if isinstance(d, dict):
-        d = d['crossattn']
+        d = d["crossattn"]
 
     return d
 
@@ -785,6 +926,7 @@ def get_obj_from_str(string, reload=False):
 
 def load_model(checkpoint_info=None, already_loaded_state_dict=None):
     from modules import sd_hijack
+
     checkpoint_info = checkpoint_info or select_checkpoint()
 
     timer = Timer()
@@ -801,8 +943,19 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
     else:
         state_dict = get_checkpoint_state_dict(checkpoint_info, timer)
 
-    checkpoint_config = sd_models_config.find_checkpoint_config(state_dict, checkpoint_info)
-    clip_is_included_into_sd = any(x for x in [sd1_clip_weight, sd2_clip_weight, sdxl_clip_weight, sdxl_refiner_clip_weight] if x in state_dict)
+    checkpoint_config = sd_models_config.find_checkpoint_config(
+        state_dict, checkpoint_info
+    )
+    clip_is_included_into_sd = any(
+        x
+        for x in [
+            sd1_clip_weight,
+            sd2_clip_weight,
+            sdxl_clip_weight,
+            sdxl_refiner_clip_weight,
+        ]
+        if x in state_dict
+    )
 
     timer.record("find config")
 
@@ -815,7 +968,10 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
 
     sd_model = None
     try:
-        with sd_disable_initialization.DisableInitialization(disable_clip=clip_is_included_into_sd or shared.cmd_opts.do_not_download_clip):
+        with sd_disable_initialization.DisableInitialization(
+            disable_clip=clip_is_included_into_sd
+            or shared.cmd_opts.do_not_download_clip
+        ):
             with sd_disable_initialization.InitializeOnMeta():
                 sd_model = instantiate_from_config(sd_config.model, state_dict)
 
@@ -823,7 +979,10 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
         errors.display(e, "creating model quickly", full_traceback=True)
 
     if sd_model is None:
-        print('Failed to create model quickly; will retry using slow method.', file=sys.stderr)
+        print(
+            "Failed to create model quickly; will retry using slow method.",
+            file=sys.stderr,
+        )
 
         with sd_disable_initialization.InitializeOnMeta():
             sd_model = instantiate_from_config(sd_config.model, state_dict)
@@ -836,12 +995,16 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
         weight_dtype_conversion = None
     else:
         weight_dtype_conversion = {
-            'first_stage_model': None,
-            'alphas_cumprod': None,
-            '': torch.float16,
+            "first_stage_model": None,
+            "alphas_cumprod": None,
+            "": torch.float16,
         }
 
-    with sd_disable_initialization.LoadStateDictOnMeta(state_dict, device=model_target_device(sd_model), weight_dtype_conversion=weight_dtype_conversion):
+    with sd_disable_initialization.LoadStateDictOnMeta(
+        state_dict,
+        device=model_target_device(sd_model),
+        weight_dtype_conversion=weight_dtype_conversion,
+    ):
         load_model_weights(sd_model, checkpoint_info, state_dict, timer)
 
     timer.record("load weights from state dict")
@@ -857,7 +1020,9 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
     model_data.set_sd_model(sd_model)
     model_data.was_loaded_at_least_once = True
 
-    sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)  # Reload embeddings after model load as they may or may not fit the model
+    sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(
+        force_reload=True
+    )  # Reload embeddings after model load as they may or may not fit the model
 
     timer.record("load textual inversion embeddings")
 
@@ -884,7 +1049,10 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
     Additionally deletes loaded models that are over the limit set in settings (sd_checkpoints_limit).
     """
 
-    if sd_model is not None and sd_model.sd_checkpoint_info.filename == checkpoint_info.filename:
+    if (
+        sd_model is not None
+        and sd_model.sd_checkpoint_info.filename == checkpoint_info.filename
+    ):
         return sd_model
 
     if shared.opts.sd_checkpoints_keep_in_cpu:
@@ -899,7 +1067,9 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
             continue
 
         if len(model_data.loaded_sd_models) > shared.opts.sd_checkpoints_limit > 0:
-            print(f"Unloading model {len(model_data.loaded_sd_models)} over the limit of {shared.opts.sd_checkpoints_limit}: {loaded_model.sd_checkpoint_info.title}")
+            print(
+                f"Unloading model {len(model_data.loaded_sd_models)} over the limit of {shared.opts.sd_checkpoints_limit}: {loaded_model.sd_checkpoint_info.title}"
+            )
             del model_data.loaded_sd_models[i]
             send_model_to_trash(loaded_model)
             timer.record("send model to trash")
@@ -911,14 +1081,25 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         model_data.set_sd_model(already_loaded, already_loaded=True)
 
         if not SkipWritingToConfig.skip:
-            shared.opts.data["sd_model_checkpoint"] = already_loaded.sd_checkpoint_info.title
-            shared.opts.data["sd_checkpoint_hash"] = already_loaded.sd_checkpoint_info.sha256
+            shared.opts.data["sd_model_checkpoint"] = (
+                already_loaded.sd_checkpoint_info.title
+            )
+            shared.opts.data["sd_checkpoint_hash"] = (
+                already_loaded.sd_checkpoint_info.sha256
+            )
 
-        print(f"Using already loaded model {already_loaded.sd_checkpoint_info.title}: done in {timer.summary()}")
+        print(
+            f"Using already loaded model {already_loaded.sd_checkpoint_info.title}: done in {timer.summary()}"
+        )
         sd_vae.reload_vae_weights(already_loaded)
         return model_data.sd_model
-    elif shared.opts.sd_checkpoints_limit > 1 and len(model_data.loaded_sd_models) < shared.opts.sd_checkpoints_limit:
-        print(f"Loading model {checkpoint_info.title} ({len(model_data.loaded_sd_models) + 1} out of {shared.opts.sd_checkpoints_limit})")
+    elif (
+        shared.opts.sd_checkpoints_limit > 1
+        and len(model_data.loaded_sd_models) < shared.opts.sd_checkpoints_limit
+    ):
+        print(
+            f"Loading model {checkpoint_info.title} ({len(model_data.loaded_sd_models) + 1} out of {shared.opts.sd_checkpoints_limit})"
+        )
 
         model_data.sd_model = None
         load_model(checkpoint_info)
@@ -931,7 +1112,9 @@ def reuse_model_from_already_loaded(sd_model, checkpoint_info, timer):
         sd_vae.loaded_vae_file = getattr(sd_model, "loaded_vae_file", None)
         sd_vae.checkpoint_info = sd_model.sd_checkpoint_info
 
-        print(f"Reusing loaded model {sd_model.sd_checkpoint_info.title} to load {checkpoint_info.title}")
+        print(
+            f"Reusing loaded model {sd_model.sd_checkpoint_info.title} to load {checkpoint_info.title}"
+        )
         return sd_model
     else:
         return None
@@ -952,11 +1135,18 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
         if check_fp8(sd_model) != devices.fp8:
             # load from state dict again to prevent extra numerical errors
             forced_reload = True
-        elif sd_model.sd_model_checkpoint == checkpoint_info.filename and not forced_reload:
+        elif (
+            sd_model.sd_model_checkpoint == checkpoint_info.filename
+            and not forced_reload
+        ):
             return sd_model
 
     sd_model = reuse_model_from_already_loaded(sd_model, checkpoint_info, timer)
-    if not forced_reload and sd_model is not None and sd_model.sd_checkpoint_info.filename == checkpoint_info.filename:
+    if (
+        not forced_reload
+        and sd_model is not None
+        and sd_model.sd_checkpoint_info.filename == checkpoint_info.filename
+    ):
         return sd_model
 
     if sd_model is not None:
@@ -966,7 +1156,9 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
 
     state_dict = get_checkpoint_state_dict(checkpoint_info, timer)
 
-    checkpoint_config = sd_models_config.find_checkpoint_config(state_dict, checkpoint_info)
+    checkpoint_config = sd_models_config.find_checkpoint_config(
+        state_dict, checkpoint_info
+    )
 
     timer.record("find config")
 
@@ -1013,7 +1205,7 @@ def apply_token_merging(sd_model, token_merging_ratio):
     Applies speed and memory optimizations from tomesd.
     """
 
-    current_token_merging_ratio = getattr(sd_model, 'applied_token_merged_ratio', 0)
+    current_token_merging_ratio = getattr(sd_model, "applied_token_merged_ratio", 0)
 
     if current_token_merging_ratio == token_merging_ratio:
         return
@@ -1028,7 +1220,7 @@ def apply_token_merging(sd_model, token_merging_ratio):
             use_rand=False,  # can cause issues with some samplers
             merge_attn=True,
             merge_crossattn=False,
-            merge_mlp=False
+            merge_mlp=False,
         )
 
     sd_model.applied_token_merged_ratio = token_merging_ratio

--- a/modules/sd_models_config.py
+++ b/modules/sd_models_config.py
@@ -5,24 +5,36 @@ import torch
 from modules import shared, paths, sd_disable_initialization, devices
 
 sd_configs_path = shared.sd_configs_path
-sd_repo_configs_path = os.path.join(paths.paths['Stable Diffusion'], "configs", "stable-diffusion")
-sd_xl_repo_configs_path = os.path.join(paths.paths['Stable Diffusion XL'], "configs", "inference")
+sd_repo_configs_path = os.path.join(
+    paths.paths["Stable Diffusion"], "configs", "stable-diffusion"
+)
+sd_xl_repo_configs_path = os.path.join(
+    paths.paths["Stable Diffusion XL"], "configs", "inference"
+)
 
 
 config_default = shared.sd_default_config
 config_sd2 = os.path.join(sd_repo_configs_path, "v2-inference.yaml")
 config_sd2v = os.path.join(sd_repo_configs_path, "v2-inference-v.yaml")
-config_sd2_inpainting = os.path.join(sd_repo_configs_path, "v2-inpainting-inference.yaml")
+config_sd2_inpainting = os.path.join(
+    sd_repo_configs_path, "v2-inpainting-inference.yaml"
+)
 config_sdxl = os.path.join(sd_xl_repo_configs_path, "sd_xl_base.yaml")
 config_sdxl_refiner = os.path.join(sd_xl_repo_configs_path, "sd_xl_refiner.yaml")
 config_sdxl_inpainting = os.path.join(sd_configs_path, "sd_xl_inpaint.yaml")
 config_depth_model = os.path.join(sd_repo_configs_path, "v2-midas-inference.yaml")
-config_unclip = os.path.join(sd_repo_configs_path, "v2-1-stable-unclip-l-inference.yaml")
-config_unopenclip = os.path.join(sd_repo_configs_path, "v2-1-stable-unclip-h-inference.yaml")
+config_unclip = os.path.join(
+    sd_repo_configs_path, "v2-1-stable-unclip-l-inference.yaml"
+)
+config_unopenclip = os.path.join(
+    sd_repo_configs_path, "v2-1-stable-unclip-h-inference.yaml"
+)
 config_inpainting = os.path.join(sd_configs_path, "v1-inpainting-inference.yaml")
 config_instruct_pix2pix = os.path.join(sd_configs_path, "instruct-pix2pix.yaml")
 config_alt_diffusion = os.path.join(sd_configs_path, "alt-diffusion-inference.yaml")
-config_alt_diffusion_m18 = os.path.join(sd_configs_path, "alt-diffusion-m18-inference.yaml")
+config_alt_diffusion_m18 = os.path.join(
+    sd_configs_path, "alt-diffusion-m18-inference.yaml"
+)
 config_sd3 = os.path.join(sd_configs_path, "sd3-inference.yaml")
 
 
@@ -51,12 +63,16 @@ def is_using_v_parameterization_for_sd2(state_dict):
             use_linear_in_transformer=True,
             transformer_depth=1,
             context_dim=1024,
-            legacy=False
+            legacy=False,
         )
         unet.eval()
 
     with torch.no_grad():
-        unet_sd = {k.replace("model.diffusion_model.", ""): v for k, v in state_dict.items() if "model.diffusion_model." in k}
+        unet_sd = {
+            k.replace("model.diffusion_model.", ""): v
+            for k, v in state_dict.items()
+            if "model.diffusion_model." in k
+        }
         unet.load_state_dict(unet_sd, strict=True)
         unet.to(device=device, dtype=devices.dtype_unet)
 
@@ -64,28 +80,43 @@ def is_using_v_parameterization_for_sd2(state_dict):
         x_test = torch.ones((1, 4, 8, 8), device=device) * 0.5
 
         with devices.autocast():
-            out = (unet(x_test, torch.asarray([999], device=device), context=test_cond) - x_test).mean().cpu().item()
+            out = (
+                (
+                    unet(x_test, torch.asarray([999], device=device), context=test_cond)
+                    - x_test
+                )
+                .mean()
+                .cpu()
+                .item()
+            )
 
     return out < -1
 
 
 def guess_model_config_from_state_dict(sd, filename):
-    sd2_cond_proj_weight = sd.get('cond_stage_model.model.transformer.resblocks.0.attn.in_proj_weight', None)
-    diffusion_model_input = sd.get('model.diffusion_model.input_blocks.0.0.weight', None)
-    sd2_variations_weight = sd.get('embedder.model.ln_final.weight', None)
+    sd2_cond_proj_weight = sd.get(
+        "cond_stage_model.model.transformer.resblocks.0.attn.in_proj_weight", None
+    )
+    diffusion_model_input = sd.get(
+        "model.diffusion_model.input_blocks.0.0.weight", None
+    )
+    sd2_variations_weight = sd.get("embedder.model.ln_final.weight", None)
 
     if "model.diffusion_model.x_embedder.proj.weight" in sd:
         return config_sd3
 
-    if sd.get('conditioner.embedders.1.model.ln_final.weight', None) is not None:
+    if sd.get("conditioner.embedders.1.model.ln_final.weight", None) is not None:
         if diffusion_model_input.shape[1] == 9:
             return config_sdxl_inpainting
         else:
             return config_sdxl
 
-    if sd.get('conditioner.embedders.0.model.ln_final.weight', None) is not None:
+    if sd.get("conditioner.embedders.0.model.ln_final.weight", None) is not None:
         return config_sdxl_refiner
-    elif sd.get('depth_model.model.pretrained.act_postprocess3.0.project.0.bias', None) is not None:
+    elif (
+        sd.get("depth_model.model.pretrained.act_postprocess3.0.project.0.bias", None)
+        is not None
+    ):
         return config_depth_model
     elif sd2_variations_weight is not None and sd2_variations_weight.shape[0] == 768:
         return config_unclip
@@ -106,8 +137,11 @@ def guess_model_config_from_state_dict(sd, filename):
         if diffusion_model_input.shape[1] == 8:
             return config_instruct_pix2pix
 
-    if sd.get('cond_stage_model.roberta.embeddings.word_embeddings.weight', None) is not None:
-        if sd.get('cond_stage_model.transformation.weight').size()[0] == 1024:
+    if (
+        sd.get("cond_stage_model.roberta.embeddings.word_embeddings.weight", None)
+        is not None
+    ):
+        if sd.get("cond_stage_model.transformation.weight").size()[0] == 1024:
             return config_alt_diffusion_m18
         return config_alt_diffusion
 
@@ -134,4 +168,3 @@ def find_checkpoint_config_near_filename(info):
         return config
 
     return None
-

--- a/modules/sd_models_types.py
+++ b/modules/sd_models_types.py
@@ -18,7 +18,7 @@ class WebuiSdModel(LatentDiffusion):
     sd_model_checkpoint: str
     """path to the file on disk that model weights were obtained from"""
 
-    sd_checkpoint_info: 'CheckpointInfo'
+    sd_checkpoint_info: "CheckpointInfo"
     """structure with additional information about the file with model's weights"""
 
     is_sdxl: bool

--- a/modules/sd_models_xl.py
+++ b/modules/sd_models_xl.py
@@ -9,41 +9,60 @@ from modules import devices, shared, prompt_parser
 from modules import torch_utils
 
 
-def get_learned_conditioning(self: sgm.models.diffusion.DiffusionEngine, batch: prompt_parser.SdConditioning | list[str]):
+def get_learned_conditioning(
+    self: sgm.models.diffusion.DiffusionEngine,
+    batch: prompt_parser.SdConditioning | list[str],
+):
     for embedder in self.conditioner.embedders:
         embedder.ucg_rate = 0.0
 
-    width = getattr(batch, 'width', 1024) or 1024
-    height = getattr(batch, 'height', 1024) or 1024
-    is_negative_prompt = getattr(batch, 'is_negative_prompt', False)
-    aesthetic_score = shared.opts.sdxl_refiner_low_aesthetic_score if is_negative_prompt else shared.opts.sdxl_refiner_high_aesthetic_score
+    width = getattr(batch, "width", 1024) or 1024
+    height = getattr(batch, "height", 1024) or 1024
+    is_negative_prompt = getattr(batch, "is_negative_prompt", False)
+    aesthetic_score = (
+        shared.opts.sdxl_refiner_low_aesthetic_score
+        if is_negative_prompt
+        else shared.opts.sdxl_refiner_high_aesthetic_score
+    )
 
     devices_args = dict(device=devices.device, dtype=devices.dtype)
 
     sdxl_conds = {
         "txt": batch,
-        "original_size_as_tuple": torch.tensor([height, width], **devices_args).repeat(len(batch), 1),
-        "crop_coords_top_left": torch.tensor([shared.opts.sdxl_crop_top, shared.opts.sdxl_crop_left], **devices_args).repeat(len(batch), 1),
-        "target_size_as_tuple": torch.tensor([height, width], **devices_args).repeat(len(batch), 1),
-        "aesthetic_score": torch.tensor([aesthetic_score], **devices_args).repeat(len(batch), 1),
+        "original_size_as_tuple": torch.tensor([height, width], **devices_args).repeat(
+            len(batch), 1
+        ),
+        "crop_coords_top_left": torch.tensor(
+            [shared.opts.sdxl_crop_top, shared.opts.sdxl_crop_left], **devices_args
+        ).repeat(len(batch), 1),
+        "target_size_as_tuple": torch.tensor([height, width], **devices_args).repeat(
+            len(batch), 1
+        ),
+        "aesthetic_score": torch.tensor([aesthetic_score], **devices_args).repeat(
+            len(batch), 1
+        ),
     }
 
-    force_zero_negative_prompt = is_negative_prompt and all(x == '' for x in batch)
-    c = self.conditioner(sdxl_conds, force_zero_embeddings=['txt'] if force_zero_negative_prompt else [])
+    force_zero_negative_prompt = is_negative_prompt and all(x == "" for x in batch)
+    c = self.conditioner(
+        sdxl_conds, force_zero_embeddings=["txt"] if force_zero_negative_prompt else []
+    )
 
     return c
 
 
 def apply_model(self: sgm.models.diffusion.DiffusionEngine, x, t, cond):
     """WARNING: This function is called once per denoising iteration. DO NOT add
-    expensive functionc calls such as `model.state_dict`. """
+    expensive functionc calls such as `model.state_dict`."""
     if self.is_sdxl_inpaint:
-        x = torch.cat([x] + cond['c_concat'], dim=1)
+        x = torch.cat([x] + cond["c_concat"], dim=1)
 
     return self.model(x, t, cond)
 
 
-def get_first_stage_encoding(self, x):  # SDXL's encode_first_stage does everything so get_first_stage_encoding is just there for compatibility
+def get_first_stage_encoding(
+    self, x
+):  # SDXL's encode_first_stage does everything so get_first_stage_encoding is just there for compatibility
     return x
 
 
@@ -55,7 +74,11 @@ sgm.models.diffusion.DiffusionEngine.get_first_stage_encoding = get_first_stage_
 def encode_embedding_init_text(self: sgm.modules.GeneralConditioner, init_text, nvpt):
     res = []
 
-    for embedder in [embedder for embedder in self.embedders if hasattr(embedder, 'encode_embedding_init_text')]:
+    for embedder in [
+        embedder
+        for embedder in self.embedders
+        if hasattr(embedder, "encode_embedding_init_text")
+    ]:
         encoded = embedder.encode_embedding_init_text(init_text, nvpt)
         res.append(encoded)
 
@@ -63,20 +86,27 @@ def encode_embedding_init_text(self: sgm.modules.GeneralConditioner, init_text, 
 
 
 def tokenize(self: sgm.modules.GeneralConditioner, texts):
-    for embedder in [embedder for embedder in self.embedders if hasattr(embedder, 'tokenize')]:
+    for embedder in [
+        embedder for embedder in self.embedders if hasattr(embedder, "tokenize")
+    ]:
         return embedder.tokenize(texts)
 
-    raise AssertionError('no tokenizer available')
-
+    raise AssertionError("no tokenizer available")
 
 
 def process_texts(self, texts):
-    for embedder in [embedder for embedder in self.embedders if hasattr(embedder, 'process_texts')]:
+    for embedder in [
+        embedder for embedder in self.embedders if hasattr(embedder, "process_texts")
+    ]:
         return embedder.process_texts(texts)
 
 
 def get_target_prompt_token_count(self, token_count):
-    for embedder in [embedder for embedder in self.embedders if hasattr(embedder, 'get_target_prompt_token_count')]:
+    for embedder in [
+        embedder
+        for embedder in self.embedders
+        if hasattr(embedder, "get_target_prompt_token_count")
+    ]:
         return embedder.get_target_prompt_token_count(token_count)
 
 
@@ -84,7 +114,9 @@ def get_target_prompt_token_count(self, token_count):
 sgm.modules.GeneralConditioner.encode_embedding_init_text = encode_embedding_init_text
 sgm.modules.GeneralConditioner.tokenize = tokenize
 sgm.modules.GeneralConditioner.process_texts = process_texts
-sgm.modules.GeneralConditioner.get_target_prompt_token_count = get_target_prompt_token_count
+sgm.modules.GeneralConditioner.get_target_prompt_token_count = (
+    get_target_prompt_token_count
+)
 
 
 def extend_sdxl(model):
@@ -92,14 +124,23 @@ def extend_sdxl(model):
 
     dtype = torch_utils.get_param(model.model.diffusion_model).dtype
     model.model.diffusion_model.dtype = dtype
-    model.model.conditioning_key = 'crossattn'
-    model.cond_stage_key = 'txt'
+    model.model.conditioning_key = "crossattn"
+    model.cond_stage_key = "txt"
     # model.cond_stage_model will be set in sd_hijack
 
-    model.parameterization = "v" if isinstance(model.denoiser.scaling, sgm.modules.diffusionmodules.denoiser_scaling.VScaling) else "eps"
+    model.parameterization = (
+        "v"
+        if isinstance(
+            model.denoiser.scaling,
+            sgm.modules.diffusionmodules.denoiser_scaling.VScaling,
+        )
+        else "eps"
+    )
 
     discretization = sgm.modules.diffusionmodules.discretizer.LegacyDDPMDiscretization()
-    model.alphas_cumprod = torch.asarray(discretization.alphas_cumprod, device=devices.device, dtype=torch.float32)
+    model.alphas_cumprod = torch.asarray(
+        discretization.alphas_cumprod, device=devices.device, dtype=torch.float32
+    )
 
     model.conditioner.wrapped = torch.nn.Module()
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import functools
 import logging
-from modules import sd_samplers_kdiffusion, sd_samplers_timesteps, sd_samplers_lcm, shared, sd_samplers_common, sd_schedulers
+from modules import (
+    sd_samplers_kdiffusion,
+    sd_samplers_timesteps,
+    sd_samplers_lcm,
+    shared,
+    sd_samplers_common,
+    sd_schedulers,
+)
 
 # imports for functions that previously were here and are used by other modules
 samples_to_image_grid = sd_samplers_common.samples_to_image_grid
@@ -33,7 +40,7 @@ def find_sampler_config(name):
 def create_sampler(name, model):
     config = find_sampler_config(name)
 
-    assert config is not None, f'bad sampler name: {name}'
+    assert config is not None, f"bad sampler name: {name}"
 
     if model.is_sdxl and config.options.get("no_sdxl", False):
         raise Exception(f"Sampler {config.name} is not supported for SDXL")
@@ -79,12 +86,16 @@ def get_hr_sampler_and_scheduler(d: dict):
     sampler = d.get("Sampler") if hr_sampler == "Use same sampler" else hr_sampler
 
     hr_scheduler = d.get("Hires schedule type", "Use same scheduler")
-    scheduler = d.get("Schedule type") if hr_scheduler == "Use same scheduler" else hr_scheduler
+    scheduler = (
+        d.get("Schedule type") if hr_scheduler == "Use same scheduler" else hr_scheduler
+    )
 
     sampler, scheduler = get_sampler_and_scheduler(sampler, scheduler)
 
     sampler = sampler if sampler != d.get("Sampler") else "Use same sampler"
-    scheduler = scheduler if scheduler != d.get("Schedule type") else "Use same scheduler"
+    scheduler = (
+        scheduler if scheduler != d.get("Schedule type") else "Use same scheduler"
+    )
 
     return sampler, scheduler
 
@@ -100,7 +111,9 @@ def get_hr_scheduler_from_infotext(d: dict):
 @functools.cache
 def get_sampler_and_scheduler(sampler_name, scheduler_name, *, convert_automatic=True):
     default_sampler = samplers[0]
-    found_scheduler = sd_schedulers.schedulers_map.get(scheduler_name, sd_schedulers.schedulers[0])
+    found_scheduler = sd_schedulers.schedulers_map.get(
+        scheduler_name, sd_schedulers.schedulers[0]
+    )
 
     name = sampler_name or default_sampler.name
 
@@ -110,13 +123,16 @@ def get_sampler_and_scheduler(sampler_name, scheduler_name, *, convert_automatic
         for name_option in name_options:
             if name.endswith(" " + name_option):
                 found_scheduler = scheduler
-                name = name[0:-(len(name_option) + 1)]
+                name = name[0 : -(len(name_option) + 1)]
                 break
 
     sampler = all_samplers_map.get(name, default_sampler)
 
     # revert back to Automatic if it's the default scheduler for the selected sampler
-    if convert_automatic and sampler.options.get('scheduler', None) == found_scheduler.name:
+    if (
+        convert_automatic
+        and sampler.options.get("scheduler", None) == found_scheduler.name
+    ):
         found_scheduler = sd_schedulers.schedulers[0]
 
     return sampler.name, found_scheduler.label
@@ -124,9 +140,13 @@ def get_sampler_and_scheduler(sampler_name, scheduler_name, *, convert_automatic
 
 def fix_p_invalid_sampler_and_scheduler(p):
     i_sampler_name, i_scheduler = p.sampler_name, p.scheduler
-    p.sampler_name, p.scheduler = get_sampler_and_scheduler(p.sampler_name, p.scheduler, convert_automatic=False)
+    p.sampler_name, p.scheduler = get_sampler_and_scheduler(
+        p.sampler_name, p.scheduler, convert_automatic=False
+    )
     if p.sampler_name != i_sampler_name or i_scheduler != p.scheduler:
-        logging.warning(f'Sampler Scheduler autocorrection: "{i_sampler_name}" -> "{p.sampler_name}", "{i_scheduler}" -> "{p.scheduler}"')
+        logging.warning(
+            f'Sampler Scheduler autocorrection: "{i_sampler_name}" -> "{p.sampler_name}", "{i_scheduler}" -> "{p.scheduler}"'
+        )
 
 
 set_samplers()

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -26,7 +26,7 @@ def pad_cond(tensor, repeats, empty):
     if not isinstance(tensor, dict):
         return torch.cat([tensor, empty.repeat((tensor.shape[0], repeats, 1))], axis=1)
 
-    tensor['crossattn'] = pad_cond(tensor['crossattn'], repeats, empty)
+    tensor["crossattn"] = pad_cond(tensor["crossattn"], repeats, empty)
     return tensor
 
 
@@ -72,18 +72,24 @@ class CFGDenoiser(torch.nn.Module):
         raise NotImplementedError()
 
     def combine_denoised(self, x_out, conds_list, uncond, cond_scale):
-        denoised_uncond = x_out[-uncond.shape[0]:]
+        denoised_uncond = x_out[-uncond.shape[0] :]
         denoised = torch.clone(denoised_uncond)
 
         for i, conds in enumerate(conds_list):
             for cond_index, weight in conds:
-                denoised[i] += (x_out[cond_index] - denoised_uncond[i]) * (weight * cond_scale)
+                denoised[i] += (x_out[cond_index] - denoised_uncond[i]) * (
+                    weight * cond_scale
+                )
 
         return denoised
 
     def combine_denoised_for_edit_model(self, x_out, cond_scale):
         out_cond, out_img_cond, out_uncond = x_out.chunk(3)
-        denoised = out_uncond + cond_scale * (out_cond - out_img_cond) + self.image_cfg_scale * (out_img_cond - out_uncond)
+        denoised = (
+            out_uncond
+            + cond_scale * (out_cond - out_img_cond)
+            + self.image_cfg_scale * (out_img_cond - out_uncond)
+        )
 
         return denoised
 
@@ -94,8 +100,8 @@ class CFGDenoiser(torch.nn.Module):
         self.model_wrap = None
 
         c, uc = self.p.get_conds()
-        self.sampler.sampler_extra_args['cond'] = c
-        self.sampler.sampler_extra_args['uncond'] = uc
+        self.sampler.sampler_extra_args["cond"] = c
+        self.sampler.sampler_extra_args["uncond"] = uc
 
     def pad_cond_uncond(self, cond, uncond):
         empty = shared.sd_model.cond_stage_model_empty_prompt
@@ -135,19 +141,21 @@ class CFGDenoiser(torch.nn.Module):
         """
 
         is_dict_cond = isinstance(uncond, dict)
-        uncond_vec = uncond['crossattn'] if is_dict_cond else uncond
+        uncond_vec = uncond["crossattn"] if is_dict_cond else uncond
 
         if uncond_vec.shape[1] < cond.shape[1]:
             last_vector = uncond_vec[:, -1:]
-            last_vector_repeated = last_vector.repeat([1, cond.shape[1] - uncond_vec.shape[1], 1])
+            last_vector_repeated = last_vector.repeat(
+                [1, cond.shape[1] - uncond_vec.shape[1], 1]
+            )
             uncond_vec = torch.hstack([uncond_vec, last_vector_repeated])
             self.padded_cond_uncond_v0 = True
         elif uncond_vec.shape[1] > cond.shape[1]:
-            uncond_vec = uncond_vec[:, :cond.shape[1]]
+            uncond_vec = uncond_vec[:, : cond.shape[1]]
             self.padded_cond_uncond_v0 = True
 
         if is_dict_cond:
-            uncond['crossattn'] = uncond_vec
+            uncond["crossattn"] = uncond_vec
         else:
             uncond = uncond_vec
 
@@ -158,17 +166,23 @@ class CFGDenoiser(torch.nn.Module):
             raise sd_samplers_common.InterruptedException
 
         if sd_samplers_common.apply_refiner(self, sigma):
-            cond = self.sampler.sampler_extra_args['cond']
-            uncond = self.sampler.sampler_extra_args['uncond']
+            cond = self.sampler.sampler_extra_args["cond"]
+            uncond = self.sampler.sampler_extra_args["uncond"]
 
         # at self.image_cfg_scale == 1.0 produced results for edit model are the same as with normal sampling,
         # so is_edit_model is set to False to support AND composition.
-        is_edit_model = shared.sd_model.cond_stage_key == "edit" and self.image_cfg_scale is not None and self.image_cfg_scale != 1.0
+        is_edit_model = (
+            shared.sd_model.cond_stage_key == "edit"
+            and self.image_cfg_scale is not None
+            and self.image_cfg_scale != 1.0
+        )
 
         conds_list, tensor = prompt_parser.reconstruct_multicond_batch(cond, self.step)
         uncond = prompt_parser.reconstruct_cond_batch(uncond, self.step)
 
-        assert not is_edit_model or all(len(conds) == 1 for conds in conds_list), "AND is not supported for InstructPix2Pix checkpoint (unless using Image CFG scale = 1.0)"
+        assert (
+            not is_edit_model or all(len(conds) == 1 for conds in conds_list)
+        ), "AND is not supported for InstructPix2Pix checkpoint (unless using Image CFG scale = 1.0)"
 
         # If we use masks, blending between the denoised and original latent images occurs here.
         def apply_blend(current_latent):
@@ -176,7 +190,16 @@ class CFGDenoiser(torch.nn.Module):
 
             if self.p.scripts is not None:
                 from modules import scripts
-                mba = scripts.MaskBlendArgs(current_latent, self.nmask, self.init_latent, self.mask, blended_latent, denoiser=self, sigma=sigma)
+
+                mba = scripts.MaskBlendArgs(
+                    current_latent,
+                    self.nmask,
+                    self.init_latent,
+                    self.mask,
+                    blended_latent,
+                    denoiser=self,
+                    sigma=sigma,
+                )
                 self.p.scripts.on_mask_blend(self.p, mba)
                 blended_latent = mba.blended_latent
 
@@ -191,24 +214,75 @@ class CFGDenoiser(torch.nn.Module):
 
         if shared.sd_model.model.conditioning_key == "crossattn-adm":
             image_uncond = torch.zeros_like(image_cond)
-            make_condition_dict = lambda c_crossattn, c_adm: {"c_crossattn": [c_crossattn], "c_adm": c_adm}
+            make_condition_dict = lambda c_crossattn, c_adm: {
+                "c_crossattn": [c_crossattn],
+                "c_adm": c_adm,
+            }
         else:
             image_uncond = image_cond
             if isinstance(uncond, dict):
-                make_condition_dict = lambda c_crossattn, c_concat: {**c_crossattn, "c_concat": [c_concat]}
+                make_condition_dict = lambda c_crossattn, c_concat: {
+                    **c_crossattn,
+                    "c_concat": [c_concat],
+                }
             else:
-                make_condition_dict = lambda c_crossattn, c_concat: {"c_crossattn": [c_crossattn], "c_concat": [c_concat]}
+                make_condition_dict = lambda c_crossattn, c_concat: {
+                    "c_crossattn": [c_crossattn],
+                    "c_concat": [c_concat],
+                }
 
         if not is_edit_model:
-            x_in = torch.cat([torch.stack([x[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [x])
-            sigma_in = torch.cat([torch.stack([sigma[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [sigma])
-            image_cond_in = torch.cat([torch.stack([image_cond[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [image_uncond])
+            x_in = torch.cat(
+                [torch.stack([x[i] for _ in range(n)]) for i, n in enumerate(repeats)]
+                + [x]
+            )
+            sigma_in = torch.cat(
+                [
+                    torch.stack([sigma[i] for _ in range(n)])
+                    for i, n in enumerate(repeats)
+                ]
+                + [sigma]
+            )
+            image_cond_in = torch.cat(
+                [
+                    torch.stack([image_cond[i] for _ in range(n)])
+                    for i, n in enumerate(repeats)
+                ]
+                + [image_uncond]
+            )
         else:
-            x_in = torch.cat([torch.stack([x[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [x] + [x])
-            sigma_in = torch.cat([torch.stack([sigma[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [sigma] + [sigma])
-            image_cond_in = torch.cat([torch.stack([image_cond[i] for _ in range(n)]) for i, n in enumerate(repeats)] + [image_uncond] + [torch.zeros_like(self.init_latent)])
+            x_in = torch.cat(
+                [torch.stack([x[i] for _ in range(n)]) for i, n in enumerate(repeats)]
+                + [x]
+                + [x]
+            )
+            sigma_in = torch.cat(
+                [
+                    torch.stack([sigma[i] for _ in range(n)])
+                    for i, n in enumerate(repeats)
+                ]
+                + [sigma]
+                + [sigma]
+            )
+            image_cond_in = torch.cat(
+                [
+                    torch.stack([image_cond[i] for _ in range(n)])
+                    for i, n in enumerate(repeats)
+                ]
+                + [image_uncond]
+                + [torch.zeros_like(self.init_latent)]
+            )
 
-        denoiser_params = CFGDenoiserParams(x_in, image_cond_in, sigma_in, state.sampling_step, state.sampling_steps, tensor, uncond, self)
+        denoiser_params = CFGDenoiserParams(
+            x_in,
+            image_cond_in,
+            sigma_in,
+            state.sampling_step,
+            state.sampling_steps,
+            tensor,
+            uncond,
+            self,
+        )
         cfg_denoiser_callback(denoiser_params)
         x_in = denoiser_params.x
         image_cond_in = denoiser_params.image_cond
@@ -217,14 +291,26 @@ class CFGDenoiser(torch.nn.Module):
         uncond = denoiser_params.text_uncond
         skip_uncond = False
 
-        if shared.opts.skip_early_cond != 0. and self.step / self.total_steps <= shared.opts.skip_early_cond:
+        if (
+            shared.opts.skip_early_cond != 0.0
+            and self.step / self.total_steps <= shared.opts.skip_early_cond
+        ):
             skip_uncond = True
-            self.p.extra_generation_params["Skip Early CFG"] = shared.opts.skip_early_cond
-        elif (self.step % 2 or shared.opts.s_min_uncond_all) and s_min_uncond > 0 and sigma[0] < s_min_uncond and not is_edit_model:
+            self.p.extra_generation_params["Skip Early CFG"] = (
+                shared.opts.skip_early_cond
+            )
+        elif (
+            (self.step % 2 or shared.opts.s_min_uncond_all)
+            and s_min_uncond > 0
+            and sigma[0] < s_min_uncond
+            and not is_edit_model
+        ):
             skip_uncond = True
             self.p.extra_generation_params["NGMS"] = s_min_uncond
             if shared.opts.s_min_uncond_all:
-                self.p.extra_generation_params["NGMS all steps"] = shared.opts.s_min_uncond_all
+                self.p.extra_generation_params["NGMS all steps"] = (
+                    shared.opts.s_min_uncond_all
+                )
 
         if skip_uncond:
             x_in = x_in[:-batch_size]
@@ -246,16 +332,24 @@ class CFGDenoiser(torch.nn.Module):
                 cond_in = catenate_conds([tensor, uncond])
 
             if shared.opts.batch_cond_uncond:
-                x_out = self.inner_model(x_in, sigma_in, cond=make_condition_dict(cond_in, image_cond_in))
+                x_out = self.inner_model(
+                    x_in, sigma_in, cond=make_condition_dict(cond_in, image_cond_in)
+                )
             else:
                 x_out = torch.zeros_like(x_in)
                 for batch_offset in range(0, x_out.shape[0], batch_size):
                     a = batch_offset
                     b = a + batch_size
-                    x_out[a:b] = self.inner_model(x_in[a:b], sigma_in[a:b], cond=make_condition_dict(subscript_cond(cond_in, a, b), image_cond_in[a:b]))
+                    x_out[a:b] = self.inner_model(
+                        x_in[a:b],
+                        sigma_in[a:b],
+                        cond=make_condition_dict(
+                            subscript_cond(cond_in, a, b), image_cond_in[a:b]
+                        ),
+                    )
         else:
             x_out = torch.zeros_like(x_in)
-            batch_size = batch_size*2 if shared.opts.batch_cond_uncond else batch_size
+            batch_size = batch_size * 2 if shared.opts.batch_cond_uncond else batch_size
             for batch_offset in range(0, tensor.shape[0], batch_size):
                 a = batch_offset
                 b = min(a + batch_size, tensor.shape[0])
@@ -265,48 +359,75 @@ class CFGDenoiser(torch.nn.Module):
                 else:
                     c_crossattn = torch.cat([tensor[a:b]], uncond)
 
-                x_out[a:b] = self.inner_model(x_in[a:b], sigma_in[a:b], cond=make_condition_dict(c_crossattn, image_cond_in[a:b]))
+                x_out[a:b] = self.inner_model(
+                    x_in[a:b],
+                    sigma_in[a:b],
+                    cond=make_condition_dict(c_crossattn, image_cond_in[a:b]),
+                )
 
             if not skip_uncond:
-                x_out[-uncond.shape[0]:] = self.inner_model(x_in[-uncond.shape[0]:], sigma_in[-uncond.shape[0]:], cond=make_condition_dict(uncond, image_cond_in[-uncond.shape[0]:]))
+                x_out[-uncond.shape[0] :] = self.inner_model(
+                    x_in[-uncond.shape[0] :],
+                    sigma_in[-uncond.shape[0] :],
+                    cond=make_condition_dict(uncond, image_cond_in[-uncond.shape[0] :]),
+                )
 
         denoised_image_indexes = [x[0][0] for x in conds_list]
         if skip_uncond:
-            fake_uncond = torch.cat([x_out[i:i+1] for i in denoised_image_indexes])
-            x_out = torch.cat([x_out, fake_uncond])  # we skipped uncond denoising, so we put cond-denoised image to where the uncond-denoised image should be
+            fake_uncond = torch.cat([x_out[i : i + 1] for i in denoised_image_indexes])
+            x_out = torch.cat(
+                [x_out, fake_uncond]
+            )  # we skipped uncond denoising, so we put cond-denoised image to where the uncond-denoised image should be
 
-        denoised_params = CFGDenoisedParams(x_out, state.sampling_step, state.sampling_steps, self.inner_model)
+        denoised_params = CFGDenoisedParams(
+            x_out, state.sampling_step, state.sampling_steps, self.inner_model
+        )
         cfg_denoised_callback(denoised_params)
 
         if self.need_last_noise_uncond:
-            self.last_noise_uncond = torch.clone(x_out[-uncond.shape[0]:])
+            self.last_noise_uncond = torch.clone(x_out[-uncond.shape[0] :])
 
         if is_edit_model:
-            denoised = self.combine_denoised_for_edit_model(x_out, cond_scale * self.cond_scale_miltiplier)
+            denoised = self.combine_denoised_for_edit_model(
+                x_out, cond_scale * self.cond_scale_miltiplier
+            )
         elif skip_uncond:
             denoised = self.combine_denoised(x_out, conds_list, uncond, 1.0)
         else:
-            denoised = self.combine_denoised(x_out, conds_list, uncond, cond_scale * self.cond_scale_miltiplier)
+            denoised = self.combine_denoised(
+                x_out, conds_list, uncond, cond_scale * self.cond_scale_miltiplier
+            )
 
         # Blend in the original latents (after)
         if not self.mask_before_denoising and self.mask is not None:
             denoised = apply_blend(denoised)
 
-        self.sampler.last_latent = self.get_pred_x0(torch.cat([x_in[i:i + 1] for i in denoised_image_indexes]), torch.cat([x_out[i:i + 1] for i in denoised_image_indexes]), sigma)
+        self.sampler.last_latent = self.get_pred_x0(
+            torch.cat([x_in[i : i + 1] for i in denoised_image_indexes]),
+            torch.cat([x_out[i : i + 1] for i in denoised_image_indexes]),
+            sigma,
+        )
 
         if opts.live_preview_content == "Prompt":
             preview = self.sampler.last_latent
         elif opts.live_preview_content == "Negative prompt":
-            preview = self.get_pred_x0(x_in[-uncond.shape[0]:], x_out[-uncond.shape[0]:], sigma)
+            preview = self.get_pred_x0(
+                x_in[-uncond.shape[0] :], x_out[-uncond.shape[0] :], sigma
+            )
         else:
-            preview = self.get_pred_x0(torch.cat([x_in[i:i+1] for i in denoised_image_indexes]), torch.cat([denoised[i:i+1] for i in denoised_image_indexes]), sigma)
+            preview = self.get_pred_x0(
+                torch.cat([x_in[i : i + 1] for i in denoised_image_indexes]),
+                torch.cat([denoised[i : i + 1] for i in denoised_image_indexes]),
+                sigma,
+            )
 
         sd_samplers_common.store_latent(preview)
 
-        after_cfg_callback_params = AfterCFGCallbackParams(denoised, state.sampling_step, state.sampling_steps)
+        after_cfg_callback_params = AfterCFGCallbackParams(
+            denoised, state.sampling_step, state.sampling_steps
+        )
         cfg_after_cfg_callback(after_cfg_callback_params)
         denoised = after_cfg_callback_params.x
 
         self.step += 1
         return denoised
-

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -3,12 +3,22 @@ from collections import namedtuple
 import numpy as np
 import torch
 from PIL import Image
-from modules import devices, images, sd_vae_approx, sd_samplers, sd_vae_taesd, shared, sd_models
+from modules import (
+    devices,
+    images,
+    sd_vae_approx,
+    sd_samplers,
+    sd_vae_taesd,
+    shared,
+    sd_models,
+)
 from modules.shared import opts, state
 import k_diffusion.sampling
 
 
-SamplerDataTuple = namedtuple('SamplerData', ['name', 'constructor', 'aliases', 'options'])
+SamplerDataTuple = namedtuple(
+    "SamplerData", ["name", "constructor", "aliases", "options"]
+)
 
 
 class SamplerData(SamplerDataTuple):
@@ -21,8 +31,12 @@ class SamplerData(SamplerDataTuple):
 
 def setup_img2img_steps(p, steps=None):
     if opts.img2img_fix_steps or steps is not None:
-        requested_steps = (steps or p.steps)
-        steps = int(requested_steps / min(p.denoising_strength, 0.999)) if p.denoising_strength > 0 else 0
+        requested_steps = steps or p.steps
+        steps = (
+            int(requested_steps / min(p.denoising_strength, 0.999))
+            if p.denoising_strength > 0
+            else 0
+        )
         t_enc = requested_steps - 1
     else:
         steps = p.steps
@@ -37,34 +51,52 @@ approximation_indexes = {"Full": 0, "Approx NN": 1, "Approx cheap": 2, "TAESD": 
 def samples_to_images_tensor(sample, approximation=None, model=None):
     """Transforms 4-channel latent space images into 3-channel RGB image tensors, with values in range [-1, 1]."""
 
-    if approximation is None or (shared.state.interrupted and opts.live_preview_fast_interrupt):
+    if approximation is None or (
+        shared.state.interrupted and opts.live_preview_fast_interrupt
+    ):
         approximation = approximation_indexes.get(opts.show_progress_type, 0)
 
         from modules import lowvram
-        if approximation == 0 and lowvram.is_enabled(shared.sd_model) and not shared.opts.live_preview_allow_lowvram_full:
+
+        if (
+            approximation == 0
+            and lowvram.is_enabled(shared.sd_model)
+            and not shared.opts.live_preview_allow_lowvram_full
+        ):
             approximation = 1
 
     if approximation == 2:
         x_sample = sd_vae_approx.cheap_approximation(sample)
     elif approximation == 1:
-        x_sample = sd_vae_approx.model()(sample.to(devices.device, devices.dtype)).detach()
+        x_sample = sd_vae_approx.model()(
+            sample.to(devices.device, devices.dtype)
+        ).detach()
     elif approximation == 3:
-        x_sample = sd_vae_taesd.decoder_model()(sample.to(devices.device, devices.dtype)).detach()
+        x_sample = sd_vae_taesd.decoder_model()(
+            sample.to(devices.device, devices.dtype)
+        ).detach()
         x_sample = x_sample * 2 - 1
     else:
         if model is None:
             model = shared.sd_model
-        with torch.no_grad(), devices.without_autocast(): # fixes an issue with unstable VAEs that are flaky even in fp32
-            x_sample = model.decode_first_stage(sample.to(model.first_stage_model.dtype))
+        with (
+            torch.no_grad(),
+            devices.without_autocast(),
+        ):  # fixes an issue with unstable VAEs that are flaky even in fp32
+            x_sample = model.decode_first_stage(
+                sample.to(model.first_stage_model.dtype)
+            )
 
     return x_sample
 
 
 def single_sample_to_image(sample, approximation=None):
-    x_sample = samples_to_images_tensor(sample.unsqueeze(0), approximation)[0] * 0.5 + 0.5
+    x_sample = (
+        samples_to_images_tensor(sample.unsqueeze(0), approximation)[0] * 0.5 + 0.5
+    )
 
     x_sample = torch.clamp(x_sample, min=0.0, max=1.0)
-    x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
+    x_sample = 255.0 * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
     x_sample = x_sample.astype(np.uint8)
 
     return Image.fromarray(x_sample)
@@ -81,11 +113,13 @@ def sample_to_image(samples, index=0, approximation=None):
 
 
 def samples_to_image_grid(samples, approximation=None):
-    return images.image_grid([single_sample_to_image(sample, approximation) for sample in samples])
+    return images.image_grid(
+        [single_sample_to_image(sample, approximation) for sample in samples]
+    )
 
 
 def images_tensor_to_samples(image, approximation=None, model=None):
-    '''image[0, 1] -> latent'''
+    """image[0, 1] -> latent"""
     if approximation is None:
         approximation = approximation_indexes.get(opts.sd_vae_encode_method, 0)
 
@@ -100,12 +134,14 @@ def images_tensor_to_samples(image, approximation=None, model=None):
         image = image.to(shared.device, dtype=devices.dtype_vae)
         image = image * 2 - 1
         if len(image) > 1:
-            x_latent = torch.stack([
-                model.get_first_stage_encoding(
-                    model.encode_first_stage(torch.unsqueeze(img, 0))
-                )[0]
-                for img in image
-            ])
+            x_latent = torch.stack(
+                [
+                    model.get_first_stage_encoding(
+                        model.encode_first_stage(torch.unsqueeze(img, 0))
+                    )[0]
+                    for img in image
+                ]
+            )
         else:
             x_latent = model.get_first_stage_encoding(model.encode_first_stage(image))
 
@@ -115,7 +151,11 @@ def images_tensor_to_samples(image, approximation=None, model=None):
 def store_latent(decoded):
     state.current_latent = decoded
 
-    if opts.live_previews_enable and opts.show_progress_every_n_steps > 0 and shared.state.sampling_step % opts.show_progress_every_n_steps == 0:
+    if (
+        opts.live_previews_enable
+        and opts.show_progress_every_n_steps > 0
+        and shared.state.sampling_step % opts.show_progress_every_n_steps == 0
+    ):
         if not shared.parallel_processing_allowed:
             shared.state.assign_current_image(sample_to_image(decoded))
 
@@ -158,13 +198,21 @@ replace_torchsde_browinan()
 def apply_refiner(cfg_denoiser, sigma=None):
     if opts.refiner_switch_by_sample_steps or sigma is None:
         completed_ratio = cfg_denoiser.step / cfg_denoiser.total_steps
-        cfg_denoiser.p.extra_generation_params["Refiner switch by sampling steps"] = True
+        cfg_denoiser.p.extra_generation_params["Refiner switch by sampling steps"] = (
+            True
+        )
 
     else:
         # torch.max(sigma) only to handle rare case where we might have different sigmas in the same batch
         try:
-            timestep = torch.argmin(torch.abs(cfg_denoiser.inner_model.sigmas.to(sigma.device) - torch.max(sigma)))
-        except AttributeError:  # for samplers that don't use sigmas (DDIM) sigma is actually the timestep
+            timestep = torch.argmin(
+                torch.abs(
+                    cfg_denoiser.inner_model.sigmas.to(sigma.device) - torch.max(sigma)
+                )
+            )
+        except (
+            AttributeError
+        ):  # for samplers that don't use sigmas (DDIM) sigma is actually the timestep
             timestep = torch.max(sigma).to(dtype=int)
         completed_ratio = (999 - timestep) / 1000
 
@@ -174,7 +222,10 @@ def apply_refiner(cfg_denoiser, sigma=None):
     if refiner_switch_at is not None and completed_ratio < refiner_switch_at:
         return False
 
-    if refiner_checkpoint_info is None or shared.sd_model.sd_checkpoint_info == refiner_checkpoint_info:
+    if (
+        refiner_checkpoint_info is None
+        or shared.sd_model.sd_checkpoint_info == refiner_checkpoint_info
+    ):
         return False
 
     if getattr(cfg_denoiser.p, "enable_hr", False):
@@ -187,10 +238,14 @@ def apply_refiner(cfg_denoiser, sigma=None):
             return False
 
         if opts.hires_fix_refiner_pass != "second pass":
-            cfg_denoiser.p.extra_generation_params['Hires refiner'] = opts.hires_fix_refiner_pass
+            cfg_denoiser.p.extra_generation_params["Hires refiner"] = (
+                opts.hires_fix_refiner_pass
+            )
 
-    cfg_denoiser.p.extra_generation_params['Refiner'] = refiner_checkpoint_info.short_title
-    cfg_denoiser.p.extra_generation_params['Refiner switch at'] = refiner_switch_at
+    cfg_denoiser.p.extra_generation_params["Refiner"] = (
+        refiner_checkpoint_info.short_title
+    )
+    cfg_denoiser.p.extra_generation_params["Refiner switch at"] = refiner_switch_at
 
     with sd_models.SkipWritingToConfig():
         sd_models.reload_model_weights(info=refiner_checkpoint_info)
@@ -214,13 +269,15 @@ class TorchHijack:
         self.rng = p.rng
 
     def __getattr__(self, item):
-        if item == 'randn_like':
+        if item == "randn_like":
             return self.randn_like
 
         if hasattr(torch, item):
             return getattr(torch, item)
 
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{item}'"
+        )
 
     def randn_like(self, x):
         return self.rng.next()
@@ -239,14 +296,16 @@ class Sampler:
         self.s_min_uncond = None
         self.s_churn = 0.0
         self.s_tmin = 0.0
-        self.s_tmax = float('inf')
+        self.s_tmax = float("inf")
         self.s_noise = 1.0
 
-        self.eta_option_field = 'eta_ancestral'
-        self.eta_infotext_field = 'Eta'
+        self.eta_option_field = "eta_ancestral"
+        self.eta_infotext_field = "Eta"
         self.eta_default = 1.0
 
-        self.conditioning_key = getattr(shared.sd_model.model, 'conditioning_key', 'crossattn')
+        self.conditioning_key = getattr(
+            shared.sd_model.model, "conditioning_key", "crossattn"
+        )
 
         self.p = None
         self.model_wrap_cfg = None
@@ -254,7 +313,7 @@ class Sampler:
         self.options = {}
 
     def callback_state(self, d):
-        step = d['i']
+        step = d["i"]
 
         if self.stop_at is not None and step > self.stop_at:
             raise InterruptedException
@@ -272,9 +331,9 @@ class Sampler:
             return func()
         except RecursionError:
             print(
-                'Encountered RecursionError during sampling, returning last latent. '
-                'rho >5 with a polyexponential scheduler may cause this error. '
-                'You should try to use a smaller rho value instead.'
+                "Encountered RecursionError during sampling, returning last latent. "
+                "rho >5 with a polyexponential scheduler may cause this error. "
+                "You should try to use a smaller rho value instead."
             )
             return self.last_latent
         except InterruptedException:
@@ -286,48 +345,53 @@ class Sampler:
     def initialize(self, p) -> dict:
         self.p = p
         self.model_wrap_cfg.p = p
-        self.model_wrap_cfg.mask = p.mask if hasattr(p, 'mask') else None
-        self.model_wrap_cfg.nmask = p.nmask if hasattr(p, 'nmask') else None
+        self.model_wrap_cfg.mask = p.mask if hasattr(p, "mask") else None
+        self.model_wrap_cfg.nmask = p.nmask if hasattr(p, "nmask") else None
         self.model_wrap_cfg.step = 0
-        self.model_wrap_cfg.image_cfg_scale = getattr(p, 'image_cfg_scale', None)
-        self.eta = p.eta if p.eta is not None else getattr(opts, self.eta_option_field, 0.0)
-        self.s_min_uncond = getattr(p, 's_min_uncond', 0.0)
+        self.model_wrap_cfg.image_cfg_scale = getattr(p, "image_cfg_scale", None)
+        self.eta = (
+            p.eta if p.eta is not None else getattr(opts, self.eta_option_field, 0.0)
+        )
+        self.s_min_uncond = getattr(p, "s_min_uncond", 0.0)
 
         k_diffusion.sampling.torch = TorchHijack(p)
 
         extra_params_kwargs = {}
         for param_name in self.extra_params:
-            if hasattr(p, param_name) and param_name in inspect.signature(self.func).parameters:
+            if (
+                hasattr(p, param_name)
+                and param_name in inspect.signature(self.func).parameters
+            ):
                 extra_params_kwargs[param_name] = getattr(p, param_name)
 
-        if 'eta' in inspect.signature(self.func).parameters:
+        if "eta" in inspect.signature(self.func).parameters:
             if self.eta != self.eta_default:
                 p.extra_generation_params[self.eta_infotext_field] = self.eta
 
-            extra_params_kwargs['eta'] = self.eta
+            extra_params_kwargs["eta"] = self.eta
 
         if len(self.extra_params) > 0:
-            s_churn = getattr(opts, 's_churn', p.s_churn)
-            s_tmin = getattr(opts, 's_tmin', p.s_tmin)
-            s_tmax = getattr(opts, 's_tmax', p.s_tmax) or self.s_tmax # 0 = inf
-            s_noise = getattr(opts, 's_noise', p.s_noise)
+            s_churn = getattr(opts, "s_churn", p.s_churn)
+            s_tmin = getattr(opts, "s_tmin", p.s_tmin)
+            s_tmax = getattr(opts, "s_tmax", p.s_tmax) or self.s_tmax  # 0 = inf
+            s_noise = getattr(opts, "s_noise", p.s_noise)
 
-            if 's_churn' in extra_params_kwargs and s_churn != self.s_churn:
-                extra_params_kwargs['s_churn'] = s_churn
+            if "s_churn" in extra_params_kwargs and s_churn != self.s_churn:
+                extra_params_kwargs["s_churn"] = s_churn
                 p.s_churn = s_churn
-                p.extra_generation_params['Sigma churn'] = s_churn
-            if 's_tmin' in extra_params_kwargs and s_tmin != self.s_tmin:
-                extra_params_kwargs['s_tmin'] = s_tmin
+                p.extra_generation_params["Sigma churn"] = s_churn
+            if "s_tmin" in extra_params_kwargs and s_tmin != self.s_tmin:
+                extra_params_kwargs["s_tmin"] = s_tmin
                 p.s_tmin = s_tmin
-                p.extra_generation_params['Sigma tmin'] = s_tmin
-            if 's_tmax' in extra_params_kwargs and s_tmax != self.s_tmax:
-                extra_params_kwargs['s_tmax'] = s_tmax
+                p.extra_generation_params["Sigma tmin"] = s_tmin
+            if "s_tmax" in extra_params_kwargs and s_tmax != self.s_tmax:
+                extra_params_kwargs["s_tmax"] = s_tmax
                 p.s_tmax = s_tmax
-                p.extra_generation_params['Sigma tmax'] = s_tmax
-            if 's_noise' in extra_params_kwargs and s_noise != self.s_noise:
-                extra_params_kwargs['s_noise'] = s_noise
+                p.extra_generation_params["Sigma tmax"] = s_tmax
+            if "s_noise" in extra_params_kwargs and s_noise != self.s_noise:
+                extra_params_kwargs["s_noise"] = s_noise
                 p.s_noise = s_noise
-                p.extra_generation_params['Sigma noise'] = s_noise
+                p.extra_generation_params["Sigma noise"] = s_noise
 
         return extra_params_kwargs
 
@@ -337,14 +401,36 @@ class Sampler:
             return None
 
         from k_diffusion.sampling import BrownianTreeNoiseSampler
-        sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-        current_iter_seeds = p.all_seeds[p.iteration * p.batch_size:(p.iteration + 1) * p.batch_size]
-        return BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=current_iter_seeds)
 
-    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+        sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
+        current_iter_seeds = p.all_seeds[
+            p.iteration * p.batch_size : (p.iteration + 1) * p.batch_size
+        ]
+        return BrownianTreeNoiseSampler(
+            x, sigma_min, sigma_max, seed=current_iter_seeds
+        )
+
+    def sample(
+        self,
+        p,
+        x,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         raise NotImplementedError()
 
-    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample_img2img(
+        self,
+        p,
+        x,
+        noise,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         raise NotImplementedError()
 
     def add_infotext(self, p):

--- a/modules/sd_samplers_extra.py
+++ b/modules/sd_samplers_extra.py
@@ -4,7 +4,16 @@ import k_diffusion.sampling
 
 
 @torch.no_grad()
-def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=None, s_noise=1., restart_list=None):
+def restart_sampler(
+    model,
+    x,
+    sigmas,
+    extra_args=None,
+    callback=None,
+    disable=None,
+    s_noise=1.0,
+    restart_list=None,
+):
     """Implements restart sampling in Restart Sampling for Improving Generative Processes (2023)
     Restart_list format: {min_sigma: [ restart_steps, restart_times, max_sigma]}
     If restart_list is None: will choose restart_list automatically, otherwise will use the given restart_list
@@ -19,7 +28,15 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
         denoised = model(x, old_sigma * s_in, **extra_args)
         d = to_d(x, old_sigma, denoised)
         if callback is not None:
-            callback({'x': x, 'i': step_id, 'sigma': new_sigma, 'sigma_hat': old_sigma, 'denoised': denoised})
+            callback(
+                {
+                    "x": x,
+                    "i": step_id,
+                    "sigma": new_sigma,
+                    "sigma_hat": old_sigma,
+                    "denoised": denoised,
+                }
+            )
         dt = new_sigma - old_sigma
         if new_sigma == 0 or not second_order:
             # Euler method
@@ -42,12 +59,20 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
             if steps >= 36:
                 restart_steps = steps // 4
                 restart_times = 2
-            sigmas = get_sigmas_karras(steps - restart_steps * restart_times, sigmas[-2].item(), sigmas[0].item(), device=sigmas.device)
+            sigmas = get_sigmas_karras(
+                steps - restart_steps * restart_times,
+                sigmas[-2].item(),
+                sigmas[0].item(),
+                device=sigmas.device,
+            )
             restart_list = {0.1: [restart_steps + 1, restart_times, 2]}
         else:
             restart_list = {}
 
-    restart_list = {int(torch.argmin(abs(sigmas - key), dim=0)): value for key, value in restart_list.items()}
+    restart_list = {
+        int(torch.argmin(abs(sigmas - key), dim=0)): value
+        for key, value in restart_list.items()
+    }
 
     step_list = []
     for i in range(len(sigmas) - 1):
@@ -57,7 +82,12 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
             min_idx = i + 1
             max_idx = int(torch.argmin(abs(sigmas - restart_max), dim=0))
             if max_idx < min_idx:
-                sigma_restart = get_sigmas_karras(restart_steps, sigmas[min_idx].item(), sigmas[max_idx].item(), device=sigmas.device)[:-1]
+                sigma_restart = get_sigmas_karras(
+                    restart_steps,
+                    sigmas[min_idx].item(),
+                    sigmas[max_idx].item(),
+                    device=sigmas.device,
+                )[:-1]
                 while restart_times > 0:
                     restart_times -= 1
                     step_list.extend(zip(sigma_restart[:-1], sigma_restart[1:]))
@@ -67,7 +97,12 @@ def restart_sampler(model, x, sigmas, extra_args=None, callback=None, disable=No
         if last_sigma is None:
             last_sigma = old_sigma
         elif last_sigma < old_sigma:
-            x = x + k_diffusion.sampling.torch.randn_like(x) * s_noise * (old_sigma ** 2 - last_sigma ** 2) ** 0.5
+            x = (
+                x
+                + k_diffusion.sampling.torch.randn_like(x)
+                * s_noise
+                * (old_sigma**2 - last_sigma**2) ** 0.5
+            )
         x = heun_step(x, old_sigma, new_sigma)
         last_sigma = new_sigma
 

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -1,7 +1,13 @@
 import torch
 import inspect
 import k_diffusion.sampling
-from modules import sd_samplers_common, sd_samplers_extra, sd_samplers_cfg_denoiser, sd_schedulers, devices
+from modules import (
+    sd_samplers_common,
+    sd_samplers_extra,
+    sd_samplers_cfg_denoiser,
+    sd_schedulers,
+    devices,
+)
 from modules.sd_samplers_cfg_denoiser import CFGDenoiser  # noqa: F401
 from modules.script_callbacks import ExtraNoiseParams, extra_noise_callback
 
@@ -9,40 +15,103 @@ from modules.shared import opts
 import modules.shared as shared
 
 samplers_k_diffusion = [
-    ('DPM++ 2M', 'sample_dpmpp_2m', ['k_dpmpp_2m'], {'scheduler': 'karras'}),
-    ('DPM++ SDE', 'sample_dpmpp_sde', ['k_dpmpp_sde'], {'scheduler': 'karras', "second_order": True, "brownian_noise": True}),
-    ('DPM++ 2M SDE', 'sample_dpmpp_2m_sde', ['k_dpmpp_2m_sde'], {'scheduler': 'exponential', "brownian_noise": True}),
-    ('DPM++ 2M SDE Heun', 'sample_dpmpp_2m_sde', ['k_dpmpp_2m_sde_heun'], {'scheduler': 'exponential', "brownian_noise": True, "solver_type": "heun"}),
-    ('DPM++ 2S a', 'sample_dpmpp_2s_ancestral', ['k_dpmpp_2s_a'], {'scheduler': 'karras', "uses_ensd": True, "second_order": True}),
-    ('DPM++ 3M SDE', 'sample_dpmpp_3m_sde', ['k_dpmpp_3m_sde'], {'scheduler': 'exponential', 'discard_next_to_last_sigma': True, "brownian_noise": True}),
-    ('Euler a', 'sample_euler_ancestral', ['k_euler_a', 'k_euler_ancestral'], {"uses_ensd": True}),
-    ('Euler', 'sample_euler', ['k_euler'], {}),
-    ('LMS', 'sample_lms', ['k_lms'], {}),
-    ('Heun', 'sample_heun', ['k_heun'], {"second_order": True}),
-    ('DPM2', 'sample_dpm_2', ['k_dpm_2'], {'scheduler': 'karras', 'discard_next_to_last_sigma': True, "second_order": True}),
-    ('DPM2 a', 'sample_dpm_2_ancestral', ['k_dpm_2_a'], {'scheduler': 'karras', 'discard_next_to_last_sigma': True, "uses_ensd": True, "second_order": True}),
-    ('DPM fast', 'sample_dpm_fast', ['k_dpm_fast'], {"uses_ensd": True}),
-    ('DPM adaptive', 'sample_dpm_adaptive', ['k_dpm_ad'], {"uses_ensd": True}),
-    ('Restart', sd_samplers_extra.restart_sampler, ['restart'], {'scheduler': 'karras', "second_order": True}),
+    ("DPM++ 2M", "sample_dpmpp_2m", ["k_dpmpp_2m"], {"scheduler": "karras"}),
+    (
+        "DPM++ SDE",
+        "sample_dpmpp_sde",
+        ["k_dpmpp_sde"],
+        {"scheduler": "karras", "second_order": True, "brownian_noise": True},
+    ),
+    (
+        "DPM++ 2M SDE",
+        "sample_dpmpp_2m_sde",
+        ["k_dpmpp_2m_sde"],
+        {"scheduler": "exponential", "brownian_noise": True},
+    ),
+    (
+        "DPM++ 2M SDE Heun",
+        "sample_dpmpp_2m_sde",
+        ["k_dpmpp_2m_sde_heun"],
+        {"scheduler": "exponential", "brownian_noise": True, "solver_type": "heun"},
+    ),
+    (
+        "DPM++ 2S a",
+        "sample_dpmpp_2s_ancestral",
+        ["k_dpmpp_2s_a"],
+        {"scheduler": "karras", "uses_ensd": True, "second_order": True},
+    ),
+    (
+        "DPM++ 3M SDE",
+        "sample_dpmpp_3m_sde",
+        ["k_dpmpp_3m_sde"],
+        {
+            "scheduler": "exponential",
+            "discard_next_to_last_sigma": True,
+            "brownian_noise": True,
+        },
+    ),
+    (
+        "Euler a",
+        "sample_euler_ancestral",
+        ["k_euler_a", "k_euler_ancestral"],
+        {"uses_ensd": True},
+    ),
+    ("Euler", "sample_euler", ["k_euler"], {}),
+    ("LMS", "sample_lms", ["k_lms"], {}),
+    ("Heun", "sample_heun", ["k_heun"], {"second_order": True}),
+    (
+        "DPM2",
+        "sample_dpm_2",
+        ["k_dpm_2"],
+        {
+            "scheduler": "karras",
+            "discard_next_to_last_sigma": True,
+            "second_order": True,
+        },
+    ),
+    (
+        "DPM2 a",
+        "sample_dpm_2_ancestral",
+        ["k_dpm_2_a"],
+        {
+            "scheduler": "karras",
+            "discard_next_to_last_sigma": True,
+            "uses_ensd": True,
+            "second_order": True,
+        },
+    ),
+    ("DPM fast", "sample_dpm_fast", ["k_dpm_fast"], {"uses_ensd": True}),
+    ("DPM adaptive", "sample_dpm_adaptive", ["k_dpm_ad"], {"uses_ensd": True}),
+    (
+        "Restart",
+        sd_samplers_extra.restart_sampler,
+        ["restart"],
+        {"scheduler": "karras", "second_order": True},
+    ),
 ]
 
 
 samplers_data_k_diffusion = [
-    sd_samplers_common.SamplerData(label, lambda model, funcname=funcname: KDiffusionSampler(funcname, model), aliases, options)
+    sd_samplers_common.SamplerData(
+        label,
+        lambda model, funcname=funcname: KDiffusionSampler(funcname, model),
+        aliases,
+        options,
+    )
     for label, funcname, aliases, options in samplers_k_diffusion
     if callable(funcname) or hasattr(k_diffusion.sampling, funcname)
 ]
 
 sampler_extra_params = {
-    'sample_euler': ['s_churn', 's_tmin', 's_tmax', 's_noise'],
-    'sample_heun': ['s_churn', 's_tmin', 's_tmax', 's_noise'],
-    'sample_dpm_2': ['s_churn', 's_tmin', 's_tmax', 's_noise'],
-    'sample_dpm_fast': ['s_noise'],
-    'sample_dpm_2_ancestral': ['s_noise'],
-    'sample_dpmpp_2s_ancestral': ['s_noise'],
-    'sample_dpmpp_sde': ['s_noise'],
-    'sample_dpmpp_2m_sde': ['s_noise'],
-    'sample_dpmpp_3m_sde': ['s_noise'],
+    "sample_euler": ["s_churn", "s_tmin", "s_tmax", "s_noise"],
+    "sample_heun": ["s_churn", "s_tmin", "s_tmax", "s_noise"],
+    "sample_dpm_2": ["s_churn", "s_tmin", "s_tmax", "s_noise"],
+    "sample_dpm_fast": ["s_noise"],
+    "sample_dpm_2_ancestral": ["s_noise"],
+    "sample_dpmpp_2s_ancestral": ["s_noise"],
+    "sample_dpmpp_sde": ["s_noise"],
+    "sample_dpmpp_2m_sde": ["s_noise"],
+    "sample_dpmpp_3m_sde": ["s_noise"],
 }
 
 k_diffusion_samplers_map = {x.name: x for x in samplers_data_k_diffusion}
@@ -53,13 +122,19 @@ class CFGDenoiserKDiffusion(sd_samplers_cfg_denoiser.CFGDenoiser):
     @property
     def inner_model(self):
         if self.model_wrap is None:
-            denoiser_constructor = getattr(shared.sd_model, 'create_denoiser', None)
+            denoiser_constructor = getattr(shared.sd_model, "create_denoiser", None)
 
             if denoiser_constructor is not None:
                 self.model_wrap = denoiser_constructor()
             else:
-                denoiser = k_diffusion.external.CompVisVDenoiser if shared.sd_model.parameterization == "v" else k_diffusion.external.CompVisDenoiser
-                self.model_wrap = denoiser(shared.sd_model, quantize=shared.opts.enable_quantization)
+                denoiser = (
+                    k_diffusion.external.CompVisVDenoiser
+                    if shared.sd_model.parameterization == "v"
+                    else k_diffusion.external.CompVisDenoiser
+                )
+                self.model_wrap = denoiser(
+                    shared.sd_model, quantize=shared.opts.enable_quantization
+                )
 
         return self.model_wrap
 
@@ -71,56 +146,76 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         self.extra_params = sampler_extra_params.get(funcname, [])
 
         self.options = options or {}
-        self.func = funcname if callable(funcname) else getattr(k_diffusion.sampling, self.funcname)
+        self.func = (
+            funcname
+            if callable(funcname)
+            else getattr(k_diffusion.sampling, self.funcname)
+        )
 
         self.model_wrap_cfg = CFGDenoiserKDiffusion(self)
         self.model_wrap = self.model_wrap_cfg.inner_model
 
     def get_sigmas(self, p, steps):
-        discard_next_to_last_sigma = self.config is not None and self.config.options.get('discard_next_to_last_sigma', False)
+        discard_next_to_last_sigma = (
+            self.config is not None
+            and self.config.options.get("discard_next_to_last_sigma", False)
+        )
         if opts.always_discard_next_to_last_sigma and not discard_next_to_last_sigma:
             discard_next_to_last_sigma = True
             p.extra_generation_params["Discard penultimate sigma"] = True
 
         steps += 1 if discard_next_to_last_sigma else 0
 
-        scheduler_name = (p.hr_scheduler if p.is_hr_pass else p.scheduler) or 'Automatic'
-        if scheduler_name == 'Automatic':
-            scheduler_name = self.config.options.get('scheduler', None)
+        scheduler_name = (
+            p.hr_scheduler if p.is_hr_pass else p.scheduler
+        ) or "Automatic"
+        if scheduler_name == "Automatic":
+            scheduler_name = self.config.options.get("scheduler", None)
 
         scheduler = sd_schedulers.schedulers_map.get(scheduler_name)
 
-        m_sigma_min, m_sigma_max = self.model_wrap.sigmas[0].item(), self.model_wrap.sigmas[-1].item()
-        sigma_min, sigma_max = (0.1, 10) if opts.use_old_karras_scheduler_sigmas else (m_sigma_min, m_sigma_max)
+        m_sigma_min, m_sigma_max = (
+            self.model_wrap.sigmas[0].item(),
+            self.model_wrap.sigmas[-1].item(),
+        )
+        sigma_min, sigma_max = (
+            (0.1, 10)
+            if opts.use_old_karras_scheduler_sigmas
+            else (m_sigma_min, m_sigma_max)
+        )
 
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif scheduler is None or scheduler.function is None:
             sigmas = self.model_wrap.get_sigmas(steps)
         else:
-            sigmas_kwargs = {'sigma_min': sigma_min, 'sigma_max': sigma_max}
+            sigmas_kwargs = {"sigma_min": sigma_min, "sigma_max": sigma_max}
 
-            if scheduler.label != 'Automatic' and not p.is_hr_pass:
+            if scheduler.label != "Automatic" and not p.is_hr_pass:
                 p.extra_generation_params["Schedule type"] = scheduler.label
             elif scheduler.label != p.extra_generation_params.get("Schedule type"):
                 p.extra_generation_params["Hires schedule type"] = scheduler.label
 
             if opts.sigma_min != 0 and opts.sigma_min != m_sigma_min:
-                sigmas_kwargs['sigma_min'] = opts.sigma_min
+                sigmas_kwargs["sigma_min"] = opts.sigma_min
                 p.extra_generation_params["Schedule min sigma"] = opts.sigma_min
 
             if opts.sigma_max != 0 and opts.sigma_max != m_sigma_max:
-                sigmas_kwargs['sigma_max'] = opts.sigma_max
+                sigmas_kwargs["sigma_max"] = opts.sigma_max
                 p.extra_generation_params["Schedule max sigma"] = opts.sigma_max
 
-            if scheduler.default_rho != -1 and opts.rho != 0 and opts.rho != scheduler.default_rho:
-                sigmas_kwargs['rho'] = opts.rho
+            if (
+                scheduler.default_rho != -1
+                and opts.rho != 0
+                and opts.rho != scheduler.default_rho
+            ):
+                sigmas_kwargs["rho"] = opts.rho
                 p.extra_generation_params["Schedule rho"] = opts.rho
 
             if scheduler.need_inner_model:
-                sigmas_kwargs['inner_model'] = self.model_wrap
+                sigmas_kwargs["inner_model"] = self.model_wrap
 
-            if scheduler.label == 'Beta':
+            if scheduler.label == "Beta":
                 p.extra_generation_params["Beta schedule alpha"] = opts.beta_dist_alpha
                 p.extra_generation_params["Beta schedule beta"] = opts.beta_dist_beta
 
@@ -131,13 +226,22 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
 
         return sigmas.cpu()
 
-    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample_img2img(
+        self,
+        p,
+        x,
+        noise,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         steps, t_enc = sd_samplers_common.setup_img2img_steps(p, steps)
 
         sigmas = self.get_sigmas(p, steps)
-        sigma_sched = sigmas[steps - t_enc - 1:]
+        sigma_sched = sigmas[steps - t_enc - 1 :]
 
-        if hasattr(shared.sd_model, 'add_noise_to_latent'):
+        if hasattr(shared.sd_model, "add_noise_to_latent"):
             xi = shared.sd_model.add_noise_to_latent(x, noise, sigma_sched[0])
         else:
             xi = x + noise * sigma_sched[0]
@@ -152,42 +256,60 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 
-        if 'sigma_min' in parameters:
+        if "sigma_min" in parameters:
             ## last sigma is zero which isn't allowed by DPM Fast & Adaptive so taking value before last
-            extra_params_kwargs['sigma_min'] = sigma_sched[-2]
-        if 'sigma_max' in parameters:
-            extra_params_kwargs['sigma_max'] = sigma_sched[0]
-        if 'n' in parameters:
-            extra_params_kwargs['n'] = len(sigma_sched) - 1
-        if 'sigma_sched' in parameters:
-            extra_params_kwargs['sigma_sched'] = sigma_sched
-        if 'sigmas' in parameters:
-            extra_params_kwargs['sigmas'] = sigma_sched
+            extra_params_kwargs["sigma_min"] = sigma_sched[-2]
+        if "sigma_max" in parameters:
+            extra_params_kwargs["sigma_max"] = sigma_sched[0]
+        if "n" in parameters:
+            extra_params_kwargs["n"] = len(sigma_sched) - 1
+        if "sigma_sched" in parameters:
+            extra_params_kwargs["sigma_sched"] = sigma_sched
+        if "sigmas" in parameters:
+            extra_params_kwargs["sigmas"] = sigma_sched
 
-        if self.config.options.get('brownian_noise', False):
+        if self.config.options.get("brownian_noise", False):
             noise_sampler = self.create_noise_sampler(x, sigmas, p)
-            extra_params_kwargs['noise_sampler'] = noise_sampler
+            extra_params_kwargs["noise_sampler"] = noise_sampler
 
-        if self.config.options.get('solver_type', None) == 'heun':
-            extra_params_kwargs['solver_type'] = 'heun'
+        if self.config.options.get("solver_type", None) == "heun":
+            extra_params_kwargs["solver_type"] = "heun"
 
         self.model_wrap_cfg.init_latent = x
         self.last_latent = x
         self.sampler_extra_args = {
-            'cond': conditioning,
-            'image_cond': image_conditioning,
-            'uncond': unconditional_conditioning,
-            'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            "cond": conditioning,
+            "image_cond": image_conditioning,
+            "uncond": unconditional_conditioning,
+            "cond_scale": p.cfg_scale,
+            "s_min_uncond": self.s_min_uncond,
         }
 
-        samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
+        samples = self.launch_sampling(
+            t_enc + 1,
+            lambda: self.func(
+                self.model_wrap_cfg,
+                xi,
+                extra_args=self.sampler_extra_args,
+                disable=False,
+                callback=self.callback_state,
+                **extra_params_kwargs,
+            ),
+        )
 
         self.add_infotext(p)
 
         return samples
 
-    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample(
+        self,
+        p,
+        x,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         steps = steps or p.steps
 
         sigmas = self.get_sigmas(p, steps)
@@ -201,36 +323,44 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 
-        if 'n' in parameters:
-            extra_params_kwargs['n'] = steps
+        if "n" in parameters:
+            extra_params_kwargs["n"] = steps
 
-        if 'sigma_min' in parameters:
-            extra_params_kwargs['sigma_min'] = self.model_wrap.sigmas[0].item()
-            extra_params_kwargs['sigma_max'] = self.model_wrap.sigmas[-1].item()
+        if "sigma_min" in parameters:
+            extra_params_kwargs["sigma_min"] = self.model_wrap.sigmas[0].item()
+            extra_params_kwargs["sigma_max"] = self.model_wrap.sigmas[-1].item()
 
-        if 'sigmas' in parameters:
-            extra_params_kwargs['sigmas'] = sigmas
+        if "sigmas" in parameters:
+            extra_params_kwargs["sigmas"] = sigmas
 
-        if self.config.options.get('brownian_noise', False):
+        if self.config.options.get("brownian_noise", False):
             noise_sampler = self.create_noise_sampler(x, sigmas, p)
-            extra_params_kwargs['noise_sampler'] = noise_sampler
+            extra_params_kwargs["noise_sampler"] = noise_sampler
 
-        if self.config.options.get('solver_type', None) == 'heun':
-            extra_params_kwargs['solver_type'] = 'heun'
+        if self.config.options.get("solver_type", None) == "heun":
+            extra_params_kwargs["solver_type"] = "heun"
 
         self.last_latent = x
         self.sampler_extra_args = {
-            'cond': conditioning,
-            'image_cond': image_conditioning,
-            'uncond': unconditional_conditioning,
-            'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            "cond": conditioning,
+            "image_cond": image_conditioning,
+            "uncond": unconditional_conditioning,
+            "cond_scale": p.cfg_scale,
+            "s_min_uncond": self.s_min_uncond,
         }
 
-        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
+        samples = self.launch_sampling(
+            steps,
+            lambda: self.func(
+                self.model_wrap_cfg,
+                x,
+                extra_args=self.sampler_extra_args,
+                disable=False,
+                callback=self.callback_state,
+                **extra_params_kwargs,
+            ),
+        )
 
         self.add_infotext(p)
 
         return samples
-
-

--- a/modules/sd_samplers_lcm.py
+++ b/modules/sd_samplers_lcm.py
@@ -4,23 +4,36 @@ from k_diffusion import utils, sampling
 from k_diffusion.external import DiscreteEpsDDPMDenoiser
 from k_diffusion.sampling import default_noise_sampler, trange
 
-from modules import shared, sd_samplers_cfg_denoiser, sd_samplers_kdiffusion, sd_samplers_common
+from modules import (
+    shared,
+    sd_samplers_cfg_denoiser,
+    sd_samplers_kdiffusion,
+    sd_samplers_common,
+)
 
 
 class LCMCompVisDenoiser(DiscreteEpsDDPMDenoiser):
     def __init__(self, model):
         timesteps = 1000
-        original_timesteps = 50     # LCM Original Timesteps (default=50, for current version of LCM)
+        original_timesteps = (
+            50  # LCM Original Timesteps (default=50, for current version of LCM)
+        )
         self.skip_steps = timesteps // original_timesteps
 
-        alphas_cumprod_valid = torch.zeros((original_timesteps), dtype=torch.float32, device=model.device)
+        alphas_cumprod_valid = torch.zeros(
+            (original_timesteps), dtype=torch.float32, device=model.device
+        )
         for x in range(original_timesteps):
-            alphas_cumprod_valid[original_timesteps - 1 - x] = model.alphas_cumprod[timesteps - 1 - x * self.skip_steps]
+            alphas_cumprod_valid[original_timesteps - 1 - x] = model.alphas_cumprod[
+                timesteps - 1 - x * self.skip_steps
+            ]
 
         super().__init__(model, alphas_cumprod_valid, quantize=None)
 
-
-    def get_sigmas(self, n=None,):
+    def get_sigmas(
+        self,
+        n=None,
+    ):
         if n is None:
             return sampling.append_zero(self.sigmas.flip(0))
 
@@ -31,21 +44,23 @@ class LCMCompVisDenoiser(DiscreteEpsDDPMDenoiser):
 
         return sampling.append_zero(self.t_to_sigma(t))
 
-
     def sigma_to_t(self, sigma, quantize=None):
         log_sigma = sigma.log()
         dists = log_sigma - self.log_sigmas[:, None]
-        return dists.abs().argmin(dim=0).view(sigma.shape) * self.skip_steps + (self.skip_steps - 1)
-
+        return dists.abs().argmin(dim=0).view(sigma.shape) * self.skip_steps + (
+            self.skip_steps - 1
+        )
 
     def t_to_sigma(self, timestep):
-        t = torch.clamp(((timestep - (self.skip_steps - 1)) / self.skip_steps).float(), min=0, max=(len(self.sigmas) - 1))
+        t = torch.clamp(
+            ((timestep - (self.skip_steps - 1)) / self.skip_steps).float(),
+            min=0,
+            max=(len(self.sigmas) - 1),
+        )
         return super().t_to_sigma(t)
-
 
     def get_eps(self, *args, **kwargs):
         return self.inner_model.apply_model(*args, **kwargs)
-
 
     def get_scaled_out(self, sigma, output, input):
         sigma_data = 0.5
@@ -56,14 +71,17 @@ class LCMCompVisDenoiser(DiscreteEpsDDPMDenoiser):
 
         return c_out * output + c_skip * input
 
-
     def forward(self, input, sigma, **kwargs):
-        c_out, c_in = [utils.append_dims(x, input.ndim) for x in self.get_scalings(sigma)]
+        c_out, c_in = [
+            utils.append_dims(x, input.ndim) for x in self.get_scalings(sigma)
+        ]
         eps = self.get_eps(input * c_in, self.sigma_to_t(sigma), **kwargs)
         return self.get_scaled_out(sigma, input + eps * c_out, input)
 
 
-def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None):
+def sample_lcm(
+    model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None
+):
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
@@ -72,7 +90,15 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
         denoised = model(x, sigmas[i] * s_in, **extra_args)
 
         if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
+            callback(
+                {
+                    "x": x,
+                    "i": i,
+                    "sigma": sigmas[i],
+                    "sigma_hat": sigmas[i],
+                    "denoised": denoised,
+                }
+            )
 
         x = denoised
         if sigmas[i + 1] > 0:
@@ -97,8 +123,13 @@ class LCMSampler(sd_samplers_kdiffusion.KDiffusionSampler):
         self.model_wrap = self.model_wrap_cfg.inner_model
 
 
-samplers_lcm = [('LCM', sample_lcm, ['k_lcm'], {})]
+samplers_lcm = [("LCM", sample_lcm, ["k_lcm"], {})]
 samplers_data_lcm = [
-    sd_samplers_common.SamplerData(label, lambda model, funcname=funcname: LCMSampler(funcname, model), aliases, options)
+    sd_samplers_common.SamplerData(
+        label,
+        lambda model, funcname=funcname: LCMSampler(funcname, model),
+        aliases,
+        options,
+    )
     for label, funcname, aliases, options in samplers_lcm
 ]

--- a/modules/sd_samplers_timesteps.py
+++ b/modules/sd_samplers_timesteps.py
@@ -9,15 +9,20 @@ from modules.shared import opts
 import modules.shared as shared
 
 samplers_timesteps = [
-    ('DDIM', sd_samplers_timesteps_impl.ddim, ['ddim'], {}),
-    ('DDIM CFG++', sd_samplers_timesteps_impl.ddim_cfgpp, ['ddim_cfgpp'], {}),
-    ('PLMS', sd_samplers_timesteps_impl.plms, ['plms'], {}),
-    ('UniPC', sd_samplers_timesteps_impl.unipc, ['unipc'], {}),
+    ("DDIM", sd_samplers_timesteps_impl.ddim, ["ddim"], {}),
+    ("DDIM CFG++", sd_samplers_timesteps_impl.ddim_cfgpp, ["ddim_cfgpp"], {}),
+    ("PLMS", sd_samplers_timesteps_impl.plms, ["plms"], {}),
+    ("UniPC", sd_samplers_timesteps_impl.unipc, ["unipc"], {}),
 ]
 
 
 samplers_data_timesteps = [
-    sd_samplers_common.SamplerData(label, lambda model, funcname=funcname: CompVisSampler(funcname, model), aliases, options)
+    sd_samplers_common.SamplerData(
+        label,
+        lambda model, funcname=funcname: CompVisSampler(funcname, model),
+        aliases,
+        options,
+    )
     for label, funcname, aliases, options in samplers_timesteps
 ]
 
@@ -37,7 +42,16 @@ class CompVisTimestepsVDenoiser(torch.nn.Module):
         self.inner_model = model
 
     def predict_eps_from_z_and_v(self, x_t, t, v):
-        return torch.sqrt(self.inner_model.alphas_cumprod)[t.to(torch.int), None, None, None] * v + torch.sqrt(1 - self.inner_model.alphas_cumprod)[t.to(torch.int), None, None, None] * x_t
+        return (
+            torch.sqrt(self.inner_model.alphas_cumprod)[
+                t.to(torch.int), None, None, None
+            ]
+            * v
+            + torch.sqrt(1 - self.inner_model.alphas_cumprod)[
+                t.to(torch.int), None, None, None
+            ]
+            * x_t
+        )
 
     def forward(self, input, timesteps, **kwargs):
         model_output = self.inner_model.apply_model(input, timesteps, **kwargs)
@@ -46,7 +60,6 @@ class CompVisTimestepsVDenoiser(torch.nn.Module):
 
 
 class CFGDenoiserTimesteps(CFGDenoiser):
-
     def __init__(self, sampler):
         super().__init__(sampler)
 
@@ -66,7 +79,11 @@ class CFGDenoiserTimesteps(CFGDenoiser):
     @property
     def inner_model(self):
         if self.model_wrap is None:
-            denoiser = CompVisTimestepsVDenoiser if shared.sd_model.parameterization == "v" else CompVisTimestepsDenoiser
+            denoiser = (
+                CompVisTimestepsVDenoiser
+                if shared.sd_model.parameterization == "v"
+                else CompVisTimestepsDenoiser
+            )
             self.model_wrap = denoiser(shared.sd_model)
 
         return self.model_wrap
@@ -76,26 +93,43 @@ class CompVisSampler(sd_samplers_common.Sampler):
     def __init__(self, funcname, sd_model):
         super().__init__(funcname)
 
-        self.eta_option_field = 'eta_ddim'
-        self.eta_infotext_field = 'Eta DDIM'
+        self.eta_option_field = "eta_ddim"
+        self.eta_infotext_field = "Eta DDIM"
         self.eta_default = 0.0
 
         self.model_wrap_cfg = CFGDenoiserTimesteps(self)
         self.model_wrap = self.model_wrap_cfg.inner_model
 
     def get_timesteps(self, p, steps):
-        discard_next_to_last_sigma = self.config is not None and self.config.options.get('discard_next_to_last_sigma', False)
+        discard_next_to_last_sigma = (
+            self.config is not None
+            and self.config.options.get("discard_next_to_last_sigma", False)
+        )
         if opts.always_discard_next_to_last_sigma and not discard_next_to_last_sigma:
             discard_next_to_last_sigma = True
             p.extra_generation_params["Discard penultimate sigma"] = True
 
         steps += 1 if discard_next_to_last_sigma else 0
 
-        timesteps = torch.clip(torch.asarray(list(range(0, 1000, 1000 // steps)), device=devices.device) + 1, 0, 999)
+        timesteps = torch.clip(
+            torch.asarray(list(range(0, 1000, 1000 // steps)), device=devices.device)
+            + 1,
+            0,
+            999,
+        )
 
         return timesteps
 
-    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample_img2img(
+        self,
+        p,
+        x,
+        noise,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         steps, t_enc = sd_samplers_common.setup_img2img_steps(p, steps)
 
         timesteps = self.get_timesteps(p, steps)
@@ -117,51 +151,81 @@ class CompVisSampler(sd_samplers_common.Sampler):
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 
-        if 'timesteps' in parameters:
-            extra_params_kwargs['timesteps'] = timesteps_sched
-        if 'is_img2img' in parameters:
-            extra_params_kwargs['is_img2img'] = True
+        if "timesteps" in parameters:
+            extra_params_kwargs["timesteps"] = timesteps_sched
+        if "is_img2img" in parameters:
+            extra_params_kwargs["is_img2img"] = True
 
         self.model_wrap_cfg.init_latent = x
         self.last_latent = x
         self.sampler_extra_args = {
-            'cond': conditioning,
-            'image_cond': image_conditioning,
-            'uncond': unconditional_conditioning,
-            'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            "cond": conditioning,
+            "image_cond": image_conditioning,
+            "uncond": unconditional_conditioning,
+            "cond_scale": p.cfg_scale,
+            "s_min_uncond": self.s_min_uncond,
         }
 
-        samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
+        samples = self.launch_sampling(
+            t_enc + 1,
+            lambda: self.func(
+                self.model_wrap_cfg,
+                xi,
+                extra_args=self.sampler_extra_args,
+                disable=False,
+                callback=self.callback_state,
+                **extra_params_kwargs,
+            ),
+        )
 
         self.add_infotext(p)
 
         return samples
 
-    def sample(self, p, x, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+    def sample(
+        self,
+        p,
+        x,
+        conditioning,
+        unconditional_conditioning,
+        steps=None,
+        image_conditioning=None,
+    ):
         steps = steps or p.steps
         timesteps = self.get_timesteps(p, steps)
 
         extra_params_kwargs = self.initialize(p)
         parameters = inspect.signature(self.func).parameters
 
-        if 'timesteps' in parameters:
-            extra_params_kwargs['timesteps'] = timesteps
+        if "timesteps" in parameters:
+            extra_params_kwargs["timesteps"] = timesteps
 
         self.last_latent = x
         self.sampler_extra_args = {
-            'cond': conditioning,
-            'image_cond': image_conditioning,
-            'uncond': unconditional_conditioning,
-            'cond_scale': p.cfg_scale,
-            's_min_uncond': self.s_min_uncond
+            "cond": conditioning,
+            "image_cond": image_conditioning,
+            "uncond": unconditional_conditioning,
+            "cond_scale": p.cfg_scale,
+            "s_min_uncond": self.s_min_uncond,
         }
-        samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
+        samples = self.launch_sampling(
+            steps,
+            lambda: self.func(
+                self.model_wrap_cfg,
+                x,
+                extra_args=self.sampler_extra_args,
+                disable=False,
+                callback=self.callback_state,
+                **extra_params_kwargs,
+            ),
+        )
 
         self.add_infotext(p)
 
         return samples
 
 
-sys.modules['modules.sd_samplers_compvis'] = sys.modules[__name__]
-VanillaStableDiffusionSampler = CompVisSampler  # temp. compatibility with older extensions
+sys.modules["modules.sd_samplers_compvis"] = sys.modules[__name__]
+VanillaStableDiffusionSampler = (
+    CompVisSampler  # temp. compatibility with older extensions
+)

--- a/modules/sd_samplers_timesteps_impl.py
+++ b/modules/sd_samplers_timesteps_impl.py
@@ -12,9 +12,15 @@ from modules.torch_utils import float64
 def ddim(model, x, timesteps, extra_args=None, callback=None, disable=None, eta=0.0):
     alphas_cumprod = model.inner_model.inner_model.alphas_cumprod
     alphas = alphas_cumprod[timesteps]
-    alphas_prev = alphas_cumprod[torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))].to(float64(x))
+    alphas_prev = alphas_cumprod[
+        torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))
+    ].to(float64(x))
     sqrt_one_minus_alphas = torch.sqrt(1 - alphas)
-    sigmas = eta * np.sqrt((1 - alphas_prev.cpu().numpy()) / (1 - alphas.cpu()) * (1 - alphas.cpu() / alphas_prev.cpu().numpy()))
+    sigmas = eta * np.sqrt(
+        (1 - alphas_prev.cpu().numpy())
+        / (1 - alphas.cpu())
+        * (1 - alphas.cpu() / alphas_prev.cpu().numpy())
+    )
 
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones((x.shape[0]))
@@ -30,27 +36,35 @@ def ddim(model, x, timesteps, extra_args=None, callback=None, disable=None, eta=
         sqrt_one_minus_at = sqrt_one_minus_alphas[index].item() * s_x
 
         pred_x0 = (x - sqrt_one_minus_at * e_t) / a_t.sqrt()
-        dir_xt = (1. - a_prev - sigma_t ** 2).sqrt() * e_t
+        dir_xt = (1.0 - a_prev - sigma_t**2).sqrt() * e_t
         noise = sigma_t * k_diffusion.sampling.torch.randn_like(x)
         x = a_prev.sqrt() * pred_x0 + dir_xt + noise
 
         if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': 0, 'sigma_hat': 0, 'denoised': pred_x0})
+            callback({"x": x, "i": i, "sigma": 0, "sigma_hat": 0, "denoised": pred_x0})
 
     return x
 
 
 @torch.no_grad()
-def ddim_cfgpp(model, x, timesteps, extra_args=None, callback=None, disable=None, eta=0.0):
-    """ Implements CFG++: Manifold-constrained Classifier Free Guidance For Diffusion Models (2024).
+def ddim_cfgpp(
+    model, x, timesteps, extra_args=None, callback=None, disable=None, eta=0.0
+):
+    """Implements CFG++: Manifold-constrained Classifier Free Guidance For Diffusion Models (2024).
     Uses the unconditional noise prediction instead of the conditional noise to guide the denoising direction.
     The CFG scale is divided by 12.5 to map CFG from [0.0, 12.5] to [0, 1.0].
     """
     alphas_cumprod = model.inner_model.inner_model.alphas_cumprod
     alphas = alphas_cumprod[timesteps]
-    alphas_prev = alphas_cumprod[torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))].to(float64(x))
+    alphas_prev = alphas_cumprod[
+        torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))
+    ].to(float64(x))
     sqrt_one_minus_alphas = torch.sqrt(1 - alphas)
-    sigmas = eta * np.sqrt((1 - alphas_prev.cpu().numpy()) / (1 - alphas.cpu()) * (1 - alphas.cpu() / alphas_prev.cpu().numpy()))
+    sigmas = eta * np.sqrt(
+        (1 - alphas_prev.cpu().numpy())
+        / (1 - alphas.cpu())
+        * (1 - alphas.cpu() / alphas_prev.cpu().numpy())
+    )
 
     model.cond_scale_miltiplier = 1 / 12.5
     model.need_last_noise_uncond = True
@@ -70,12 +84,12 @@ def ddim_cfgpp(model, x, timesteps, extra_args=None, callback=None, disable=None
         sqrt_one_minus_at = sqrt_one_minus_alphas[index].item() * s_x
 
         pred_x0 = (x - sqrt_one_minus_at * e_t) / a_t.sqrt()
-        dir_xt = (1. - a_prev - sigma_t ** 2).sqrt() * last_noise_uncond
+        dir_xt = (1.0 - a_prev - sigma_t**2).sqrt() * last_noise_uncond
         noise = sigma_t * k_diffusion.sampling.torch.randn_like(x)
         x = a_prev.sqrt() * pred_x0 + dir_xt + noise
 
         if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': 0, 'sigma_hat': 0, 'denoised': pred_x0})
+            callback({"x": x, "i": i, "sigma": 0, "sigma_hat": 0, "denoised": pred_x0})
 
     return x
 
@@ -84,7 +98,9 @@ def ddim_cfgpp(model, x, timesteps, extra_args=None, callback=None, disable=None
 def plms(model, x, timesteps, extra_args=None, callback=None, disable=None):
     alphas_cumprod = model.inner_model.inner_model.alphas_cumprod
     alphas = alphas_cumprod[timesteps]
-    alphas_prev = alphas_cumprod[torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))].to(float64(x))
+    alphas_prev = alphas_cumprod[
+        torch.nn.functional.pad(timesteps[:-1], pad=(1, 0))
+    ].to(float64(x))
     sqrt_one_minus_alphas = torch.sqrt(1 - alphas)
 
     extra_args = {} if extra_args is None else extra_args
@@ -102,7 +118,7 @@ def plms(model, x, timesteps, extra_args=None, callback=None, disable=None):
         pred_x0 = (x - sqrt_one_minus_at * e_t) / a_t.sqrt()
 
         # direction pointing to x_t
-        dir_xt = (1. - a_prev).sqrt() * e_t
+        dir_xt = (1.0 - a_prev).sqrt() * e_t
         x_prev = a_prev.sqrt() * pred_x0 + dir_xt
         return x_prev, pred_x0
 
@@ -126,7 +142,9 @@ def plms(model, x, timesteps, extra_args=None, callback=None, disable=None):
             e_t_prime = (23 * e_t - 16 * old_eps[-1] + 5 * old_eps[-2]) / 12
         else:
             # 4nd order Pseudo Linear Multistep (Adams-Bashforth)
-            e_t_prime = (55 * e_t - 59 * old_eps[-1] + 37 * old_eps[-2] - 9 * old_eps[-3]) / 24
+            e_t_prime = (
+                55 * e_t - 59 * old_eps[-1] + 37 * old_eps[-2] - 9 * old_eps[-3]
+            ) / 24
 
         x_prev, pred_x0 = get_x_prev_and_pred_x0(e_t_prime, index)
 
@@ -137,7 +155,7 @@ def plms(model, x, timesteps, extra_args=None, callback=None, disable=None):
         x = x_prev
 
         if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': 0, 'sigma_hat': 0, 'denoised': pred_x0})
+            callback({"x": x, "i": i, "sigma": 0, "sigma_hat": 0, "denoised": pred_x0})
 
     return x
 
@@ -147,7 +165,15 @@ class UniPCCFG(uni_pc.UniPC):
         super().__init__(None, *args, **kwargs)
 
         def after_update(x, model_x):
-            callback({'x': x, 'i': self.index, 'sigma': 0, 'sigma_hat': 0, 'denoised': model_x})
+            callback(
+                {
+                    "x": x,
+                    "i": self.index,
+                    "sigma": 0,
+                    "sigma_hat": 0,
+                    "denoised": model_x,
+                }
+            )
             self.index += 1
 
         self.cfg_model = cfg_model
@@ -157,7 +183,7 @@ class UniPCCFG(uni_pc.UniPC):
         self.after_update = after_update
 
     def get_model_input_time(self, t_continuous):
-        return (t_continuous - 1. / self.noise_schedule.total_N) * 1000.
+        return (t_continuous - 1.0 / self.noise_schedule.total_N) * 1000.0
 
     def model(self, x, t):
         t_input = self.get_model_input_time(t)
@@ -167,12 +193,32 @@ class UniPCCFG(uni_pc.UniPC):
         return res
 
 
-def unipc(model, x, timesteps, extra_args=None, callback=None, disable=None, is_img2img=False):
+def unipc(
+    model, x, timesteps, extra_args=None, callback=None, disable=None, is_img2img=False
+):
     alphas_cumprod = model.inner_model.inner_model.alphas_cumprod
 
-    ns = uni_pc.NoiseScheduleVP('discrete', alphas_cumprod=alphas_cumprod)
-    t_start = timesteps[-1] / 1000 + 1 / 1000 if is_img2img else None  # this is likely off by a bit - if someone wants to fix it please by all means
-    unipc_sampler = UniPCCFG(model, extra_args, callback, ns, predict_x0=True, thresholding=False, variant=shared.opts.uni_pc_variant)
-    x = unipc_sampler.sample(x, steps=len(timesteps), t_start=t_start, skip_type=shared.opts.uni_pc_skip_type, method="multistep", order=shared.opts.uni_pc_order, lower_order_final=shared.opts.uni_pc_lower_order_final)
+    ns = uni_pc.NoiseScheduleVP("discrete", alphas_cumprod=alphas_cumprod)
+    t_start = (
+        timesteps[-1] / 1000 + 1 / 1000 if is_img2img else None
+    )  # this is likely off by a bit - if someone wants to fix it please by all means
+    unipc_sampler = UniPCCFG(
+        model,
+        extra_args,
+        callback,
+        ns,
+        predict_x0=True,
+        thresholding=False,
+        variant=shared.opts.uni_pc_variant,
+    )
+    x = unipc_sampler.sample(
+        x,
+        steps=len(timesteps),
+        t_start=t_start,
+        skip_type=shared.opts.uni_pc_skip_type,
+        method="multistep",
+        order=shared.opts.uni_pc_order,
+        lower_order_final=shared.opts.uni_pc_lower_order_final,
+    )
 
     return x

--- a/modules/sd_schedulers.py
+++ b/modules/sd_schedulers.py
@@ -33,10 +33,7 @@ def uniform(n, sigma_min, sigma_max, inner_model, device):
 def sgm_uniform(n, sigma_min, sigma_max, inner_model, device):
     start = inner_model.sigma_to_t(torch.tensor(sigma_max))
     end = inner_model.sigma_to_t(torch.tensor(sigma_min))
-    sigs = [
-        inner_model.t_to_sigma(ts)
-        for ts in torch.linspace(start, end, n + 1)[:-1]
-    ]
+    sigs = [inner_model.t_to_sigma(ts) for ts in torch.linspace(start, end, n + 1)[:-1]]
     sigs += [0.0]
     return torch.FloatTensor(sigs).to(device)
 
@@ -57,10 +54,34 @@ def get_align_your_steps_sigmas(n, sigma_min, sigma_max, device):
         return interped_ys
 
     if shared.sd_model.is_sdxl:
-        sigmas = [14.615, 6.315, 3.771, 2.181, 1.342, 0.862, 0.555, 0.380, 0.234, 0.113, 0.029]
+        sigmas = [
+            14.615,
+            6.315,
+            3.771,
+            2.181,
+            1.342,
+            0.862,
+            0.555,
+            0.380,
+            0.234,
+            0.113,
+            0.029,
+        ]
     else:
         # Default to SD 1.5 sigmas.
-        sigmas = [14.615, 6.475, 3.861, 2.697, 1.886, 1.396, 0.963, 0.652, 0.399, 0.152, 0.029]
+        sigmas = [
+            14.615,
+            6.475,
+            3.861,
+            2.697,
+            1.886,
+            1.396,
+            0.963,
+            0.652,
+            0.399,
+            0.152,
+            0.029,
+        ]
 
     if n != len(sigmas):
         sigmas = np.append(loglinear_interp(sigmas, n), [0.0])
@@ -74,7 +95,9 @@ def kl_optimal(n, sigma_min, sigma_max, device):
     alpha_min = torch.arctan(torch.tensor(sigma_min, device=device))
     alpha_max = torch.arctan(torch.tensor(sigma_max, device=device))
     step_indices = torch.arange(n + 1, device=device)
-    sigmas = torch.tan(step_indices / n * alpha_min + (1.0 - step_indices / n) * alpha_max)
+    sigmas = torch.tan(
+        step_indices / n * alpha_min + (1.0 - step_indices / n) * alpha_max
+    )
     return sigmas
 
 
@@ -87,7 +110,9 @@ def simple_scheduler(n, sigma_min, sigma_max, inner_model, device):
     return torch.FloatTensor(sigs).to(device)
 
 
-def normal_scheduler(n, sigma_min, sigma_max, inner_model, device, sgm=False, floor=False):
+def normal_scheduler(
+    n, sigma_min, sigma_max, inner_model, device, sgm=False, floor=False
+):
     start = inner_model.sigma_to_t(torch.tensor(sigma_max))
     end = inner_model.sigma_to_t(torch.tensor(sigma_min))
 
@@ -122,24 +147,39 @@ def beta_scheduler(n, sigma_min, sigma_max, inner_model, device):
     beta = shared.opts.beta_dist_beta
     timesteps = 1 - np.linspace(0, 1, n)
     timesteps = [stats.beta.ppf(x, alpha, beta) for x in timesteps]
-    sigmas = [sigma_min + (x * (sigma_max-sigma_min)) for x in timesteps]
+    sigmas = [sigma_min + (x * (sigma_max - sigma_min)) for x in timesteps]
     sigmas += [0.0]
     return torch.FloatTensor(sigmas).to(device)
 
 
 schedulers = [
-    Scheduler('automatic', 'Automatic', None),
-    Scheduler('uniform', 'Uniform', uniform, need_inner_model=True),
-    Scheduler('karras', 'Karras', k_diffusion.sampling.get_sigmas_karras, default_rho=7.0),
-    Scheduler('exponential', 'Exponential', k_diffusion.sampling.get_sigmas_exponential),
-    Scheduler('polyexponential', 'Polyexponential', k_diffusion.sampling.get_sigmas_polyexponential, default_rho=1.0),
-    Scheduler('sgm_uniform', 'SGM Uniform', sgm_uniform, need_inner_model=True, aliases=["SGMUniform"]),
-    Scheduler('kl_optimal', 'KL Optimal', kl_optimal),
-    Scheduler('align_your_steps', 'Align Your Steps', get_align_your_steps_sigmas),
-    Scheduler('simple', 'Simple', simple_scheduler, need_inner_model=True),
-    Scheduler('normal', 'Normal', normal_scheduler, need_inner_model=True),
-    Scheduler('ddim', 'DDIM', ddim_scheduler, need_inner_model=True),
-    Scheduler('beta', 'Beta', beta_scheduler, need_inner_model=True),
+    Scheduler("automatic", "Automatic", None),
+    Scheduler("uniform", "Uniform", uniform, need_inner_model=True),
+    Scheduler(
+        "karras", "Karras", k_diffusion.sampling.get_sigmas_karras, default_rho=7.0
+    ),
+    Scheduler(
+        "exponential", "Exponential", k_diffusion.sampling.get_sigmas_exponential
+    ),
+    Scheduler(
+        "polyexponential",
+        "Polyexponential",
+        k_diffusion.sampling.get_sigmas_polyexponential,
+        default_rho=1.0,
+    ),
+    Scheduler(
+        "sgm_uniform",
+        "SGM Uniform",
+        sgm_uniform,
+        need_inner_model=True,
+        aliases=["SGMUniform"],
+    ),
+    Scheduler("kl_optimal", "KL Optimal", kl_optimal),
+    Scheduler("align_your_steps", "Align Your Steps", get_align_your_steps_sigmas),
+    Scheduler("simple", "Simple", simple_scheduler, need_inner_model=True),
+    Scheduler("normal", "Normal", normal_scheduler, need_inner_model=True),
+    Scheduler("ddim", "DDIM", ddim_scheduler, need_inner_model=True),
+    Scheduler("beta", "Beta", beta_scheduler, need_inner_model=True),
 ]
 
 schedulers_map = {**{x.name: x for x in schedulers}, **{x.label: x for x in schedulers}}

--- a/modules/sd_unet.py
+++ b/modules/sd_unet.py
@@ -7,6 +7,7 @@ current_unet_option = None
 current_unet = None
 original_forward = None  # not used, only left temporarily for compatibility
 
+
 def list_unets():
     new_unets = script_callbacks.list_unets_callback()
 
@@ -91,4 +92,3 @@ def create_unet_forward(original_forward):
         return original_forward(self, x, timesteps, context, *args, **kwargs)
 
     return UNetModel_forward
-

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -2,7 +2,17 @@ import os
 import collections
 from dataclasses import dataclass
 
-from modules import paths, shared, devices, script_callbacks, sd_models, extra_networks, lowvram, sd_hijack, hashes
+from modules import (
+    paths,
+    shared,
+    devices,
+    script_callbacks,
+    sd_models,
+    extra_networks,
+    lowvram,
+    sd_hijack,
+    hashes,
+)
 
 import glob
 from copy import deepcopy
@@ -31,7 +41,7 @@ def get_loaded_vae_hash():
     if loaded_vae_file is None:
         return None
 
-    sha256 = hashes.sha256(loaded_vae_file, 'vae')
+    sha256 = hashes.sha256(loaded_vae_file, "vae")
 
     return sha256[0:10] if sha256 else None
 
@@ -73,26 +83,26 @@ def refresh_vae_list():
     vae_dict.clear()
 
     paths = [
-        os.path.join(sd_models.model_path, '**/*.vae.ckpt'),
-        os.path.join(sd_models.model_path, '**/*.vae.pt'),
-        os.path.join(sd_models.model_path, '**/*.vae.safetensors'),
-        os.path.join(vae_path, '**/*.ckpt'),
-        os.path.join(vae_path, '**/*.pt'),
-        os.path.join(vae_path, '**/*.safetensors'),
+        os.path.join(sd_models.model_path, "**/*.vae.ckpt"),
+        os.path.join(sd_models.model_path, "**/*.vae.pt"),
+        os.path.join(sd_models.model_path, "**/*.vae.safetensors"),
+        os.path.join(vae_path, "**/*.ckpt"),
+        os.path.join(vae_path, "**/*.pt"),
+        os.path.join(vae_path, "**/*.safetensors"),
     ]
 
     if shared.cmd_opts.ckpt_dir is not None and os.path.isdir(shared.cmd_opts.ckpt_dir):
         paths += [
-            os.path.join(shared.cmd_opts.ckpt_dir, '**/*.vae.ckpt'),
-            os.path.join(shared.cmd_opts.ckpt_dir, '**/*.vae.pt'),
-            os.path.join(shared.cmd_opts.ckpt_dir, '**/*.vae.safetensors'),
+            os.path.join(shared.cmd_opts.ckpt_dir, "**/*.vae.ckpt"),
+            os.path.join(shared.cmd_opts.ckpt_dir, "**/*.vae.pt"),
+            os.path.join(shared.cmd_opts.ckpt_dir, "**/*.vae.safetensors"),
         ]
 
     if shared.cmd_opts.vae_dir is not None and os.path.isdir(shared.cmd_opts.vae_dir):
         paths += [
-            os.path.join(shared.cmd_opts.vae_dir, '**/*.ckpt'),
-            os.path.join(shared.cmd_opts.vae_dir, '**/*.pt'),
-            os.path.join(shared.cmd_opts.vae_dir, '**/*.safetensors'),
+            os.path.join(shared.cmd_opts.vae_dir, "**/*.ckpt"),
+            os.path.join(shared.cmd_opts.vae_dir, "**/*.pt"),
+            os.path.join(shared.cmd_opts.vae_dir, "**/*.safetensors"),
         ]
 
     candidates = []
@@ -103,11 +113,15 @@ def refresh_vae_list():
         name = get_filename(filepath)
         vae_dict[name] = filepath
 
-    vae_dict.update(dict(sorted(vae_dict.items(), key=lambda item: shared.natural_sort_key(item[0]))))
+    vae_dict.update(
+        dict(
+            sorted(vae_dict.items(), key=lambda item: shared.natural_sort_key(item[0]))
+        )
+    )
 
 
 def find_vae_near_checkpoint(checkpoint_file):
-    checkpoint_path = os.path.basename(checkpoint_file).rsplit('.', 1)[0]
+    checkpoint_path = os.path.basename(checkpoint_file).rsplit(".", 1)[0]
     for vae_file in vae_dict.values():
         if os.path.basename(vae_file).startswith(checkpoint_path):
             return vae_file
@@ -126,7 +140,10 @@ class VaeResolution:
 
 
 def is_automatic():
-    return shared.opts.sd_vae in {"Automatic", "auto"}  # "auto" for people with old config
+    return shared.opts.sd_vae in {
+        "Automatic",
+        "auto",
+    }  # "auto" for people with old config
 
 
 def resolve_vae_from_setting() -> VaeResolution:
@@ -135,7 +152,7 @@ def resolve_vae_from_setting() -> VaeResolution:
 
     vae_from_options = vae_dict.get(shared.opts.sd_vae, None)
     if vae_from_options is not None:
-        return VaeResolution(vae_from_options, 'specified in settings')
+        return VaeResolution(vae_from_options, "specified in settings")
 
     if not is_automatic():
         print(f"Couldn't find VAE named {shared.opts.sd_vae}; using None instead")
@@ -159,15 +176,17 @@ def resolve_vae_from_user_metadata(checkpoint_file) -> VaeResolution:
 
 def resolve_vae_near_checkpoint(checkpoint_file) -> VaeResolution:
     vae_near_checkpoint = find_vae_near_checkpoint(checkpoint_file)
-    if vae_near_checkpoint is not None and (not shared.opts.sd_vae_overrides_per_model_preferences or is_automatic()):
-        return VaeResolution(vae_near_checkpoint, 'found near the checkpoint')
+    if vae_near_checkpoint is not None and (
+        not shared.opts.sd_vae_overrides_per_model_preferences or is_automatic()
+    ):
+        return VaeResolution(vae_near_checkpoint, "found near the checkpoint")
 
     return VaeResolution(resolved=False)
 
 
 def resolve_vae(checkpoint_file) -> VaeResolution:
     if shared.cmd_opts.vae_path is not None:
-        return VaeResolution(shared.cmd_opts.vae_path, 'from commandline argument')
+        return VaeResolution(shared.cmd_opts.vae_path, "from commandline argument")
 
     if shared.opts.sd_vae_overrides_per_model_preferences and not is_automatic():
         return resolve_vae_from_setting()
@@ -187,7 +206,11 @@ def resolve_vae(checkpoint_file) -> VaeResolution:
 
 def load_vae_dict(filename, map_location):
     vae_ckpt = sd_models.read_state_dict(filename, map_location=map_location)
-    vae_dict_1 = {k: v for k, v in vae_ckpt.items() if k[0:4] != "loss" and k not in vae_ignore_keys}
+    vae_dict_1 = {
+        k: v
+        for k, v in vae_ckpt.items()
+        if k[0:4] != "loss" and k not in vae_ignore_keys
+    }
     return vae_dict_1
 
 
@@ -204,11 +227,15 @@ def load_vae(model, vae_file=None, vae_source="from unknown source"):
             store_base_vae(model)
             _load_vae_dict(model, checkpoints_loaded[vae_file])
         else:
-            assert os.path.isfile(vae_file), f"VAE {vae_source} doesn't exist: {vae_file}"
+            assert os.path.isfile(
+                vae_file
+            ), f"VAE {vae_source} doesn't exist: {vae_file}"
             print(f"Loading VAE weights {vae_source}: {vae_file}")
             store_base_vae(model)
 
-            vae_dict_1 = load_vae_dict(vae_file, map_location=shared.weight_load_location)
+            vae_dict_1 = load_vae_dict(
+                vae_file, map_location=shared.weight_load_location
+            )
             _load_vae_dict(model, vae_dict_1)
 
             if cache_enabled:
@@ -217,7 +244,9 @@ def load_vae(model, vae_file=None, vae_source="from unknown source"):
 
         # clean up cache if limit is reached
         if cache_enabled:
-            while len(checkpoints_loaded) > shared.opts.sd_vae_checkpoint_cache + 1: # we need to count the current model
+            while (
+                len(checkpoints_loaded) > shared.opts.sd_vae_checkpoint_cache + 1
+            ):  # we need to count the current model
                 checkpoints_loaded.popitem(last=False)  # LRU
 
         # If vae used is not in dict, update it

--- a/modules/sd_vae_approx.py
+++ b/modules/sd_vae_approx.py
@@ -24,7 +24,16 @@ class VAEApprox(nn.Module):
         x = nn.functional.interpolate(x, (x.shape[2] * 2, x.shape[3] * 2))
         x = nn.functional.pad(x, (extra, extra, extra, extra))
 
-        for layer in [self.conv1, self.conv2, self.conv3, self.conv4, self.conv5, self.conv6, self.conv7, self.conv8, ]:
+        for layer in [
+            self.conv1,
+            self.conv2,
+            self.conv3,
+            self.conv4,
+            self.conv5,
+            self.conv6,
+            self.conv7,
+            self.conv8,
+        ]:
             x = layer(x)
             x = nn.functional.leaky_relu(x, 0.1)
 
@@ -35,7 +44,7 @@ def download_model(model_path, model_url):
     if not os.path.exists(model_path):
         os.makedirs(os.path.dirname(model_path), exist_ok=True)
 
-        print(f'Downloading VAEApprox model to: {model_path}')
+        print(f"Downloading VAEApprox model to: {model_path}")
         torch.hub.download_url_to_file(model_url, model_path)
 
 
@@ -52,14 +61,25 @@ def model():
     if loaded_model is None:
         model_path = os.path.join(paths.models_path, "VAE-approx", model_name)
         if not os.path.exists(model_path):
-            model_path = os.path.join(paths.script_path, "models", "VAE-approx", model_name)
+            model_path = os.path.join(
+                paths.script_path, "models", "VAE-approx", model_name
+            )
 
         if not os.path.exists(model_path):
             model_path = os.path.join(paths.models_path, "VAE-approx", model_name)
-            download_model(model_path, 'https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/download/v1.0.0-pre/' + model_name)
+            download_model(
+                model_path,
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/download/v1.0.0-pre/"
+                + model_name,
+            )
 
         loaded_model = VAEApprox(latent_channels=shared.sd_model.latent_channels)
-        loaded_model.load_state_dict(torch.load(model_path, map_location='cpu' if devices.device.type != 'cuda' else None))
+        loaded_model.load_state_dict(
+            torch.load(
+                model_path,
+                map_location="cpu" if devices.device.type != "cuda" else None,
+            )
+        )
         loaded_model.eval()
         loaded_model.to(devices.device, devices.dtype)
         sd_vae_approx_models[model_name] = loaded_model
@@ -72,27 +92,35 @@ def cheap_approximation(sample):
 
     if shared.sd_model.is_sd3:
         coeffs = [
-            [-0.0645,  0.0177,  0.1052], [ 0.0028,  0.0312,  0.0650],
-            [ 0.1848,  0.0762,  0.0360], [ 0.0944,  0.0360,  0.0889],
-            [ 0.0897,  0.0506, -0.0364], [-0.0020,  0.1203,  0.0284],
-            [ 0.0855,  0.0118,  0.0283], [-0.0539,  0.0658,  0.1047],
-            [-0.0057,  0.0116,  0.0700], [-0.0412,  0.0281, -0.0039],
-            [ 0.1106,  0.1171,  0.1220], [-0.0248,  0.0682, -0.0481],
-            [ 0.0815,  0.0846,  0.1207], [-0.0120, -0.0055, -0.0867],
-            [-0.0749, -0.0634, -0.0456], [-0.1418, -0.1457, -0.1259],
+            [-0.0645, 0.0177, 0.1052],
+            [0.0028, 0.0312, 0.0650],
+            [0.1848, 0.0762, 0.0360],
+            [0.0944, 0.0360, 0.0889],
+            [0.0897, 0.0506, -0.0364],
+            [-0.0020, 0.1203, 0.0284],
+            [0.0855, 0.0118, 0.0283],
+            [-0.0539, 0.0658, 0.1047],
+            [-0.0057, 0.0116, 0.0700],
+            [-0.0412, 0.0281, -0.0039],
+            [0.1106, 0.1171, 0.1220],
+            [-0.0248, 0.0682, -0.0481],
+            [0.0815, 0.0846, 0.1207],
+            [-0.0120, -0.0055, -0.0867],
+            [-0.0749, -0.0634, -0.0456],
+            [-0.1418, -0.1457, -0.1259],
         ]
     elif shared.sd_model.is_sdxl:
         coeffs = [
-            [ 0.3448,  0.4168,  0.4395],
-            [-0.1953, -0.0290,  0.0250],
-            [ 0.1074,  0.0886, -0.0163],
+            [0.3448, 0.4168, 0.4395],
+            [-0.1953, -0.0290, 0.0250],
+            [0.1074, 0.0886, -0.0163],
             [-0.3730, -0.2499, -0.2088],
         ]
     else:
         coeffs = [
-            [ 0.298,  0.207,  0.208],
-            [ 0.187,  0.286,  0.173],
-            [-0.158,  0.189,  0.264],
+            [0.298, 0.207, 0.208],
+            [0.187, 0.286, 0.173],
+            [-0.158, 0.189, 0.264],
             [-0.184, -0.271, -0.473],
         ]
 

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -4,6 +4,7 @@ Tiny AutoEncoder for Stable Diffusion
 
 https://github.com/madebyollin/taesd
 """
+
 import os
 import torch
 import torch.nn as nn
@@ -26,8 +27,16 @@ class Clamp(nn.Module):
 class Block(nn.Module):
     def __init__(self, n_in, n_out):
         super().__init__()
-        self.conv = nn.Sequential(conv(n_in, n_out), nn.ReLU(), conv(n_out, n_out), nn.ReLU(), conv(n_out, n_out))
-        self.skip = nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
+        self.conv = nn.Sequential(
+            conv(n_in, n_out),
+            nn.ReLU(),
+            conv(n_out, n_out),
+            nn.ReLU(),
+            conv(n_out, n_out),
+        )
+        self.skip = (
+            nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
+        )
         self.fuse = nn.ReLU()
 
     def forward(self, x):
@@ -36,20 +45,45 @@ class Block(nn.Module):
 
 def decoder(latent_channels=4):
     return nn.Sequential(
-        Clamp(), conv(latent_channels, 64), nn.ReLU(),
-        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
-        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
-        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
-        Block(64, 64), conv(64, 3),
+        Clamp(),
+        conv(latent_channels, 64),
+        nn.ReLU(),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        conv(64, 3),
     )
 
 
 def encoder(latent_channels=4):
     return nn.Sequential(
-        conv(3, 64), Block(64, 64),
-        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
-        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
-        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
+        conv(3, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
         conv(64, latent_channels),
     )
 
@@ -67,7 +101,11 @@ class TAESDDecoder(nn.Module):
 
         self.decoder = decoder(latent_channels)
         self.decoder.load_state_dict(
-            torch.load(decoder_path, map_location='cpu' if devices.device.type != 'cuda' else None))
+            torch.load(
+                decoder_path,
+                map_location="cpu" if devices.device.type != "cuda" else None,
+            )
+        )
 
 
 class TAESDEncoder(nn.Module):
@@ -83,14 +121,18 @@ class TAESDEncoder(nn.Module):
 
         self.encoder = encoder(latent_channels)
         self.encoder.load_state_dict(
-            torch.load(encoder_path, map_location='cpu' if devices.device.type != 'cuda' else None))
+            torch.load(
+                encoder_path,
+                map_location="cpu" if devices.device.type != "cuda" else None,
+            )
+        )
 
 
 def download_model(model_path, model_url):
     if not os.path.exists(model_path):
         os.makedirs(os.path.dirname(model_path), exist_ok=True)
 
-        print(f'Downloading TAESD model to: {model_path}')
+        print(f"Downloading TAESD model to: {model_path}")
         torch.hub.download_url_to_file(model_url, model_path)
 
 
@@ -106,7 +148,9 @@ def decoder_model():
 
     if loaded_model is None:
         model_path = os.path.join(paths_internal.models_path, "VAE-taesd", model_name)
-        download_model(model_path, 'https://github.com/madebyollin/taesd/raw/main/' + model_name)
+        download_model(
+            model_path, "https://github.com/madebyollin/taesd/raw/main/" + model_name
+        )
 
         if os.path.exists(model_path):
             loaded_model = TAESDDecoder(model_path)
@@ -114,7 +158,7 @@ def decoder_model():
             loaded_model.to(devices.device, devices.dtype)
             sd_vae_taesd_models[model_name] = loaded_model
         else:
-            raise FileNotFoundError('TAESD model not found')
+            raise FileNotFoundError("TAESD model not found")
 
     return loaded_model.decoder
 
@@ -131,7 +175,9 @@ def encoder_model():
 
     if loaded_model is None:
         model_path = os.path.join(paths_internal.models_path, "VAE-taesd", model_name)
-        download_model(model_path, 'https://github.com/madebyollin/taesd/raw/main/' + model_name)
+        download_model(
+            model_path, "https://github.com/madebyollin/taesd/raw/main/" + model_name
+        )
 
         if os.path.exists(model_path):
             loaded_model = TAESDEncoder(model_path)
@@ -139,6 +185,6 @@ def encoder_model():
             loaded_model.to(devices.device, devices.dtype)
             sd_vae_taesd_models[model_name] = loaded_model
         else:
-            raise FileNotFoundError('TAESD model not found')
+            raise FileNotFoundError("TAESD model not found")
 
     return loaded_model.encoder

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -3,8 +3,16 @@ import sys
 
 import gradio as gr
 
-from modules import shared_cmd_options, shared_gradio_themes, options, shared_items, sd_models_types
-from modules.paths_internal import models_path, script_path, data_path, sd_configs_path, sd_default_config, sd_model_file, default_sd_model_file, extensions_dir, extensions_builtin_dir  # noqa: F401
+from modules import (
+    shared_cmd_options,
+    shared_gradio_themes,
+    options,
+    shared_items,
+    sd_models_types,
+)
+from modules.paths_internal import (
+    data_path,
+)  # noqa: F401
 from modules import util
 from typing import TYPE_CHECKING
 
@@ -14,9 +22,15 @@ if TYPE_CHECKING:
 cmd_opts = shared_cmd_options.cmd_opts
 parser = shared_cmd_options.parser
 
-batch_cond_uncond = True  # old field, unused now in favor of shared.opts.batch_cond_uncond
+batch_cond_uncond = (
+    True  # old field, unused now in favor of shared.opts.batch_cond_uncond
+)
 parallel_processing_allowed = True
-styles_filename = cmd_opts.styles_file = cmd_opts.styles_file if len(cmd_opts.styles_file) > 0 else [os.path.join(data_path, 'styles.csv')]
+styles_filename = cmd_opts.styles_file = (
+    cmd_opts.styles_file
+    if len(cmd_opts.styles_file) > 0
+    else [os.path.join(data_path, "styles.csv")]
+)
 config_filename = cmd_opts.ui_settings_file
 hide_dirs = {"visible": not cmd_opts.hide_ui_dir_config}
 
@@ -32,11 +46,11 @@ hypernetworks = {}
 
 loaded_hypernetworks = []
 
-state: 'shared_state.State' = None
+state: "shared_state.State" = None
 
-prompt_styles: 'styles.StyleDatabase' = None
+prompt_styles: "styles.StyleDatabase" = None
 
-interrogator: 'interrogate.InterrogateModels' = None
+interrogator: "interrogate.InterrogateModels" = None
 
 face_restorers = []
 
@@ -69,9 +83,9 @@ progress_print_out = sys.stdout
 
 gradio_theme = gr.themes.Base()
 
-total_tqdm: 'shared_total_tqdm.TotalTQDM' = None
+total_tqdm: "shared_total_tqdm.TotalTQDM" = None
 
-mem_mon: 'memmon.MemUsageMonitor' = None
+mem_mon: "memmon.MemUsageMonitor" = None
 
 options_section = options.options_section
 OptionInfo = options.OptionInfo
@@ -91,4 +105,4 @@ refresh_checkpoints = shared_items.refresh_checkpoints
 list_samplers = shared_items.list_samplers
 reload_hypernetworks = shared_items.reload_hypernetworks
 
-hf_endpoint = os.getenv('HF_ENDPOINT', 'https://huggingface.co')
+hf_endpoint = os.getenv("HF_ENDPOINT", "https://huggingface.co")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -11,7 +11,15 @@ from modules import (
     sd_models_types,
 )
 from modules.paths_internal import (
+    default_sd_model_file,
     data_path,
+    extensions_builtin_dir,
+    extensions_dir,
+    models_path,
+    script_path,
+    sd_configs_path,
+    sd_default_config,
+    sd_model_file,
 )  # noqa: F401
 from modules import util
 from typing import TYPE_CHECKING

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -27,6 +27,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from modules import shared_state, styles, interrogate, shared_total_tqdm, memmon
 
+__all__ = [
+    "default_sd_model_file",
+    "data_path",
+    "extensions_builtin_dir",
+    "extensions_dir",
+    "models_path",
+    "script_path",
+    "sd_configs_path",
+    "sd_default_config",
+    "sd_model_file",
+]
+
 cmd_opts = shared_cmd_options.cmd_opts
 parser = shared_cmd_options.parser
 

--- a/modules/shared_cmd_options.py
+++ b/modules/shared_cmd_options.py
@@ -2,17 +2,28 @@ import os
 
 import launch
 from modules import cmd_args, script_loading
-from modules.paths_internal import models_path, script_path, data_path, sd_configs_path, sd_default_config, sd_model_file, default_sd_model_file, extensions_dir, extensions_builtin_dir  # noqa: F401
+from modules.paths_internal import (
+    extensions_dir,
+    extensions_builtin_dir,
+)  # noqa: F401
 
 parser = cmd_args.parser
 
-script_loading.preload_extensions(extensions_dir, parser, extension_list=launch.list_extensions(launch.args.ui_settings_file))
+script_loading.preload_extensions(
+    extensions_dir,
+    parser,
+    extension_list=launch.list_extensions(launch.args.ui_settings_file),
+)
 script_loading.preload_extensions(extensions_builtin_dir, parser)
 
-if os.environ.get('IGNORE_CMD_ARGS_ERRORS', None) is None:
+if os.environ.get("IGNORE_CMD_ARGS_ERRORS", None) is None:
     cmd_opts = parser.parse_args()
 else:
     cmd_opts, _ = parser.parse_known_args()
 
-cmd_opts.webui_is_non_local = any([cmd_opts.share, cmd_opts.listen, cmd_opts.ngrok, cmd_opts.server_name])
-cmd_opts.disable_extension_access = cmd_opts.webui_is_non_local and not cmd_opts.enable_insecure_extension_access
+cmd_opts.webui_is_non_local = any(
+    [cmd_opts.share, cmd_opts.listen, cmd_opts.ngrok, cmd_opts.server_name]
+)
+cmd_opts.disable_extension_access = (
+    cmd_opts.webui_is_non_local and not cmd_opts.enable_insecure_extension_access
+)

--- a/modules/shared_gradio_themes.py
+++ b/modules/shared_gradio_themes.py
@@ -37,7 +37,7 @@ gradio_hf_hub_themes = [
     "Taithrah/Minimal",
     "ysharma/huggingface",
     "ysharma/steampunk",
-    "NoCrypt/miku"
+    "NoCrypt/miku",
 ]
 
 
@@ -46,16 +46,18 @@ def reload_gradio_theme(theme_name=None):
         theme_name = shared.opts.gradio_theme
 
     default_theme_args = dict(
-        font=["Source Sans Pro", 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        font_mono=['IBM Plex Mono', 'ui-monospace', 'Consolas', 'monospace'],
+        font=["Source Sans Pro", "ui-sans-serif", "system-ui", "sans-serif"],
+        font_mono=["IBM Plex Mono", "ui-monospace", "Consolas", "monospace"],
     )
 
     if theme_name == "Default":
         shared.gradio_theme = gr.themes.Default(**default_theme_args)
     else:
         try:
-            theme_cache_dir = os.path.join(script_path, 'tmp', 'gradio_themes')
-            theme_cache_path = os.path.join(theme_cache_dir, f'{theme_name.replace("/", "_")}.json')
+            theme_cache_dir = os.path.join(script_path, "tmp", "gradio_themes")
+            theme_cache_path = os.path.join(
+                theme_cache_dir, f'{theme_name.replace("/", "_")}.json'
+            )
             if shared.opts.gradio_themes_cache and os.path.exists(theme_cache_path):
                 shared.gradio_theme = gr.themes.ThemeClass.load(theme_cache_path)
             else:
@@ -67,8 +69,12 @@ def reload_gradio_theme(theme_name=None):
             shared.gradio_theme = gr.themes.Default(**default_theme_args)
 
     # append additional values gradio_theme
-    shared.gradio_theme.sd_webui_modal_lightbox_toolbar_opacity = shared.opts.sd_webui_modal_lightbox_toolbar_opacity
-    shared.gradio_theme.sd_webui_modal_lightbox_icon_opacity = shared.opts.sd_webui_modal_lightbox_icon_opacity
+    shared.gradio_theme.sd_webui_modal_lightbox_toolbar_opacity = (
+        shared.opts.sd_webui_modal_lightbox_toolbar_opacity
+    )
+    shared.gradio_theme.sd_webui_modal_lightbox_icon_opacity = (
+        shared.opts.sd_webui_modal_lightbox_icon_opacity
+    )
 
 
 def resolve_var(name: str, gradio_theme=None, history=None):
@@ -108,5 +114,5 @@ def resolve_var(name: str, gradio_theme=None, history=None):
 
     except Exception:
         name = history[0] if history else name
-        errors.report(f'resolve_color({name})', exc_info=True)
-        return '#000000' if name.endswith("_dark") else '#ffffff'
+        errors.report(f"resolve_color({name})", exc_info=True)
+        return "#000000" if name.endswith("_dark") else "#ffffff"

--- a/modules/shared_init.py
+++ b/modules/shared_init.py
@@ -15,8 +15,11 @@ def initialize():
     os.makedirs(cmd_opts.hypernetwork_dir, exist_ok=True)
 
     from modules import options, shared_options
+
     shared.options_templates = shared_options.options_templates
-    shared.opts = options.Options(shared_options.options_templates, shared_options.restricted_opts)
+    shared.opts = options.Options(
+        shared_options.options_templates, shared_options.restricted_opts
+    )
     shared.restricted_opts = shared_options.restricted_opts
     try:
         shared.opts.load(shared.config_filename)
@@ -24,12 +27,27 @@ def initialize():
         pass
 
     from modules import devices
-    devices.device, devices.device_interrogate, devices.device_gfpgan, devices.device_esrgan, devices.device_codeformer = \
-        (devices.cpu if any(y in cmd_opts.use_cpu for y in [x, 'all']) else devices.get_optimal_device() for x in ['sd', 'interrogate', 'gfpgan', 'esrgan', 'codeformer'])
+
+    (
+        devices.device,
+        devices.device_interrogate,
+        devices.device_gfpgan,
+        devices.device_esrgan,
+        devices.device_codeformer,
+    ) = (
+        devices.cpu
+        if any(y in cmd_opts.use_cpu for y in [x, "all"])
+        else devices.get_optimal_device()
+        for x in ["sd", "interrogate", "gfpgan", "esrgan", "codeformer"]
+    )
 
     devices.dtype = torch.float32 if cmd_opts.no_half else torch.float16
-    devices.dtype_vae = torch.float32 if cmd_opts.no_half or cmd_opts.no_half_vae else torch.float16
-    devices.dtype_inference = torch.float32 if cmd_opts.precision == 'full' else devices.dtype
+    devices.dtype_vae = (
+        torch.float32 if cmd_opts.no_half or cmd_opts.no_half_vae else torch.float16
+    )
+    devices.dtype_inference = (
+        torch.float32 if cmd_opts.precision == "full" else devices.dtype
+    )
 
     if cmd_opts.precision == "half":
         msg = "--no-half and --no-half-vae conflict with --precision half"
@@ -43,18 +61,22 @@ def initialize():
     shared.weight_load_location = None if cmd_opts.lowram else "cpu"
 
     from modules import shared_state
+
     shared.state = shared_state.State()
 
     from modules import styles
+
     shared.prompt_styles = styles.StyleDatabase(shared.styles_filename)
 
     from modules import interrogate
+
     shared.interrogator = interrogate.InterrogateModels("interrogate")
 
     from modules import shared_total_tqdm
+
     shared.total_tqdm = shared_total_tqdm.TotalTQDM()
 
     from modules import memmon, devices
+
     shared.mem_mon = memmon.MemUsageMonitor("MemMon", devices.device, shared.opts)
     shared.mem_mon.start()
-

--- a/modules/shared_items.py
+++ b/modules/shared_items.py
@@ -8,11 +8,13 @@ from modules.shared_cmd_options import cmd_opts
 
 def realesrgan_models_names():
     import modules.realesrgan_model
+
     return [x.name for x in modules.realesrgan_model.get_realesrgan_models(None)]
 
 
 def dat_models_names():
     import modules.dat_model
+
     return [x.name for x in modules.dat_model.get_dat_models(None)]
 
 
@@ -54,16 +56,19 @@ def refresh_unet_list():
 
 def list_checkpoint_tiles(use_short=False):
     import modules.sd_models
+
     return modules.sd_models.checkpoint_tiles(use_short)
 
 
 def refresh_checkpoints():
     import modules.sd_models
+
     return modules.sd_models.list_models()
 
 
 def list_samplers():
     import modules.sd_samplers
+
     return modules.sd_samplers.all_samplers
 
 
@@ -76,6 +81,7 @@ def reload_hypernetworks():
 
 def get_infotext_names():
     from modules import infotext_utils, shared
+
     res = {}
 
     for info in shared.opts.data_labels.values():
@@ -113,7 +119,10 @@ def ui_reorder_categories():
 
     sections = {}
     for script in scripts.scripts_txt2img.scripts + scripts.scripts_img2img.scripts:
-        if isinstance(script.section, str) and script.section not in ui_reorder_categories_builtin_items:
+        if (
+            isinstance(script.section, str)
+            and script.section not in ui_reorder_categories_builtin_items
+        ):
             sections[script.section] = 1
 
     yield from sections
@@ -126,21 +135,28 @@ def callbacks_order_settings():
         "sd_vae_explanation": OptionHTML("""
     For categories below, callbacks added to dropdowns happen before others, in order listed.
     """),
-
     }
 
     callback_options = {}
 
     for category, _ in script_callbacks.enumerate_callbacks():
-        callback_options[category] = script_callbacks.ordered_callbacks(category, enable_user_sort=False)
+        callback_options[category] = script_callbacks.ordered_callbacks(
+            category, enable_user_sort=False
+        )
 
     for method_name in scripts.scripts_txt2img.callback_names:
-        callback_options["script_" + method_name] = scripts.scripts_txt2img.create_ordered_callbacks_list(method_name, enable_user_sort=False)
+        callback_options["script_" + method_name] = (
+            scripts.scripts_txt2img.create_ordered_callbacks_list(
+                method_name, enable_user_sort=False
+            )
+        )
 
     for method_name in scripts.scripts_img2img.callback_names:
         callbacks = callback_options.get("script_" + method_name, [])
 
-        for addition in scripts.scripts_img2img.create_ordered_callbacks_list(method_name, enable_user_sort=False):
+        for addition in scripts.scripts_img2img.create_ordered_callbacks_list(
+            method_name, enable_user_sort=False
+        ):
             if any(x.name == addition.name for x in callbacks):
                 continue
 
@@ -152,10 +168,19 @@ def callbacks_order_settings():
         if not callbacks:
             continue
 
-        option_info = OptionInfo([], f"{category} callback priority", ui_components.DropdownMulti, {"choices": [x.name for x in callbacks]})
+        option_info = OptionInfo(
+            [],
+            f"{category} callback priority",
+            ui_components.DropdownMulti,
+            {"choices": [x.name for x in callbacks]},
+        )
         option_info.needs_restart()
-        option_info.html("<div class='info'>Default order: <ol>" + "".join(f"<li>{html.escape(x.name)}</li>\n" for x in callbacks) + "</ol></div>")
-        options['prioritized_callbacks_' + category] = option_info
+        option_info.html(
+            "<div class='info'>Default order: <ol>"
+            + "".join(f"<li>{html.escape(x.name)}</li>\n" for x in callbacks)
+            + "</ol></div>"
+        )
+        options["prioritized_callbacks_" + category] = option_info
 
     return options
 
@@ -181,4 +206,4 @@ class Shared(sys.modules[__name__].__class__):
         modules.sd_models.model_data.set_sd_model(value)
 
 
-sys.modules['modules.shared'].__class__ = Shared
+sys.modules["modules.shared"].__class__ = Shared

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -1,8 +1,20 @@
 import os
 import gradio as gr
 
-from modules import localization, ui_components, shared_items, shared, interrogate, shared_gradio_themes, util, sd_emphasis
-from modules.paths_internal import models_path, script_path, data_path, sd_configs_path, sd_default_config, sd_model_file, default_sd_model_file, extensions_dir, extensions_builtin_dir, default_output_dir  # noqa: F401
+from modules import (
+    localization,
+    ui_components,
+    shared_items,
+    shared,
+    interrogate,
+    shared_gradio_themes,
+    util,
+    sd_emphasis,
+)
+from modules.paths_internal import (
+    data_path,
+    default_output_dir,
+)  # noqa: F401
 from modules.shared_cmd_options import cmd_opts
 from modules.options import options_section, OptionInfo, OptionHTML, categories
 
@@ -31,395 +43,1576 @@ categories.register_category("system", "System")
 categories.register_category("postprocessing", "Postprocessing")
 categories.register_category("training", "Training")
 
-options_templates.update(options_section(('saving-images', "Saving images/grids", "saving"), {
-    "samples_save": OptionInfo(True, "Always save all generated images"),
-    "samples_format": OptionInfo('png', 'File format for images'),
-    "samples_filename_pattern": OptionInfo("", "Images filename pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),
-    "save_images_add_number": OptionInfo(True, "Add number to filename when saving", component_args=hide_dirs),
-    "save_images_replace_action": OptionInfo("Replace", "Saving the image to an existing file", gr.Radio, {"choices": ["Replace", "Add number suffix"], **hide_dirs}),
-    "grid_save": OptionInfo(True, "Always save all generated image grids"),
-    "grid_format": OptionInfo('png', 'File format for grids'),
-    "grid_extended_filename": OptionInfo(False, "Add extended info (seed, prompt) to filename when saving grid"),
-    "grid_only_if_multiple": OptionInfo(True, "Do not save grids consisting of one picture"),
-    "grid_prevent_empty_spots": OptionInfo(False, "Prevent empty spots in grid (when set to autodetect)"),
-    "grid_zip_filename_pattern": OptionInfo("", "Archive filename pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),
-    "n_rows": OptionInfo(-1, "Grid row count; use -1 for autodetect and 0 for it to be same as batch size", gr.Slider, {"minimum": -1, "maximum": 16, "step": 1}),
-    "font": OptionInfo("", "Font for image grids that have text"),
-    "grid_text_active_color": OptionInfo("#000000", "Text color for image grids", ui_components.FormColorPicker, {}),
-    "grid_text_inactive_color": OptionInfo("#999999", "Inactive text color for image grids", ui_components.FormColorPicker, {}),
-    "grid_background_color": OptionInfo("#ffffff", "Background color for image grids", ui_components.FormColorPicker, {}),
+options_templates.update(
+    options_section(
+        ("saving-images", "Saving images/grids", "saving"),
+        {
+            "samples_save": OptionInfo(True, "Always save all generated images"),
+            "samples_format": OptionInfo("png", "File format for images"),
+            "samples_filename_pattern": OptionInfo(
+                "", "Images filename pattern", component_args=hide_dirs
+            ).link(
+                "wiki",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory",
+            ),
+            "save_images_add_number": OptionInfo(
+                True, "Add number to filename when saving", component_args=hide_dirs
+            ),
+            "save_images_replace_action": OptionInfo(
+                "Replace",
+                "Saving the image to an existing file",
+                gr.Radio,
+                {"choices": ["Replace", "Add number suffix"], **hide_dirs},
+            ),
+            "grid_save": OptionInfo(True, "Always save all generated image grids"),
+            "grid_format": OptionInfo("png", "File format for grids"),
+            "grid_extended_filename": OptionInfo(
+                False, "Add extended info (seed, prompt) to filename when saving grid"
+            ),
+            "grid_only_if_multiple": OptionInfo(
+                True, "Do not save grids consisting of one picture"
+            ),
+            "grid_prevent_empty_spots": OptionInfo(
+                False, "Prevent empty spots in grid (when set to autodetect)"
+            ),
+            "grid_zip_filename_pattern": OptionInfo(
+                "", "Archive filename pattern", component_args=hide_dirs
+            ).link(
+                "wiki",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory",
+            ),
+            "n_rows": OptionInfo(
+                -1,
+                "Grid row count; use -1 for autodetect and 0 for it to be same as batch size",
+                gr.Slider,
+                {"minimum": -1, "maximum": 16, "step": 1},
+            ),
+            "font": OptionInfo("", "Font for image grids that have text"),
+            "grid_text_active_color": OptionInfo(
+                "#000000",
+                "Text color for image grids",
+                ui_components.FormColorPicker,
+                {},
+            ),
+            "grid_text_inactive_color": OptionInfo(
+                "#999999",
+                "Inactive text color for image grids",
+                ui_components.FormColorPicker,
+                {},
+            ),
+            "grid_background_color": OptionInfo(
+                "#ffffff",
+                "Background color for image grids",
+                ui_components.FormColorPicker,
+                {},
+            ),
+            "save_images_before_face_restoration": OptionInfo(
+                False, "Save a copy of image before doing face restoration."
+            ),
+            "save_images_before_highres_fix": OptionInfo(
+                False, "Save a copy of image before applying highres fix."
+            ),
+            "save_images_before_color_correction": OptionInfo(
+                False,
+                "Save a copy of image before applying color correction to img2img results",
+            ),
+            "save_mask": OptionInfo(
+                False, "For inpainting, save a copy of the greyscale mask"
+            ),
+            "save_mask_composite": OptionInfo(
+                False, "For inpainting, save a masked composite"
+            ),
+            "jpeg_quality": OptionInfo(
+                80,
+                "Quality for saved jpeg and avif images",
+                gr.Slider,
+                {"minimum": 1, "maximum": 100, "step": 1},
+            ),
+            "webp_lossless": OptionInfo(
+                False, "Use lossless compression for webp images"
+            ),
+            "export_for_4chan": OptionInfo(
+                True, "Save copy of large images as JPG"
+            ).info(
+                "if the file size is above the limit, or either width or height are above the limit"
+            ),
+            "img_downscale_threshold": OptionInfo(
+                4.0, "File size limit for the above option, MB", gr.Number
+            ),
+            "target_side_length": OptionInfo(
+                4000, "Width/height limit for the above option, in pixels", gr.Number
+            ),
+            "img_max_size_mp": OptionInfo(200, "Maximum image size", gr.Number).info(
+                "in megapixels"
+            ),
+            "use_original_name_batch": OptionInfo(
+                True,
+                "Use original name for output filename during batch process in extras tab",
+            ),
+            "use_upscaler_name_as_suffix": OptionInfo(
+                False, "Use upscaler name as filename suffix in the extras tab"
+            ),
+            "save_selected_only": OptionInfo(
+                True, "When using 'Save' button, only save a single selected image"
+            ),
+            "save_write_log_csv": OptionInfo(
+                True, "Write log.csv when saving images using 'Save' button"
+            ),
+            "save_init_img": OptionInfo(False, "Save init images when using img2img"),
+            "temp_dir": OptionInfo(
+                "", "Directory for temporary images; leave empty for default"
+            ),
+            "clean_temp_dir_at_start": OptionInfo(
+                False, "Cleanup non-default temporary directory when starting webui"
+            ),
+            "save_incomplete_images": OptionInfo(False, "Save incomplete images").info(
+                "save images that has been interrupted in mid-generation; even if not saved, they will still show up in webui output."
+            ),
+            "notification_audio": OptionInfo(
+                True, "Play notification sound after image generation"
+            )
+            .info("notification.mp3 should be present in the root directory")
+            .needs_reload_ui(),
+            "notification_volume": OptionInfo(
+                100,
+                "Notification sound volume",
+                gr.Slider,
+                {"minimum": 0, "maximum": 100, "step": 1},
+            ).info("in %"),
+        },
+    )
+)
 
-    "save_images_before_face_restoration": OptionInfo(False, "Save a copy of image before doing face restoration."),
-    "save_images_before_highres_fix": OptionInfo(False, "Save a copy of image before applying highres fix."),
-    "save_images_before_color_correction": OptionInfo(False, "Save a copy of image before applying color correction to img2img results"),
-    "save_mask": OptionInfo(False, "For inpainting, save a copy of the greyscale mask"),
-    "save_mask_composite": OptionInfo(False, "For inpainting, save a masked composite"),
-    "jpeg_quality": OptionInfo(80, "Quality for saved jpeg and avif images", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}),
-    "webp_lossless": OptionInfo(False, "Use lossless compression for webp images"),
-    "export_for_4chan": OptionInfo(True, "Save copy of large images as JPG").info("if the file size is above the limit, or either width or height are above the limit"),
-    "img_downscale_threshold": OptionInfo(4.0, "File size limit for the above option, MB", gr.Number),
-    "target_side_length": OptionInfo(4000, "Width/height limit for the above option, in pixels", gr.Number),
-    "img_max_size_mp": OptionInfo(200, "Maximum image size", gr.Number).info("in megapixels"),
+options_templates.update(
+    options_section(
+        ("saving-paths", "Paths for saving", "saving"),
+        {
+            "outdir_samples": OptionInfo(
+                "",
+                "Output directory for images; if empty, defaults to three directories below",
+                component_args=hide_dirs,
+            ),
+            "outdir_txt2img_samples": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "txt2img-images")),
+                "Output directory for txt2img images",
+                component_args=hide_dirs,
+            ),
+            "outdir_img2img_samples": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "img2img-images")),
+                "Output directory for img2img images",
+                component_args=hide_dirs,
+            ),
+            "outdir_extras_samples": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "extras-images")),
+                "Output directory for images from extras tab",
+                component_args=hide_dirs,
+            ),
+            "outdir_grids": OptionInfo(
+                "",
+                "Output directory for grids; if empty, defaults to two directories below",
+                component_args=hide_dirs,
+            ),
+            "outdir_txt2img_grids": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "txt2img-grids")),
+                "Output directory for txt2img grids",
+                component_args=hide_dirs,
+            ),
+            "outdir_img2img_grids": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "img2img-grids")),
+                "Output directory for img2img grids",
+                component_args=hide_dirs,
+            ),
+            "outdir_save": OptionInfo(
+                util.truncate_path(os.path.join(data_path, "log", "images")),
+                "Directory for saving images using the Save button",
+                component_args=hide_dirs,
+            ),
+            "outdir_init_images": OptionInfo(
+                util.truncate_path(os.path.join(default_output_dir, "init-images")),
+                "Directory for saving init images when using img2img",
+                component_args=hide_dirs,
+            ),
+        },
+    )
+)
 
-    "use_original_name_batch": OptionInfo(True, "Use original name for output filename during batch process in extras tab"),
-    "use_upscaler_name_as_suffix": OptionInfo(False, "Use upscaler name as filename suffix in the extras tab"),
-    "save_selected_only": OptionInfo(True, "When using 'Save' button, only save a single selected image"),
-    "save_write_log_csv": OptionInfo(True, "Write log.csv when saving images using 'Save' button"),
-    "save_init_img": OptionInfo(False, "Save init images when using img2img"),
+options_templates.update(
+    options_section(
+        ("saving-to-dirs", "Saving to a directory", "saving"),
+        {
+            "save_to_dirs": OptionInfo(True, "Save images to a subdirectory"),
+            "grid_save_to_dirs": OptionInfo(True, "Save grids to a subdirectory"),
+            "use_save_to_dirs_for_ui": OptionInfo(
+                False, 'When using "Save" button, save images to a subdirectory'
+            ),
+            "directories_filename_pattern": OptionInfo(
+                "[date]", "Directory name pattern", component_args=hide_dirs
+            ).link(
+                "wiki",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory",
+            ),
+            "directories_max_prompt_words": OptionInfo(
+                8,
+                "Max prompt words for [prompt_words] pattern",
+                gr.Slider,
+                {"minimum": 1, "maximum": 20, "step": 1, **hide_dirs},
+            ),
+        },
+    )
+)
 
-    "temp_dir":  OptionInfo("", "Directory for temporary images; leave empty for default"),
-    "clean_temp_dir_at_start": OptionInfo(False, "Cleanup non-default temporary directory when starting webui"),
+options_templates.update(
+    options_section(
+        ("upscaling", "Upscaling", "postprocessing"),
+        {
+            "ESRGAN_tile": OptionInfo(
+                192,
+                "Tile size for ESRGAN upscalers.",
+                gr.Slider,
+                {"minimum": 0, "maximum": 512, "step": 16},
+            ).info("0 = no tiling"),
+            "ESRGAN_tile_overlap": OptionInfo(
+                8,
+                "Tile overlap for ESRGAN upscalers.",
+                gr.Slider,
+                {"minimum": 0, "maximum": 48, "step": 1},
+            ).info("Low values = visible seam"),
+            "realesrgan_enabled_models": OptionInfo(
+                ["R-ESRGAN 4x+", "R-ESRGAN 4x+ Anime6B"],
+                "Select which Real-ESRGAN models to show in the web UI.",
+                gr.CheckboxGroup,
+                lambda: {"choices": shared_items.realesrgan_models_names()},
+            ),
+            "dat_enabled_models": OptionInfo(
+                ["DAT x2", "DAT x3", "DAT x4"],
+                "Select which DAT models to show in the web UI.",
+                gr.CheckboxGroup,
+                lambda: {"choices": shared_items.dat_models_names()},
+            ),
+            "DAT_tile": OptionInfo(
+                192,
+                "Tile size for DAT upscalers.",
+                gr.Slider,
+                {"minimum": 0, "maximum": 512, "step": 16},
+            ).info("0 = no tiling"),
+            "DAT_tile_overlap": OptionInfo(
+                8,
+                "Tile overlap for DAT upscalers.",
+                gr.Slider,
+                {"minimum": 0, "maximum": 48, "step": 1},
+            ).info("Low values = visible seam"),
+            "upscaler_for_img2img": OptionInfo(
+                None,
+                "Upscaler for img2img",
+                gr.Dropdown,
+                lambda: {"choices": [x.name for x in shared.sd_upscalers]},
+            ),
+            "set_scale_by_when_changing_upscaler": OptionInfo(
+                False,
+                "Automatically set the Scale by factor based on the name of the selected Upscaler.",
+            ),
+        },
+    )
+)
 
-    "save_incomplete_images": OptionInfo(False, "Save incomplete images").info("save images that has been interrupted in mid-generation; even if not saved, they will still show up in webui output."),
+options_templates.update(
+    options_section(
+        ("face-restoration", "Face restoration", "postprocessing"),
+        {
+            "face_restoration": OptionInfo(
+                False, "Restore faces", infotext="Face restoration"
+            ).info(
+                "will use a third-party model on generation result to reconstruct faces"
+            ),
+            "face_restoration_model": OptionInfo(
+                "CodeFormer",
+                "Face restoration model",
+                gr.Radio,
+                lambda: {"choices": [x.name() for x in shared.face_restorers]},
+            ),
+            "code_former_weight": OptionInfo(
+                0.5,
+                "CodeFormer weight",
+                gr.Slider,
+                {"minimum": 0, "maximum": 1, "step": 0.01},
+            ).info("0 = maximum effect; 1 = minimum effect"),
+            "face_restoration_unload": OptionInfo(
+                False, "Move face restoration model from VRAM into RAM after processing"
+            ),
+        },
+    )
+)
 
-    "notification_audio": OptionInfo(True, "Play notification sound after image generation").info("notification.mp3 should be present in the root directory").needs_reload_ui(),
-    "notification_volume": OptionInfo(100, "Notification sound volume", gr.Slider, {"minimum": 0, "maximum": 100, "step": 1}).info("in %"),
-}))
+options_templates.update(
+    options_section(
+        ("system", "System", "system"),
+        {
+            "auto_launch_browser": OptionInfo(
+                "Local",
+                "Automatically open webui in browser on startup",
+                gr.Radio,
+                lambda: {"choices": ["Disable", "Local", "Remote"]},
+            ),
+            "enable_console_prompts": OptionInfo(
+                shared.cmd_opts.enable_console_prompts,
+                "Print prompts to console when generating with txt2img and img2img.",
+            ),
+            "show_warnings": OptionInfo(
+                False, "Show warnings in console."
+            ).needs_reload_ui(),
+            "show_gradio_deprecation_warnings": OptionInfo(
+                True, "Show gradio deprecation warnings in console."
+            ).needs_reload_ui(),
+            "memmon_poll_rate": OptionInfo(
+                8,
+                "VRAM usage polls per second during generation.",
+                gr.Slider,
+                {"minimum": 0, "maximum": 40, "step": 1},
+            ).info("0 = disable"),
+            "samples_log_stdout": OptionInfo(
+                False, "Always print all generation info to standard output"
+            ),
+            "multiple_tqdm": OptionInfo(
+                True,
+                "Add a second progress bar to the console that shows progress for an entire job.",
+            ),
+            "enable_upscale_progressbar": OptionInfo(
+                True, "Show a progress bar in the console for tiled upscaling."
+            ),
+            "print_hypernet_extra": OptionInfo(
+                False, "Print extra hypernetwork information to console."
+            ),
+            "list_hidden_files": OptionInfo(
+                True, "Load models/files in hidden directories"
+            ).info('directory is hidden if its name starts with "."'),
+            "disable_mmap_load_safetensors": OptionInfo(
+                False, "Disable memmapping for loading .safetensors files."
+            ).info("fixes very slow loading speed in some cases"),
+            "hide_ldm_prints": OptionInfo(
+                True,
+                "Prevent Stability-AI's ldm/sgm modules from printing noise to console.",
+            ),
+            "dump_stacks_on_signal": OptionInfo(
+                False, "Print stack traces before exiting the program with ctrl+c."
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('saving-paths', "Paths for saving", "saving"), {
-    "outdir_samples": OptionInfo("", "Output directory for images; if empty, defaults to three directories below", component_args=hide_dirs),
-    "outdir_txt2img_samples": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'txt2img-images')), 'Output directory for txt2img images', component_args=hide_dirs),
-    "outdir_img2img_samples": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'img2img-images')), 'Output directory for img2img images', component_args=hide_dirs),
-    "outdir_extras_samples": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'extras-images')), 'Output directory for images from extras tab', component_args=hide_dirs),
-    "outdir_grids": OptionInfo("", "Output directory for grids; if empty, defaults to two directories below", component_args=hide_dirs),
-    "outdir_txt2img_grids": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'txt2img-grids')), 'Output directory for txt2img grids', component_args=hide_dirs),
-    "outdir_img2img_grids": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'img2img-grids')), 'Output directory for img2img grids', component_args=hide_dirs),
-    "outdir_save": OptionInfo(util.truncate_path(os.path.join(data_path, 'log', 'images')), "Directory for saving images using the Save button", component_args=hide_dirs),
-    "outdir_init_images": OptionInfo(util.truncate_path(os.path.join(default_output_dir, 'init-images')), "Directory for saving init images when using img2img", component_args=hide_dirs),
-}))
-
-options_templates.update(options_section(('saving-to-dirs', "Saving to a directory", "saving"), {
-    "save_to_dirs": OptionInfo(True, "Save images to a subdirectory"),
-    "grid_save_to_dirs": OptionInfo(True, "Save grids to a subdirectory"),
-    "use_save_to_dirs_for_ui": OptionInfo(False, "When using \"Save\" button, save images to a subdirectory"),
-    "directories_filename_pattern": OptionInfo("[date]", "Directory name pattern", component_args=hide_dirs).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"),
-    "directories_max_prompt_words": OptionInfo(8, "Max prompt words for [prompt_words] pattern", gr.Slider, {"minimum": 1, "maximum": 20, "step": 1, **hide_dirs}),
-}))
-
-options_templates.update(options_section(('upscaling', "Upscaling", "postprocessing"), {
-    "ESRGAN_tile": OptionInfo(192, "Tile size for ESRGAN upscalers.", gr.Slider, {"minimum": 0, "maximum": 512, "step": 16}).info("0 = no tiling"),
-    "ESRGAN_tile_overlap": OptionInfo(8, "Tile overlap for ESRGAN upscalers.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}).info("Low values = visible seam"),
-    "realesrgan_enabled_models": OptionInfo(["R-ESRGAN 4x+", "R-ESRGAN 4x+ Anime6B"], "Select which Real-ESRGAN models to show in the web UI.", gr.CheckboxGroup, lambda: {"choices": shared_items.realesrgan_models_names()}),
-    "dat_enabled_models": OptionInfo(["DAT x2", "DAT x3", "DAT x4"], "Select which DAT models to show in the web UI.", gr.CheckboxGroup, lambda: {"choices": shared_items.dat_models_names()}),
-    "DAT_tile": OptionInfo(192, "Tile size for DAT upscalers.", gr.Slider, {"minimum": 0, "maximum": 512, "step": 16}).info("0 = no tiling"),
-    "DAT_tile_overlap": OptionInfo(8, "Tile overlap for DAT upscalers.", gr.Slider, {"minimum": 0, "maximum": 48, "step": 1}).info("Low values = visible seam"),
-    "upscaler_for_img2img": OptionInfo(None, "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}),
-    "set_scale_by_when_changing_upscaler": OptionInfo(False, "Automatically set the Scale by factor based on the name of the selected Upscaler."),
-}))
-
-options_templates.update(options_section(('face-restoration', "Face restoration", "postprocessing"), {
-    "face_restoration": OptionInfo(False, "Restore faces", infotext='Face restoration').info("will use a third-party model on generation result to reconstruct faces"),
-    "face_restoration_model": OptionInfo("CodeFormer", "Face restoration model", gr.Radio, lambda: {"choices": [x.name() for x in shared.face_restorers]}),
-    "code_former_weight": OptionInfo(0.5, "CodeFormer weight", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}).info("0 = maximum effect; 1 = minimum effect"),
-    "face_restoration_unload": OptionInfo(False, "Move face restoration model from VRAM into RAM after processing"),
-}))
-
-options_templates.update(options_section(('system', "System", "system"), {
-    "auto_launch_browser": OptionInfo("Local", "Automatically open webui in browser on startup", gr.Radio, lambda: {"choices": ["Disable", "Local", "Remote"]}),
-    "enable_console_prompts": OptionInfo(shared.cmd_opts.enable_console_prompts, "Print prompts to console when generating with txt2img and img2img."),
-    "show_warnings": OptionInfo(False, "Show warnings in console.").needs_reload_ui(),
-    "show_gradio_deprecation_warnings": OptionInfo(True, "Show gradio deprecation warnings in console.").needs_reload_ui(),
-    "memmon_poll_rate": OptionInfo(8, "VRAM usage polls per second during generation.", gr.Slider, {"minimum": 0, "maximum": 40, "step": 1}).info("0 = disable"),
-    "samples_log_stdout": OptionInfo(False, "Always print all generation info to standard output"),
-    "multiple_tqdm": OptionInfo(True, "Add a second progress bar to the console that shows progress for an entire job."),
-    "enable_upscale_progressbar": OptionInfo(True, "Show a progress bar in the console for tiled upscaling."),
-    "print_hypernet_extra": OptionInfo(False, "Print extra hypernetwork information to console."),
-    "list_hidden_files": OptionInfo(True, "Load models/files in hidden directories").info("directory is hidden if its name starts with \".\""),
-    "disable_mmap_load_safetensors": OptionInfo(False, "Disable memmapping for loading .safetensors files.").info("fixes very slow loading speed in some cases"),
-    "hide_ldm_prints": OptionInfo(True, "Prevent Stability-AI's ldm/sgm modules from printing noise to console."),
-    "dump_stacks_on_signal": OptionInfo(False, "Print stack traces before exiting the program with ctrl+c."),
-}))
-
-options_templates.update(options_section(('profiler', "Profiler", "system"), {
-    "profiling_explanation": OptionHTML("""
+options_templates.update(
+    options_section(
+        ("profiler", "Profiler", "system"),
+        {
+            "profiling_explanation": OptionHTML("""
 Those settings allow you to enable torch profiler when generating pictures.
 Profiling allows you to see which code uses how much of computer's resources during generation.
 Each generation writes its own profile to one file, overwriting previous.
 The file can be viewed in <a href="chrome:tracing">Chrome</a>, or on a <a href="https://ui.perfetto.dev/">Perfetto</a> web site.
 Warning: writing profile can take a lot of time, up to 30 seconds, and the file itelf can be around 500MB in size.
 """),
-    "profiling_enable": OptionInfo(False, "Enable profiling"),
-    "profiling_activities": OptionInfo(["CPU"], "Activities", gr.CheckboxGroup, {"choices": ["CPU", "CUDA"]}),
-    "profiling_record_shapes": OptionInfo(True, "Record shapes"),
-    "profiling_profile_memory": OptionInfo(True, "Profile memory"),
-    "profiling_with_stack": OptionInfo(True, "Include python stack"),
-    "profiling_filename": OptionInfo("trace.json", "Profile filename"),
-}))
+            "profiling_enable": OptionInfo(False, "Enable profiling"),
+            "profiling_activities": OptionInfo(
+                ["CPU"], "Activities", gr.CheckboxGroup, {"choices": ["CPU", "CUDA"]}
+            ),
+            "profiling_record_shapes": OptionInfo(True, "Record shapes"),
+            "profiling_profile_memory": OptionInfo(True, "Profile memory"),
+            "profiling_with_stack": OptionInfo(True, "Include python stack"),
+            "profiling_filename": OptionInfo("trace.json", "Profile filename"),
+        },
+    )
+)
 
-options_templates.update(options_section(('API', "API", "system"), {
-    "api_enable_requests": OptionInfo(True, "Allow http:// and https:// URLs for input images in API", restrict_api=True),
-    "api_forbid_local_requests": OptionInfo(True, "Forbid URLs to local resources", restrict_api=True),
-    "api_useragent": OptionInfo("", "User agent for requests", restrict_api=True),
-}))
+options_templates.update(
+    options_section(
+        ("API", "API", "system"),
+        {
+            "api_enable_requests": OptionInfo(
+                True,
+                "Allow http:// and https:// URLs for input images in API",
+                restrict_api=True,
+            ),
+            "api_forbid_local_requests": OptionInfo(
+                True, "Forbid URLs to local resources", restrict_api=True
+            ),
+            "api_useragent": OptionInfo(
+                "", "User agent for requests", restrict_api=True
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('training', "Training", "training"), {
-    "unload_models_when_training": OptionInfo(False, "Move VAE and CLIP to RAM when training if possible. Saves VRAM."),
-    "pin_memory": OptionInfo(False, "Turn on pin_memory for DataLoader. Makes training slightly faster but can increase memory usage."),
-    "save_optimizer_state": OptionInfo(False, "Saves Optimizer state as separate *.optim file. Training of embedding or HN can be resumed with the matching optim file."),
-    "save_training_settings_to_txt": OptionInfo(True, "Save textual inversion and hypernet settings to a text file whenever training starts."),
-    "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
-    "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
-    "training_image_repeats_per_epoch": OptionInfo(1, "Number of repeats for a single input image per epoch; used only for displaying epoch number", gr.Number, {"precision": 0}),
-    "training_write_csv_every": OptionInfo(500, "Save an csv containing the loss to log directory every N steps, 0 to disable"),
-    "training_xattention_optimizations": OptionInfo(False, "Use cross attention optimizations while training"),
-    "training_enable_tensorboard": OptionInfo(False, "Enable tensorboard logging."),
-    "training_tensorboard_save_images": OptionInfo(False, "Save generated images within tensorboard."),
-    "training_tensorboard_flush_every": OptionInfo(120, "How often, in seconds, to flush the pending tensorboard events and summaries to disk."),
-}))
+options_templates.update(
+    options_section(
+        ("training", "Training", "training"),
+        {
+            "unload_models_when_training": OptionInfo(
+                False, "Move VAE and CLIP to RAM when training if possible. Saves VRAM."
+            ),
+            "pin_memory": OptionInfo(
+                False,
+                "Turn on pin_memory for DataLoader. Makes training slightly faster but can increase memory usage.",
+            ),
+            "save_optimizer_state": OptionInfo(
+                False,
+                "Saves Optimizer state as separate *.optim file. Training of embedding or HN can be resumed with the matching optim file.",
+            ),
+            "save_training_settings_to_txt": OptionInfo(
+                True,
+                "Save textual inversion and hypernet settings to a text file whenever training starts.",
+            ),
+            "dataset_filename_word_regex": OptionInfo("", "Filename word regex"),
+            "dataset_filename_join_string": OptionInfo(" ", "Filename join string"),
+            "training_image_repeats_per_epoch": OptionInfo(
+                1,
+                "Number of repeats for a single input image per epoch; used only for displaying epoch number",
+                gr.Number,
+                {"precision": 0},
+            ),
+            "training_write_csv_every": OptionInfo(
+                500,
+                "Save an csv containing the loss to log directory every N steps, 0 to disable",
+            ),
+            "training_xattention_optimizations": OptionInfo(
+                False, "Use cross attention optimizations while training"
+            ),
+            "training_enable_tensorboard": OptionInfo(
+                False, "Enable tensorboard logging."
+            ),
+            "training_tensorboard_save_images": OptionInfo(
+                False, "Save generated images within tensorboard."
+            ),
+            "training_tensorboard_flush_every": OptionInfo(
+                120,
+                "How often, in seconds, to flush the pending tensorboard events and summaries to disk.",
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('sd', "Stable Diffusion", "sd"), {
-    "sd_model_checkpoint": OptionInfo(None, "Stable Diffusion checkpoint", gr.Dropdown, lambda: {"choices": shared_items.list_checkpoint_tiles(shared.opts.sd_checkpoint_dropdown_use_short)}, refresh=shared_items.refresh_checkpoints, infotext='Model hash'),
-    "sd_checkpoints_limit": OptionInfo(1, "Maximum number of checkpoints loaded at the same time", gr.Slider, {"minimum": 1, "maximum": 10, "step": 1}),
-    "sd_checkpoints_keep_in_cpu": OptionInfo(True, "Only keep one model on device").info("will keep models other than the currently used one in RAM rather than VRAM"),
-    "sd_checkpoint_cache": OptionInfo(0, "Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}).info("obsolete; set to 0 and use the two settings above instead"),
-    "sd_unet": OptionInfo("Automatic", "SD Unet", gr.Dropdown, lambda: {"choices": shared_items.sd_unet_items()}, refresh=shared_items.refresh_unet_list).info("choose Unet model: Automatic = use one with same filename as checkpoint; None = use Unet from checkpoint"),
-    "enable_quantization": OptionInfo(False, "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds").needs_reload_ui(),
-    "emphasis": OptionInfo("Original", "Emphasis mode", gr.Radio, lambda: {"choices": [x.name for x in sd_emphasis.options]}, infotext="Emphasis").info("makes it possible to make model to pay (more:1.1) or (less:0.9) attention to text when you use the syntax in prompt; " + sd_emphasis.get_options_descriptions()),
-    "enable_batch_seeds": OptionInfo(True, "Make K-diffusion samplers produce same images in a batch as when making a single image"),
-    "comma_padding_backtrack": OptionInfo(20, "Prompt word wrap length limit", gr.Slider, {"minimum": 0, "maximum": 74, "step": 1}).info("in tokens - for texts shorter than specified, if they don't fit into 75 token limit, move them to the next 75 token chunk"),
-    "sdxl_clip_l_skip": OptionInfo(False, "Clip skip SDXL", gr.Checkbox).info("Enable Clip skip for the secondary clip model in sdxl. Has no effect on SD 1.5 or SD 2.0/2.1."),
-    "CLIP_stop_at_last_layers": OptionInfo(1, "Clip skip", gr.Slider, {"minimum": 1, "maximum": 12, "step": 1}, infotext="Clip skip").link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#clip-skip").info("ignore last layers of CLIP network; 1 ignores none, 2 ignores one layer"),
-    "upcast_attn": OptionInfo(False, "Upcast cross attention layer to float32"),
-    "randn_source": OptionInfo("GPU", "Random number generator source.", gr.Radio, {"choices": ["GPU", "CPU", "NV"]}, infotext="RNG").info("changes seeds drastically; use CPU to produce the same picture across different videocard vendors; use NV to produce same picture as on NVidia videocards"),
-    "tiling": OptionInfo(False, "Tiling", infotext='Tiling').info("produce a tileable picture"),
-    "hires_fix_refiner_pass": OptionInfo("second pass", "Hires fix: which pass to enable refiner for", gr.Radio, {"choices": ["first pass", "second pass", "both passes"]}, infotext="Hires refiner"),
-}))
+options_templates.update(
+    options_section(
+        ("sd", "Stable Diffusion", "sd"),
+        {
+            "sd_model_checkpoint": OptionInfo(
+                None,
+                "Stable Diffusion checkpoint",
+                gr.Dropdown,
+                lambda: {
+                    "choices": shared_items.list_checkpoint_tiles(
+                        shared.opts.sd_checkpoint_dropdown_use_short
+                    )
+                },
+                refresh=shared_items.refresh_checkpoints,
+                infotext="Model hash",
+            ),
+            "sd_checkpoints_limit": OptionInfo(
+                1,
+                "Maximum number of checkpoints loaded at the same time",
+                gr.Slider,
+                {"minimum": 1, "maximum": 10, "step": 1},
+            ),
+            "sd_checkpoints_keep_in_cpu": OptionInfo(
+                True, "Only keep one model on device"
+            ).info(
+                "will keep models other than the currently used one in RAM rather than VRAM"
+            ),
+            "sd_checkpoint_cache": OptionInfo(
+                0,
+                "Checkpoints to cache in RAM",
+                gr.Slider,
+                {"minimum": 0, "maximum": 10, "step": 1},
+            ).info("obsolete; set to 0 and use the two settings above instead"),
+            "sd_unet": OptionInfo(
+                "Automatic",
+                "SD Unet",
+                gr.Dropdown,
+                lambda: {"choices": shared_items.sd_unet_items()},
+                refresh=shared_items.refresh_unet_list,
+            ).info(
+                "choose Unet model: Automatic = use one with same filename as checkpoint; None = use Unet from checkpoint"
+            ),
+            "enable_quantization": OptionInfo(
+                False,
+                "Enable quantization in K samplers for sharper and cleaner results. This may change existing seeds",
+            ).needs_reload_ui(),
+            "emphasis": OptionInfo(
+                "Original",
+                "Emphasis mode",
+                gr.Radio,
+                lambda: {"choices": [x.name for x in sd_emphasis.options]},
+                infotext="Emphasis",
+            ).info(
+                "makes it possible to make model to pay (more:1.1) or (less:0.9) attention to text when you use the syntax in prompt; "
+                + sd_emphasis.get_options_descriptions()
+            ),
+            "enable_batch_seeds": OptionInfo(
+                True,
+                "Make K-diffusion samplers produce same images in a batch as when making a single image",
+            ),
+            "comma_padding_backtrack": OptionInfo(
+                20,
+                "Prompt word wrap length limit",
+                gr.Slider,
+                {"minimum": 0, "maximum": 74, "step": 1},
+            ).info(
+                "in tokens - for texts shorter than specified, if they don't fit into 75 token limit, move them to the next 75 token chunk"
+            ),
+            "sdxl_clip_l_skip": OptionInfo(False, "Clip skip SDXL", gr.Checkbox).info(
+                "Enable Clip skip for the secondary clip model in sdxl. Has no effect on SD 1.5 or SD 2.0/2.1."
+            ),
+            "CLIP_stop_at_last_layers": OptionInfo(
+                1,
+                "Clip skip",
+                gr.Slider,
+                {"minimum": 1, "maximum": 12, "step": 1},
+                infotext="Clip skip",
+            )
+            .link(
+                "wiki",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#clip-skip",
+            )
+            .info(
+                "ignore last layers of CLIP network; 1 ignores none, 2 ignores one layer"
+            ),
+            "upcast_attn": OptionInfo(False, "Upcast cross attention layer to float32"),
+            "randn_source": OptionInfo(
+                "GPU",
+                "Random number generator source.",
+                gr.Radio,
+                {"choices": ["GPU", "CPU", "NV"]},
+                infotext="RNG",
+            ).info(
+                "changes seeds drastically; use CPU to produce the same picture across different videocard vendors; use NV to produce same picture as on NVidia videocards"
+            ),
+            "tiling": OptionInfo(False, "Tiling", infotext="Tiling").info(
+                "produce a tileable picture"
+            ),
+            "hires_fix_refiner_pass": OptionInfo(
+                "second pass",
+                "Hires fix: which pass to enable refiner for",
+                gr.Radio,
+                {"choices": ["first pass", "second pass", "both passes"]},
+                infotext="Hires refiner",
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('sdxl', "Stable Diffusion XL", "sd"), {
-    "sdxl_crop_top": OptionInfo(0, "crop top coordinate"),
-    "sdxl_crop_left": OptionInfo(0, "crop left coordinate"),
-    "sdxl_refiner_low_aesthetic_score": OptionInfo(2.5, "SDXL low aesthetic score", gr.Number).info("used for refiner model negative prompt"),
-    "sdxl_refiner_high_aesthetic_score": OptionInfo(6.0, "SDXL high aesthetic score", gr.Number).info("used for refiner model prompt"),
-}))
+options_templates.update(
+    options_section(
+        ("sdxl", "Stable Diffusion XL", "sd"),
+        {
+            "sdxl_crop_top": OptionInfo(0, "crop top coordinate"),
+            "sdxl_crop_left": OptionInfo(0, "crop left coordinate"),
+            "sdxl_refiner_low_aesthetic_score": OptionInfo(
+                2.5, "SDXL low aesthetic score", gr.Number
+            ).info("used for refiner model negative prompt"),
+            "sdxl_refiner_high_aesthetic_score": OptionInfo(
+                6.0, "SDXL high aesthetic score", gr.Number
+            ).info("used for refiner model prompt"),
+        },
+    )
+)
 
-options_templates.update(options_section(('sd3', "Stable Diffusion 3", "sd"), {
-    "sd3_enable_t5": OptionInfo(False, "Enable T5").info("load T5 text encoder; increases VRAM use by a lot, potentially improving quality of generation; requires model reload to apply"),
-}))
+options_templates.update(
+    options_section(
+        ("sd3", "Stable Diffusion 3", "sd"),
+        {
+            "sd3_enable_t5": OptionInfo(False, "Enable T5").info(
+                "load T5 text encoder; increases VRAM use by a lot, potentially improving quality of generation; requires model reload to apply"
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('vae', "VAE", "sd"), {
-    "sd_vae_explanation": OptionHTML("""
+options_templates.update(
+    options_section(
+        ("vae", "VAE", "sd"),
+        {
+            "sd_vae_explanation": OptionHTML("""
 <abbr title='Variational autoencoder'>VAE</abbr> is a neural network that transforms a standard <abbr title='red/green/blue'>RGB</abbr>
 image into latent space representation and back. Latent space representation is what stable diffusion is working on during sampling
 (i.e. when the progress bar is between empty and full). For txt2img, VAE is used to create a resulting image after the sampling is finished.
 For img2img, VAE is used to process user's input image before the sampling, and to create an image after sampling.
 """),
-    "sd_vae_checkpoint_cache": OptionInfo(0, "VAE Checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
-    "sd_vae": OptionInfo("Automatic", "SD VAE", gr.Dropdown, lambda: {"choices": shared_items.sd_vae_items()}, refresh=shared_items.refresh_vae_list, infotext='VAE').info("choose VAE model: Automatic = use one with same filename as checkpoint; None = use VAE from checkpoint"),
-    "sd_vae_overrides_per_model_preferences": OptionInfo(True, "Selected VAE overrides per-model preferences").info("you can set per-model VAE either by editing user metadata for checkpoints, or by making the VAE have same name as checkpoint"),
-    "auto_vae_precision_bfloat16": OptionInfo(False, "Automatically convert VAE to bfloat16").info("triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image; if enabled, overrides the option below"),
-    "auto_vae_precision": OptionInfo(True, "Automatically revert VAE to 32-bit floats").info("triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image"),
-    "sd_vae_encode_method": OptionInfo("Full", "VAE type for encode", gr.Radio, {"choices": ["Full", "TAESD"]}, infotext='VAE Encoder').info("method to encode image to latent (use in img2img, hires-fix or inpaint mask)"),
-    "sd_vae_decode_method": OptionInfo("Full", "VAE type for decode", gr.Radio, {"choices": ["Full", "TAESD"]}, infotext='VAE Decoder').info("method to decode latent to image"),
-}))
+            "sd_vae_checkpoint_cache": OptionInfo(
+                0,
+                "VAE Checkpoints to cache in RAM",
+                gr.Slider,
+                {"minimum": 0, "maximum": 10, "step": 1},
+            ),
+            "sd_vae": OptionInfo(
+                "Automatic",
+                "SD VAE",
+                gr.Dropdown,
+                lambda: {"choices": shared_items.sd_vae_items()},
+                refresh=shared_items.refresh_vae_list,
+                infotext="VAE",
+            ).info(
+                "choose VAE model: Automatic = use one with same filename as checkpoint; None = use VAE from checkpoint"
+            ),
+            "sd_vae_overrides_per_model_preferences": OptionInfo(
+                True, "Selected VAE overrides per-model preferences"
+            ).info(
+                "you can set per-model VAE either by editing user metadata for checkpoints, or by making the VAE have same name as checkpoint"
+            ),
+            "auto_vae_precision_bfloat16": OptionInfo(
+                False, "Automatically convert VAE to bfloat16"
+            ).info(
+                "triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image; if enabled, overrides the option below"
+            ),
+            "auto_vae_precision": OptionInfo(
+                True, "Automatically revert VAE to 32-bit floats"
+            ).info(
+                "triggers when a tensor with NaNs is produced in VAE; disabling the option in this case will result in a black square image"
+            ),
+            "sd_vae_encode_method": OptionInfo(
+                "Full",
+                "VAE type for encode",
+                gr.Radio,
+                {"choices": ["Full", "TAESD"]},
+                infotext="VAE Encoder",
+            ).info(
+                "method to encode image to latent (use in img2img, hires-fix or inpaint mask)"
+            ),
+            "sd_vae_decode_method": OptionInfo(
+                "Full",
+                "VAE type for decode",
+                gr.Radio,
+                {"choices": ["Full", "TAESD"]},
+                infotext="VAE Decoder",
+            ).info("method to decode latent to image"),
+        },
+    )
+)
 
-options_templates.update(options_section(('img2img', "img2img", "sd"), {
-    "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Conditional mask weight'),
-    "initial_noise_multiplier": OptionInfo(1.0, "Noise multiplier for img2img", gr.Slider, {"minimum": 0.0, "maximum": 1.5, "step": 0.001}, infotext='Noise multiplier'),
-    "img2img_extra_noise": OptionInfo(0.0, "Extra noise multiplier for img2img and hires fix", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Extra noise').info("0 = disabled (default); should be lower than denoising strength"),
-    "img2img_color_correction": OptionInfo(False, "Apply color correction to img2img results to match original colors."),
-    "img2img_fix_steps": OptionInfo(False, "With img2img, do exactly the amount of steps the slider specifies.").info("normally you'd do less with less denoising"),
-    "img2img_background_color": OptionInfo("#ffffff", "With img2img, fill transparent parts of the input image with this color.", ui_components.FormColorPicker, {}),
-    "img2img_editor_height": OptionInfo(720, "Height of the image editor", gr.Slider, {"minimum": 80, "maximum": 1600, "step": 1}).info("in pixels").needs_reload_ui(),
-    "img2img_sketch_default_brush_color": OptionInfo("#ffffff", "Sketch initial brush color", ui_components.FormColorPicker, {}).info("default brush color of img2img sketch").needs_reload_ui(),
-    "img2img_inpaint_mask_brush_color": OptionInfo("#ffffff", "Inpaint mask brush color", ui_components.FormColorPicker,  {}).info("brush color of inpaint mask").needs_reload_ui(),
-    "img2img_inpaint_sketch_default_brush_color": OptionInfo("#ffffff", "Inpaint sketch initial brush color", ui_components.FormColorPicker, {}).info("default brush color of img2img inpaint sketch").needs_reload_ui(),
-    "return_mask": OptionInfo(False, "For inpainting, include the greyscale mask in results for web"),
-    "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
-    "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
-    "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
-}))
+options_templates.update(
+    options_section(
+        ("img2img", "img2img", "sd"),
+        {
+            "inpainting_mask_weight": OptionInfo(
+                1.0,
+                "Inpainting conditioning mask strength",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.0, "step": 0.01},
+                infotext="Conditional mask weight",
+            ),
+            "initial_noise_multiplier": OptionInfo(
+                1.0,
+                "Noise multiplier for img2img",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.5, "step": 0.001},
+                infotext="Noise multiplier",
+            ),
+            "img2img_extra_noise": OptionInfo(
+                0.0,
+                "Extra noise multiplier for img2img and hires fix",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.0, "step": 0.01},
+                infotext="Extra noise",
+            ).info("0 = disabled (default); should be lower than denoising strength"),
+            "img2img_color_correction": OptionInfo(
+                False,
+                "Apply color correction to img2img results to match original colors.",
+            ),
+            "img2img_fix_steps": OptionInfo(
+                False,
+                "With img2img, do exactly the amount of steps the slider specifies.",
+            ).info("normally you'd do less with less denoising"),
+            "img2img_background_color": OptionInfo(
+                "#ffffff",
+                "With img2img, fill transparent parts of the input image with this color.",
+                ui_components.FormColorPicker,
+                {},
+            ),
+            "img2img_editor_height": OptionInfo(
+                720,
+                "Height of the image editor",
+                gr.Slider,
+                {"minimum": 80, "maximum": 1600, "step": 1},
+            )
+            .info("in pixels")
+            .needs_reload_ui(),
+            "img2img_sketch_default_brush_color": OptionInfo(
+                "#ffffff",
+                "Sketch initial brush color",
+                ui_components.FormColorPicker,
+                {},
+            )
+            .info("default brush color of img2img sketch")
+            .needs_reload_ui(),
+            "img2img_inpaint_mask_brush_color": OptionInfo(
+                "#ffffff", "Inpaint mask brush color", ui_components.FormColorPicker, {}
+            )
+            .info("brush color of inpaint mask")
+            .needs_reload_ui(),
+            "img2img_inpaint_sketch_default_brush_color": OptionInfo(
+                "#ffffff",
+                "Inpaint sketch initial brush color",
+                ui_components.FormColorPicker,
+                {},
+            )
+            .info("default brush color of img2img inpaint sketch")
+            .needs_reload_ui(),
+            "return_mask": OptionInfo(
+                False, "For inpainting, include the greyscale mask in results for web"
+            ),
+            "return_mask_composite": OptionInfo(
+                False, "For inpainting, include masked composite in results for web"
+            ),
+            "img2img_batch_show_results_limit": OptionInfo(
+                32,
+                "Show the first N batch img2img results in UI",
+                gr.Slider,
+                {"minimum": -1, "maximum": 1000, "step": 1},
+            ).info("0: disable, -1: show all images. Too many images can cause lag"),
+            "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info(
+                "when inpainting, overlay the original image over the areas that weren't inpainted."
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {
-    "cross_attention_optimization": OptionInfo("Automatic", "Cross attention optimization", gr.Dropdown, lambda: {"choices": shared_items.cross_attention_optimizations()}),
-    "s_min_uncond": OptionInfo(0.0, "Negative Guidance minimum sigma", gr.Slider, {"minimum": 0.0, "maximum": 15.0, "step": 0.01}, infotext='NGMS').link("PR", "https://github.com/AUTOMATIC1111/stablediffusion-webui/pull/9177").info("skip negative prompt for some steps when the image is almost ready; 0=disable, higher=faster"),
-    "s_min_uncond_all": OptionInfo(False, "Negative Guidance minimum sigma all steps", infotext='NGMS all steps').info("By default, NGMS above skips every other step; this makes it skip all steps"),
-    "token_merging_ratio": OptionInfo(0.0, "Token merging ratio", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}, infotext='Token merging ratio').link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9256").info("0=disable, higher=faster"),
-    "token_merging_ratio_img2img": OptionInfo(0.0, "Token merging ratio for img2img", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}).info("only applies if non-zero and overrides above"),
-    "token_merging_ratio_hr": OptionInfo(0.0, "Token merging ratio for high-res pass", gr.Slider, {"minimum": 0.0, "maximum": 0.9, "step": 0.1}, infotext='Token merging ratio hr').info("only applies if non-zero and overrides above"),
-    "pad_cond_uncond": OptionInfo(False, "Pad prompt/negative prompt", infotext='Pad conds').info("improves performance when prompt and negative prompt have different lengths; changes seeds"),
-    "pad_cond_uncond_v0": OptionInfo(False, "Pad prompt/negative prompt (v0)", infotext='Pad conds v0').info("alternative implementation for the above; used prior to 1.6.0 for DDIM sampler; overrides the above if set; WARNING: truncates negative prompt if it's too long; changes seeds"),
-    "persistent_cond_cache": OptionInfo(True, "Persistent cond cache").info("do not recalculate conds from prompts if prompts have not changed since previous calculation"),
-    "batch_cond_uncond": OptionInfo(True, "Batch cond/uncond").info("do both conditional and unconditional denoising in one batch; uses a bit more VRAM during sampling, but improves speed; previously this was controlled by --always-batch-cond-uncond commandline argument"),
-    "fp8_storage": OptionInfo("Disable", "FP8 weight", gr.Radio, {"choices": ["Disable", "Enable for SDXL", "Enable"]}).info("Use FP8 to store Linear/Conv layers' weight. Require pytorch>=2.1.0."),
-    "cache_fp16_weight": OptionInfo(False, "Cache FP16 weight for LoRA").info("Cache fp16 weight when enabling FP8, will increase the quality of LoRA. Use more system ram."),
-}))
+options_templates.update(
+    options_section(
+        ("optimizations", "Optimizations", "sd"),
+        {
+            "cross_attention_optimization": OptionInfo(
+                "Automatic",
+                "Cross attention optimization",
+                gr.Dropdown,
+                lambda: {"choices": shared_items.cross_attention_optimizations()},
+            ),
+            "s_min_uncond": OptionInfo(
+                0.0,
+                "Negative Guidance minimum sigma",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 15.0, "step": 0.01},
+                infotext="NGMS",
+            )
+            .link(
+                "PR", "https://github.com/AUTOMATIC1111/stablediffusion-webui/pull/9177"
+            )
+            .info(
+                "skip negative prompt for some steps when the image is almost ready; 0=disable, higher=faster"
+            ),
+            "s_min_uncond_all": OptionInfo(
+                False,
+                "Negative Guidance minimum sigma all steps",
+                infotext="NGMS all steps",
+            ).info(
+                "By default, NGMS above skips every other step; this makes it skip all steps"
+            ),
+            "token_merging_ratio": OptionInfo(
+                0.0,
+                "Token merging ratio",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 0.9, "step": 0.1},
+                infotext="Token merging ratio",
+            )
+            .link(
+                "PR",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9256",
+            )
+            .info("0=disable, higher=faster"),
+            "token_merging_ratio_img2img": OptionInfo(
+                0.0,
+                "Token merging ratio for img2img",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 0.9, "step": 0.1},
+            ).info("only applies if non-zero and overrides above"),
+            "token_merging_ratio_hr": OptionInfo(
+                0.0,
+                "Token merging ratio for high-res pass",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 0.9, "step": 0.1},
+                infotext="Token merging ratio hr",
+            ).info("only applies if non-zero and overrides above"),
+            "pad_cond_uncond": OptionInfo(
+                False, "Pad prompt/negative prompt", infotext="Pad conds"
+            ).info(
+                "improves performance when prompt and negative prompt have different lengths; changes seeds"
+            ),
+            "pad_cond_uncond_v0": OptionInfo(
+                False, "Pad prompt/negative prompt (v0)", infotext="Pad conds v0"
+            ).info(
+                "alternative implementation for the above; used prior to 1.6.0 for DDIM sampler; overrides the above if set; WARNING: truncates negative prompt if it's too long; changes seeds"
+            ),
+            "persistent_cond_cache": OptionInfo(True, "Persistent cond cache").info(
+                "do not recalculate conds from prompts if prompts have not changed since previous calculation"
+            ),
+            "batch_cond_uncond": OptionInfo(True, "Batch cond/uncond").info(
+                "do both conditional and unconditional denoising in one batch; uses a bit more VRAM during sampling, but improves speed; previously this was controlled by --always-batch-cond-uncond commandline argument"
+            ),
+            "fp8_storage": OptionInfo(
+                "Disable",
+                "FP8 weight",
+                gr.Radio,
+                {"choices": ["Disable", "Enable for SDXL", "Enable"]},
+            ).info(
+                "Use FP8 to store Linear/Conv layers' weight. Require pytorch>=2.1.0."
+            ),
+            "cache_fp16_weight": OptionInfo(False, "Cache FP16 weight for LoRA").info(
+                "Cache fp16 weight when enabling FP8, will increase the quality of LoRA. Use more system ram."
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('compatibility', "Compatibility", "sd"), {
-    "auto_backcompat": OptionInfo(True, "Automatic backward compatibility").info("automatically enable options for backwards compatibility when importing generation parameters from infotext that has program version."),
-    "use_old_emphasis_implementation": OptionInfo(False, "Use old emphasis implementation. Can be useful to reproduce old seeds."),
-    "use_old_karras_scheduler_sigmas": OptionInfo(False, "Use old karras scheduler sigmas (0.1 to 10)."),
-    "no_dpmpp_sde_batch_determinism": OptionInfo(False, "Do not make DPM++ SDE deterministic across different batch sizes."),
-    "use_old_hires_fix_width_height": OptionInfo(False, "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to)."),
-    "hires_fix_use_firstpass_conds": OptionInfo(False, "For hires fix, calculate conds of second pass using extra networks of first pass."),
-    "use_old_scheduling": OptionInfo(False, "Use old prompt editing timelines.", infotext="Old prompt editing timelines").info("For [red:green:N]; old: If N < 1, it's a fraction of steps (and hires fix uses range from 0 to 1), if N >= 1, it's an absolute number of steps; new: If N has a decimal point in it, it's a fraction of steps (and hires fix uses range from 1 to 2), othewrwise it's an absolute number of steps"),
-    "use_downcasted_alpha_bar": OptionInfo(False, "Downcast model alphas_cumprod to fp16 before sampling. For reproducing old seeds.", infotext="Downcast alphas_cumprod"),
-    "refiner_switch_by_sample_steps": OptionInfo(False, "Switch to refiner by sampling steps instead of model timesteps. Old behavior for refiner.", infotext="Refiner switch by sampling steps")
-}))
+options_templates.update(
+    options_section(
+        ("compatibility", "Compatibility", "sd"),
+        {
+            "auto_backcompat": OptionInfo(
+                True, "Automatic backward compatibility"
+            ).info(
+                "automatically enable options for backwards compatibility when importing generation parameters from infotext that has program version."
+            ),
+            "use_old_emphasis_implementation": OptionInfo(
+                False,
+                "Use old emphasis implementation. Can be useful to reproduce old seeds.",
+            ),
+            "use_old_karras_scheduler_sigmas": OptionInfo(
+                False, "Use old karras scheduler sigmas (0.1 to 10)."
+            ),
+            "no_dpmpp_sde_batch_determinism": OptionInfo(
+                False,
+                "Do not make DPM++ SDE deterministic across different batch sizes.",
+            ),
+            "use_old_hires_fix_width_height": OptionInfo(
+                False,
+                "For hires fix, use width/height sliders to set final resolution rather than first pass (disables Upscale by, Resize width/height to).",
+            ),
+            "hires_fix_use_firstpass_conds": OptionInfo(
+                False,
+                "For hires fix, calculate conds of second pass using extra networks of first pass.",
+            ),
+            "use_old_scheduling": OptionInfo(
+                False,
+                "Use old prompt editing timelines.",
+                infotext="Old prompt editing timelines",
+            ).info(
+                "For [red:green:N]; old: If N < 1, it's a fraction of steps (and hires fix uses range from 0 to 1), if N >= 1, it's an absolute number of steps; new: If N has a decimal point in it, it's a fraction of steps (and hires fix uses range from 1 to 2), othewrwise it's an absolute number of steps"
+            ),
+            "use_downcasted_alpha_bar": OptionInfo(
+                False,
+                "Downcast model alphas_cumprod to fp16 before sampling. For reproducing old seeds.",
+                infotext="Downcast alphas_cumprod",
+            ),
+            "refiner_switch_by_sample_steps": OptionInfo(
+                False,
+                "Switch to refiner by sampling steps instead of model timesteps. Old behavior for refiner.",
+                infotext="Refiner switch by sampling steps",
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('interrogate', "Interrogate"), {
-    "interrogate_keep_models_in_memory": OptionInfo(False, "Keep models in VRAM"),
-    "interrogate_return_ranks": OptionInfo(False, "Include ranks of model tags matches in results.").info("booru only"),
-    "interrogate_clip_num_beams": OptionInfo(1, "BLIP: num_beams", gr.Slider, {"minimum": 1, "maximum": 16, "step": 1}),
-    "interrogate_clip_min_length": OptionInfo(24, "BLIP: minimum description length", gr.Slider, {"minimum": 1, "maximum": 128, "step": 1}),
-    "interrogate_clip_max_length": OptionInfo(48, "BLIP: maximum description length", gr.Slider, {"minimum": 1, "maximum": 256, "step": 1}),
-    "interrogate_clip_dict_limit": OptionInfo(1500, "CLIP: maximum number of lines in text file").info("0 = No limit"),
-    "interrogate_clip_skip_categories": OptionInfo([], "CLIP: skip inquire categories", gr.CheckboxGroup, lambda: {"choices": interrogate.category_types()}, refresh=interrogate.category_types),
-    "interrogate_deepbooru_score_threshold": OptionInfo(0.5, "deepbooru: score threshold", gr.Slider, {"minimum": 0, "maximum": 1, "step": 0.01}),
-    "deepbooru_sort_alpha": OptionInfo(True, "deepbooru: sort tags alphabetically").info("if not: sort by score"),
-    "deepbooru_use_spaces": OptionInfo(True, "deepbooru: use spaces in tags").info("if not: use underscores"),
-    "deepbooru_escape": OptionInfo(True, "deepbooru: escape (\\) brackets").info("so they are used as literal brackets and not for emphasis"),
-    "deepbooru_filter_tags": OptionInfo("", "deepbooru: filter out those tags").info("separate by comma"),
-}))
+options_templates.update(
+    options_section(
+        ("interrogate", "Interrogate"),
+        {
+            "interrogate_keep_models_in_memory": OptionInfo(
+                False, "Keep models in VRAM"
+            ),
+            "interrogate_return_ranks": OptionInfo(
+                False, "Include ranks of model tags matches in results."
+            ).info("booru only"),
+            "interrogate_clip_num_beams": OptionInfo(
+                1,
+                "BLIP: num_beams",
+                gr.Slider,
+                {"minimum": 1, "maximum": 16, "step": 1},
+            ),
+            "interrogate_clip_min_length": OptionInfo(
+                24,
+                "BLIP: minimum description length",
+                gr.Slider,
+                {"minimum": 1, "maximum": 128, "step": 1},
+            ),
+            "interrogate_clip_max_length": OptionInfo(
+                48,
+                "BLIP: maximum description length",
+                gr.Slider,
+                {"minimum": 1, "maximum": 256, "step": 1},
+            ),
+            "interrogate_clip_dict_limit": OptionInfo(
+                1500, "CLIP: maximum number of lines in text file"
+            ).info("0 = No limit"),
+            "interrogate_clip_skip_categories": OptionInfo(
+                [],
+                "CLIP: skip inquire categories",
+                gr.CheckboxGroup,
+                lambda: {"choices": interrogate.category_types()},
+                refresh=interrogate.category_types,
+            ),
+            "interrogate_deepbooru_score_threshold": OptionInfo(
+                0.5,
+                "deepbooru: score threshold",
+                gr.Slider,
+                {"minimum": 0, "maximum": 1, "step": 0.01},
+            ),
+            "deepbooru_sort_alpha": OptionInfo(
+                True, "deepbooru: sort tags alphabetically"
+            ).info("if not: sort by score"),
+            "deepbooru_use_spaces": OptionInfo(
+                True, "deepbooru: use spaces in tags"
+            ).info("if not: use underscores"),
+            "deepbooru_escape": OptionInfo(
+                True, "deepbooru: escape (\\) brackets"
+            ).info("so they are used as literal brackets and not for emphasis"),
+            "deepbooru_filter_tags": OptionInfo(
+                "", "deepbooru: filter out those tags"
+            ).info("separate by comma"),
+        },
+    )
+)
 
-options_templates.update(options_section(('extra_networks', "Extra Networks", "sd"), {
-    "extra_networks_show_hidden_directories": OptionInfo(True, "Show hidden directories").info("directory is hidden if its name starts with \".\"."),
-    "extra_networks_dir_button_function": OptionInfo(False, "Add a '/' to the beginning of directory buttons").info("Buttons will display the contents of the selected directory without acting as a search filter."),
-    "extra_networks_hidden_models": OptionInfo("When searched", "Show cards for models in hidden directories", gr.Radio, {"choices": ["Always", "When searched", "Never"]}).info('"When searched" option will only show the item when the search string has 4 characters or more'),
-    "extra_networks_default_multiplier": OptionInfo(1.0, "Default multiplier for extra networks", gr.Slider, {"minimum": 0.0, "maximum": 2.0, "step": 0.01}),
-    "extra_networks_card_width": OptionInfo(0, "Card width for Extra Networks").info("in pixels"),
-    "extra_networks_card_height": OptionInfo(0, "Card height for Extra Networks").info("in pixels"),
-    "extra_networks_card_text_scale": OptionInfo(1.0, "Card text scale", gr.Slider, {"minimum": 0.0, "maximum": 2.0, "step": 0.01}).info("1 = original size"),
-    "extra_networks_card_show_desc": OptionInfo(True, "Show description on card"),
-    "extra_networks_card_description_is_html": OptionInfo(False, "Treat card description as HTML"),
-    "extra_networks_card_order_field": OptionInfo("Path", "Default order field for Extra Networks cards", gr.Dropdown, {"choices": ['Path', 'Name', 'Date Created', 'Date Modified']}).needs_reload_ui(),
-    "extra_networks_card_order": OptionInfo("Ascending", "Default order for Extra Networks cards", gr.Dropdown, {"choices": ['Ascending', 'Descending']}).needs_reload_ui(),
-    "extra_networks_tree_view_style": OptionInfo("Dirs", "Extra Networks directory view style", gr.Radio, {"choices": ["Tree", "Dirs"]}).needs_reload_ui(),
-    "extra_networks_tree_view_default_enabled": OptionInfo(True, "Show the Extra Networks directory view by default").needs_reload_ui(),
-    "extra_networks_tree_view_default_width": OptionInfo(180, "Default width for the Extra Networks directory tree view", gr.Number).needs_reload_ui(),
-    "extra_networks_add_text_separator": OptionInfo(" ", "Extra networks separator").info("extra text to add before <...> when adding extra network to prompt"),
-    "ui_extra_networks_tab_reorder": OptionInfo("", "Extra networks tab order").needs_reload_ui(),
-    "textual_inversion_print_at_load": OptionInfo(False, "Print a list of Textual Inversion embeddings when loading model"),
-    "textual_inversion_add_hashes_to_infotext": OptionInfo(True, "Add Textual Inversion hashes to infotext"),
-    "sd_hypernetwork": OptionInfo("None", "Add hypernetwork to prompt", gr.Dropdown, lambda: {"choices": ["None", *shared.hypernetworks]}, refresh=shared_items.reload_hypernetworks),
-}))
+options_templates.update(
+    options_section(
+        ("extra_networks", "Extra Networks", "sd"),
+        {
+            "extra_networks_show_hidden_directories": OptionInfo(
+                True, "Show hidden directories"
+            ).info('directory is hidden if its name starts with ".".'),
+            "extra_networks_dir_button_function": OptionInfo(
+                False, "Add a '/' to the beginning of directory buttons"
+            ).info(
+                "Buttons will display the contents of the selected directory without acting as a search filter."
+            ),
+            "extra_networks_hidden_models": OptionInfo(
+                "When searched",
+                "Show cards for models in hidden directories",
+                gr.Radio,
+                {"choices": ["Always", "When searched", "Never"]},
+            ).info(
+                '"When searched" option will only show the item when the search string has 4 characters or more'
+            ),
+            "extra_networks_default_multiplier": OptionInfo(
+                1.0,
+                "Default multiplier for extra networks",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 2.0, "step": 0.01},
+            ),
+            "extra_networks_card_width": OptionInfo(
+                0, "Card width for Extra Networks"
+            ).info("in pixels"),
+            "extra_networks_card_height": OptionInfo(
+                0, "Card height for Extra Networks"
+            ).info("in pixels"),
+            "extra_networks_card_text_scale": OptionInfo(
+                1.0,
+                "Card text scale",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 2.0, "step": 0.01},
+            ).info("1 = original size"),
+            "extra_networks_card_show_desc": OptionInfo(
+                True, "Show description on card"
+            ),
+            "extra_networks_card_description_is_html": OptionInfo(
+                False, "Treat card description as HTML"
+            ),
+            "extra_networks_card_order_field": OptionInfo(
+                "Path",
+                "Default order field for Extra Networks cards",
+                gr.Dropdown,
+                {"choices": ["Path", "Name", "Date Created", "Date Modified"]},
+            ).needs_reload_ui(),
+            "extra_networks_card_order": OptionInfo(
+                "Ascending",
+                "Default order for Extra Networks cards",
+                gr.Dropdown,
+                {"choices": ["Ascending", "Descending"]},
+            ).needs_reload_ui(),
+            "extra_networks_tree_view_style": OptionInfo(
+                "Dirs",
+                "Extra Networks directory view style",
+                gr.Radio,
+                {"choices": ["Tree", "Dirs"]},
+            ).needs_reload_ui(),
+            "extra_networks_tree_view_default_enabled": OptionInfo(
+                True, "Show the Extra Networks directory view by default"
+            ).needs_reload_ui(),
+            "extra_networks_tree_view_default_width": OptionInfo(
+                180,
+                "Default width for the Extra Networks directory tree view",
+                gr.Number,
+            ).needs_reload_ui(),
+            "extra_networks_add_text_separator": OptionInfo(
+                " ", "Extra networks separator"
+            ).info(
+                "extra text to add before <...> when adding extra network to prompt"
+            ),
+            "ui_extra_networks_tab_reorder": OptionInfo(
+                "", "Extra networks tab order"
+            ).needs_reload_ui(),
+            "textual_inversion_print_at_load": OptionInfo(
+                False, "Print a list of Textual Inversion embeddings when loading model"
+            ),
+            "textual_inversion_add_hashes_to_infotext": OptionInfo(
+                True, "Add Textual Inversion hashes to infotext"
+            ),
+            "sd_hypernetwork": OptionInfo(
+                "None",
+                "Add hypernetwork to prompt",
+                gr.Dropdown,
+                lambda: {"choices": ["None", *shared.hypernetworks]},
+                refresh=shared_items.reload_hypernetworks,
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('ui_prompt_editing', "Prompt editing", "ui"), {
-    "keyedit_precision_attention": OptionInfo(0.1, "Precision for (attention:1.1) when editing the prompt with Ctrl+up/down", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
-    "keyedit_precision_extra": OptionInfo(0.05, "Precision for <extra networks:0.9> when editing the prompt with Ctrl+up/down", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
-    "keyedit_delimiters": OptionInfo(r".,\/!?%^*;:{}=`~() ", "Word delimiters when editing the prompt with Ctrl+up/down"),
-    "keyedit_delimiters_whitespace": OptionInfo(["Tab", "Carriage Return", "Line Feed"], "Ctrl+up/down whitespace delimiters", gr.CheckboxGroup, lambda: {"choices": ["Tab", "Carriage Return", "Line Feed"]}),
-    "keyedit_move": OptionInfo(True, "Alt+left/right moves prompt elements"),
-    "disable_token_counters": OptionInfo(False, "Disable prompt token counters"),
-    "include_styles_into_token_counters": OptionInfo(True, "Count tokens of enabled styles").info("When calculating how many tokens the prompt has, also consider tokens added by enabled styles."),
-}))
+options_templates.update(
+    options_section(
+        ("ui_prompt_editing", "Prompt editing", "ui"),
+        {
+            "keyedit_precision_attention": OptionInfo(
+                0.1,
+                "Precision for (attention:1.1) when editing the prompt with Ctrl+up/down",
+                gr.Slider,
+                {"minimum": 0.01, "maximum": 0.2, "step": 0.001},
+            ),
+            "keyedit_precision_extra": OptionInfo(
+                0.05,
+                "Precision for <extra networks:0.9> when editing the prompt with Ctrl+up/down",
+                gr.Slider,
+                {"minimum": 0.01, "maximum": 0.2, "step": 0.001},
+            ),
+            "keyedit_delimiters": OptionInfo(
+                r".,\/!?%^*;:{}=`~() ",
+                "Word delimiters when editing the prompt with Ctrl+up/down",
+            ),
+            "keyedit_delimiters_whitespace": OptionInfo(
+                ["Tab", "Carriage Return", "Line Feed"],
+                "Ctrl+up/down whitespace delimiters",
+                gr.CheckboxGroup,
+                lambda: {"choices": ["Tab", "Carriage Return", "Line Feed"]},
+            ),
+            "keyedit_move": OptionInfo(True, "Alt+left/right moves prompt elements"),
+            "disable_token_counters": OptionInfo(
+                False, "Disable prompt token counters"
+            ),
+            "include_styles_into_token_counters": OptionInfo(
+                True, "Count tokens of enabled styles"
+            ).info(
+                "When calculating how many tokens the prompt has, also consider tokens added by enabled styles."
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
-    "return_grid": OptionInfo(True, "Show grid in gallery"),
-    "do_not_show_images": OptionInfo(False, "Do not show any images in gallery"),
-    "js_modal_lightbox": OptionInfo(True, "Full page image viewer: enable"),
-    "js_modal_lightbox_initially_zoomed": OptionInfo(True, "Full page image viewer: show images zoomed in by default"),
-    "js_modal_lightbox_gamepad": OptionInfo(False, "Full page image viewer: navigate with gamepad"),
-    "js_modal_lightbox_gamepad_repeat": OptionInfo(250, "Full page image viewer: gamepad repeat period").info("in milliseconds"),
-    "sd_webui_modal_lightbox_icon_opacity": OptionInfo(1, "Full page image viewer: control icon unfocused opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
-    "sd_webui_modal_lightbox_toolbar_opacity": OptionInfo(0.9, "Full page image viewer: tool bar opacity", gr.Slider, {"minimum": 0.0, "maximum": 1, "step": 0.01}, onchange=shared.reload_gradio_theme).info('for mouse only').needs_reload_ui(),
-    "gallery_height": OptionInfo("", "Gallery height", gr.Textbox).info("can be any valid CSS value, for example 768px or 20em").needs_reload_ui(),
-    "open_dir_button_choice": OptionInfo("Subdirectory", "What directory the [📂] button opens", gr.Radio, {"choices": ["Output Root", "Subdirectory", "Subdirectory (even temp dir)"]}),
-}))
+options_templates.update(
+    options_section(
+        ("ui_gallery", "Gallery", "ui"),
+        {
+            "return_grid": OptionInfo(True, "Show grid in gallery"),
+            "do_not_show_images": OptionInfo(
+                False, "Do not show any images in gallery"
+            ),
+            "js_modal_lightbox": OptionInfo(True, "Full page image viewer: enable"),
+            "js_modal_lightbox_initially_zoomed": OptionInfo(
+                True, "Full page image viewer: show images zoomed in by default"
+            ),
+            "js_modal_lightbox_gamepad": OptionInfo(
+                False, "Full page image viewer: navigate with gamepad"
+            ),
+            "js_modal_lightbox_gamepad_repeat": OptionInfo(
+                250, "Full page image viewer: gamepad repeat period"
+            ).info("in milliseconds"),
+            "sd_webui_modal_lightbox_icon_opacity": OptionInfo(
+                1,
+                "Full page image viewer: control icon unfocused opacity",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1, "step": 0.01},
+                onchange=shared.reload_gradio_theme,
+            )
+            .info("for mouse only")
+            .needs_reload_ui(),
+            "sd_webui_modal_lightbox_toolbar_opacity": OptionInfo(
+                0.9,
+                "Full page image viewer: tool bar opacity",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1, "step": 0.01},
+                onchange=shared.reload_gradio_theme,
+            )
+            .info("for mouse only")
+            .needs_reload_ui(),
+            "gallery_height": OptionInfo("", "Gallery height", gr.Textbox)
+            .info("can be any valid CSS value, for example 768px or 20em")
+            .needs_reload_ui(),
+            "open_dir_button_choice": OptionInfo(
+                "Subdirectory",
+                "What directory the [📂] button opens",
+                gr.Radio,
+                {
+                    "choices": [
+                        "Output Root",
+                        "Subdirectory",
+                        "Subdirectory (even temp dir)",
+                    ]
+                },
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {
-    "compact_prompt_box": OptionInfo(False, "Compact prompt layout").info("puts prompt and negative prompt inside the Generate tab, leaving more vertical space for the image on the right").needs_reload_ui(),
-    "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group").needs_reload_ui(),
-    "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row").needs_reload_ui(),
-    "sd_checkpoint_dropdown_use_short": OptionInfo(False, "Checkpoint dropdown: use filenames without paths").info("models in subdirectories like photo/sd15.ckpt will be listed as just sd15.ckpt"),
-    "hires_fix_show_sampler": OptionInfo(False, "Hires fix: show hires checkpoint and sampler selection").needs_reload_ui(),
-    "hires_fix_show_prompts": OptionInfo(False, "Hires fix: show hires prompt and negative prompt").needs_reload_ui(),
-    "txt2img_settings_accordion": OptionInfo(False, "Settings in txt2img hidden under Accordion").needs_reload_ui(),
-    "img2img_settings_accordion": OptionInfo(False, "Settings in img2img hidden under Accordion").needs_reload_ui(),
-    "interrupt_after_current": OptionInfo(True, "Don't Interrupt in the middle").info("when using Interrupt button, if generating more than one image, stop after the generation of an image has finished, instead of immediately"),
-}))
+options_templates.update(
+    options_section(
+        ("ui_alternatives", "UI alternatives", "ui"),
+        {
+            "compact_prompt_box": OptionInfo(False, "Compact prompt layout")
+            .info(
+                "puts prompt and negative prompt inside the Generate tab, leaving more vertical space for the image on the right"
+            )
+            .needs_reload_ui(),
+            "samplers_in_dropdown": OptionInfo(
+                True, "Use dropdown for sampler selection instead of radio group"
+            ).needs_reload_ui(),
+            "dimensions_and_batch_together": OptionInfo(
+                True, "Show Width/Height and Batch sliders in same row"
+            ).needs_reload_ui(),
+            "sd_checkpoint_dropdown_use_short": OptionInfo(
+                False, "Checkpoint dropdown: use filenames without paths"
+            ).info(
+                "models in subdirectories like photo/sd15.ckpt will be listed as just sd15.ckpt"
+            ),
+            "hires_fix_show_sampler": OptionInfo(
+                False, "Hires fix: show hires checkpoint and sampler selection"
+            ).needs_reload_ui(),
+            "hires_fix_show_prompts": OptionInfo(
+                False, "Hires fix: show hires prompt and negative prompt"
+            ).needs_reload_ui(),
+            "txt2img_settings_accordion": OptionInfo(
+                False, "Settings in txt2img hidden under Accordion"
+            ).needs_reload_ui(),
+            "img2img_settings_accordion": OptionInfo(
+                False, "Settings in img2img hidden under Accordion"
+            ).needs_reload_ui(),
+            "interrupt_after_current": OptionInfo(
+                True, "Don't Interrupt in the middle"
+            ).info(
+                "when using Interrupt button, if generating more than one image, stop after the generation of an image has finished, instead of immediately"
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('ui', "User interface", "ui"), {
-    "localization": OptionInfo("None", "Localization", gr.Dropdown, lambda: {"choices": ["None"] + list(localization.localizations.keys())}, refresh=lambda: localization.list_localizations(cmd_opts.localizations_dir)).needs_reload_ui(),
-    "quicksettings_list": OptionInfo(["sd_model_checkpoint"], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(shared.opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear at the top of page rather than in settings tab").needs_reload_ui(),
-    "ui_tab_order": OptionInfo([], "UI tab order", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
-    "hidden_tabs": OptionInfo([], "Hidden UI tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
-    "ui_reorder_list": OptionInfo([], "UI item order for txt2img/img2img tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared_items.ui_reorder_categories())}).info("selected items appear first").needs_reload_ui(),
-    "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
-    "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
-    "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
-    "send_seed": OptionInfo(True, "Send seed when sending prompt or image to other interface"),
-    "send_size": OptionInfo(True, "Send size when sending prompt or image to another interface"),
-    "enable_reloading_ui_scripts": OptionInfo(False, "Reload UI scripts when using Reload UI option").info("useful for developing: if you make changes to UI scripts code, it is applied when the UI is reloded."),
+options_templates.update(
+    options_section(
+        ("ui", "User interface", "ui"),
+        {
+            "localization": OptionInfo(
+                "None",
+                "Localization",
+                gr.Dropdown,
+                lambda: {"choices": ["None"] + list(localization.localizations.keys())},
+                refresh=lambda: localization.list_localizations(
+                    cmd_opts.localizations_dir
+                ),
+            ).needs_reload_ui(),
+            "quicksettings_list": OptionInfo(
+                ["sd_model_checkpoint"],
+                "Quicksettings list",
+                ui_components.DropdownMulti,
+                lambda: {"choices": list(shared.opts.data_labels.keys())},
+            )
+            .js("info", "settingsHintsShowQuicksettings")
+            .info(
+                "setting entries that appear at the top of page rather than in settings tab"
+            )
+            .needs_reload_ui(),
+            "ui_tab_order": OptionInfo(
+                [],
+                "UI tab order",
+                ui_components.DropdownMulti,
+                lambda: {"choices": list(shared.tab_names)},
+            ).needs_reload_ui(),
+            "hidden_tabs": OptionInfo(
+                [],
+                "Hidden UI tabs",
+                ui_components.DropdownMulti,
+                lambda: {"choices": list(shared.tab_names)},
+            ).needs_reload_ui(),
+            "ui_reorder_list": OptionInfo(
+                [],
+                "UI item order for txt2img/img2img tabs",
+                ui_components.DropdownMulti,
+                lambda: {"choices": list(shared_items.ui_reorder_categories())},
+            )
+            .info("selected items appear first")
+            .needs_reload_ui(),
+            "gradio_theme": OptionInfo(
+                "Default",
+                "Gradio theme",
+                ui_components.DropdownEditable,
+                lambda: {
+                    "choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes
+                },
+            )
+            .info(
+                "you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>."
+            )
+            .needs_reload_ui(),
+            "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info(
+                "disable to update the selected Gradio theme"
+            ),
+            "show_progress_in_title": OptionInfo(
+                True, "Show generation progress in window title."
+            ),
+            "send_seed": OptionInfo(
+                True, "Send seed when sending prompt or image to other interface"
+            ),
+            "send_size": OptionInfo(
+                True, "Send size when sending prompt or image to another interface"
+            ),
+            "enable_reloading_ui_scripts": OptionInfo(
+                False, "Reload UI scripts when using Reload UI option"
+            ).info(
+                "useful for developing: if you make changes to UI scripts code, it is applied when the UI is reloded."
+            ),
+        },
+    )
+)
 
-}))
 
-
-options_templates.update(options_section(('infotext', "Infotext", "ui"), {
-    "infotext_explanation": OptionHTML("""
+options_templates.update(
+    options_section(
+        ("infotext", "Infotext", "ui"),
+        {
+            "infotext_explanation": OptionHTML("""
 Infotext is what this software calls the text that contains generation parameters and can be used to generate the same picture again.
 It is displayed in UI below the image. To use infotext, paste it into the prompt and click the ↙️ paste button.
 """),
-    "enable_pnginfo": OptionInfo(True, "Write infotext to metadata of the generated image"),
-    "save_txt": OptionInfo(False, "Create a text file with infotext next to every generated image"),
-
-    "add_model_name_to_info": OptionInfo(True, "Add model name to infotext"),
-    "add_model_hash_to_info": OptionInfo(True, "Add model hash to infotext"),
-    "add_vae_name_to_info": OptionInfo(True, "Add VAE name to infotext"),
-    "add_vae_hash_to_info": OptionInfo(True, "Add VAE hash to infotext"),
-    "add_user_name_to_info": OptionInfo(False, "Add user name to infotext when authenticated"),
-    "add_version_to_infotext": OptionInfo(True, "Add program version to infotext"),
-    "disable_weights_auto_swap": OptionInfo(True, "Disregard checkpoint information from pasted infotext").info("when reading generation parameters from text into UI"),
-    "infotext_skip_pasting": OptionInfo([], "Disregard fields from pasted infotext", ui_components.DropdownMulti, lambda: {"choices": shared_items.get_infotext_names()}),
-    "infotext_styles": OptionInfo("Apply if any", "Infer styles from prompts of pasted infotext", gr.Radio, {"choices": ["Ignore", "Apply", "Discard", "Apply if any"]}).info("when reading generation parameters from text into UI)").html("""<ul style='margin-left: 1.5em'>
+            "enable_pnginfo": OptionInfo(
+                True, "Write infotext to metadata of the generated image"
+            ),
+            "save_txt": OptionInfo(
+                False, "Create a text file with infotext next to every generated image"
+            ),
+            "add_model_name_to_info": OptionInfo(True, "Add model name to infotext"),
+            "add_model_hash_to_info": OptionInfo(True, "Add model hash to infotext"),
+            "add_vae_name_to_info": OptionInfo(True, "Add VAE name to infotext"),
+            "add_vae_hash_to_info": OptionInfo(True, "Add VAE hash to infotext"),
+            "add_user_name_to_info": OptionInfo(
+                False, "Add user name to infotext when authenticated"
+            ),
+            "add_version_to_infotext": OptionInfo(
+                True, "Add program version to infotext"
+            ),
+            "disable_weights_auto_swap": OptionInfo(
+                True, "Disregard checkpoint information from pasted infotext"
+            ).info("when reading generation parameters from text into UI"),
+            "infotext_skip_pasting": OptionInfo(
+                [],
+                "Disregard fields from pasted infotext",
+                ui_components.DropdownMulti,
+                lambda: {"choices": shared_items.get_infotext_names()},
+            ),
+            "infotext_styles": OptionInfo(
+                "Apply if any",
+                "Infer styles from prompts of pasted infotext",
+                gr.Radio,
+                {"choices": ["Ignore", "Apply", "Discard", "Apply if any"]},
+            )
+            .info("when reading generation parameters from text into UI)")
+            .html("""<ul style='margin-left: 1.5em'>
 <li>Ignore: keep prompt and styles dropdown as it is.</li>
 <li>Apply: remove style text from prompt, always replace styles dropdown value with found styles (even if none are found).</li>
 <li>Discard: remove style text from prompt, keep styles dropdown as it is.</li>
 <li>Apply if any: remove style text from prompt; if any styles are found in prompt, put them into styles dropdown, otherwise keep it as it is.</li>
 </ul>"""),
+        },
+    )
+)
 
-}))
+options_templates.update(
+    options_section(
+        ("ui", "Live previews", "ui"),
+        {
+            "show_progressbar": OptionInfo(True, "Show progressbar"),
+            "live_previews_enable": OptionInfo(
+                True, "Show live previews of the created image"
+            ),
+            "live_previews_image_format": OptionInfo(
+                "png",
+                "Live preview file format",
+                gr.Radio,
+                {"choices": ["jpeg", "png", "webp"]},
+            ),
+            "show_progress_grid": OptionInfo(
+                True, "Show previews of all images generated in a batch as a grid"
+            ),
+            "show_progress_every_n_steps": OptionInfo(
+                10,
+                "Live preview display period",
+                gr.Slider,
+                {"minimum": -1, "maximum": 32, "step": 1},
+            ).info(
+                "in sampling steps - show new live preview image every N sampling steps; -1 = only show after completion of batch"
+            ),
+            "show_progress_type": OptionInfo(
+                "Approx NN",
+                "Live preview method",
+                gr.Radio,
+                {"choices": ["Full", "Approx NN", "Approx cheap", "TAESD"]},
+            ).info(
+                "Full = slow but pretty; Approx NN and TAESD = fast but low quality; Approx cheap = super fast but terrible otherwise"
+            ),
+            "live_preview_allow_lowvram_full": OptionInfo(
+                False, "Allow Full live preview method with lowvram/medvram"
+            ).info(
+                "If not, Approx NN will be used instead; Full live preview method is very detrimental to speed if lowvram/medvram optimizations are enabled"
+            ),
+            "live_preview_content": OptionInfo(
+                "Prompt",
+                "Live preview subject",
+                gr.Radio,
+                {"choices": ["Combined", "Prompt", "Negative prompt"]},
+            ),
+            "live_preview_refresh_period": OptionInfo(
+                1000, "Progressbar and preview update period"
+            ).info("in milliseconds"),
+            "live_preview_fast_interrupt": OptionInfo(
+                False, "Return image with chosen live preview method on interrupt"
+            ).info("makes interrupts faster"),
+            "js_live_preview_in_modal_lightbox": OptionInfo(
+                False, "Show Live preview in full page image viewer"
+            ),
+            "prevent_screen_sleep_during_generation": OptionInfo(
+                True, "Prevent screen sleep during generation"
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('ui', "Live previews", "ui"), {
-    "show_progressbar": OptionInfo(True, "Show progressbar"),
-    "live_previews_enable": OptionInfo(True, "Show live previews of the created image"),
-    "live_previews_image_format": OptionInfo("png", "Live preview file format", gr.Radio, {"choices": ["jpeg", "png", "webp"]}),
-    "show_progress_grid": OptionInfo(True, "Show previews of all images generated in a batch as a grid"),
-    "show_progress_every_n_steps": OptionInfo(10, "Live preview display period", gr.Slider, {"minimum": -1, "maximum": 32, "step": 1}).info("in sampling steps - show new live preview image every N sampling steps; -1 = only show after completion of batch"),
-    "show_progress_type": OptionInfo("Approx NN", "Live preview method", gr.Radio, {"choices": ["Full", "Approx NN", "Approx cheap", "TAESD"]}).info("Full = slow but pretty; Approx NN and TAESD = fast but low quality; Approx cheap = super fast but terrible otherwise"),
-    "live_preview_allow_lowvram_full": OptionInfo(False, "Allow Full live preview method with lowvram/medvram").info("If not, Approx NN will be used instead; Full live preview method is very detrimental to speed if lowvram/medvram optimizations are enabled"),
-    "live_preview_content": OptionInfo("Prompt", "Live preview subject", gr.Radio, {"choices": ["Combined", "Prompt", "Negative prompt"]}),
-    "live_preview_refresh_period": OptionInfo(1000, "Progressbar and preview update period").info("in milliseconds"),
-    "live_preview_fast_interrupt": OptionInfo(False, "Return image with chosen live preview method on interrupt").info("makes interrupts faster"),
-    "js_live_preview_in_modal_lightbox": OptionInfo(False, "Show Live preview in full page image viewer"),
-    "prevent_screen_sleep_during_generation": OptionInfo(True, "Prevent screen sleep during generation"),
-}))
+options_templates.update(
+    options_section(
+        ("sampler-params", "Sampler parameters", "sd"),
+        {
+            "hide_samplers": OptionInfo(
+                [],
+                "Hide samplers in user interface",
+                gr.CheckboxGroup,
+                lambda: {"choices": [x.name for x in shared_items.list_samplers()]},
+            ).needs_reload_ui(),
+            "eta_ddim": OptionInfo(
+                0.0,
+                "Eta for DDIM",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.0, "step": 0.01},
+                infotext="Eta DDIM",
+            ).info("noise multiplier; higher = more unpredictable results"),
+            "eta_ancestral": OptionInfo(
+                1.0,
+                "Eta for k-diffusion samplers",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.0, "step": 0.01},
+                infotext="Eta",
+            ).info(
+                "noise multiplier; currently only applies to ancestral samplers (i.e. Euler a) and SDE samplers"
+            ),
+            "ddim_discretize": OptionInfo(
+                "uniform",
+                "img2img DDIM discretize",
+                gr.Radio,
+                {"choices": ["uniform", "quad"]},
+            ),
+            "s_churn": OptionInfo(
+                0.0,
+                "sigma churn",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 100.0, "step": 0.01},
+                infotext="Sigma churn",
+            ).info("amount of stochasticity; only applies to Euler, Heun, and DPM2"),
+            "s_tmin": OptionInfo(
+                0.0,
+                "sigma tmin",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 10.0, "step": 0.01},
+                infotext="Sigma tmin",
+            ).info(
+                "enable stochasticity; start value of the sigma range; only applies to Euler, Heun, and DPM2"
+            ),
+            "s_tmax": OptionInfo(
+                0.0,
+                "sigma tmax",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 999.0, "step": 0.01},
+                infotext="Sigma tmax",
+            ).info(
+                "0 = inf; end value of the sigma range; only applies to Euler, Heun, and DPM2"
+            ),
+            "s_noise": OptionInfo(
+                1.0,
+                "sigma noise",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.1, "step": 0.001},
+                infotext="Sigma noise",
+            ).info(
+                "amount of additional noise to counteract loss of detail during sampling"
+            ),
+            "sigma_min": OptionInfo(
+                0.0, "sigma min", gr.Number, infotext="Schedule min sigma"
+            ).info(
+                "0 = default (~0.03); minimum noise strength for k-diffusion noise scheduler"
+            ),
+            "sigma_max": OptionInfo(
+                0.0, "sigma max", gr.Number, infotext="Schedule max sigma"
+            ).info(
+                "0 = default (~14.6); maximum noise strength for k-diffusion noise scheduler"
+            ),
+            "rho": OptionInfo(0.0, "rho", gr.Number, infotext="Schedule rho").info(
+                "0 = default (7 for karras, 1 for polyexponential); higher values result in a steeper noise schedule (decreases faster)"
+            ),
+            "eta_noise_seed_delta": OptionInfo(
+                0, "Eta noise seed delta", gr.Number, {"precision": 0}, infotext="ENSD"
+            ).info(
+                "ENSD; does not improve anything, just produces different results for ancestral samplers - only useful for reproducing images"
+            ),
+            "always_discard_next_to_last_sigma": OptionInfo(
+                False,
+                "Always discard next-to-last sigma",
+                infotext="Discard penultimate sigma",
+            ).link(
+                "PR",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6044",
+            ),
+            "sgm_noise_multiplier": OptionInfo(
+                False, "SGM noise multiplier", infotext="SGM noise multiplier"
+            )
+            .link(
+                "PR",
+                "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12818",
+            )
+            .info(
+                "Match initial noise to official SDXL implementation - only useful for reproducing images"
+            ),
+            "uni_pc_variant": OptionInfo(
+                "bh1",
+                "UniPC variant",
+                gr.Radio,
+                {"choices": ["bh1", "bh2", "vary_coeff"]},
+                infotext="UniPC variant",
+            ),
+            "uni_pc_skip_type": OptionInfo(
+                "time_uniform",
+                "UniPC skip type",
+                gr.Radio,
+                {"choices": ["time_uniform", "time_quadratic", "logSNR"]},
+                infotext="UniPC skip type",
+            ),
+            "uni_pc_order": OptionInfo(
+                3,
+                "UniPC order",
+                gr.Slider,
+                {"minimum": 1, "maximum": 50, "step": 1},
+                infotext="UniPC order",
+            ).info("must be < sampling steps"),
+            "uni_pc_lower_order_final": OptionInfo(
+                True, "UniPC lower order final", infotext="UniPC lower order final"
+            ),
+            "sd_noise_schedule": OptionInfo(
+                "Default",
+                "Noise schedule for sampling",
+                gr.Radio,
+                {"choices": ["Default", "Zero Terminal SNR"]},
+                infotext="Noise Schedule",
+            ).info("for use with zero terminal SNR trained models"),
+            "skip_early_cond": OptionInfo(
+                0.0,
+                "Ignore negative prompt during early sampling",
+                gr.Slider,
+                {"minimum": 0.0, "maximum": 1.0, "step": 0.01},
+                infotext="Skip Early CFG",
+            ).info(
+                "disables CFG on a proportion of steps at the beginning of generation; 0=skip none; 1=skip all; can both improve sample diversity/quality and speed up sampling"
+            ),
+            "beta_dist_alpha": OptionInfo(
+                0.6,
+                "Beta scheduler - alpha",
+                gr.Slider,
+                {"minimum": 0.01, "maximum": 1.0, "step": 0.01},
+                infotext="Beta scheduler alpha",
+            ).info(
+                "Default = 0.6; the alpha parameter of the beta distribution used in Beta sampling"
+            ),
+            "beta_dist_beta": OptionInfo(
+                0.6,
+                "Beta scheduler - beta",
+                gr.Slider,
+                {"minimum": 0.01, "maximum": 1.0, "step": 0.01},
+                infotext="Beta scheduler beta",
+            ).info(
+                "Default = 0.6; the beta parameter of the beta distribution used in Beta sampling"
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('sampler-params', "Sampler parameters", "sd"), {
-    "hide_samplers": OptionInfo([], "Hide samplers in user interface", gr.CheckboxGroup, lambda: {"choices": [x.name for x in shared_items.list_samplers()]}).needs_reload_ui(),
-    "eta_ddim": OptionInfo(0.0, "Eta for DDIM", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Eta DDIM').info("noise multiplier; higher = more unpredictable results"),
-    "eta_ancestral": OptionInfo(1.0, "Eta for k-diffusion samplers", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Eta').info("noise multiplier; currently only applies to ancestral samplers (i.e. Euler a) and SDE samplers"),
-    "ddim_discretize": OptionInfo('uniform', "img2img DDIM discretize", gr.Radio, {"choices": ['uniform', 'quad']}),
-    's_churn': OptionInfo(0.0, "sigma churn", gr.Slider, {"minimum": 0.0, "maximum": 100.0, "step": 0.01}, infotext='Sigma churn').info('amount of stochasticity; only applies to Euler, Heun, and DPM2'),
-    's_tmin':  OptionInfo(0.0, "sigma tmin",  gr.Slider, {"minimum": 0.0, "maximum": 10.0, "step": 0.01}, infotext='Sigma tmin').info('enable stochasticity; start value of the sigma range; only applies to Euler, Heun, and DPM2'),
-    's_tmax':  OptionInfo(0.0, "sigma tmax",  gr.Slider, {"minimum": 0.0, "maximum": 999.0, "step": 0.01}, infotext='Sigma tmax').info("0 = inf; end value of the sigma range; only applies to Euler, Heun, and DPM2"),
-    's_noise': OptionInfo(1.0, "sigma noise", gr.Slider, {"minimum": 0.0, "maximum": 1.1, "step": 0.001}, infotext='Sigma noise').info('amount of additional noise to counteract loss of detail during sampling'),
-    'sigma_min': OptionInfo(0.0, "sigma min", gr.Number, infotext='Schedule min sigma').info("0 = default (~0.03); minimum noise strength for k-diffusion noise scheduler"),
-    'sigma_max': OptionInfo(0.0, "sigma max", gr.Number, infotext='Schedule max sigma').info("0 = default (~14.6); maximum noise strength for k-diffusion noise scheduler"),
-    'rho':  OptionInfo(0.0, "rho", gr.Number, infotext='Schedule rho').info("0 = default (7 for karras, 1 for polyexponential); higher values result in a steeper noise schedule (decreases faster)"),
-    'eta_noise_seed_delta': OptionInfo(0, "Eta noise seed delta", gr.Number, {"precision": 0}, infotext='ENSD').info("ENSD; does not improve anything, just produces different results for ancestral samplers - only useful for reproducing images"),
-    'always_discard_next_to_last_sigma': OptionInfo(False, "Always discard next-to-last sigma", infotext='Discard penultimate sigma').link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/6044"),
-    'sgm_noise_multiplier': OptionInfo(False, "SGM noise multiplier", infotext='SGM noise multiplier').link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12818").info("Match initial noise to official SDXL implementation - only useful for reproducing images"),
-    'uni_pc_variant': OptionInfo("bh1", "UniPC variant", gr.Radio, {"choices": ["bh1", "bh2", "vary_coeff"]}, infotext='UniPC variant'),
-    'uni_pc_skip_type': OptionInfo("time_uniform", "UniPC skip type", gr.Radio, {"choices": ["time_uniform", "time_quadratic", "logSNR"]}, infotext='UniPC skip type'),
-    'uni_pc_order': OptionInfo(3, "UniPC order", gr.Slider, {"minimum": 1, "maximum": 50, "step": 1}, infotext='UniPC order').info("must be < sampling steps"),
-    'uni_pc_lower_order_final': OptionInfo(True, "UniPC lower order final", infotext='UniPC lower order final'),
-    'sd_noise_schedule': OptionInfo("Default", "Noise schedule for sampling", gr.Radio, {"choices": ["Default", "Zero Terminal SNR"]}, infotext="Noise Schedule").info("for use with zero terminal SNR trained models"),
-    'skip_early_cond': OptionInfo(0.0, "Ignore negative prompt during early sampling", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext="Skip Early CFG").info("disables CFG on a proportion of steps at the beginning of generation; 0=skip none; 1=skip all; can both improve sample diversity/quality and speed up sampling"),
-    'beta_dist_alpha': OptionInfo(0.6, "Beta scheduler - alpha", gr.Slider, {"minimum": 0.01, "maximum": 1.0, "step": 0.01}, infotext='Beta scheduler alpha').info('Default = 0.6; the alpha parameter of the beta distribution used in Beta sampling'),
-    'beta_dist_beta': OptionInfo(0.6, "Beta scheduler - beta", gr.Slider, {"minimum": 0.01, "maximum": 1.0, "step": 0.01}, infotext='Beta scheduler beta').info('Default = 0.6; the beta parameter of the beta distribution used in Beta sampling'),
-}))
+options_templates.update(
+    options_section(
+        ("postprocessing", "Postprocessing", "postprocessing"),
+        {
+            "postprocessing_enable_in_main_ui": OptionInfo(
+                [],
+                "Enable postprocessing operations in txt2img and img2img tabs",
+                ui_components.DropdownMulti,
+                lambda: {
+                    "choices": [x.name for x in shared_items.postprocessing_scripts()]
+                },
+            ),
+            "postprocessing_disable_in_extras": OptionInfo(
+                [],
+                "Disable postprocessing operations in extras tab",
+                ui_components.DropdownMulti,
+                lambda: {
+                    "choices": [x.name for x in shared_items.postprocessing_scripts()]
+                },
+            ),
+            "postprocessing_operation_order": OptionInfo(
+                [],
+                "Postprocessing operation order",
+                ui_components.DropdownMulti,
+                lambda: {
+                    "choices": [x.name for x in shared_items.postprocessing_scripts()]
+                },
+            ),
+            "upscaling_max_images_in_cache": OptionInfo(
+                5,
+                "Maximum number of images in upscaling cache",
+                gr.Slider,
+                {"minimum": 0, "maximum": 10, "step": 1},
+            ),
+            "postprocessing_existing_caption_action": OptionInfo(
+                "Ignore",
+                "Action for existing captions",
+                gr.Radio,
+                {"choices": ["Ignore", "Keep", "Prepend", "Append"]},
+            ).info(
+                "when generating captions using postprocessing; Ignore = use generated; Keep = use original; Prepend/Append = combine both"
+            ),
+        },
+    )
+)
 
-options_templates.update(options_section(('postprocessing', "Postprocessing", "postprocessing"), {
-    'postprocessing_enable_in_main_ui': OptionInfo([], "Enable postprocessing operations in txt2img and img2img tabs", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
-    'postprocessing_disable_in_extras': OptionInfo([], "Disable postprocessing operations in extras tab", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
-    'postprocessing_operation_order': OptionInfo([], "Postprocessing operation order", ui_components.DropdownMulti, lambda: {"choices": [x.name for x in shared_items.postprocessing_scripts()]}),
-    'upscaling_max_images_in_cache': OptionInfo(5, "Maximum number of images in upscaling cache", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
-    'postprocessing_existing_caption_action': OptionInfo("Ignore", "Action for existing captions", gr.Radio, {"choices": ["Ignore", "Keep", "Prepend", "Append"]}).info("when generating captions using postprocessing; Ignore = use generated; Keep = use original; Prepend/Append = combine both"),
-}))
-
-options_templates.update(options_section((None, "Hidden options"), {
-    "disabled_extensions": OptionInfo([], "Disable these extensions"),
-    "disable_all_extensions": OptionInfo("none", "Disable all extensions (preserves the list of disabled extensions)", gr.Radio, {"choices": ["none", "extra", "all"]}),
-    "restore_config_state_file": OptionInfo("", "Config state file to restore from, under 'config-states/' folder"),
-    "sd_checkpoint_hash": OptionInfo("", "SHA256 hash of the current checkpoint"),
-}))
+options_templates.update(
+    options_section(
+        (None, "Hidden options"),
+        {
+            "disabled_extensions": OptionInfo([], "Disable these extensions"),
+            "disable_all_extensions": OptionInfo(
+                "none",
+                "Disable all extensions (preserves the list of disabled extensions)",
+                gr.Radio,
+                {"choices": ["none", "extra", "all"]},
+            ),
+            "restore_config_state_file": OptionInfo(
+                "", "Config state file to restore from, under 'config-states/' folder"
+            ),
+            "sd_checkpoint_hash": OptionInfo(
+                "", "SHA256 hash of the current checkpoint"
+            ),
+        },
+    )
+)

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -17,7 +17,7 @@ class State:
     job_no = 0
     job_count = 0
     processing_has_refined_job_count = False
-    job_timestamp = '0'
+    job_timestamp = "0"
     sampling_step = 0
     sampling_steps = 0
     current_latent = None
@@ -85,7 +85,10 @@ class State:
         log.info("Received stop generating request")
 
     def nextjob(self):
-        if shared.opts.live_previews_enable and shared.opts.show_progress_every_n_steps == -1:
+        if (
+            shared.opts.live_previews_enable
+            and shared.opts.show_progress_every_n_steps == -1
+        ):
             self.do_set_current_image()
 
         self.job_no += 1
@@ -139,7 +142,12 @@ class State:
         if not shared.parallel_processing_allowed:
             return
 
-        if self.sampling_step - self.current_image_sampling_step >= shared.opts.show_progress_every_n_steps and shared.opts.live_previews_enable and shared.opts.show_progress_every_n_steps != -1:
+        if (
+            self.sampling_step - self.current_image_sampling_step
+            >= shared.opts.show_progress_every_n_steps
+            and shared.opts.live_previews_enable
+            and shared.opts.show_progress_every_n_steps != -1
+        ):
             self.do_set_current_image()
 
     def do_set_current_image(self):
@@ -150,9 +158,13 @@ class State:
 
         try:
             if shared.opts.show_progress_grid:
-                self.assign_current_image(modules.sd_samplers.samples_to_image_grid(self.current_latent))
+                self.assign_current_image(
+                    modules.sd_samplers.samples_to_image_grid(self.current_latent)
+                )
             else:
-                self.assign_current_image(modules.sd_samplers.sample_to_image(self.current_latent))
+                self.assign_current_image(
+                    modules.sd_samplers.sample_to_image(self.current_latent)
+                )
 
             self.current_image_sampling_step = self.sampling_step
 
@@ -162,7 +174,10 @@ class State:
             errors.record_exception()
 
     def assign_current_image(self, image):
-        if shared.opts.live_previews_image_format == 'jpeg' and image.mode in ('RGBA', 'P'):
-            image = image.convert('RGB')
+        if shared.opts.live_previews_image_format == "jpeg" and image.mode in (
+            "RGBA",
+            "P",
+        ):
+            image = image.convert("RGB")
         self.current_image = image
         self.id_live_preview += 1

--- a/modules/shared_total_tqdm.py
+++ b/modules/shared_total_tqdm.py
@@ -12,18 +12,24 @@ class TotalTQDM:
             desc="Total progress",
             total=shared.state.job_count * shared.state.sampling_steps,
             position=1,
-            file=shared.progress_print_out
+            file=shared.progress_print_out,
         )
 
     def update(self):
-        if not shared.opts.multiple_tqdm or shared.cmd_opts.disable_console_progressbars:
+        if (
+            not shared.opts.multiple_tqdm
+            or shared.cmd_opts.disable_console_progressbars
+        ):
             return
         if self._tqdm is None:
             self.reset()
         self._tqdm.update()
 
     def updateTotal(self, new_total):
-        if not shared.opts.multiple_tqdm or shared.cmd_opts.disable_console_progressbars:
+        if (
+            not shared.opts.multiple_tqdm
+            or shared.cmd_opts.disable_console_progressbars
+        ):
             return
         if self._tqdm is None:
             self.reset()
@@ -34,4 +40,3 @@ class TotalTQDM:
             self._tqdm.refresh()
             self._tqdm.close()
             self._tqdm = None
-

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -45,13 +45,13 @@ def extract_style_text_from_prompt(style_text, prompt):
     if "{prompt}" in stripped_style_text:
         left, _, right = stripped_style_text.partition("{prompt}")
         if stripped_prompt.startswith(left) and stripped_prompt.endswith(right):
-            prompt = stripped_prompt[len(left):len(stripped_prompt)-len(right)]
+            prompt = stripped_prompt[len(left) : len(stripped_prompt) - len(right)]
             return True, prompt
     else:
         if stripped_prompt.endswith(stripped_style_text):
-            prompt = stripped_prompt[:len(stripped_prompt)-len(stripped_style_text)]
+            prompt = stripped_prompt[: len(stripped_prompt) - len(stripped_style_text)]
 
-            if prompt.endswith(', '):
+            if prompt.endswith(", "):
                 prompt = prompt[:-2]
 
             return True, prompt
@@ -68,11 +68,15 @@ def extract_original_prompts(style: PromptStyle, prompt, negative_prompt):
     if not style.prompt and not style.negative_prompt:
         return False, prompt, negative_prompt
 
-    match_positive, extracted_positive = extract_style_text_from_prompt(style.prompt, prompt)
+    match_positive, extracted_positive = extract_style_text_from_prompt(
+        style.prompt, prompt
+    )
     if not match_positive:
         return False, prompt, negative_prompt
 
-    match_negative, extracted_negative = extract_style_text_from_prompt(style.negative_prompt, negative_prompt)
+    match_negative, extracted_negative = extract_style_text_from_prompt(
+        style.negative_prompt, negative_prompt
+    )
     if not match_negative:
         return False, prompt, negative_prompt
 
@@ -87,9 +91,11 @@ class StyleDatabase:
         self.all_styles_files: list[Path] = []
 
         folder, file = os.path.split(self.paths[0])
-        if '*' in file or '?' in file:
+        if "*" in file or "?" in file:
             # if the first path is a wildcard pattern, find the first match else use "folder/styles.csv" as the default path
-            self.default_path = next(Path(folder).glob(file), Path(os.path.join(folder, 'styles.csv')))
+            self.default_path = next(
+                Path(folder).glob(file), Path(os.path.join(folder, "styles.csv"))
+            )
             self.paths.insert(0, self.default_path)
         else:
             self.default_path = Path(self.paths[0])
@@ -109,7 +115,7 @@ class StyleDatabase:
         all_styles_files = []
         for pattern in self.paths:
             folder, file = os.path.split(pattern)
-            if '*' in file or '?' in file:
+            if "*" in file or "?" in file:
                 found_files = Path(folder).glob(file)
                 [all_styles_files.append(file) for file in found_files]
             else:
@@ -118,14 +124,18 @@ class StyleDatabase:
 
         # Remove any duplicate entries
         seen = set()
-        self.all_styles_files = [s for s in all_styles_files if not (s in seen or seen.add(s))]
+        self.all_styles_files = [
+            s for s in all_styles_files if not (s in seen or seen.add(s))
+        ]
 
         for styles_file in self.all_styles_files:
             if len(all_styles_files) > 1:
                 # add divider when more than styles file
                 # '---------------- STYLES ----------------'
-                divider = f' {styles_file.stem.upper()} '.center(40, '-')
-                self.styles[divider] = PromptStyle(f"{divider}", None, None, "do_not_save")
+                divider = f" {styles_file.stem.upper()} ".center(40, "-")
+                self.styles[divider] = PromptStyle(
+                    f"{divider}", None, None, "do_not_save"
+                )
             if styles_file.is_file():
                 self.load_from_csv(styles_file)
 
@@ -145,7 +155,7 @@ class StyleDatabase:
                         row["name"], prompt, negative_prompt, str(path)
                     )
         except Exception:
-            errors.report(f'Error loading styles from {path}: ', exc_info=True)
+            errors.report(f"Error loading styles from {path}: ", exc_info=True)
 
     def get_style_paths(self) -> set:
         """Returns a set of all distinct paths of files that styles are loaded from."""

--- a/modules/sub_quadratic_attention.py
+++ b/modules/sub_quadratic_attention.py
@@ -18,13 +18,13 @@ import math
 from typing import Optional, NamedTuple
 
 
-def narrow_trunc(
-    input: Tensor,
-    dim: int,
-    start: int,
-    length: int
-) -> Tensor:
-    return torch.narrow(input, dim, start, length if input.shape[dim] >= start + length else input.shape[dim] - start)
+def narrow_trunc(input: Tensor, dim: int, start: int, length: int) -> Tensor:
+    return torch.narrow(
+        input,
+        dim,
+        start,
+        length if input.shape[dim] >= start + length else input.shape[dim] - start,
+    )
 
 
 class AttnChunk(NamedTuple):
@@ -60,14 +60,18 @@ def _summarize_chunk(
     attn_weights = torch.baddbmm(
         torch.zeros(1, 1, 1, device=query.device, dtype=query.dtype),
         query,
-        key.transpose(1,2),
+        key.transpose(1, 2),
         alpha=scale,
         beta=0,
     )
     max_score, _ = torch.max(attn_weights, -1, keepdim=True)
     max_score = max_score.detach()
     exp_weights = torch.exp(attn_weights - max_score)
-    exp_values = torch.bmm(exp_weights, value) if query.device.type == 'mps' else torch.bmm(exp_weights, value.to(exp_weights.dtype)).to(value.dtype)
+    exp_values = (
+        torch.bmm(exp_weights, value)
+        if query.device.type == "mps"
+        else torch.bmm(exp_weights, value.to(exp_weights.dtype)).to(value.dtype)
+    )
     max_score = max_score.squeeze(-1)
     return AttnChunk(exp_values, exp_weights.sum(dim=-1), max_score)
 
@@ -83,18 +87,8 @@ def _query_chunk_attention(
     _, _, v_channels_per_head = value.shape
 
     def chunk_scanner(chunk_idx: int) -> AttnChunk:
-        key_chunk = narrow_trunc(
-            key,
-            1,
-            chunk_idx,
-            kv_chunk_size
-        )
-        value_chunk = narrow_trunc(
-            value,
-            1,
-            chunk_idx,
-            kv_chunk_size
-        )
+        key_chunk = narrow_trunc(key, 1, chunk_idx, kv_chunk_size)
+        value_chunk = narrow_trunc(value, 1, chunk_idx, kv_chunk_size)
         return summarize_chunk(query, key_chunk, value_chunk)
 
     chunks: list[AttnChunk] = [
@@ -123,13 +117,17 @@ def _get_attention_scores_no_kv_chunking(
     attn_scores = torch.baddbmm(
         torch.zeros(1, 1, 1, device=query.device, dtype=query.dtype),
         query,
-        key.transpose(1,2),
+        key.transpose(1, 2),
         alpha=scale,
         beta=0,
     )
     attn_probs = attn_scores.softmax(dim=-1)
     del attn_scores
-    hidden_states_slice = torch.bmm(attn_probs, value) if query.device.type == 'mps' else torch.bmm(attn_probs, value.to(attn_probs.dtype)).to(value.dtype)
+    hidden_states_slice = (
+        torch.bmm(attn_probs, value)
+        if query.device.type == "mps"
+        else torch.bmm(attn_probs, value.to(attn_probs.dtype)).to(value.dtype)
+    )
     return hidden_states_slice
 
 
@@ -148,49 +146,47 @@ def efficient_dot_product_attention(
     use_checkpoint=True,
 ):
     """Computes efficient dot-product attention given query, key, and value.
-      This is efficient version of attention presented in
-      https://arxiv.org/abs/2112.05682v2 which comes with O(sqrt(n)) memory requirements.
-      Args:
-        query: queries for calculating attention with shape of
-          `[batch * num_heads, tokens, channels_per_head]`.
-        key: keys for calculating attention with shape of
-          `[batch * num_heads, tokens, channels_per_head]`.
-        value: values to be used in attention with shape of
-          `[batch * num_heads, tokens, channels_per_head]`.
-        query_chunk_size: int: query chunks size
-        kv_chunk_size: Optional[int]: key/value chunks size. if None: defaults to sqrt(key_tokens)
-        kv_chunk_size_min: Optional[int]: key/value minimum chunk size. only considered when kv_chunk_size is None. changes `sqrt(key_tokens)` into `max(sqrt(key_tokens), kv_chunk_size_min)`, to ensure our chunk sizes don't get too small (smaller chunks = more chunks = less concurrent work done).
-        use_checkpoint: bool: whether to use checkpointing (recommended True for training, False for inference)
-      Returns:
-        Output of shape `[batch * num_heads, query_tokens, channels_per_head]`.
-      """
+    This is efficient version of attention presented in
+    https://arxiv.org/abs/2112.05682v2 which comes with O(sqrt(n)) memory requirements.
+    Args:
+      query: queries for calculating attention with shape of
+        `[batch * num_heads, tokens, channels_per_head]`.
+      key: keys for calculating attention with shape of
+        `[batch * num_heads, tokens, channels_per_head]`.
+      value: values to be used in attention with shape of
+        `[batch * num_heads, tokens, channels_per_head]`.
+      query_chunk_size: int: query chunks size
+      kv_chunk_size: Optional[int]: key/value chunks size. if None: defaults to sqrt(key_tokens)
+      kv_chunk_size_min: Optional[int]: key/value minimum chunk size. only considered when kv_chunk_size is None. changes `sqrt(key_tokens)` into `max(sqrt(key_tokens), kv_chunk_size_min)`, to ensure our chunk sizes don't get too small (smaller chunks = more chunks = less concurrent work done).
+      use_checkpoint: bool: whether to use checkpointing (recommended True for training, False for inference)
+    Returns:
+      Output of shape `[batch * num_heads, query_tokens, channels_per_head]`.
+    """
     batch_x_heads, q_tokens, q_channels_per_head = query.shape
     _, k_tokens, _ = key.shape
-    scale = q_channels_per_head ** -0.5
+    scale = q_channels_per_head**-0.5
 
     kv_chunk_size = min(kv_chunk_size or int(math.sqrt(k_tokens)), k_tokens)
     if kv_chunk_size_min is not None:
         kv_chunk_size = max(kv_chunk_size, kv_chunk_size_min)
 
     def get_query_chunk(chunk_idx: int) -> Tensor:
-        return narrow_trunc(
-            query,
-            1,
-            chunk_idx,
-            min(query_chunk_size, q_tokens)
-        )
+        return narrow_trunc(query, 1, chunk_idx, min(query_chunk_size, q_tokens))
 
     summarize_chunk: SummarizeChunk = partial(_summarize_chunk, scale=scale)
-    summarize_chunk: SummarizeChunk = partial(checkpoint, summarize_chunk) if use_checkpoint else summarize_chunk
-    compute_query_chunk_attn: ComputeQueryChunkAttn = partial(
-        _get_attention_scores_no_kv_chunking,
-        scale=scale
-    ) if k_tokens <= kv_chunk_size else (
+    summarize_chunk: SummarizeChunk = (
+        partial(checkpoint, summarize_chunk) if use_checkpoint else summarize_chunk
+    )
+    compute_query_chunk_attn: ComputeQueryChunkAttn = (
+        partial(_get_attention_scores_no_kv_chunking, scale=scale)
+        if k_tokens <= kv_chunk_size
         # fast-path for when there's just 1 key-value chunk per query chunk (this is just sliced attention btw)
-        partial(
-            _query_chunk_attention,
-            kv_chunk_size=kv_chunk_size,
-            summarize_chunk=summarize_chunk,
+        else (
+            partial(
+                _query_chunk_attention,
+                kv_chunk_size=kv_chunk_size,
+                summarize_chunk=summarize_chunk,
+            )
         )
     )
 
@@ -210,6 +206,8 @@ def efficient_dot_product_attention(
             value=value,
         )
 
-        res[:, i * query_chunk_size:i * query_chunk_size + attn_scores.shape[1], :] = attn_scores
+        res[
+            :, i * query_chunk_size : i * query_chunk_size + attn_scores.shape[1], :
+        ] = attn_scores
 
     return res

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -37,7 +37,7 @@ environment_whitelist = {
 
 def pretty_bytes(num, suffix="B"):
     for unit in ["", "K", "M", "G", "T", "P", "E", "Z", "Y"]:
-        if abs(num) < 1024 or unit == 'Y':
+        if abs(num) < 1024 or unit == "Y":
             return f"{num:.0f}{unit}{suffix}"
         num /= 1024
 
@@ -71,6 +71,7 @@ def get_cpu_info():
     cpu_info = {"model": platform.processor()}
     try:
         import psutil
+
         cpu_info["count logical"] = psutil.cpu_count(logical=True)
         cpu_info["count physical"] = psutil.cpu_count(logical=False)
     except Exception as e:
@@ -81,22 +82,46 @@ def get_cpu_info():
 def get_ram_info():
     try:
         import psutil
+
         ram = psutil.virtual_memory()
-        return {x: pretty_bytes(getattr(ram, x, 0)) for x in ["total", "used", "free", "active", "inactive", "buffers", "cached", "shared"] if getattr(ram, x, 0) != 0}
+        return {
+            x: pretty_bytes(getattr(ram, x, 0))
+            for x in [
+                "total",
+                "used",
+                "free",
+                "active",
+                "inactive",
+                "buffers",
+                "cached",
+                "shared",
+            ]
+            if getattr(ram, x, 0) != 0
+        }
     except Exception as e:
         return str(e)
 
 
 def get_packages():
     try:
-        return subprocess.check_output([sys.executable, '-m', 'pip', 'freeze', '--all']).decode("utf8").splitlines()
+        return (
+            subprocess.check_output([sys.executable, "-m", "pip", "freeze", "--all"])
+            .decode("utf8")
+            .splitlines()
+        )
     except Exception as pip_error:
         try:
             import importlib.metadata
+
             packages = importlib.metadata.distributions()
-            return sorted([f"{package.metadata['Name']}=={package.version}" for package in packages])
+            return sorted(
+                [
+                    f"{package.metadata['Name']}=={package.version}"
+                    for package in packages
+                ]
+            )
         except Exception as e2:
-            return {'error pip': pip_error, 'error importlib': str(e2)}
+            return {"error pip": pip_error, "error importlib": str(e2)}
 
 
 def get_dict():
@@ -116,8 +141,14 @@ def get_dict():
         "Exceptions": errors.get_exceptions(),
         "CPU": get_cpu_info(),
         "RAM": get_ram_info(),
-        "Extensions": get_extensions(enabled=True, fallback_disabled_extensions=config.get('disabled_extensions', [])),
-        "Inactive extensions": get_extensions(enabled=False, fallback_disabled_extensions=config.get('disabled_extensions', [])),
+        "Extensions": get_extensions(
+            enabled=True,
+            fallback_disabled_extensions=config.get("disabled_extensions", []),
+        ),
+        "Inactive extensions": get_extensions(
+            enabled=False,
+            fallback_disabled_extensions=config.get("disabled_extensions", []),
+        ),
         "Environment": get_environment(),
         "Config": config,
         "Startup": timer.startup_record,
@@ -135,11 +166,17 @@ def get_argv():
     res = []
 
     for v in sys.argv:
-        if shared_cmd_options.cmd_opts.gradio_auth and shared_cmd_options.cmd_opts.gradio_auth == v:
+        if (
+            shared_cmd_options.cmd_opts.gradio_auth
+            and shared_cmd_options.cmd_opts.gradio_auth == v
+        ):
             res.append("<hidden>")
             continue
 
-        if shared_cmd_options.cmd_opts.api_auth and shared_cmd_options.cmd_opts.api_auth == v:
+        if (
+            shared_cmd_options.cmd_opts.api_auth
+            and shared_cmd_options.cmd_opts.api_auth == v
+        ):
             res.append("<hidden>")
             continue
 
@@ -154,40 +191,48 @@ re_newline = re.compile(r"\r*\n")
 def get_torch_sysinfo():
     try:
         import torch.utils.collect_env
+
         info = torch.utils.collect_env.get_env_info()._asdict()
 
-        return {k: re.split(re_newline, str(v)) if "\n" in str(v) else v for k, v in info.items()}
+        return {
+            k: re.split(re_newline, str(v)) if "\n" in str(v) else v
+            for k, v in info.items()
+        }
     except Exception as e:
         return str(e)
 
 
 def run_git(path, *args):
     try:
-        return subprocess.check_output([launch_utils.git, '-C', path, *args], shell=False, encoding='utf8').strip()
+        return subprocess.check_output(
+            [launch_utils.git, "-C", path, *args], shell=False, encoding="utf8"
+        ).strip()
     except Exception as e:
         return str(e)
 
 
 def git_status(path):
-    if (Path(path) / '.git').is_dir():
-        return run_git(paths_internal.script_path, 'status')
+    if (Path(path) / ".git").is_dir():
+        return run_git(paths_internal.script_path, "status")
 
 
 def get_info_from_repo_path(path: Path):
-    is_repo = (path / '.git').is_dir()
+    is_repo = (path / ".git").is_dir()
     return {
-        'name': path.name,
-        'path': str(path),
-        'commit': run_git(path, 'rev-parse', 'HEAD') if is_repo else None,
-        'branch': run_git(path, 'branch', '--show-current') if is_repo else None,
-        'remote': run_git(path, 'remote', 'get-url', 'origin') if is_repo else None,
+        "name": path.name,
+        "path": str(path),
+        "commit": run_git(path, "rev-parse", "HEAD") if is_repo else None,
+        "branch": run_git(path, "branch", "--show-current") if is_repo else None,
+        "remote": run_git(path, "remote", "get-url", "origin") if is_repo else None,
     }
 
 
 def get_extensions(*, enabled, fallback_disabled_extensions=None):
     try:
         from modules import extensions
+
         if extensions.extensions:
+
             def to_json(x: extensions.Extension):
                 return {
                     "name": x.name,
@@ -196,9 +241,19 @@ def get_extensions(*, enabled, fallback_disabled_extensions=None):
                     "branch": x.branch,
                     "remote": x.remote,
                 }
-            return [to_json(x) for x in extensions.extensions if not x.is_builtin and x.enabled == enabled]
+
+            return [
+                to_json(x)
+                for x in extensions.extensions
+                if not x.is_builtin and x.enabled == enabled
+            ]
         else:
-            return [get_info_from_repo_path(d) for d in Path(paths_internal.extensions_dir).iterdir() if d.is_dir() and enabled != (str(d.name) in fallback_disabled_extensions)]
+            return [
+                get_info_from_repo_path(d)
+                for d in Path(paths_internal.extensions_dir).iterdir()
+                if d.is_dir()
+                and enabled != (str(d.name) in fallback_disabled_extensions)
+            ]
     except Exception as e:
         return str(e)
 
@@ -206,10 +261,11 @@ def get_extensions(*, enabled, fallback_disabled_extensions=None):
 def get_config():
     try:
         from modules import shared
+
         return shared.opts.data
     except Exception as _:
         try:
-            with open(shared_cmd_options.cmd_opts.ui_settings_file, 'r') as f:
+            with open(shared_cmd_options.cmd_opts.ui_settings_file, "r") as f:
                 return json.load(f)
         except Exception as e:
             return str(e)

--- a/modules/textual_inversion/autocrop.py
+++ b/modules/textual_inversion/autocrop.py
@@ -12,7 +12,7 @@ RED = "#F00"
 
 
 def crop_image(im, settings):
-    """ Intelligently crop an image to the subject matter """
+    """Intelligently crop an image to the subject matter"""
 
     scale_by = 1
     if is_landscape(im.width, im.height):
@@ -72,9 +72,15 @@ def crop_image(im, settings):
 
 
 def focal_point(im, settings):
-    corner_points = image_corner_points(im, settings) if settings.corner_points_weight > 0 else []
-    entropy_points = image_entropy_points(im, settings) if settings.entropy_points_weight > 0 else []
-    face_points = image_face_points(im, settings) if settings.face_points_weight > 0 else []
+    corner_points = (
+        image_corner_points(im, settings) if settings.corner_points_weight > 0 else []
+    )
+    entropy_points = (
+        image_entropy_points(im, settings) if settings.entropy_points_weight > 0 else []
+    )
+    face_points = (
+        image_face_points(im, settings) if settings.face_points_weight > 0 else []
+    )
 
     pois = []
 
@@ -112,7 +118,11 @@ def focal_point(im, settings):
         if corner_centroid is not None:
             color = BLUE
             box = corner_centroid.bounding(max_size * corner_centroid.weight)
-            d.text((box[0], box[1] - 15), f"Edge: {corner_centroid.weight:.02f}", fill=color)
+            d.text(
+                (box[0], box[1] - 15),
+                f"Edge: {corner_centroid.weight:.02f}",
+                fill=color,
+            )
             d.ellipse(box, outline=color)
             if len(corner_points) > 1:
                 for f in corner_points:
@@ -120,7 +130,11 @@ def focal_point(im, settings):
         if entropy_centroid is not None:
             color = "#ff0"
             box = entropy_centroid.bounding(max_size * entropy_centroid.weight)
-            d.text((box[0], box[1] - 15), f"Entropy: {entropy_centroid.weight:.02f}", fill=color)
+            d.text(
+                (box[0], box[1] - 15),
+                f"Entropy: {entropy_centroid.weight:.02f}",
+                fill=color,
+            )
             d.ellipse(box, outline=color)
             if len(entropy_points) > 1:
                 for f in entropy_points:
@@ -128,7 +142,9 @@ def focal_point(im, settings):
         if face_centroid is not None:
             color = RED
             box = face_centroid.bounding(max_size * face_centroid.weight)
-            d.text((box[0], box[1] - 15), f"Face: {face_centroid.weight:.02f}", fill=color)
+            d.text(
+                (box[0], box[1] - 15), f"Face: {face_centroid.weight:.02f}", fill=color
+            )
             d.ellipse(box, outline=color)
             if len(face_points) > 1:
                 for f in face_points:
@@ -147,7 +163,7 @@ def image_face_points(im, settings):
             (im.width, im.height),
             0.9,  # score threshold
             0.3,  # nms threshold
-            5000  # keep top k before nms
+            5000,  # keep top k before nms
         )
         faces = detector.detect(np.array(im))
         results = []
@@ -160,9 +176,11 @@ def image_face_points(im, settings):
                 results.append(
                     PointOfInterest(
                         int(x + (w * 0.5)),  # face focus left/right is center
-                        int(y + (h * 0.33)),  # face focus up/down is close to the top of the head
+                        int(
+                            y + (h * 0.33)
+                        ),  # face focus up/down is close to the top of the head
                         size=w,
-                        weight=1 / len(faces[1])
+                        weight=1 / len(faces[1]),
                     )
                 )
         return results
@@ -171,29 +189,42 @@ def image_face_points(im, settings):
         gray = cv2.cvtColor(np_im, cv2.COLOR_BGR2GRAY)
 
         tries = [
-            [f'{cv2.data.haarcascades}haarcascade_eye.xml', 0.01],
-            [f'{cv2.data.haarcascades}haarcascade_frontalface_default.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_profileface.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_frontalface_alt.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_frontalface_alt2.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_frontalface_alt_tree.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_eye_tree_eyeglasses.xml', 0.05],
-            [f'{cv2.data.haarcascades}haarcascade_upperbody.xml', 0.05]
+            [f"{cv2.data.haarcascades}haarcascade_eye.xml", 0.01],
+            [f"{cv2.data.haarcascades}haarcascade_frontalface_default.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_profileface.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_frontalface_alt.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_frontalface_alt2.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_frontalface_alt_tree.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_eye_tree_eyeglasses.xml", 0.05],
+            [f"{cv2.data.haarcascades}haarcascade_upperbody.xml", 0.05],
         ]
         for t in tries:
             classifier = cv2.CascadeClassifier(t[0])
-            minsize = int(min(im.width, im.height) * t[1])  # at least N percent of the smallest side
+            minsize = int(
+                min(im.width, im.height) * t[1]
+            )  # at least N percent of the smallest side
             try:
-                faces = classifier.detectMultiScale(gray, scaleFactor=1.1,
-                                                    minNeighbors=7, minSize=(minsize, minsize),
-                                                    flags=cv2.CASCADE_SCALE_IMAGE)
+                faces = classifier.detectMultiScale(
+                    gray,
+                    scaleFactor=1.1,
+                    minNeighbors=7,
+                    minSize=(minsize, minsize),
+                    flags=cv2.CASCADE_SCALE_IMAGE,
+                )
             except Exception:
                 continue
 
             if faces:
                 rects = [[f[0], f[1], f[0] + f[2], f[1] + f[3]] for f in faces]
-                return [PointOfInterest((r[0] + r[2]) // 2, (r[1] + r[3]) // 2, size=abs(r[0] - r[2]),
-                                        weight=1 / len(rects)) for r in rects]
+                return [
+                    PointOfInterest(
+                        (r[0] + r[2]) // 2,
+                        (r[1] + r[3]) // 2,
+                        size=abs(r[0] - r[2]),
+                        weight=1 / len(rects),
+                    )
+                    for r in rects
+                ]
     return []
 
 
@@ -202,7 +233,7 @@ def image_corner_points(im, settings):
 
     # naive attempt at preventing focal points from collecting at watermarks near the bottom
     gd = ImageDraw.Draw(grayscale)
-    gd.rectangle([0, im.height * .9, im.width, im.height], fill="#999")
+    gd.rectangle([0, im.height * 0.9, im.width, im.height], fill="#999")
 
     np_im = np.array(grayscale)
 
@@ -244,7 +275,7 @@ def image_entropy_points(im, settings):
         crop = im.crop(tuple(crop_current))
         e = image_entropy(crop)
 
-        if (e > e_max):
+        if e > e_max:
             e_max = e
             crop_best = list(crop_current)
 
@@ -298,19 +329,23 @@ def is_square(w, h):
     return w == h
 
 
-model_dir_opencv = os.path.join(paths_internal.models_path, 'opencv')
-if parse_version(cv2.__version__) >= parse_version('4.8'):
-    model_file_path = os.path.join(model_dir_opencv, 'face_detection_yunet_2023mar.onnx')
-    model_url = 'https://github.com/opencv/opencv_zoo/blob/b6e370b10f641879a87890d44e42173077154a05/models/face_detection_yunet/face_detection_yunet_2023mar.onnx?raw=true'
+model_dir_opencv = os.path.join(paths_internal.models_path, "opencv")
+if parse_version(cv2.__version__) >= parse_version("4.8"):
+    model_file_path = os.path.join(
+        model_dir_opencv, "face_detection_yunet_2023mar.onnx"
+    )
+    model_url = "https://github.com/opencv/opencv_zoo/blob/b6e370b10f641879a87890d44e42173077154a05/models/face_detection_yunet/face_detection_yunet_2023mar.onnx?raw=true"
 else:
-    model_file_path = os.path.join(model_dir_opencv, 'face_detection_yunet.onnx')
-    model_url = 'https://github.com/opencv/opencv_zoo/blob/91fb0290f50896f38a0ab1e558b74b16bc009428/models/face_detection_yunet/face_detection_yunet_2022mar.onnx?raw=true'
+    model_file_path = os.path.join(model_dir_opencv, "face_detection_yunet.onnx")
+    model_url = "https://github.com/opencv/opencv_zoo/blob/91fb0290f50896f38a0ab1e558b74b16bc009428/models/face_detection_yunet/face_detection_yunet_2022mar.onnx?raw=true"
 
 
 def download_and_cache_models():
     if not os.path.exists(model_file_path):
         os.makedirs(model_dir_opencv, exist_ok=True)
-        print(f"downloading face detection model from '{model_url}' to '{model_file_path}'")
+        print(
+            f"downloading face detection model from '{model_url}' to '{model_file_path}'"
+        )
         response = requests.get(model_url)
         with open(model_file_path, "wb") as f:
             f.write(response.content)
@@ -329,12 +364,21 @@ class PointOfInterest:
             self.x - size // 2,
             self.y - size // 2,
             self.x + size // 2,
-            self.y + size // 2
+            self.y + size // 2,
         ]
 
 
 class Settings:
-    def __init__(self, crop_width=512, crop_height=512, corner_points_weight=0.5, entropy_points_weight=0.5, face_points_weight=0.5, annotate_image=False, dnn_model_path=None):
+    def __init__(
+        self,
+        crop_width=512,
+        crop_height=512,
+        corner_points_weight=0.5,
+        entropy_points_weight=0.5,
+        face_points_weight=0.5,
+        annotate_image=False,
+        dnn_model_path=None,
+    ):
         self.crop_width = crop_width
         self.crop_height = crop_height
         self.corner_points_weight = corner_points_weight

--- a/modules/textual_inversion/dataset.py
+++ b/modules/textual_inversion/dataset.py
@@ -18,7 +18,17 @@ re_numbers_at_start = re.compile(r"^[-\d]+\s*")
 
 
 class DatasetEntry:
-    def __init__(self, filename=None, filename_text=None, latent_dist=None, latent_sample=None, cond=None, cond_text=None, pixel_values=None, weight=None):
+    def __init__(
+        self,
+        filename=None,
+        filename_text=None,
+        latent_dist=None,
+        latent_sample=None,
+        cond=None,
+        cond_text=None,
+        pixel_values=None,
+        weight=None,
+    ):
         self.filename = filename
         self.filename_text = filename_text
         self.weight = weight
@@ -30,8 +40,32 @@ class DatasetEntry:
 
 
 class PersonalizedBase(Dataset):
-    def __init__(self, data_root, width, height, repeats, flip_p=0.5, placeholder_token="*", model=None, cond_model=None, device=None, template_file=None, include_cond=False, batch_size=1, gradient_step=1, shuffle_tags=False, tag_drop_out=0, latent_sampling_method='once', varsize=False, use_weight=False):
-        re_word = re.compile(shared.opts.dataset_filename_word_regex) if shared.opts.dataset_filename_word_regex else None
+    def __init__(
+        self,
+        data_root,
+        width,
+        height,
+        repeats,
+        flip_p=0.5,
+        placeholder_token="*",
+        model=None,
+        cond_model=None,
+        device=None,
+        template_file=None,
+        include_cond=False,
+        batch_size=1,
+        gradient_step=1,
+        shuffle_tags=False,
+        tag_drop_out=0,
+        latent_sampling_method="once",
+        varsize=False,
+        use_weight=False,
+    ):
+        re_word = (
+            re.compile(shared.opts.dataset_filename_word_regex)
+            if shared.opts.dataset_filename_word_regex
+            else None
+        )
 
         self.placeholder_token = placeholder_token
 
@@ -44,11 +78,13 @@ class PersonalizedBase(Dataset):
 
         self.lines = lines
 
-        assert data_root, 'dataset directory not specified'
+        assert data_root, "dataset directory not specified"
         assert os.path.isdir(data_root), "Dataset directory doesn't exist"
         assert os.listdir(data_root), "Dataset directory is empty"
 
-        self.image_paths = [os.path.join(data_root, file_path) for file_path in os.listdir(data_root)]
+        self.image_paths = [
+            os.path.join(data_root, file_path) for file_path in os.listdir(data_root)
+        ]
 
         self.shuffle_tags = shuffle_tags
         self.tag_drop_out = tag_drop_out
@@ -61,11 +97,11 @@ class PersonalizedBase(Dataset):
                 raise Exception("interrupted")
             try:
                 image = images.read(path)
-                #Currently does not work for single color transparency
-                #We would need to read image.info['transparency'] for that
-                if use_weight and 'A' in image.getbands():
-                    alpha_channel = image.getchannel('A')
-                image = image.convert('RGB')
+                # Currently does not work for single color transparency
+                # We would need to read image.info['transparency'] for that
+                if use_weight and "A" in image.getbands():
+                    alpha_channel = image.getchannel("A")
+                image = image.convert("RGB")
                 if not varsize:
                     image = image.resize((width, height), PIL.Image.BICUBIC)
             except Exception:
@@ -79,56 +115,78 @@ class PersonalizedBase(Dataset):
                     filename_text = file.read()
             else:
                 filename_text = os.path.splitext(filename)[0]
-                filename_text = re.sub(re_numbers_at_start, '', filename_text)
+                filename_text = re.sub(re_numbers_at_start, "", filename_text)
                 if re_word:
                     tokens = re_word.findall(filename_text)
-                    filename_text = (shared.opts.dataset_filename_join_string or "").join(tokens)
+                    filename_text = (
+                        shared.opts.dataset_filename_join_string or ""
+                    ).join(tokens)
 
             npimage = np.array(image).astype(np.uint8)
             npimage = (npimage / 127.5 - 1.0).astype(np.float32)
 
-            torchdata = torch.from_numpy(npimage).permute(2, 0, 1).to(device=device, dtype=torch.float32)
+            torchdata = (
+                torch.from_numpy(npimage)
+                .permute(2, 0, 1)
+                .to(device=device, dtype=torch.float32)
+            )
             latent_sample = None
 
             with devices.autocast():
                 latent_dist = model.encode_first_stage(torchdata.unsqueeze(dim=0))
 
-            #Perform latent sampling, even for random sampling.
-            #We need the sample dimensions for the weights
+            # Perform latent sampling, even for random sampling.
+            # We need the sample dimensions for the weights
             if latent_sampling_method == "deterministic":
                 if isinstance(latent_dist, DiagonalGaussianDistribution):
                     # Works only for DiagonalGaussianDistribution
                     latent_dist.std = 0
                 else:
                     latent_sampling_method = "once"
-            latent_sample = model.get_first_stage_encoding(latent_dist).squeeze().to(devices.cpu)
+            latent_sample = (
+                model.get_first_stage_encoding(latent_dist).squeeze().to(devices.cpu)
+            )
 
             if use_weight and alpha_channel is not None:
                 channels, *latent_size = latent_sample.shape
                 weight_img = alpha_channel.resize(latent_size)
                 npweight = np.array(weight_img).astype(np.float32)
-                #Repeat for every channel in the latent sample
-                weight = torch.tensor([npweight] * channels).reshape([channels] + latent_size)
-                #Normalize the weight to a minimum of 0 and a mean of 1, that way the loss will be comparable to default.
+                # Repeat for every channel in the latent sample
+                weight = torch.tensor([npweight] * channels).reshape(
+                    [channels] + latent_size
+                )
+                # Normalize the weight to a minimum of 0 and a mean of 1, that way the loss will be comparable to default.
                 weight -= weight.min()
                 weight /= weight.mean()
             elif use_weight:
-                #If an image does not have a alpha channel, add a ones weight map anyway so we can stack it later
+                # If an image does not have a alpha channel, add a ones weight map anyway so we can stack it later
                 weight = torch.ones(latent_sample.shape)
             else:
                 weight = None
 
             if latent_sampling_method == "random":
-                entry = DatasetEntry(filename=path, filename_text=filename_text, latent_dist=latent_dist, weight=weight)
+                entry = DatasetEntry(
+                    filename=path,
+                    filename_text=filename_text,
+                    latent_dist=latent_dist,
+                    weight=weight,
+                )
             else:
-                entry = DatasetEntry(filename=path, filename_text=filename_text, latent_sample=latent_sample, weight=weight)
+                entry = DatasetEntry(
+                    filename=path,
+                    filename_text=filename_text,
+                    latent_sample=latent_sample,
+                    weight=weight,
+                )
 
             if not (self.tag_drop_out != 0 or self.shuffle_tags):
                 entry.cond_text = self.create_text(filename_text)
 
             if include_cond and not (self.tag_drop_out != 0 or self.shuffle_tags):
                 with devices.autocast():
-                    entry.cond = cond_model([entry.cond_text]).to(devices.cpu).squeeze(0)
+                    entry.cond = (
+                        cond_model([entry.cond_text]).to(devices.cpu).squeeze(0)
+                    )
             groups[image.size].append(len(self.dataset))
             self.dataset.append(entry)
             del torchdata
@@ -151,12 +209,12 @@ class PersonalizedBase(Dataset):
 
     def create_text(self, filename_text):
         text = random.choice(self.lines)
-        tags = filename_text.split(',')
+        tags = filename_text.split(",")
         if self.tag_drop_out != 0:
             tags = [t for t in tags if random.random() > self.tag_drop_out]
         if self.shuffle_tags:
             random.shuffle(tags)
-        text = text.replace("[filewords]", ','.join(tags))
+        text = text.replace("[filewords]", ",".join(tags))
         text = text.replace("[name]", self.placeholder_token)
         return text
 
@@ -168,7 +226,9 @@ class PersonalizedBase(Dataset):
         if self.tag_drop_out != 0 or self.shuffle_tags:
             entry.cond_text = self.create_text(entry.filename_text)
         if self.latent_sampling_method == "random":
-            entry.latent_sample = shared.sd_model.get_first_stage_encoding(entry.latent_dist).to(devices.cpu)
+            entry.latent_sample = shared.sd_model.get_first_stage_encoding(
+                entry.latent_dist
+            ).to(devices.cpu)
         return entry
 
 
@@ -182,7 +242,9 @@ class GroupedBatchSampler(Sampler):
         expected = [len(g) / n * n_batch * batch_size for g in data_source.groups]
         self.base = [int(e) // batch_size for e in expected]
         self.n_rand_batches = nrb = n_batch - sum(self.base)
-        self.probs = [e%batch_size/nrb/batch_size if nrb>0 else 0 for e in expected]
+        self.probs = [
+            e % batch_size / nrb / batch_size if nrb > 0 else 0 for e in expected
+        ]
         self.batch_size = batch_size
 
     def __len__(self):
@@ -196,7 +258,7 @@ class GroupedBatchSampler(Sampler):
 
         batches = []
         for g in self.groups:
-            batches.extend(g[i*b:(i+1)*b] for i in range(len(g) // b))
+            batches.extend(g[i * b : (i + 1) * b] for i in range(len(g) // b))
         for _ in range(self.n_rand_batches):
             rand_group = choices(self.groups, self.probs)[0]
             batches.append(choices(rand_group, k=b))
@@ -207,8 +269,14 @@ class GroupedBatchSampler(Sampler):
 
 
 class PersonalizedDataLoader(DataLoader):
-    def __init__(self, dataset, latent_sampling_method="once", batch_size=1, pin_memory=False):
-        super(PersonalizedDataLoader, self).__init__(dataset, batch_sampler=GroupedBatchSampler(dataset, batch_size), pin_memory=pin_memory)
+    def __init__(
+        self, dataset, latent_sampling_method="once", batch_size=1, pin_memory=False
+    ):
+        super(PersonalizedDataLoader, self).__init__(
+            dataset,
+            batch_sampler=GroupedBatchSampler(dataset, batch_size),
+            pin_memory=pin_memory,
+        )
         if latent_sampling_method == "random":
             self.collate_fn = collate_wrapper_random
         else:
@@ -219,20 +287,24 @@ class BatchLoader:
     def __init__(self, data):
         self.cond_text = [entry.cond_text for entry in data]
         self.cond = [entry.cond for entry in data]
-        self.latent_sample = torch.stack([entry.latent_sample for entry in data]).squeeze(1)
+        self.latent_sample = torch.stack(
+            [entry.latent_sample for entry in data]
+        ).squeeze(1)
         if all(entry.weight is not None for entry in data):
             self.weight = torch.stack([entry.weight for entry in data]).squeeze(1)
         else:
             self.weight = None
-        #self.emb_index = [entry.emb_index for entry in data]
-        #print(self.latent_sample.device)
+        # self.emb_index = [entry.emb_index for entry in data]
+        # print(self.latent_sample.device)
 
     def pin_memory(self):
         self.latent_sample = self.latent_sample.pin_memory()
         return self
 
+
 def collate_wrapper(batch):
     return BatchLoader(batch)
+
 
 class BatchLoaderRandom(BatchLoader):
     def __init__(self, data):
@@ -240,6 +312,7 @@ class BatchLoaderRandom(BatchLoader):
 
     def pin_memory(self):
         return self
+
 
 def collate_wrapper_random(batch):
     return BatchLoaderRandom(batch)

--- a/modules/textual_inversion/image_embedding.py
+++ b/modules/textual_inversion/image_embedding.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class EmbeddingEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, torch.Tensor):
-            return {'TORCHTENSOR': obj.cpu().detach().numpy().tolist()}
+            return {"TORCHTENSOR": obj.cpu().detach().numpy().tolist()}
         return json.JSONEncoder.default(self, obj)
 
 
@@ -24,8 +24,8 @@ class EmbeddingDecoder(json.JSONDecoder):
         json.JSONDecoder.__init__(self, *args, object_hook=self.object_hook, **kwargs)
 
     def object_hook(self, d):
-        if 'TORCHTENSOR' in d:
-            return torch.from_numpy(np.array(d['TORCHTENSOR']))
+        if "TORCHTENSOR" in d:
+            return torch.from_numpy(np.array(d["TORCHTENSOR"]))
         return d
 
 
@@ -47,12 +47,16 @@ def lcg(m=2**32, a=1664525, c=1013904223, seed=0):
 
 def xor_block(block):
     g = lcg()
-    randblock = np.array([next(g) for _ in range(np.prod(block.shape))]).astype(np.uint8).reshape(block.shape)
+    randblock = (
+        np.array([next(g) for _ in range(np.prod(block.shape))])
+        .astype(np.uint8)
+        .reshape(block.shape)
+    )
     return np.bitwise_xor(block.astype(np.uint8), randblock & 0x0F)
 
 
 def style_block(block, sequence):
-    im = Image.new('RGB', (block.shape[1], block.shape[0]))
+    im = Image.new("RGB", (block.shape[1], block.shape[0]))
     draw = ImageDraw.Draw(im)
     i = 0
     for x in range(-6, im.size[0], 8):
@@ -62,7 +66,9 @@ def style_block(block, sequence):
                 offset = 4
             shade = sequence[i % len(sequence)]
             i += 1
-            draw.ellipse((x+offset, y, x+6+offset, y+6), fill=(shade, shade, shade))
+            draw.ellipse(
+                (x + offset, y, x + 6 + offset, y + 6), fill=(shade, shade, shade)
+            )
 
     fg = np.array(im).astype(np.uint8) & 0xF0
 
@@ -71,14 +77,16 @@ def style_block(block, sequence):
 
 def insert_image_data_embed(image, data):
     d = 3
-    data_compressed = zlib.compress(json.dumps(data, cls=EmbeddingEncoder).encode(), level=9)
+    data_compressed = zlib.compress(
+        json.dumps(data, cls=EmbeddingEncoder).encode(), level=9
+    )
     data_np_ = np.frombuffer(data_compressed, np.uint8).copy()
     data_np_high = data_np_ >> 4
     data_np_low = data_np_ & 0x0F
 
     h = image.size[1]
-    next_size = data_np_low.shape[0] + (h-(data_np_low.shape[0] % h))
-    next_size = next_size + ((h*d)-(next_size % (h*d)))
+    next_size = data_np_low.shape[0] + (h - (data_np_low.shape[0] % h))
+    next_size = next_size + ((h * d) - (next_size % (h * d)))
 
     data_np_low = np.resize(data_np_low, next_size)
     data_np_low = data_np_low.reshape((h, -1, d))
@@ -86,21 +94,33 @@ def insert_image_data_embed(image, data):
     data_np_high = np.resize(data_np_high, next_size)
     data_np_high = data_np_high.reshape((h, -1, d))
 
-    edge_style = list(data['string_to_param'].values())[0].cpu().detach().numpy().tolist()[0][:1024]
-    edge_style = (np.abs(edge_style)/np.max(np.abs(edge_style))*255).astype(np.uint8)
+    edge_style = (
+        list(data["string_to_param"].values())[0]
+        .cpu()
+        .detach()
+        .numpy()
+        .tolist()[0][:1024]
+    )
+    edge_style = (np.abs(edge_style) / np.max(np.abs(edge_style)) * 255).astype(
+        np.uint8
+    )
 
     data_np_low = style_block(data_np_low, sequence=edge_style)
     data_np_low = xor_block(data_np_low)
     data_np_high = style_block(data_np_high, sequence=edge_style[::-1])
     data_np_high = xor_block(data_np_high)
 
-    im_low = Image.fromarray(data_np_low, mode='RGB')
-    im_high = Image.fromarray(data_np_high, mode='RGB')
+    im_low = Image.fromarray(data_np_low, mode="RGB")
+    im_high = Image.fromarray(data_np_high, mode="RGB")
 
-    background = Image.new('RGB', (image.size[0]+im_low.size[0]+im_high.size[0]+2, image.size[1]), (0, 0, 0))
+    background = Image.new(
+        "RGB",
+        (image.size[0] + im_low.size[0] + im_high.size[0] + 2, image.size[1]),
+        (0, 0, 0),
+    )
     background.paste(im_low, (0, 0))
-    background.paste(image, (im_low.size[0]+1, 0))
-    background.paste(im_high, (im_low.size[0]+1+image.size[0]+1, 0))
+    background.paste(image, (im_low.size[0] + 1, 0))
+    background.paste(im_high, (im_low.size[0] + 1 + image.size[0] + 1, 0))
 
     return background
 
@@ -108,21 +128,30 @@ def insert_image_data_embed(image, data):
 def crop_black(img, tol=0):
     mask = (img > tol).all(2)
     mask0, mask1 = mask.any(0), mask.any(1)
-    col_start, col_end = mask0.argmax(), mask.shape[1]-mask0[::-1].argmax()
-    row_start, row_end = mask1.argmax(), mask.shape[0]-mask1[::-1].argmax()
+    col_start, col_end = mask0.argmax(), mask.shape[1] - mask0[::-1].argmax()
+    row_start, row_end = mask1.argmax(), mask.shape[0] - mask1[::-1].argmax()
     return img[row_start:row_end, col_start:col_end]
 
 
 def extract_image_data_embed(image):
     d = 3
-    outarr = crop_black(np.array(image.convert('RGB').getdata()).reshape(image.size[1], image.size[0], d).astype(np.uint8)) & 0x0F
+    outarr = (
+        crop_black(
+            np.array(image.convert("RGB").getdata())
+            .reshape(image.size[1], image.size[0], d)
+            .astype(np.uint8)
+        )
+        & 0x0F
+    )
     black_cols = np.where(np.sum(outarr, axis=(0, 2)) == 0)
     if black_cols[0].shape[0] < 2:
-        logger.debug(f'{os.path.basename(getattr(image, "filename", "unknown image file"))}: no embedded information found.')
+        logger.debug(
+            f'{os.path.basename(getattr(image, "filename", "unknown image file"))}: no embedded information found.'
+        )
         return None
 
-    data_block_lower = outarr[:, :black_cols[0].min(), :].astype(np.uint8)
-    data_block_upper = outarr[:, black_cols[0].max()+1:, :].astype(np.uint8)
+    data_block_lower = outarr[:, : black_cols[0].min(), :].astype(np.uint8)
+    data_block_upper = outarr[:, black_cols[0].max() + 1 :, :].astype(np.uint8)
 
     data_block_lower = xor_block(data_block_lower)
     data_block_upper = xor_block(data_block_upper)
@@ -134,11 +163,14 @@ def extract_image_data_embed(image):
     return json.loads(data, cls=EmbeddingDecoder)
 
 
-def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, textfont=None):
+def caption_image_overlay(
+    srcimage, title, footerLeft, footerMid, footerRight, textfont=None
+):
     from modules.images import get_font
+
     if textfont:
         warnings.warn(
-            'passing in a textfont to caption_image_overlay is deprecated and does nothing',
+            "passing in a textfont to caption_image_overlay is deprecated and does nothing",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -147,12 +179,12 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
     image = srcimage.copy()
     fontsize = 32
     factor = 1.5
-    gradient = Image.new('RGBA', (1, image.size[1]), color=(0, 0, 0, 0))
+    gradient = Image.new("RGBA", (1, image.size[1]), color=(0, 0, 0, 0))
     for y in range(image.size[1]):
-        mag = 1-cos(y/image.size[1]*factor)
-        mag = max(mag, 1-cos((image.size[1]-y)/image.size[1]*factor*1.1))
-        gradient.putpixel((0, y), (0, 0, 0, int(mag*255)))
-    image = Image.alpha_composite(image.convert('RGBA'), gradient.resize(image.size))
+        mag = 1 - cos(y / image.size[1] * factor)
+        mag = max(mag, 1 - cos((image.size[1] - y) / image.size[1] * factor * 1.1))
+        gradient.putpixel((0, y), (0, 0, 0, int(mag * 255)))
+    image = Image.alpha_composite(image.convert("RGBA"), gradient.resize(image.size))
 
     draw = ImageDraw.Draw(image)
 
@@ -160,40 +192,63 @@ def caption_image_overlay(srcimage, title, footerLeft, footerMid, footerRight, t
     padding = 10
 
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
-    fontsize = min(int(fontsize * (((image.size[0]*0.75)-(padding*4))/w)), 72)
+    fontsize = min(int(fontsize * (((image.size[0] * 0.75) - (padding * 4)) / w)), 72)
     font = get_font(fontsize)
     _, _, w, h = draw.textbbox((0, 0), title, font=font)
-    draw.text((padding, padding), title, anchor='lt', font=font, fill=(255, 255, 255, 230))
+    draw.text(
+        (padding, padding), title, anchor="lt", font=font, fill=(255, 255, 255, 230)
+    )
 
     _, _, w, h = draw.textbbox((0, 0), footerLeft, font=font)
-    fontsize_left = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+    fontsize_left = min(int(fontsize * (((image.size[0] / 3) - (padding)) / w)), 72)
     _, _, w, h = draw.textbbox((0, 0), footerMid, font=font)
-    fontsize_mid = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+    fontsize_mid = min(int(fontsize * (((image.size[0] / 3) - (padding)) / w)), 72)
     _, _, w, h = draw.textbbox((0, 0), footerRight, font=font)
-    fontsize_right = min(int(fontsize * (((image.size[0]/3)-(padding))/w)), 72)
+    fontsize_right = min(int(fontsize * (((image.size[0] / 3) - (padding)) / w)), 72)
 
     font = get_font(min(fontsize_left, fontsize_mid, fontsize_right))
 
-    draw.text((padding, image.size[1]-padding),               footerLeft, anchor='ls', font=font, fill=(255, 255, 255, 230))
-    draw.text((image.size[0]/2, image.size[1]-padding),       footerMid, anchor='ms', font=font, fill=(255, 255, 255, 230))
-    draw.text((image.size[0]-padding, image.size[1]-padding), footerRight, anchor='rs', font=font, fill=(255, 255, 255, 230))
+    draw.text(
+        (padding, image.size[1] - padding),
+        footerLeft,
+        anchor="ls",
+        font=font,
+        fill=(255, 255, 255, 230),
+    )
+    draw.text(
+        (image.size[0] / 2, image.size[1] - padding),
+        footerMid,
+        anchor="ms",
+        font=font,
+        fill=(255, 255, 255, 230),
+    )
+    draw.text(
+        (image.size[0] - padding, image.size[1] - padding),
+        footerRight,
+        anchor="rs",
+        font=font,
+        fill=(255, 255, 255, 230),
+    )
 
     return image
 
 
-if __name__ == '__main__':
-
-    testEmbed = Image.open('test_embedding.png')
+if __name__ == "__main__":
+    testEmbed = Image.open("test_embedding.png")
     data = extract_image_data_embed(testEmbed)
     assert data is not None
 
-    data = embedding_from_b64(testEmbed.text['sd-ti-embedding'])
+    data = embedding_from_b64(testEmbed.text["sd-ti-embedding"])
     assert data is not None
 
-    image = Image.new('RGBA', (512, 512), (255, 255, 200, 255))
-    cap_image = caption_image_overlay(image, 'title', 'footerLeft', 'footerMid', 'footerRight')
+    image = Image.new("RGBA", (512, 512), (255, 255, 200, 255))
+    cap_image = caption_image_overlay(
+        image, "title", "footerLeft", "footerMid", "footerRight"
+    )
 
-    test_embed = {'string_to_param': {'*': torch.from_numpy(np.random.random((2, 4096)))}}
+    test_embed = {
+        "string_to_param": {"*": torch.from_numpy(np.random.random((2, 4096)))}
+    }
 
     embedded_image = insert_image_data_embed(cap_image, test_embed)
 
@@ -208,17 +263,113 @@ if __name__ == '__main__':
     g = lcg()
     shared_random = np.array([next(g) for _ in range(100)]).astype(np.uint8).tolist()
 
-    reference_random = [253, 242, 127,  44, 157,  27, 239, 133,  38,  79, 167,   4, 177,
-                         95, 130,  79,  78,  14,  52, 215, 220, 194, 126,  28, 240, 179,
-                        160, 153, 149,  50, 105,  14,  21, 218, 199,  18,  54, 198, 193,
-                         38, 128,  19,  53, 195, 124,  75, 205,  12,   6, 145,   0,  28,
-                         30, 148,   8,  45, 218, 171,  55, 249,  97, 166,  12,  35,   0,
-                         41, 221, 122, 215, 170,  31, 113, 186,  97, 119,  31,  23, 185,
-                         66, 140,  30,  41,  37,  63, 137, 109, 216,  55, 159, 145,  82,
-                         204, 86,  73, 222,  44, 198, 118, 240,  97]
+    reference_random = [
+        253,
+        242,
+        127,
+        44,
+        157,
+        27,
+        239,
+        133,
+        38,
+        79,
+        167,
+        4,
+        177,
+        95,
+        130,
+        79,
+        78,
+        14,
+        52,
+        215,
+        220,
+        194,
+        126,
+        28,
+        240,
+        179,
+        160,
+        153,
+        149,
+        50,
+        105,
+        14,
+        21,
+        218,
+        199,
+        18,
+        54,
+        198,
+        193,
+        38,
+        128,
+        19,
+        53,
+        195,
+        124,
+        75,
+        205,
+        12,
+        6,
+        145,
+        0,
+        28,
+        30,
+        148,
+        8,
+        45,
+        218,
+        171,
+        55,
+        249,
+        97,
+        166,
+        12,
+        35,
+        0,
+        41,
+        221,
+        122,
+        215,
+        170,
+        31,
+        113,
+        186,
+        97,
+        119,
+        31,
+        23,
+        185,
+        66,
+        140,
+        30,
+        41,
+        37,
+        63,
+        137,
+        109,
+        216,
+        55,
+        159,
+        145,
+        82,
+        204,
+        86,
+        73,
+        222,
+        44,
+        198,
+        118,
+        240,
+        97,
+    ]
 
     assert shared_random == reference_random
 
-    hunna_kay_random_sum = sum(np.array([next(g) for _ in range(100000)]).astype(np.uint8).tolist())
+    hunna_kay_random_sum = sum(
+        np.array([next(g) for _ in range(100000)]).astype(np.uint8).tolist()
+    )
 
     assert 12731374 == hunna_kay_random_sum

--- a/modules/textual_inversion/learn_schedule.py
+++ b/modules/textual_inversion/learn_schedule.py
@@ -7,7 +7,7 @@ class LearnScheduleIterator:
         specify learn_rate as "0.001:100, 0.00001:1000, 1e-5:10000" to have lr of 0.001 until step 100, 0.00001 until 1000, and 1e-5 until 10000
         """
 
-        pairs = learn_rate.split(',')
+        pairs = learn_rate.split(",")
         self.rates = []
         self.it = 0
         self.maxit = 0
@@ -15,7 +15,7 @@ class LearnScheduleIterator:
             for pair in pairs:
                 if not pair.strip():
                     continue
-                tmp = pair.split(':')
+                tmp = pair.split(":")
                 if len(tmp) == 2:
                     step = int(tmp[1])
                     if step > cur_step:
@@ -33,8 +33,9 @@ class LearnScheduleIterator:
                     return
             assert self.rates
         except (ValueError, AssertionError) as e:
-            raise Exception('Invalid learning rate schedule. It should be a number or, for example, like "0.001:100, 0.00001:1000, 1e-5:10000" to have lr of 0.001 until step 100, 0.00001 until 1000, and 1e-5 until 10000.') from e
-
+            raise Exception(
+                'Invalid learning rate schedule. It should be a number or, for example, like "0.001:100, 0.00001:1000, 1e-5:10000" to have lr of 0.001 until step 100, 0.00001 until 1000, and 1e-5 until 10000.'
+            ) from e
 
     def __iter__(self):
         return self
@@ -50,11 +51,11 @@ class LearnScheduleIterator:
 class LearnRateScheduler:
     def __init__(self, learn_rate, max_steps, cur_step=0, verbose=True):
         self.schedules = LearnScheduleIterator(learn_rate, max_steps, cur_step)
-        (self.learn_rate,  self.end_step) = next(self.schedules)
+        (self.learn_rate, self.end_step) = next(self.schedules)
         self.verbose = verbose
 
         if self.verbose:
-            print(f'Training at rate of {self.learn_rate} until step {self.end_step}')
+            print(f"Training at rate of {self.learn_rate} until step {self.end_step}")
 
         self.finished = False
 
@@ -74,8 +75,9 @@ class LearnRateScheduler:
             return
 
         if self.verbose:
-            tqdm.tqdm.write(f'Training at rate of {self.learn_rate} until step {self.end_step}')
+            tqdm.tqdm.write(
+                f"Training at rate of {self.learn_rate} until step {self.end_step}"
+            )
 
         for pg in optimizer.param_groups:
-            pg['lr'] = self.learn_rate
-
+            pg["lr"] = self.learn_rate

--- a/modules/textual_inversion/saving_settings.py
+++ b/modules/textual_inversion/saving_settings.py
@@ -54,7 +54,7 @@ def save_settings_to_file(log_directory, all_params):
     params = {"datetime": now.strftime("%Y-%m-%d %H:%M:%S")}
 
     keys = saved_params_all
-    if all_params.get('preview_from_txt2img'):
+    if all_params.get("preview_from_txt2img"):
         keys = keys | saved_params_previews
 
     params.update({k: v for k, v in all_params.items() if k in keys})

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -817,7 +817,6 @@ def train_embedding(
                     shared.sd_model.first_stage_model.to(devices.device)
 
                     p = processing.StableDiffusionProcessingTxt2Img(
-                        sd_model=shared.sd_model,
                         do_not_save_grid=True,
                         do_not_save_samples=True,
                         do_not_reload_embeddings=True,

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -12,11 +12,27 @@ import safetensors.torch
 import numpy as np
 from PIL import Image, PngImagePlugin
 
-from modules import shared, devices, sd_hijack, sd_models, images, sd_samplers, sd_hijack_checkpoint, errors, hashes
+from modules import (
+    shared,
+    devices,
+    sd_hijack,
+    sd_models,
+    images,
+    sd_samplers,
+    sd_hijack_checkpoint,
+    errors,
+    hashes,
+)
 import modules.textual_inversion.dataset
 from modules.textual_inversion.learn_schedule import LearnRateScheduler
 
-from modules.textual_inversion.image_embedding import embedding_to_b64, embedding_from_b64, insert_image_data_embed, extract_image_data_embed, caption_image_overlay
+from modules.textual_inversion.image_embedding import (
+    embedding_to_b64,
+    embedding_from_b64,
+    insert_image_data_embed,
+    extract_image_data_embed,
+    caption_image_overlay,
+)
 from modules.textual_inversion.saving_settings import save_settings_to_file
 
 
@@ -65,8 +81,8 @@ class Embedding:
 
         if shared.opts.save_optimizer_state and self.optimizer_state_dict is not None:
             optimizer_saved_dict = {
-                'hash': self.checksum(),
-                'optimizer_state_dict': self.optimizer_state_dict,
+                "hash": self.checksum(),
+                "optimizer_state_dict": self.optimizer_state_dict,
             }
             torch.save(optimizer_saved_dict, f"{filename}.optim")
 
@@ -80,7 +96,7 @@ class Embedding:
                 r = (r * 281 ^ int(v) * 997) & 0xFFFFFFFF
             return r
 
-        self.cached_checksum = f'{const_hash(self.vec.reshape(-1) * 100) & 0xffff:04x}'
+        self.cached_checksum = f"{const_hash(self.vec.reshape(-1) * 100) & 0xffff:04x}"
         return self.cached_checksum
 
     def set_hash(self, v):
@@ -133,17 +149,19 @@ class EmbeddingDatabase:
             self.ids_lookup[first_id] = []
         if name in self.word_embeddings:
             # remove old one from the lookup list
-            lookup = [x for x in self.ids_lookup[first_id] if x[1].name!=name]
+            lookup = [x for x in self.ids_lookup[first_id] if x[1].name != name]
         else:
             lookup = self.ids_lookup[first_id]
         if embedding is not None:
             lookup += [(ids, embedding)]
-        self.ids_lookup[first_id] = sorted(lookup, key=lambda x: len(x[0]), reverse=True)
+        self.ids_lookup[first_id] = sorted(
+            lookup, key=lambda x: len(x[0]), reverse=True
+        )
         if embedding is None:
             # unregister embedding with specified name
             if name in self.word_embeddings:
                 del self.word_embeddings[name]
-            if len(self.ids_lookup[first_id])==0:
+            if len(self.ids_lookup[first_id]) == 0:
                 del self.ids_lookup[first_id]
             return None
         self.word_embeddings[name] = embedding
@@ -158,39 +176,42 @@ class EmbeddingDatabase:
         name, ext = os.path.splitext(filename)
         ext = ext.upper()
 
-        if ext in ['.PNG', '.WEBP', '.JXL', '.AVIF']:
+        if ext in [".PNG", ".WEBP", ".JXL", ".AVIF"]:
             _, second_ext = os.path.splitext(name)
-            if second_ext.upper() == '.PREVIEW':
+            if second_ext.upper() == ".PREVIEW":
                 return
 
             embed_image = Image.open(path)
-            if hasattr(embed_image, 'text') and 'sd-ti-embedding' in embed_image.text:
-                data = embedding_from_b64(embed_image.text['sd-ti-embedding'])
-                name = data.get('name', name)
+            if hasattr(embed_image, "text") and "sd-ti-embedding" in embed_image.text:
+                data = embedding_from_b64(embed_image.text["sd-ti-embedding"])
+                name = data.get("name", name)
             else:
                 data = extract_image_data_embed(embed_image)
                 if data:
-                    name = data.get('name', name)
+                    name = data.get("name", name)
                 else:
                     # if data is None, means this is not an embedding, just a preview image
                     return
-        elif ext in ['.BIN', '.PT']:
+        elif ext in [".BIN", ".PT"]:
             data = torch.load(path, map_location="cpu")
-        elif ext in ['.SAFETENSORS']:
+        elif ext in [".SAFETENSORS"]:
             data = safetensors.torch.load_file(path, device="cpu")
         else:
             return
 
         if data is not None:
-            embedding = create_embedding_from_data(data, name, filename=filename, filepath=path)
+            embedding = create_embedding_from_data(
+                data, name, filename=filename, filepath=path
+            )
 
             if self.expected_shape == -1 or self.expected_shape == embedding.shape:
                 self.register_embedding(embedding, shared.sd_model)
             else:
                 self.skipped_embeddings[name] = embedding
         else:
-            print(f"Unable to load Textual inversion embedding due to data issue: '{name}'.")
-
+            print(
+                f"Unable to load Textual inversion embedding due to data issue: '{name}'."
+            )
 
     def load_from_dir(self, embdir):
         if not os.path.isdir(embdir.path):
@@ -231,16 +252,29 @@ class EmbeddingDatabase:
 
         # re-sort word_embeddings because load_from_dir may not load in alphabetic order.
         # using a temporary copy so we don't reinitialize self.word_embeddings in case other objects have a reference to it.
-        sorted_word_embeddings = {e.name: e for e in sorted(self.word_embeddings.values(), key=lambda e: e.name.lower())}
+        sorted_word_embeddings = {
+            e.name: e
+            for e in sorted(self.word_embeddings.values(), key=lambda e: e.name.lower())
+        }
         self.word_embeddings.clear()
         self.word_embeddings.update(sorted_word_embeddings)
 
-        displayed_embeddings = (tuple(self.word_embeddings.keys()), tuple(self.skipped_embeddings.keys()))
-        if shared.opts.textual_inversion_print_at_load and self.previously_displayed_embeddings != displayed_embeddings:
+        displayed_embeddings = (
+            tuple(self.word_embeddings.keys()),
+            tuple(self.skipped_embeddings.keys()),
+        )
+        if (
+            shared.opts.textual_inversion_print_at_load
+            and self.previously_displayed_embeddings != displayed_embeddings
+        ):
             self.previously_displayed_embeddings = displayed_embeddings
-            print(f"Textual inversion embeddings loaded({len(self.word_embeddings)}): {', '.join(self.word_embeddings.keys())}")
+            print(
+                f"Textual inversion embeddings loaded({len(self.word_embeddings)}): {', '.join(self.word_embeddings.keys())}"
+            )
             if self.skipped_embeddings:
-                print(f"Textual inversion embeddings skipped({len(self.skipped_embeddings)}): {', '.join(self.skipped_embeddings.keys())}")
+                print(
+                    f"Textual inversion embeddings skipped({len(self.skipped_embeddings)}): {', '.join(self.skipped_embeddings.keys())}"
+                )
 
     def find_embedding_at_position(self, tokens, offset):
         token = tokens[offset]
@@ -250,29 +284,31 @@ class EmbeddingDatabase:
             return None, None
 
         for ids, embedding in possible_matches:
-            if tokens[offset:offset + len(ids)] == ids:
+            if tokens[offset : offset + len(ids)] == ids:
                 return embedding, len(ids)
 
         return None, None
 
 
-def create_embedding(name, num_vectors_per_token, overwrite_old, init_text='*'):
+def create_embedding(name, num_vectors_per_token, overwrite_old, init_text="*"):
     cond_model = shared.sd_model.cond_stage_model
 
     with devices.autocast():
         cond_model([""])  # will send cond model to GPU if lowvram/medvram is active
 
-    #cond_model expects at least some text, so we provide '*' as backup.
-    embedded = cond_model.encode_embedding_init_text(init_text or '*', num_vectors_per_token)
+    # cond_model expects at least some text, so we provide '*' as backup.
+    embedded = cond_model.encode_embedding_init_text(
+        init_text or "*", num_vectors_per_token
+    )
     vec = torch.zeros((num_vectors_per_token, embedded.shape[1]), device=devices.device)
 
-    #Only copy if we provided an init_text, otherwise keep vectors as zeros
+    # Only copy if we provided an init_text, otherwise keep vectors as zeros
     if init_text:
         for i in range(num_vectors_per_token):
             vec[i] = embedded[i * int(embedded.shape[0]) // num_vectors_per_token]
 
     # Remove illegal characters from name.
-    name = "".join( x for x in name if (x.isalnum() or x in "._- "))
+    name = "".join(x for x in name if (x.isalnum() or x in "._- "))
     fn = os.path.join(shared.cmd_opts.embeddings_dir, f"{name}.pt")
     if not overwrite_old:
         assert not os.path.exists(fn), f"file {fn} already exists"
@@ -284,21 +320,30 @@ def create_embedding(name, num_vectors_per_token, overwrite_old, init_text='*'):
     return fn
 
 
-def create_embedding_from_data(data, name, filename='unknown embedding file', filepath=None):
-    if 'string_to_param' in data:  # textual inversion embeddings
-        param_dict = data['string_to_param']
-        param_dict = getattr(param_dict, '_parameters', param_dict)  # fix for torch 1.12.1 loading saved file from torch 1.11
-        assert len(param_dict) == 1, 'embedding file has multiple terms in it'
+def create_embedding_from_data(
+    data, name, filename="unknown embedding file", filepath=None
+):
+    if "string_to_param" in data:  # textual inversion embeddings
+        param_dict = data["string_to_param"]
+        param_dict = getattr(
+            param_dict, "_parameters", param_dict
+        )  # fix for torch 1.12.1 loading saved file from torch 1.11
+        assert len(param_dict) == 1, "embedding file has multiple terms in it"
         emb = next(iter(param_dict.items()))[1]
         vec = emb.detach().to(devices.device, dtype=torch.float32)
         shape = vec.shape[-1]
         vectors = vec.shape[0]
-    elif type(data) == dict and 'clip_g' in data and 'clip_l' in data:  # SDXL embedding
-        vec = {k: v.detach().to(devices.device, dtype=torch.float32) for k, v in data.items()}
-        shape = data['clip_g'].shape[-1] + data['clip_l'].shape[-1]
-        vectors = data['clip_g'].shape[0]
-    elif type(data) == dict and type(next(iter(data.values()))) == torch.Tensor:  # diffuser concepts
-        assert len(data.keys()) == 1, 'embedding file has multiple terms in it'
+    elif type(data) == dict and "clip_g" in data and "clip_l" in data:  # SDXL embedding
+        vec = {
+            k: v.detach().to(devices.device, dtype=torch.float32)
+            for k, v in data.items()
+        }
+        shape = data["clip_g"].shape[-1] + data["clip_l"].shape[-1]
+        vectors = data["clip_g"].shape[0]
+    elif (
+        type(data) == dict and type(next(iter(data.values()))) == torch.Tensor
+    ):  # diffuser concepts
+        assert len(data.keys()) == 1, "embedding file has multiple terms in it"
 
         emb = next(iter(data.values()))
         if len(emb.shape) == 1:
@@ -307,18 +352,20 @@ def create_embedding_from_data(data, name, filename='unknown embedding file', fi
         shape = vec.shape[-1]
         vectors = vec.shape[0]
     else:
-        raise Exception(f"Couldn't identify {filename} as neither textual inversion embedding nor diffuser concept.")
+        raise Exception(
+            f"Couldn't identify {filename} as neither textual inversion embedding nor diffuser concept."
+        )
 
     embedding = Embedding(vec, name)
-    embedding.step = data.get('step', None)
-    embedding.sd_checkpoint = data.get('sd_checkpoint', None)
-    embedding.sd_checkpoint_name = data.get('sd_checkpoint_name', None)
+    embedding.step = data.get("step", None)
+    embedding.sd_checkpoint = data.get("sd_checkpoint", None)
+    embedding.sd_checkpoint_name = data.get("sd_checkpoint_name", None)
     embedding.vectors = vectors
     embedding.shape = shape
 
     if filepath:
         embedding.filename = filepath
-        embedding.set_hash(hashes.sha256(filepath, "textual_inversion/" + name) or '')
+        embedding.set_hash(hashes.sha256(filepath, "textual_inversion/" + name) or "")
 
     return embedding
 
@@ -329,10 +376,14 @@ def write_loss(log_directory, filename, step, epoch_len, values):
 
     if step % shared.opts.training_write_csv_every != 0:
         return
-    write_csv_header = False if os.path.exists(os.path.join(log_directory, filename)) else True
+    write_csv_header = (
+        False if os.path.exists(os.path.join(log_directory, filename)) else True
+    )
 
-    with open(os.path.join(log_directory, filename), "a+", newline='') as fout:
-        csv_writer = csv.DictWriter(fout, fieldnames=["step", "epoch", "epoch_step", *(values.keys())])
+    with open(os.path.join(log_directory, filename), "a+", newline="") as fout:
+        csv_writer = csv.DictWriter(
+            fout, fieldnames=["step", "epoch", "epoch_step", *(values.keys())]
+        )
 
         if write_csv_header:
             csv_writer.writeheader()
@@ -340,40 +391,68 @@ def write_loss(log_directory, filename, step, epoch_len, values):
         epoch = (step - 1) // epoch_len
         epoch_step = (step - 1) % epoch_len
 
-        csv_writer.writerow({
-            "step": step,
-            "epoch": epoch,
-            "epoch_step": epoch_step,
-            **values,
-        })
+        csv_writer.writerow(
+            {
+                "step": step,
+                "epoch": epoch,
+                "epoch_step": epoch_step,
+                **values,
+            }
+        )
+
 
 def tensorboard_setup(log_directory):
     from torch.utils.tensorboard import SummaryWriter
+
     os.makedirs(os.path.join(log_directory, "tensorboard"), exist_ok=True)
     return SummaryWriter(
-            log_dir=os.path.join(log_directory, "tensorboard"),
-            flush_secs=shared.opts.training_tensorboard_flush_every)
+        log_dir=os.path.join(log_directory, "tensorboard"),
+        flush_secs=shared.opts.training_tensorboard_flush_every,
+    )
+
 
 def tensorboard_add(tensorboard_writer, loss, global_step, step, learn_rate, epoch_num):
     tensorboard_add_scaler(tensorboard_writer, "Loss/train", loss, global_step)
-    tensorboard_add_scaler(tensorboard_writer, f"Loss/train/epoch-{epoch_num}", loss, step)
-    tensorboard_add_scaler(tensorboard_writer, "Learn rate/train", learn_rate, global_step)
-    tensorboard_add_scaler(tensorboard_writer, f"Learn rate/train/epoch-{epoch_num}", learn_rate, step)
+    tensorboard_add_scaler(
+        tensorboard_writer, f"Loss/train/epoch-{epoch_num}", loss, step
+    )
+    tensorboard_add_scaler(
+        tensorboard_writer, "Learn rate/train", learn_rate, global_step
+    )
+    tensorboard_add_scaler(
+        tensorboard_writer, f"Learn rate/train/epoch-{epoch_num}", learn_rate, step
+    )
+
 
 def tensorboard_add_scaler(tensorboard_writer, tag, value, step):
-    tensorboard_writer.add_scalar(tag=tag,
-        scalar_value=value, global_step=step)
+    tensorboard_writer.add_scalar(tag=tag, scalar_value=value, global_step=step)
+
 
 def tensorboard_add_image(tensorboard_writer, tag, pil_image, step):
     # Convert a pil image to a torch tensor
     img_tensor = torch.as_tensor(np.array(pil_image, copy=True))
-    img_tensor = img_tensor.view(pil_image.size[1], pil_image.size[0],
-        len(pil_image.getbands()))
+    img_tensor = img_tensor.view(
+        pil_image.size[1], pil_image.size[0], len(pil_image.getbands())
+    )
     img_tensor = img_tensor.permute((2, 0, 1))
 
     tensorboard_writer.add_image(tag, img_tensor, global_step=step)
 
-def validate_train_inputs(model_name, learn_rate, batch_size, gradient_step, data_root, template_file, template_filename, steps, save_model_every, create_image_every, log_directory, name="embedding"):
+
+def validate_train_inputs(
+    model_name,
+    learn_rate,
+    batch_size,
+    gradient_step,
+    data_root,
+    template_file,
+    template_filename,
+    steps,
+    save_model_every,
+    create_image_every,
+    log_directory,
+    name="embedding",
+):
     assert model_name, f"{name} not selected"
     assert learn_rate, "Learning rate is empty or 0"
     assert isinstance(batch_size, int), "Batch size must be integer"
@@ -385,7 +464,9 @@ def validate_train_inputs(model_name, learn_rate, batch_size, gradient_step, dat
     assert os.listdir(data_root), "Dataset directory is empty"
     assert template_filename, "Prompt template file not selected"
     assert template_file, f"Prompt template file {template_filename} not found"
-    assert os.path.isfile(template_file.path), f"Prompt template file {template_filename} doesn't exist"
+    assert os.path.isfile(
+        template_file.path
+    ), f"Prompt template file {template_filename} doesn't exist"
     assert steps, "Max steps is empty or 0"
     assert isinstance(steps, int), "Max steps must be integer"
     assert steps > 0, "Max steps must be positive"
@@ -397,22 +478,68 @@ def validate_train_inputs(model_name, learn_rate, batch_size, gradient_step, dat
         assert log_directory, "Log directory is empty"
 
 
-def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_step, data_root, log_directory, training_width, training_height, varsize, steps, clip_grad_mode, clip_grad_value, shuffle_tags, tag_drop_out, latent_sampling_method, use_weight, create_image_every, save_embedding_every, template_filename, save_image_with_stored_embedding, preview_from_txt2img, preview_prompt, preview_negative_prompt, preview_steps, preview_sampler_name, preview_cfg_scale, preview_seed, preview_width, preview_height):
+def train_embedding(
+    id_task,
+    embedding_name,
+    learn_rate,
+    batch_size,
+    gradient_step,
+    data_root,
+    log_directory,
+    training_width,
+    training_height,
+    varsize,
+    steps,
+    clip_grad_mode,
+    clip_grad_value,
+    shuffle_tags,
+    tag_drop_out,
+    latent_sampling_method,
+    use_weight,
+    create_image_every,
+    save_embedding_every,
+    template_filename,
+    save_image_with_stored_embedding,
+    preview_from_txt2img,
+    preview_prompt,
+    preview_negative_prompt,
+    preview_steps,
+    preview_sampler_name,
+    preview_cfg_scale,
+    preview_seed,
+    preview_width,
+    preview_height,
+):
     from modules import processing
 
     save_embedding_every = save_embedding_every or 0
     create_image_every = create_image_every or 0
     template_file = textual_inversion_templates.get(template_filename, None)
-    validate_train_inputs(embedding_name, learn_rate, batch_size, gradient_step, data_root, template_file, template_filename, steps, save_embedding_every, create_image_every, log_directory, name="embedding")
+    validate_train_inputs(
+        embedding_name,
+        learn_rate,
+        batch_size,
+        gradient_step,
+        data_root,
+        template_file,
+        template_filename,
+        steps,
+        save_embedding_every,
+        create_image_every,
+        log_directory,
+        name="embedding",
+    )
     template_file = template_file.path
 
     shared.state.job = "train-embedding"
     shared.state.textinfo = "Initializing textual inversion training..."
     shared.state.job_count = steps
 
-    filename = os.path.join(shared.cmd_opts.embeddings_dir, f'{embedding_name}.pt')
+    filename = os.path.join(shared.cmd_opts.embeddings_dir, f"{embedding_name}.pt")
 
-    log_directory = os.path.join(log_directory, datetime.datetime.now().strftime("%Y-%m-%d"), embedding_name)
+    log_directory = os.path.join(
+        log_directory, datetime.datetime.now().strftime("%Y-%m-%d"), embedding_name
+    )
     unload = shared.opts.unload_models_when_training
 
     if save_embedding_every > 0:
@@ -440,15 +567,23 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
 
     initial_step = embedding.step or 0
     if initial_step >= steps:
-        shared.state.textinfo = "Model has already been trained beyond specified max steps"
+        shared.state.textinfo = (
+            "Model has already been trained beyond specified max steps"
+        )
         return embedding, filename
 
     scheduler = LearnRateScheduler(learn_rate, steps, initial_step)
-    clip_grad = torch.nn.utils.clip_grad_value_ if clip_grad_mode == "value" else \
-        torch.nn.utils.clip_grad_norm_ if clip_grad_mode == "norm" else \
-        None
+    clip_grad = (
+        torch.nn.utils.clip_grad_value_
+        if clip_grad_mode == "value"
+        else torch.nn.utils.clip_grad_norm_
+        if clip_grad_mode == "norm"
+        else None
+    )
     if clip_grad:
-        clip_grad_sched = LearnRateScheduler(clip_grad_value, steps, initial_step, verbose=False)
+        clip_grad_sched = LearnRateScheduler(
+            clip_grad_value, steps, initial_step, verbose=False
+        )
     # dataset loading may take a while, so input validations and early returns should be done before this
     shared.state.textinfo = f"Preparing dataset from {html.escape(data_root)}..."
     old_parallel_processing_allowed = shared.parallel_processing_allowed
@@ -462,27 +597,64 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
 
     pin_memory = shared.opts.pin_memory
 
-    ds = modules.textual_inversion.dataset.PersonalizedBase(data_root=data_root, width=training_width, height=training_height, repeats=shared.opts.training_image_repeats_per_epoch, placeholder_token=embedding_name, model=shared.sd_model, cond_model=shared.sd_model.cond_stage_model, device=devices.device, template_file=template_file, batch_size=batch_size, gradient_step=gradient_step, shuffle_tags=shuffle_tags, tag_drop_out=tag_drop_out, latent_sampling_method=latent_sampling_method, varsize=varsize, use_weight=use_weight)
+    ds = modules.textual_inversion.dataset.PersonalizedBase(
+        data_root=data_root,
+        width=training_width,
+        height=training_height,
+        repeats=shared.opts.training_image_repeats_per_epoch,
+        placeholder_token=embedding_name,
+        model=shared.sd_model,
+        cond_model=shared.sd_model.cond_stage_model,
+        device=devices.device,
+        template_file=template_file,
+        batch_size=batch_size,
+        gradient_step=gradient_step,
+        shuffle_tags=shuffle_tags,
+        tag_drop_out=tag_drop_out,
+        latent_sampling_method=latent_sampling_method,
+        varsize=varsize,
+        use_weight=use_weight,
+    )
 
     if shared.opts.save_training_settings_to_txt:
-        save_settings_to_file(log_directory, {**dict(model_name=checkpoint.model_name, model_hash=checkpoint.shorthash, num_of_dataset_images=len(ds), num_vectors_per_token=len(embedding.vec)), **locals()})
+        save_settings_to_file(
+            log_directory,
+            {
+                **dict(
+                    model_name=checkpoint.model_name,
+                    model_hash=checkpoint.shorthash,
+                    num_of_dataset_images=len(ds),
+                    num_vectors_per_token=len(embedding.vec),
+                ),
+                **locals(),
+            },
+        )
 
     latent_sampling_method = ds.latent_sampling_method
 
-    dl = modules.textual_inversion.dataset.PersonalizedDataLoader(ds, latent_sampling_method=latent_sampling_method, batch_size=ds.batch_size, pin_memory=pin_memory)
+    dl = modules.textual_inversion.dataset.PersonalizedDataLoader(
+        ds,
+        latent_sampling_method=latent_sampling_method,
+        batch_size=ds.batch_size,
+        pin_memory=pin_memory,
+    )
 
     if unload:
         shared.parallel_processing_allowed = False
         shared.sd_model.first_stage_model.to(devices.cpu)
 
     embedding.vec.requires_grad = True
-    optimizer = torch.optim.AdamW([embedding.vec], lr=scheduler.learn_rate, weight_decay=0.0)
+    optimizer = torch.optim.AdamW(
+        [embedding.vec], lr=scheduler.learn_rate, weight_decay=0.0
+    )
     if shared.opts.save_optimizer_state:
         optimizer_state_dict = None
         if os.path.exists(f"{filename}.optim"):
-            optimizer_saved_dict = torch.load(f"{filename}.optim", map_location='cpu')
-            if embedding.checksum() == optimizer_saved_dict.get('hash', None):
-                optimizer_state_dict = optimizer_saved_dict.get('optimizer_state_dict', None)
+            optimizer_saved_dict = torch.load(f"{filename}.optim", map_location="cpu")
+            if embedding.checksum() == optimizer_saved_dict.get("hash", None):
+                optimizer_state_dict = optimizer_saved_dict.get(
+                    "optimizer_state_dict", None
+                )
 
         if optimizer_state_dict is not None:
             optimizer.load_state_dict(optimizer_state_dict)
@@ -496,23 +668,28 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
     gradient_step = ds.gradient_step
     # n steps = batch_size * gradient_step * n image processed
     steps_per_epoch = len(ds) // batch_size // gradient_step
-    max_steps_per_epoch = len(ds) // batch_size - (len(ds) // batch_size) % gradient_step
+    max_steps_per_epoch = (
+        len(ds) // batch_size - (len(ds) // batch_size) % gradient_step
+    )
     loss_step = 0
-    _loss_step = 0 #internal
+    _loss_step = 0  # internal
 
     last_saved_file = "<none>"
     last_saved_image = "<none>"
     forced_filename = "<none>"
     embedding_yet_to_be_embedded = False
 
-    is_training_inpainting_model = shared.sd_model.model.conditioning_key in {'hybrid', 'concat'}
+    is_training_inpainting_model = shared.sd_model.model.conditioning_key in {
+        "hybrid",
+        "concat",
+    }
     img_c = None
 
     pbar = tqdm.tqdm(total=steps - initial_step)
     try:
         sd_hijack_checkpoint.add()
 
-        for _ in range((steps-initial_step) * gradient_step):
+        for _ in range((steps - initial_step) * gradient_step):
             if scheduler.finished:
                 break
             if shared.state.interrupted:
@@ -538,14 +715,19 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
 
                     if is_training_inpainting_model:
                         if img_c is None:
-                            img_c = processing.txt2img_image_conditioning(shared.sd_model, c, training_width, training_height)
+                            img_c = processing.txt2img_image_conditioning(
+                                shared.sd_model, c, training_width, training_height
+                            )
 
                         cond = {"c_concat": [img_c], "c_crossattn": [c]}
                     else:
                         cond = c
 
                     if use_weight:
-                        loss = shared.sd_model.weighted_forward(x, cond, w)[0] / gradient_step
+                        loss = (
+                            shared.sd_model.weighted_forward(x, cond, w)[0]
+                            / gradient_step
+                        )
                         del w
                     else:
                         loss = shared.sd_model.forward(x, cond)[0] / gradient_step
@@ -578,18 +760,30 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
                 pbar.set_description(description)
                 if embedding_dir is not None and steps_done % save_embedding_every == 0:
                     # Before saving, change name to match current checkpoint.
-                    embedding_name_every = f'{embedding_name}-{steps_done}'
-                    last_saved_file = os.path.join(embedding_dir, f'{embedding_name_every}.pt')
-                    save_embedding(embedding, optimizer, checkpoint, embedding_name_every, last_saved_file, remove_cached_checksum=True)
+                    embedding_name_every = f"{embedding_name}-{steps_done}"
+                    last_saved_file = os.path.join(
+                        embedding_dir, f"{embedding_name_every}.pt"
+                    )
+                    save_embedding(
+                        embedding,
+                        optimizer,
+                        checkpoint,
+                        embedding_name_every,
+                        last_saved_file,
+                        remove_cached_checksum=True,
+                    )
                     embedding_yet_to_be_embedded = True
 
-                write_loss(log_directory, "textual_inversion_loss.csv", embedding.step, steps_per_epoch, {
-                    "loss": f"{loss_step:.7f}",
-                    "learn_rate": scheduler.learn_rate
-                })
+                write_loss(
+                    log_directory,
+                    "textual_inversion_loss.csv",
+                    embedding.step,
+                    steps_per_epoch,
+                    {"loss": f"{loss_step:.7f}", "learn_rate": scheduler.learn_rate},
+                )
 
                 if images_dir is not None and steps_done % create_image_every == 0:
-                    forced_filename = f'{embedding_name}-{steps_done}'
+                    forced_filename = f"{embedding_name}-{steps_done}"
                     last_saved_image = os.path.join(images_dir, forced_filename)
 
                     shared.sd_model.first_stage_model.to(devices.device)
@@ -605,7 +799,9 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
                         p.prompt = preview_prompt
                         p.negative_prompt = preview_negative_prompt
                         p.steps = preview_steps
-                        p.sampler_name = sd_samplers.samplers_map[preview_sampler_name.lower()]
+                        p.sampler_name = sd_samplers.samplers_map[
+                            preview_sampler_name.lower()
+                        ]
                         p.cfg_scale = preview_cfg_scale
                         p.seed = preview_seed
                         p.width = preview_width
@@ -620,7 +816,9 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
 
                     with closing(p):
                         processed = processing.process_images(p)
-                        image = processed.images[0] if len(processed.images) > 0 else None
+                        image = (
+                            processed.images[0] if len(processed.images) > 0 else None
+                        )
 
                     if unload:
                         shared.sd_model.first_stage_model.to(devices.cpu)
@@ -628,15 +826,39 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
                     if image is not None:
                         shared.state.assign_current_image(image)
 
-                        last_saved_image, last_text_info = images.save_image(image, images_dir, "", p.seed, p.prompt, shared.opts.samples_format, processed.infotexts[0], p=p, forced_filename=forced_filename, save_to_dirs=False)
+                        last_saved_image, last_text_info = images.save_image(
+                            image,
+                            images_dir,
+                            "",
+                            p.seed,
+                            p.prompt,
+                            shared.opts.samples_format,
+                            processed.infotexts[0],
+                            p=p,
+                            forced_filename=forced_filename,
+                            save_to_dirs=False,
+                        )
                         last_saved_image += f", prompt: {preview_text}"
 
-                        if tensorboard_writer and shared.opts.training_tensorboard_save_images:
-                            tensorboard_add_image(tensorboard_writer, f"Validation at epoch {epoch_num}", image, embedding.step)
+                        if (
+                            tensorboard_writer
+                            and shared.opts.training_tensorboard_save_images
+                        ):
+                            tensorboard_add_image(
+                                tensorboard_writer,
+                                f"Validation at epoch {epoch_num}",
+                                image,
+                                embedding.step,
+                            )
 
-                    if save_image_with_stored_embedding and os.path.exists(last_saved_file) and embedding_yet_to_be_embedded:
-
-                        last_saved_image_chunks = os.path.join(images_embeds_dir, f'{embedding_name}-{steps_done}.png')
+                    if (
+                        save_image_with_stored_embedding
+                        and os.path.exists(last_saved_file)
+                        and embedding_yet_to_be_embedded
+                    ):
+                        last_saved_image_chunks = os.path.join(
+                            images_embeds_dir, f"{embedding_name}-{steps_done}.png"
+                        )
 
                         info = PngImagePlugin.PngInfo()
                         data = torch.load(last_saved_file)
@@ -645,22 +867,39 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
                         title = f"<{data.get('name', '???')}>"
 
                         try:
-                            vectorSize = list(data['string_to_param'].values())[0].shape[0]
+                            vectorSize = list(data["string_to_param"].values())[
+                                0
+                            ].shape[0]
                         except Exception:
-                            vectorSize = '?'
+                            vectorSize = "?"
 
                         checkpoint = sd_models.select_checkpoint()
                         footer_left = checkpoint.model_name
-                        footer_mid = f'[{checkpoint.shorthash}]'
-                        footer_right = f'{vectorSize}v {steps_done}s'
+                        footer_mid = f"[{checkpoint.shorthash}]"
+                        footer_right = f"{vectorSize}v {steps_done}s"
 
-                        captioned_image = caption_image_overlay(image, title, footer_left, footer_mid, footer_right)
+                        captioned_image = caption_image_overlay(
+                            image, title, footer_left, footer_mid, footer_right
+                        )
                         captioned_image = insert_image_data_embed(captioned_image, data)
 
-                        captioned_image.save(last_saved_image_chunks, "PNG", pnginfo=info)
+                        captioned_image.save(
+                            last_saved_image_chunks, "PNG", pnginfo=info
+                        )
                         embedding_yet_to_be_embedded = False
 
-                    last_saved_image, last_text_info = images.save_image(image, images_dir, "", p.seed, p.prompt, shared.opts.samples_format, processed.infotexts[0], p=p, forced_filename=forced_filename, save_to_dirs=False)
+                    last_saved_image, last_text_info = images.save_image(
+                        image,
+                        images_dir,
+                        "",
+                        p.seed,
+                        p.prompt,
+                        shared.opts.samples_format,
+                        processed.infotexts[0],
+                        p=p,
+                        forced_filename=forced_filename,
+                        save_to_dirs=False,
+                    )
                     last_saved_image += f", prompt: {preview_text}"
 
                 shared.state.job_no = embedding.step
@@ -674,8 +913,15 @@ Last saved embedding: {html.escape(last_saved_file)}<br/>
 Last saved image: {html.escape(last_saved_image)}<br/>
 </p>
 """
-        filename = os.path.join(shared.cmd_opts.embeddings_dir, f'{embedding_name}.pt')
-        save_embedding(embedding, optimizer, checkpoint, embedding_name, filename, remove_cached_checksum=True)
+        filename = os.path.join(shared.cmd_opts.embeddings_dir, f"{embedding_name}.pt")
+        save_embedding(
+            embedding,
+            optimizer,
+            checkpoint,
+            embedding_name,
+            filename,
+            remove_cached_checksum=True,
+        )
     except Exception:
         errors.report("Error training embedding", exc_info=True)
     finally:
@@ -688,11 +934,26 @@ Last saved image: {html.escape(last_saved_image)}<br/>
     return embedding, filename
 
 
-def save_embedding(embedding, optimizer, checkpoint, embedding_name, filename, remove_cached_checksum=True):
+def save_embedding(
+    embedding,
+    optimizer,
+    checkpoint,
+    embedding_name,
+    filename,
+    remove_cached_checksum=True,
+):
     old_embedding_name = embedding.name
-    old_sd_checkpoint = embedding.sd_checkpoint if hasattr(embedding, "sd_checkpoint") else None
-    old_sd_checkpoint_name = embedding.sd_checkpoint_name if hasattr(embedding, "sd_checkpoint_name") else None
-    old_cached_checksum = embedding.cached_checksum if hasattr(embedding, "cached_checksum") else None
+    old_sd_checkpoint = (
+        embedding.sd_checkpoint if hasattr(embedding, "sd_checkpoint") else None
+    )
+    old_sd_checkpoint_name = (
+        embedding.sd_checkpoint_name
+        if hasattr(embedding, "sd_checkpoint_name")
+        else None
+    )
+    old_cached_checksum = (
+        embedding.cached_checksum if hasattr(embedding, "cached_checksum") else None
+    )
     try:
         embedding.sd_checkpoint = checkpoint.shorthash
         embedding.sd_checkpoint_name = checkpoint.model_name

--- a/modules/textual_inversion/ui.py
+++ b/modules/textual_inversion/ui.py
@@ -7,23 +7,32 @@ from modules import sd_hijack, shared
 
 
 def create_embedding(name, initialization_text, nvpt, overwrite_old):
-    filename = modules.textual_inversion.textual_inversion.create_embedding(name, nvpt, overwrite_old, init_text=initialization_text)
+    filename = modules.textual_inversion.textual_inversion.create_embedding(
+        name, nvpt, overwrite_old, init_text=initialization_text
+    )
 
     sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings()
 
-    return gr.Dropdown.update(choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys())), f"Created: {filename}", ""
+    return (
+        gr.Dropdown.update(
+            choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys())
+        ),
+        f"Created: {filename}",
+        "",
+    )
 
 
 def train_embedding(*args):
-
-    assert not shared.cmd_opts.lowvram, 'Training models with lowvram not possible'
+    assert not shared.cmd_opts.lowvram, "Training models with lowvram not possible"
 
     apply_optimizations = shared.opts.training_xattention_optimizations
     try:
         if not apply_optimizations:
             sd_hijack.undo_optimizations()
 
-        embedding, filename = modules.textual_inversion.textual_inversion.train_embedding(*args)
+        embedding, filename = (
+            modules.textual_inversion.textual_inversion.train_embedding(*args)
+        )
 
         res = f"""
 Training {'interrupted' if shared.state.interrupted else 'finished'} at {embedding.step} steps.
@@ -35,4 +44,3 @@ Embedding saved to {html.escape(filename)}
     finally:
         if not apply_optimizations:
             sd_hijack.apply_optimizations()
-

--- a/modules/timer.py
+++ b/modules/timer.py
@@ -20,7 +20,9 @@ class TimerSubcategory:
     def __exit__(self, exc_type, exc_val, exc_tb):
         elapsed_for_subcategroy = time.time() - self.start
         self.timer.base_category = self.original_base_category
-        self.timer.add_time_to_record(self.original_base_category + self.category, elapsed_for_subcategroy)
+        self.timer.add_time_to_record(
+            self.original_base_category + self.category, elapsed_for_subcategroy
+        )
         self.timer.subcategory_level -= 1
         self.timer.record(self.category, disable_log=True)
 
@@ -30,7 +32,7 @@ class Timer:
         self.start = time.time()
         self.records = {}
         self.total = 0
-        self.base_category = ''
+        self.base_category = ""
         self.print_log = print_log
         self.subcategory_level = 0
 
@@ -54,7 +56,9 @@ class Timer:
         self.total += e + extra_time
 
         if self.print_log and not disable_log:
-            print(f"{'  ' * self.subcategory_level}{category}: done in {e + extra_time:.3f}s")
+            print(
+                f"{'  ' * self.subcategory_level}{category}: done in {e + extra_time:.3f}s"
+            )
 
     def subcategory(self, name):
         self.elapsed()
@@ -65,25 +69,35 @@ class Timer:
     def summary(self):
         res = f"{self.total:.1f}s"
 
-        additions = [(category, time_taken) for category, time_taken in self.records.items() if time_taken >= 0.1 and '/' not in category]
+        additions = [
+            (category, time_taken)
+            for category, time_taken in self.records.items()
+            if time_taken >= 0.1 and "/" not in category
+        ]
         if not additions:
             return res
 
         res += " ("
-        res += ", ".join([f"{category}: {time_taken:.1f}s" for category, time_taken in additions])
+        res += ", ".join(
+            [f"{category}: {time_taken:.1f}s" for category, time_taken in additions]
+        )
         res += ")"
 
         return res
 
     def dump(self):
-        return {'total': self.total, 'records': self.records}
+        return {"total": self.total, "records": self.records}
 
     def reset(self):
         self.__init__()
 
 
 parser = argparse.ArgumentParser(add_help=False)
-parser.add_argument("--log-startup", action='store_true', help="print a detailed log of what's happening at startup")
+parser.add_argument(
+    "--log-startup",
+    action="store_true",
+    help="print a detailed log of what's happening at startup",
+)
 args = parser.parse_known_args()[0]
 
 startup_timer = Timer(print_log=args.log_startup)

--- a/modules/torch_utils.py
+++ b/modules/torch_utils.py
@@ -20,6 +20,6 @@ def get_param(model) -> torch.nn.Parameter:
 
 def float64(t: torch.Tensor):
     """return torch.float64 if device is not mps or xpu, else return torch.float32"""
-    if t.device.type in ['mps', 'xpu']:
+    if t.device.type in ["mps", "xpu"]:
         return torch.float32
     return torch.float64

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -47,7 +47,6 @@ def txt2img_create_processing(
         enable_hr = True
 
     p = processing.StableDiffusionProcessingTxt2Img(
-        sd_model=shared.sd_model,
         outpath_samples=opts.outdir_samples or opts.outdir_txt2img_samples,
         outpath_grids=opts.outdir_grids or opts.outdir_txt2img_grids,
         prompt=prompt,

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -3,7 +3,10 @@ from contextlib import closing
 
 import modules.scripts
 from modules import processing, infotext_utils
-from modules.infotext_utils import create_override_settings_dict, parse_generation_parameters
+from modules.infotext_utils import (
+    create_override_settings_dict,
+    parse_generation_parameters,
+)
 from modules.shared import opts
 import modules.shared as shared
 from modules.ui import plaintext_to_html
@@ -11,7 +14,33 @@ from PIL import Image
 import gradio as gr
 
 
-def txt2img_create_processing(id_task: str, request: gr.Request, prompt: str, negative_prompt: str, prompt_styles, n_iter: int, batch_size: int, cfg_scale: float, height: int, width: int, enable_hr: bool, denoising_strength: float, hr_scale: float, hr_upscaler: str, hr_second_pass_steps: int, hr_resize_x: int, hr_resize_y: int, hr_checkpoint_name: str, hr_sampler_name: str, hr_scheduler: str, hr_prompt: str, hr_negative_prompt, override_settings_texts, *args, force_enable_hr=False):
+def txt2img_create_processing(
+    id_task: str,
+    request: gr.Request,
+    prompt: str,
+    negative_prompt: str,
+    prompt_styles,
+    n_iter: int,
+    batch_size: int,
+    cfg_scale: float,
+    height: int,
+    width: int,
+    enable_hr: bool,
+    denoising_strength: float,
+    hr_scale: float,
+    hr_upscaler: str,
+    hr_second_pass_steps: int,
+    hr_resize_x: int,
+    hr_resize_y: int,
+    hr_checkpoint_name: str,
+    hr_sampler_name: str,
+    hr_scheduler: str,
+    hr_prompt: str,
+    hr_negative_prompt,
+    override_settings_texts,
+    *args,
+    force_enable_hr=False,
+):
     override_settings = create_override_settings_dict(override_settings_texts)
 
     if force_enable_hr:
@@ -36,9 +65,13 @@ def txt2img_create_processing(id_task: str, request: gr.Request, prompt: str, ne
         hr_second_pass_steps=hr_second_pass_steps,
         hr_resize_x=hr_resize_x,
         hr_resize_y=hr_resize_y,
-        hr_checkpoint_name=None if hr_checkpoint_name == 'Use same checkpoint' else hr_checkpoint_name,
-        hr_sampler_name=None if hr_sampler_name == 'Use same sampler' else hr_sampler_name,
-        hr_scheduler=None if hr_scheduler == 'Use same scheduler' else hr_scheduler,
+        hr_checkpoint_name=None
+        if hr_checkpoint_name == "Use same checkpoint"
+        else hr_checkpoint_name,
+        hr_sampler_name=None
+        if hr_sampler_name == "Use same sampler"
+        else hr_sampler_name,
+        hr_scheduler=None if hr_scheduler == "Use same scheduler" else hr_scheduler,
         hr_prompt=hr_prompt,
         hr_negative_prompt=hr_negative_prompt,
         override_settings=override_settings,
@@ -55,9 +88,11 @@ def txt2img_create_processing(id_task: str, request: gr.Request, prompt: str, ne
     return p
 
 
-def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, generation_info, *args):
-    assert len(gallery) > 0, 'No image to upscale'
-    assert 0 <= gallery_index < len(gallery), f'Bad image index: {gallery_index}'
+def txt2img_upscale(
+    id_task: str, request: gr.Request, gallery, gallery_index, generation_info, *args
+):
+    assert len(gallery) > 0, "No image to upscale"
+    assert 0 <= gallery_index < len(gallery), f"Bad image index: {gallery_index}"
 
     p = txt2img_create_processing(id_task, request, *args, force_enable_hr=True)
     p.batch_size = 1
@@ -67,14 +102,18 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
 
     geninfo = json.loads(generation_info)
 
-    image_info = gallery[gallery_index] if 0 <= gallery_index < len(gallery) else gallery[0]
+    image_info = (
+        gallery[gallery_index] if 0 <= gallery_index < len(gallery) else gallery[0]
+    )
     p.firstpass_image = infotext_utils.image_from_url_text(image_info)
 
-    parameters = parse_generation_parameters(geninfo.get('infotexts')[gallery_index], [])
-    p.seed = parameters.get('Seed', -1)
-    p.subseed = parameters.get('Variation seed', -1)
+    parameters = parse_generation_parameters(
+        geninfo.get("infotexts")[gallery_index], []
+    )
+    p.seed = parameters.get("Seed", -1)
+    p.subseed = parameters.get("Variation seed", -1)
 
-    p.override_settings['save_images_before_highres_fix'] = False
+    p.override_settings["save_images_before_highres_fix"] = False
 
     with closing(p):
         processed = modules.scripts.scripts_txt2img.run(p, *p.script_args)
@@ -87,16 +126,23 @@ def txt2img_upscale(id_task: str, request: gr.Request, gallery, gallery_index, g
     new_gallery = []
     for i, image in enumerate(gallery):
         if i == gallery_index:
-            geninfo["infotexts"][gallery_index: gallery_index+1] = processed.infotexts
+            geninfo["infotexts"][gallery_index : gallery_index + 1] = (
+                processed.infotexts
+            )
             new_gallery.extend(processed.images)
         else:
             fake_image = Image.new(mode="RGB", size=(1, 1))
-            fake_image.already_saved_as = image["name"].rsplit('?', 1)[0]
+            fake_image.already_saved_as = image["name"].rsplit("?", 1)[0]
             new_gallery.append(fake_image)
 
     geninfo["infotexts"][gallery_index] = processed.info
 
-    return new_gallery, json.dumps(geninfo), plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
+    return (
+        new_gallery,
+        json.dumps(geninfo),
+        plaintext_to_html(processed.info),
+        plaintext_to_html(processed.comments, classname="comments"),
+    )
 
 
 def txt2img(id_task: str, request: gr.Request, *args):
@@ -117,4 +163,9 @@ def txt2img(id_task: str, request: gr.Request, *args):
     if opts.do_not_show_images:
         processed.images = []
 
-    return processed.images, generation_info_js, plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
+    return (
+        processed.images,
+        generation_info_js,
+        plaintext_to_html(processed.info),
+        plaintext_to_html(processed.comments, classname="comments"),
+    )

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -11,6 +11,7 @@ import gradio.utils
 import numpy as np
 from PIL import Image, PngImagePlugin  # noqa: F401
 from modules.call_queue import (
+    wrap_gradio_call,
     wrap_gradio_gpu_call,
     wrap_queued_call,
     wrap_gradio_call_no_job,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -57,6 +57,8 @@ from modules.shared import opts, cmd_opts
 
 import modules.infotext_utils as parameters_copypaste
 import modules.hypernetworks.ui as hypernetworks_ui
+
+__all__ = ["wrap_gradio_call"]
 import modules.textual_inversion.ui as textual_inversion_ui
 import modules.textual_inversion.textual_inversion as textual_inversion
 import modules.shared as shared

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -10,11 +10,44 @@ import gradio as gr
 import gradio.utils
 import numpy as np
 from PIL import Image, PngImagePlugin  # noqa: F401
-from modules.call_queue import wrap_gradio_gpu_call, wrap_queued_call, wrap_gradio_call, wrap_gradio_call_no_job # noqa: F401
+from modules.call_queue import (
+    wrap_gradio_gpu_call,
+    wrap_queued_call,
+    wrap_gradio_call_no_job,
+)  # noqa: F401
 
 from modules import gradio_extensons, sd_schedulers  # noqa: F401
-from modules import sd_hijack, sd_models, script_callbacks, ui_extensions, deepbooru, extra_networks, ui_common, ui_postprocessing, progress, ui_loadsave, shared_items, ui_settings, timer, sysinfo, ui_checkpoint_merger, scripts, sd_samplers, processing, ui_extra_networks, ui_toprow, launch_utils
-from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML, InputAccordion, ResizeHandleRow
+from modules import (
+    sd_hijack,
+    sd_models,
+    script_callbacks,
+    ui_extensions,
+    deepbooru,
+    extra_networks,
+    ui_common,
+    ui_postprocessing,
+    progress,
+    ui_loadsave,
+    shared_items,
+    ui_settings,
+    timer,
+    sysinfo,
+    ui_checkpoint_merger,
+    scripts,
+    sd_samplers,
+    processing,
+    ui_extra_networks,
+    ui_toprow,
+    launch_utils,
+)
+from modules.ui_components import (
+    FormRow,
+    FormGroup,
+    ToolButton,
+    FormHTML,
+    InputAccordion,
+    ResizeHandleRow,
+)
 from modules.paths import script_path
 from modules.ui_common import create_refresh_button
 from modules.ui_gradio_extensions import reload_javascript
@@ -32,31 +65,37 @@ from modules.infotext_utils import image_from_url_text, PasteField
 
 create_setting_component = ui_settings.create_setting_component
 
-warnings.filterwarnings("default" if opts.show_warnings else "ignore", category=UserWarning)
-warnings.filterwarnings("default" if opts.show_gradio_deprecation_warnings else "ignore", category=gr.deprecation.GradioDeprecationWarning)
+warnings.filterwarnings(
+    "default" if opts.show_warnings else "ignore", category=UserWarning
+)
+warnings.filterwarnings(
+    "default" if opts.show_gradio_deprecation_warnings else "ignore",
+    category=gr.deprecation.GradioDeprecationWarning,
+)
 
 # this is a fix for Windows users. Without it, javascript files will be served with text/html content-type and the browser will not show any UI
 mimetypes.init()
-mimetypes.add_type('application/javascript', '.js')
-mimetypes.add_type('application/javascript', '.mjs')
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
 
 # Likewise, add explicit content-type header for certain missing image types
-mimetypes.add_type('image/webp', '.webp')
-mimetypes.add_type('image/avif', '.avif')
+mimetypes.add_type("image/webp", ".webp")
+mimetypes.add_type("image/avif", ".avif")
 
 if not cmd_opts.share and not cmd_opts.listen:
     # fix gradio phoning home
     gradio.utils.version_check = lambda: None
-    gradio.utils.get_local_ip_address = lambda: '127.0.0.1'
+    gradio.utils.get_local_ip_address = lambda: "127.0.0.1"
 
 if cmd_opts.ngrok is not None:
     import modules.ngrok as ngrok
-    print('ngrok authtoken detected, trying to connect...')
+
+    print("ngrok authtoken detected, trying to connect...")
     ngrok.connect(
         cmd_opts.ngrok,
         cmd_opts.port if cmd_opts.port is not None else 7860,
-        cmd_opts.ngrok_options
-        )
+        cmd_opts.ngrok_options,
+    )
 
 
 def gr_show(visible=True):
@@ -68,17 +107,17 @@ sample_img2img = sample_img2img if os.path.exists(sample_img2img) else None
 
 # Using constants for these since the variation selector isn't visible.
 # Important that they exactly match script.js for tooltip to work.
-random_symbol = '\U0001f3b2\ufe0f'  # 🎲️
-reuse_symbol = '\u267b\ufe0f'  # ♻️
-paste_symbol = '\u2199\ufe0f'  # ↙
-refresh_symbol = '\U0001f504'  # 🔄
-save_style_symbol = '\U0001f4be'  # 💾
-apply_style_symbol = '\U0001f4cb'  # 📋
-clear_prompt_symbol = '\U0001f5d1\ufe0f'  # 🗑️
-extra_networks_symbol = '\U0001F3B4'  # 🎴
-switch_values_symbol = '\U000021C5' # ⇅
-restore_progress_symbol = '\U0001F300' # 🌀
-detect_image_size_symbol = '\U0001F4D0'  # 📐
+random_symbol = "\U0001f3b2\ufe0f"  # 🎲️
+reuse_symbol = "\u267b\ufe0f"  # ♻️
+paste_symbol = "\u2199\ufe0f"  # ↙
+refresh_symbol = "\U0001f504"  # 🔄
+save_style_symbol = "\U0001f4be"  # 💾
+apply_style_symbol = "\U0001f4cb"  # 📋
+clear_prompt_symbol = "\U0001f5d1\ufe0f"  # 🗑️
+extra_networks_symbol = "\U0001f3b4"  # 🎴
+switch_values_symbol = "\U000021c5"  # ⇅
+restore_progress_symbol = "\U0001f300"  # 🌀
+detect_image_size_symbol = "\U0001f4d0"  # 📐
 
 
 plaintext_to_html = ui_common.plaintext_to_html
@@ -94,7 +133,14 @@ def calc_resolution_hires(enable, width, height, hr_scale, hr_resize_x, hr_resiz
     if not enable:
         return ""
 
-    p = processing.StableDiffusionProcessingTxt2Img(width=width, height=height, enable_hr=True, hr_scale=hr_scale, hr_resize_x=hr_resize_x, hr_resize_y=hr_resize_y)
+    p = processing.StableDiffusionProcessingTxt2Img(
+        width=width,
+        height=height,
+        enable_hr=True,
+        hr_scale=hr_scale,
+        hr_resize_x=hr_resize_x,
+        hr_resize_y=hr_resize_y,
+    )
     p.calculate_target_resolution()
 
     return f"from <span class='resolution'>{p.width}x{p.height}</span> to <span class='resolution'>{p.hr_resize_x or p.hr_upscale_to_x}x{p.hr_resize_y or p.hr_upscale_to_y}</span>"
@@ -110,13 +156,17 @@ def resize_from_to_html(width, height, scale_by):
     return f"resize: from <span class='resolution'>{width}x{height}</span> to <span class='resolution'>{target_width}x{target_height}</span>"
 
 
-def process_interrogate(interrogation_function, mode, ii_input_dir, ii_output_dir, *ii_singles):
+def process_interrogate(
+    interrogation_function, mode, ii_input_dir, ii_output_dir, *ii_singles
+):
     if mode in {0, 1, 3, 4}:
         return [interrogation_function(ii_singles[mode]), None]
     elif mode == 2:
         return [interrogation_function(ii_singles[mode]["image"]), None]
     elif mode == 5:
-        assert not shared.cmd_opts.hide_ui_dir_config, "Launched with --hide-ui-dir-config, batch img2img disabled"
+        assert (
+            not shared.cmd_opts.hide_ui_dir_config
+        ), "Launched with --hide-ui-dir-config, batch img2img disabled"
         images = shared.listfiles(ii_input_dir)
         print(f"Will process {len(images)} images.")
         if ii_output_dir != "":
@@ -128,7 +178,12 @@ def process_interrogate(interrogation_function, mode, ii_input_dir, ii_output_di
             img = Image.open(image)
             filename = os.path.basename(image)
             left, _ = os.path.splitext(filename)
-            print(interrogation_function(img), file=open(os.path.join(ii_output_dir, f"{left}.txt"), 'a', encoding='utf-8'))
+            print(
+                interrogation_function(img),
+                file=open(
+                    os.path.join(ii_output_dir, f"{left}.txt"), "a", encoding="utf-8"
+                ),
+            )
 
         return [gr.update(), None]
 
@@ -154,7 +209,9 @@ def connect_clear_prompt(button):
 
 
 def update_token_counter(text, steps, styles, *, is_positive=True):
-    params = script_callbacks.BeforeTokenCounterParams(text, steps, styles, is_positive=is_positive)
+    params = script_callbacks.BeforeTokenCounterParams(
+        text, steps, styles, is_positive=is_positive
+    )
     script_callbacks.before_token_counter_callback(params)
     text = params.prompt
     steps = params.steps
@@ -162,7 +219,11 @@ def update_token_counter(text, steps, styles, *, is_positive=True):
     is_positive = params.is_positive
 
     if shared.opts.include_styles_into_token_counters:
-        apply_styles = shared.prompt_styles.apply_styles_to_prompt if is_positive else shared.prompt_styles.apply_negative_styles_to_prompt
+        apply_styles = (
+            shared.prompt_styles.apply_styles_to_prompt
+            if is_positive
+            else shared.prompt_styles.apply_negative_styles_to_prompt
+        )
         text = apply_styles(text, styles)
 
     try:
@@ -173,16 +234,21 @@ def update_token_counter(text, steps, styles, *, is_positive=True):
         else:
             prompt_flat_list = [text]
 
-        prompt_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, steps)
+        prompt_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(
+            prompt_flat_list, steps
+        )
 
     except Exception:
         # a parsing error can happen here during typing, and we don't want to bother the user with
         # messages related to it in console
         prompt_schedules = [[[steps, text]]]
 
-    flat_prompts = reduce(lambda list1, list2: list1+list2, prompt_schedules)
+    flat_prompts = reduce(lambda list1, list2: list1 + list2, prompt_schedules)
     prompts = [prompt_text for step, prompt_text in flat_prompts]
-    token_count, max_length = max([model_hijack.get_prompt_lengths(prompt) for prompt in prompts], key=lambda args: args[0])
+    token_count, max_length = max(
+        [model_hijack.get_prompt_lengths(prompt) for prompt in prompts],
+        key=lambda args: args[0],
+    )
     return f"<span class='gr-box gr-text-input'>{token_count}/{max_length}</span>"
 
 
@@ -214,7 +280,7 @@ def apply_setting(key, value):
             return gr.update()
 
     comp_args = opts.data_labels[key].component_args
-    if comp_args and isinstance(comp_args, dict) and comp_args.get('visible') is False:
+    if comp_args and isinstance(comp_args, dict) and comp_args.get("visible") is False:
         return
 
     valtype = type(opts.data_labels[key].default)
@@ -232,14 +298,25 @@ def create_output_panel(tabname, outdir, toprow=None):
 
 
 def ordered_ui_categories():
-    user_order = {x.strip(): i * 2 + 1 for i, x in enumerate(shared.opts.ui_reorder_list)}
+    user_order = {
+        x.strip(): i * 2 + 1 for i, x in enumerate(shared.opts.ui_reorder_list)
+    }
 
-    for _, category in sorted(enumerate(shared_items.ui_reorder_categories()), key=lambda x: user_order.get(x[1], x[0] * 2 + 0)):
+    for _, category in sorted(
+        enumerate(shared_items.ui_reorder_categories()),
+        key=lambda x: user_order.get(x[1], x[0] * 2 + 0),
+    ):
         yield category
 
 
 def create_override_settings_dropdown(tabname, row):
-    dropdown = gr.Dropdown([], label="Override settings", visible=False, elem_id=f"{tabname}_override_settings", multiselect=True)
+    dropdown = gr.Dropdown(
+        [],
+        label="Override settings",
+        visible=False,
+        elem_id=f"{tabname}_override_settings",
+        multiselect=True,
+    )
 
     dropdown.change(
         fn=lambda x: gr.Dropdown.update(visible=bool(x)),
@@ -265,18 +342,27 @@ def create_ui():
     scripts.scripts_txt2img.initialize_scripts(is_img2img=False)
 
     with gr.Blocks(analytics_enabled=False) as txt2img_interface:
-        toprow = ui_toprow.Toprow(is_img2img=False, is_compact=shared.opts.compact_prompt_box)
+        toprow = ui_toprow.Toprow(
+            is_img2img=False, is_compact=shared.opts.compact_prompt_box
+        )
 
         dummy_component = gr.Label(visible=False)
 
-        extra_tabs = gr.Tabs(elem_id="txt2img_extra_tabs", elem_classes=["extra-networks"])
+        extra_tabs = gr.Tabs(
+            elem_id="txt2img_extra_tabs", elem_classes=["extra-networks"]
+        )
         extra_tabs.__enter__()
 
-        with gr.Tab("Generation", id="txt2img_generation") as txt2img_generation_tab, ResizeHandleRow(equal_height=False):
+        with (
+            gr.Tab("Generation", id="txt2img_generation") as txt2img_generation_tab,
+            ResizeHandleRow(equal_height=False),
+        ):
             with ExitStack() as stack:
                 if shared.opts.txt2img_settings_accordion:
                     stack.enter_context(gr.Accordion("Open for Settings", open=False))
-                stack.enter_context(gr.Column(variant='compact', elem_id="txt2img_settings"))
+                stack.enter_context(
+                    gr.Column(variant="compact", elem_id="txt2img_settings")
+                )
 
                 scripts.scripts_txt2img.prepare_ui()
 
@@ -287,68 +373,233 @@ def create_ui():
                     elif category == "dimensions":
                         with FormRow():
                             with gr.Column(elem_id="txt2img_column_size", scale=4):
-                                width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="txt2img_width")
-                                height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="txt2img_height")
+                                width = gr.Slider(
+                                    minimum=64,
+                                    maximum=2048,
+                                    step=8,
+                                    label="Width",
+                                    value=512,
+                                    elem_id="txt2img_width",
+                                )
+                                height = gr.Slider(
+                                    minimum=64,
+                                    maximum=2048,
+                                    step=8,
+                                    label="Height",
+                                    value=512,
+                                    elem_id="txt2img_height",
+                                )
 
-                            with gr.Column(elem_id="txt2img_dimensions_row", scale=1, elem_classes="dimensions-tools"):
-                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="txt2img_res_switch_btn", tooltip="Switch width/height")
+                            with gr.Column(
+                                elem_id="txt2img_dimensions_row",
+                                scale=1,
+                                elem_classes="dimensions-tools",
+                            ):
+                                res_switch_btn = ToolButton(
+                                    value=switch_values_symbol,
+                                    elem_id="txt2img_res_switch_btn",
+                                    tooltip="Switch width/height",
+                                )
 
                             if opts.dimensions_and_batch_together:
                                 with gr.Column(elem_id="txt2img_column_batch"):
-                                    batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="txt2img_batch_count")
-                                    batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="txt2img_batch_size")
+                                    batch_count = gr.Slider(
+                                        minimum=1,
+                                        step=1,
+                                        label="Batch count",
+                                        value=1,
+                                        elem_id="txt2img_batch_count",
+                                    )
+                                    batch_size = gr.Slider(
+                                        minimum=1,
+                                        maximum=8,
+                                        step=1,
+                                        label="Batch size",
+                                        value=1,
+                                        elem_id="txt2img_batch_size",
+                                    )
 
                     elif category == "cfg":
                         with gr.Row():
-                            cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="txt2img_cfg_scale")
+                            cfg_scale = gr.Slider(
+                                minimum=1.0,
+                                maximum=30.0,
+                                step=0.5,
+                                label="CFG Scale",
+                                value=7.0,
+                                elem_id="txt2img_cfg_scale",
+                            )
 
                     elif category == "checkboxes":
                         with FormRow(elem_classes="checkboxes-row", variant="compact"):
                             pass
 
                     elif category == "accordions":
-                        with gr.Row(elem_id="txt2img_accordions", elem_classes="accordions"):
-                            with InputAccordion(False, label="Hires. fix", elem_id="txt2img_hr") as enable_hr:
+                        with gr.Row(
+                            elem_id="txt2img_accordions", elem_classes="accordions"
+                        ):
+                            with InputAccordion(
+                                False, label="Hires. fix", elem_id="txt2img_hr"
+                            ) as enable_hr:
                                 with enable_hr.extra():
-                                    hr_final_resolution = FormHTML(value="", elem_id="txtimg_hr_finalres", label="Upscaled resolution", interactive=False, min_width=0)
+                                    hr_final_resolution = FormHTML(
+                                        value="",
+                                        elem_id="txtimg_hr_finalres",
+                                        label="Upscaled resolution",
+                                        interactive=False,
+                                        min_width=0,
+                                    )
 
-                                with FormRow(elem_id="txt2img_hires_fix_row1", variant="compact"):
-                                    hr_upscaler = gr.Dropdown(label="Upscaler", elem_id="txt2img_hr_upscaler", choices=[*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]], value=shared.latent_upscale_default_mode)
-                                    hr_second_pass_steps = gr.Slider(minimum=0, maximum=150, step=1, label='Hires steps', value=0, elem_id="txt2img_hires_steps")
-                                    denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.7, elem_id="txt2img_denoising_strength")
+                                with FormRow(
+                                    elem_id="txt2img_hires_fix_row1", variant="compact"
+                                ):
+                                    hr_upscaler = gr.Dropdown(
+                                        label="Upscaler",
+                                        elem_id="txt2img_hr_upscaler",
+                                        choices=[
+                                            *shared.latent_upscale_modes,
+                                            *[x.name for x in shared.sd_upscalers],
+                                        ],
+                                        value=shared.latent_upscale_default_mode,
+                                    )
+                                    hr_second_pass_steps = gr.Slider(
+                                        minimum=0,
+                                        maximum=150,
+                                        step=1,
+                                        label="Hires steps",
+                                        value=0,
+                                        elem_id="txt2img_hires_steps",
+                                    )
+                                    denoising_strength = gr.Slider(
+                                        minimum=0.0,
+                                        maximum=1.0,
+                                        step=0.01,
+                                        label="Denoising strength",
+                                        value=0.7,
+                                        elem_id="txt2img_denoising_strength",
+                                    )
 
-                                with FormRow(elem_id="txt2img_hires_fix_row2", variant="compact"):
-                                    hr_scale = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label="Upscale by", value=2.0, elem_id="txt2img_hr_scale")
-                                    hr_resize_x = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize width to", value=0, elem_id="txt2img_hr_resize_x")
-                                    hr_resize_y = gr.Slider(minimum=0, maximum=2048, step=8, label="Resize height to", value=0, elem_id="txt2img_hr_resize_y")
+                                with FormRow(
+                                    elem_id="txt2img_hires_fix_row2", variant="compact"
+                                ):
+                                    hr_scale = gr.Slider(
+                                        minimum=1.0,
+                                        maximum=4.0,
+                                        step=0.05,
+                                        label="Upscale by",
+                                        value=2.0,
+                                        elem_id="txt2img_hr_scale",
+                                    )
+                                    hr_resize_x = gr.Slider(
+                                        minimum=0,
+                                        maximum=2048,
+                                        step=8,
+                                        label="Resize width to",
+                                        value=0,
+                                        elem_id="txt2img_hr_resize_x",
+                                    )
+                                    hr_resize_y = gr.Slider(
+                                        minimum=0,
+                                        maximum=2048,
+                                        step=8,
+                                        label="Resize height to",
+                                        value=0,
+                                        elem_id="txt2img_hr_resize_y",
+                                    )
 
-                                with FormRow(elem_id="txt2img_hires_fix_row3", variant="compact", visible=opts.hires_fix_show_sampler) as hr_sampler_container:
+                                with FormRow(
+                                    elem_id="txt2img_hires_fix_row3",
+                                    variant="compact",
+                                    visible=opts.hires_fix_show_sampler,
+                                ) as hr_sampler_container:
+                                    hr_checkpoint_name = gr.Dropdown(
+                                        label="Checkpoint",
+                                        elem_id="hr_checkpoint",
+                                        choices=["Use same checkpoint"]
+                                        + modules.sd_models.checkpoint_tiles(
+                                            use_short=True
+                                        ),
+                                        value="Use same checkpoint",
+                                    )
+                                    create_refresh_button(
+                                        hr_checkpoint_name,
+                                        modules.sd_models.list_models,
+                                        lambda: {
+                                            "choices": ["Use same checkpoint"]
+                                            + modules.sd_models.checkpoint_tiles(
+                                                use_short=True
+                                            )
+                                        },
+                                        "hr_checkpoint_refresh",
+                                    )
 
-                                    hr_checkpoint_name = gr.Dropdown(label='Checkpoint', elem_id="hr_checkpoint", choices=["Use same checkpoint"] + modules.sd_models.checkpoint_tiles(use_short=True), value="Use same checkpoint")
-                                    create_refresh_button(hr_checkpoint_name, modules.sd_models.list_models, lambda: {"choices": ["Use same checkpoint"] + modules.sd_models.checkpoint_tiles(use_short=True)}, "hr_checkpoint_refresh")
+                                    hr_sampler_name = gr.Dropdown(
+                                        label="Hires sampling method",
+                                        elem_id="hr_sampler",
+                                        choices=["Use same sampler"]
+                                        + sd_samplers.visible_sampler_names(),
+                                        value="Use same sampler",
+                                    )
+                                    hr_scheduler = gr.Dropdown(
+                                        label="Hires schedule type",
+                                        elem_id="hr_scheduler",
+                                        choices=["Use same scheduler"]
+                                        + [x.label for x in sd_schedulers.schedulers],
+                                        value="Use same scheduler",
+                                    )
 
-                                    hr_sampler_name = gr.Dropdown(label='Hires sampling method', elem_id="hr_sampler", choices=["Use same sampler"] + sd_samplers.visible_sampler_names(), value="Use same sampler")
-                                    hr_scheduler = gr.Dropdown(label='Hires schedule type', elem_id="hr_scheduler", choices=["Use same scheduler"] + [x.label for x in sd_schedulers.schedulers], value="Use same scheduler")
-
-                                with FormRow(elem_id="txt2img_hires_fix_row4", variant="compact", visible=opts.hires_fix_show_prompts) as hr_prompts_container:
+                                with FormRow(
+                                    elem_id="txt2img_hires_fix_row4",
+                                    variant="compact",
+                                    visible=opts.hires_fix_show_prompts,
+                                ) as hr_prompts_container:
                                     with gr.Column(scale=80):
                                         with gr.Row():
-                                            hr_prompt = gr.Textbox(label="Hires prompt", elem_id="hires_prompt", show_label=False, lines=3, placeholder="Prompt for hires fix pass.\nLeave empty to use the same prompt as in first pass.", elem_classes=["prompt"])
+                                            hr_prompt = gr.Textbox(
+                                                label="Hires prompt",
+                                                elem_id="hires_prompt",
+                                                show_label=False,
+                                                lines=3,
+                                                placeholder="Prompt for hires fix pass.\nLeave empty to use the same prompt as in first pass.",
+                                                elem_classes=["prompt"],
+                                            )
                                     with gr.Column(scale=80):
                                         with gr.Row():
-                                            hr_negative_prompt = gr.Textbox(label="Hires negative prompt", elem_id="hires_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt for hires fix pass.\nLeave empty to use the same negative prompt as in first pass.", elem_classes=["prompt"])
+                                            hr_negative_prompt = gr.Textbox(
+                                                label="Hires negative prompt",
+                                                elem_id="hires_neg_prompt",
+                                                show_label=False,
+                                                lines=3,
+                                                placeholder="Negative prompt for hires fix pass.\nLeave empty to use the same negative prompt as in first pass.",
+                                                elem_classes=["prompt"],
+                                            )
 
                             scripts.scripts_txt2img.setup_ui_for_section(category)
 
                     elif category == "batch":
                         if not opts.dimensions_and_batch_together:
                             with FormRow(elem_id="txt2img_column_batch"):
-                                batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="txt2img_batch_count")
-                                batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="txt2img_batch_size")
+                                batch_count = gr.Slider(
+                                    minimum=1,
+                                    step=1,
+                                    label="Batch count",
+                                    value=1,
+                                    elem_id="txt2img_batch_count",
+                                )
+                                batch_size = gr.Slider(
+                                    minimum=1,
+                                    maximum=8,
+                                    step=1,
+                                    label="Batch size",
+                                    value=1,
+                                    elem_id="txt2img_batch_size",
+                                )
 
                     elif category == "override_settings":
                         with FormRow(elem_id="txt2img_override_settings_row") as row:
-                            override_settings = create_override_settings_dropdown('txt2img', row)
+                            override_settings = create_override_settings_dropdown(
+                                "txt2img", row
+                            )
 
                     elif category == "scripts":
                         with FormGroup(elem_id="txt2img_script_container"):
@@ -357,10 +608,21 @@ def create_ui():
                     if category not in {"accordions"}:
                         scripts.scripts_txt2img.setup_ui_for_section(category)
 
-            hr_resolution_preview_inputs = [enable_hr, width, height, hr_scale, hr_resize_x, hr_resize_y]
+            hr_resolution_preview_inputs = [
+                enable_hr,
+                width,
+                height,
+                hr_scale,
+                hr_resize_x,
+                hr_resize_y,
+            ]
 
             for component in hr_resolution_preview_inputs:
-                event = component.release if isinstance(component, gr.Slider) else component.change
+                event = (
+                    component.release
+                    if isinstance(component, gr.Slider)
+                    else component.change
+                )
 
                 event(
                     fn=calc_resolution_hires,
@@ -376,7 +638,9 @@ def create_ui():
                     show_progress=False,
                 )
 
-            output_panel = create_output_panel("txt2img", opts.outdir_txt2img_samples, toprow)
+            output_panel = create_output_panel(
+                "txt2img", opts.outdir_txt2img_samples, toprow
+            )
 
             txt2img_inputs = [
                 dummy_component,
@@ -411,7 +675,9 @@ def create_ui():
             ]
 
             txt2img_args = dict(
-                fn=wrap_gradio_gpu_call(modules.txt2img.txt2img, extra_outputs=[None, '', '']),
+                fn=wrap_gradio_gpu_call(
+                    modules.txt2img.txt2img, extra_outputs=[None, "", ""]
+                ),
                 _js="submit",
                 inputs=txt2img_inputs,
                 outputs=txt2img_outputs,
@@ -422,14 +688,24 @@ def create_ui():
             toprow.submit.click(**txt2img_args)
 
             output_panel.button_upscale.click(
-                fn=wrap_gradio_gpu_call(modules.txt2img.txt2img_upscale, extra_outputs=[None, '', '']),
+                fn=wrap_gradio_gpu_call(
+                    modules.txt2img.txt2img_upscale, extra_outputs=[None, "", ""]
+                ),
                 _js="submit_txt2img_upscale",
-                inputs=txt2img_inputs[0:1] + [output_panel.gallery, dummy_component, output_panel.generation_info] + txt2img_inputs[1:],
+                inputs=txt2img_inputs[0:1]
+                + [output_panel.gallery, dummy_component, output_panel.generation_info]
+                + txt2img_inputs[1:],
                 outputs=txt2img_outputs,
                 show_progress=False,
             )
 
-            res_switch_btn.click(fn=None, _js="function(){switchWidthHeight('txt2img')}", inputs=None, outputs=None, show_progress=False)
+            res_switch_btn.click(
+                fn=None,
+                _js="function(){switchWidthHeight('txt2img')}",
+                inputs=None,
+                outputs=None,
+                show_progress=False,
+            )
 
             toprow.restore_progress_button.click(
                 fn=progress.restore_progress,
@@ -446,52 +722,127 @@ def create_ui():
 
             txt2img_paste_fields = [
                 PasteField(toprow.prompt, "Prompt", api="prompt"),
-                PasteField(toprow.negative_prompt, "Negative prompt", api="negative_prompt"),
+                PasteField(
+                    toprow.negative_prompt, "Negative prompt", api="negative_prompt"
+                ),
                 PasteField(cfg_scale, "CFG scale", api="cfg_scale"),
                 PasteField(width, "Size-1", api="width"),
                 PasteField(height, "Size-2", api="height"),
                 PasteField(batch_size, "Batch size", api="batch_size"),
-                PasteField(toprow.ui_styles.dropdown, lambda d: d["Styles array"] if isinstance(d.get("Styles array"), list) else gr.update(), api="styles"),
-                PasteField(denoising_strength, "Denoising strength", api="denoising_strength"),
-                PasteField(enable_hr, lambda d: "Denoising strength" in d and ("Hires upscale" in d or "Hires upscaler" in d or "Hires resize-1" in d), api="enable_hr"),
+                PasteField(
+                    toprow.ui_styles.dropdown,
+                    lambda d: d["Styles array"]
+                    if isinstance(d.get("Styles array"), list)
+                    else gr.update(),
+                    api="styles",
+                ),
+                PasteField(
+                    denoising_strength, "Denoising strength", api="denoising_strength"
+                ),
+                PasteField(
+                    enable_hr,
+                    lambda d: "Denoising strength" in d
+                    and (
+                        "Hires upscale" in d
+                        or "Hires upscaler" in d
+                        or "Hires resize-1" in d
+                    ),
+                    api="enable_hr",
+                ),
                 PasteField(hr_scale, "Hires upscale", api="hr_scale"),
                 PasteField(hr_upscaler, "Hires upscaler", api="hr_upscaler"),
-                PasteField(hr_second_pass_steps, "Hires steps", api="hr_second_pass_steps"),
+                PasteField(
+                    hr_second_pass_steps, "Hires steps", api="hr_second_pass_steps"
+                ),
                 PasteField(hr_resize_x, "Hires resize-1", api="hr_resize_x"),
                 PasteField(hr_resize_y, "Hires resize-2", api="hr_resize_y"),
-                PasteField(hr_checkpoint_name, "Hires checkpoint", api="hr_checkpoint_name"),
-                PasteField(hr_sampler_name, sd_samplers.get_hr_sampler_from_infotext, api="hr_sampler_name"),
-                PasteField(hr_scheduler, sd_samplers.get_hr_scheduler_from_infotext, api="hr_scheduler"),
-                PasteField(hr_sampler_container, lambda d: gr.update(visible=True) if d.get("Hires sampler", "Use same sampler") != "Use same sampler" or d.get("Hires checkpoint", "Use same checkpoint") != "Use same checkpoint" or d.get("Hires schedule type", "Use same scheduler") != "Use same scheduler" else gr.update()),
+                PasteField(
+                    hr_checkpoint_name, "Hires checkpoint", api="hr_checkpoint_name"
+                ),
+                PasteField(
+                    hr_sampler_name,
+                    sd_samplers.get_hr_sampler_from_infotext,
+                    api="hr_sampler_name",
+                ),
+                PasteField(
+                    hr_scheduler,
+                    sd_samplers.get_hr_scheduler_from_infotext,
+                    api="hr_scheduler",
+                ),
+                PasteField(
+                    hr_sampler_container,
+                    lambda d: gr.update(visible=True)
+                    if d.get("Hires sampler", "Use same sampler") != "Use same sampler"
+                    or d.get("Hires checkpoint", "Use same checkpoint")
+                    != "Use same checkpoint"
+                    or d.get("Hires schedule type", "Use same scheduler")
+                    != "Use same scheduler"
+                    else gr.update(),
+                ),
                 PasteField(hr_prompt, "Hires prompt", api="hr_prompt"),
-                PasteField(hr_negative_prompt, "Hires negative prompt", api="hr_negative_prompt"),
-                PasteField(hr_prompts_container, lambda d: gr.update(visible=True) if d.get("Hires prompt", "") != "" or d.get("Hires negative prompt", "") != "" else gr.update()),
-                *scripts.scripts_txt2img.infotext_fields
+                PasteField(
+                    hr_negative_prompt,
+                    "Hires negative prompt",
+                    api="hr_negative_prompt",
+                ),
+                PasteField(
+                    hr_prompts_container,
+                    lambda d: gr.update(visible=True)
+                    if d.get("Hires prompt", "") != ""
+                    or d.get("Hires negative prompt", "") != ""
+                    else gr.update(),
+                ),
+                *scripts.scripts_txt2img.infotext_fields,
             ]
-            parameters_copypaste.add_paste_fields("txt2img", None, txt2img_paste_fields, override_settings)
-            parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                paste_button=toprow.paste, tabname="txt2img", source_text_component=toprow.prompt, source_image_component=None,
-            ))
+            parameters_copypaste.add_paste_fields(
+                "txt2img", None, txt2img_paste_fields, override_settings
+            )
+            parameters_copypaste.register_paste_params_button(
+                parameters_copypaste.ParamBinding(
+                    paste_button=toprow.paste,
+                    tabname="txt2img",
+                    source_text_component=toprow.prompt,
+                    source_image_component=None,
+                )
+            )
 
-            steps = scripts.scripts_txt2img.script('Sampler').steps
+            steps = scripts.scripts_txt2img.script("Sampler").steps
 
             txt2img_preview_params = [
                 toprow.prompt,
                 toprow.negative_prompt,
                 steps,
-                scripts.scripts_txt2img.script('Sampler').sampler_name,
+                scripts.scripts_txt2img.script("Sampler").sampler_name,
                 cfg_scale,
-                scripts.scripts_txt2img.script('Seed').seed,
+                scripts.scripts_txt2img.script("Seed").seed,
                 width,
                 height,
             ]
 
-            toprow.ui_styles.dropdown.change(fn=wrap_queued_call(update_token_counter), inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.token_counter])
-            toprow.ui_styles.dropdown.change(fn=wrap_queued_call(update_negative_prompt_token_counter), inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.negative_token_counter])
-            toprow.token_button.click(fn=wrap_queued_call(update_token_counter), inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.token_counter])
-            toprow.negative_token_button.click(fn=wrap_queued_call(update_negative_prompt_token_counter), inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.negative_token_counter])
+            toprow.ui_styles.dropdown.change(
+                fn=wrap_queued_call(update_token_counter),
+                inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.token_counter],
+            )
+            toprow.ui_styles.dropdown.change(
+                fn=wrap_queued_call(update_negative_prompt_token_counter),
+                inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.negative_token_counter],
+            )
+            toprow.token_button.click(
+                fn=wrap_queued_call(update_token_counter),
+                inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.token_counter],
+            )
+            toprow.negative_token_button.click(
+                fn=wrap_queued_call(update_negative_prompt_token_counter),
+                inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.negative_token_counter],
+            )
 
-        extra_networks_ui = ui_extra_networks.create_ui(txt2img_interface, [txt2img_generation_tab], 'txt2img')
+        extra_networks_ui = ui_extra_networks.create_ui(
+            txt2img_interface, [txt2img_generation_tab], "txt2img"
+        )
         ui_extra_networks.setup_ui(extra_networks_ui, output_panel.gallery)
 
         extra_tabs.__exit__()
@@ -500,25 +851,42 @@ def create_ui():
     scripts.scripts_img2img.initialize_scripts(is_img2img=True)
 
     with gr.Blocks(analytics_enabled=False) as img2img_interface:
-        toprow = ui_toprow.Toprow(is_img2img=True, is_compact=shared.opts.compact_prompt_box)
+        toprow = ui_toprow.Toprow(
+            is_img2img=True, is_compact=shared.opts.compact_prompt_box
+        )
 
-        extra_tabs = gr.Tabs(elem_id="img2img_extra_tabs", elem_classes=["extra-networks"])
+        extra_tabs = gr.Tabs(
+            elem_id="img2img_extra_tabs", elem_classes=["extra-networks"]
+        )
         extra_tabs.__enter__()
 
-        with gr.Tab("Generation", id="img2img_generation") as img2img_generation_tab, ResizeHandleRow(equal_height=False):
+        with (
+            gr.Tab("Generation", id="img2img_generation") as img2img_generation_tab,
+            ResizeHandleRow(equal_height=False),
+        ):
             with ExitStack() as stack:
                 if shared.opts.img2img_settings_accordion:
                     stack.enter_context(gr.Accordion("Open for Settings", open=False))
-                stack.enter_context(gr.Column(variant='compact', elem_id="img2img_settings"))
+                stack.enter_context(
+                    gr.Column(variant="compact", elem_id="img2img_settings")
+                )
 
                 copy_image_buttons = []
                 copy_image_destinations = {}
 
                 def add_copy_image_controls(tab_name, elem):
-                    with gr.Row(variant="compact", elem_id=f"img2img_copy_to_{tab_name}"):
-                        gr.HTML("Copy image to: ", elem_id=f"img2img_label_copy_to_{tab_name}")
+                    with gr.Row(
+                        variant="compact", elem_id=f"img2img_copy_to_{tab_name}"
+                    ):
+                        gr.HTML(
+                            "Copy image to: ",
+                            elem_id=f"img2img_label_copy_to_{tab_name}",
+                        )
 
-                        for title, name in zip(['img2img', 'sketch', 'inpaint', 'inpaint sketch'], ['img2img', 'sketch', 'inpaint', 'inpaint_sketch']):
+                        for title, name in zip(
+                            ["img2img", "sketch", "inpaint", "inpaint sketch"],
+                            ["img2img", "sketch", "inpaint", "inpaint_sketch"],
+                        ):
                             if name == tab_name:
                                 gr.Button(title, interactive=False)
                                 copy_image_destinations[name] = elem
@@ -537,67 +905,229 @@ def create_ui():
                         with gr.Tabs(elem_id="mode_img2img"):
                             img2img_selected_tab = gr.Number(value=0, visible=False)
 
-                            with gr.TabItem('img2img', id='img2img', elem_id="img2img_img2img_tab") as tab_img2img:
-                                init_img = gr.Image(label="Image for img2img", elem_id="img2img_image", show_label=False, source="upload", interactive=True, type="pil", tool="editor", image_mode="RGBA", height=opts.img2img_editor_height)
-                                add_copy_image_controls('img2img', init_img)
+                            with gr.TabItem(
+                                "img2img", id="img2img", elem_id="img2img_img2img_tab"
+                            ) as tab_img2img:
+                                init_img = gr.Image(
+                                    label="Image for img2img",
+                                    elem_id="img2img_image",
+                                    show_label=False,
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    tool="editor",
+                                    image_mode="RGBA",
+                                    height=opts.img2img_editor_height,
+                                )
+                                add_copy_image_controls("img2img", init_img)
 
-                            with gr.TabItem('Sketch', id='img2img_sketch', elem_id="img2img_img2img_sketch_tab") as tab_sketch:
-                                sketch = gr.Image(label="Image for img2img", elem_id="img2img_sketch", show_label=False, source="upload", interactive=True, type="pil", tool="color-sketch", image_mode="RGB", height=opts.img2img_editor_height, brush_color=opts.img2img_sketch_default_brush_color)
-                                add_copy_image_controls('sketch', sketch)
+                            with gr.TabItem(
+                                "Sketch",
+                                id="img2img_sketch",
+                                elem_id="img2img_img2img_sketch_tab",
+                            ) as tab_sketch:
+                                sketch = gr.Image(
+                                    label="Image for img2img",
+                                    elem_id="img2img_sketch",
+                                    show_label=False,
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    tool="color-sketch",
+                                    image_mode="RGB",
+                                    height=opts.img2img_editor_height,
+                                    brush_color=opts.img2img_sketch_default_brush_color,
+                                )
+                                add_copy_image_controls("sketch", sketch)
 
-                            with gr.TabItem('Inpaint', id='inpaint', elem_id="img2img_inpaint_tab") as tab_inpaint:
-                                init_img_with_mask = gr.Image(label="Image for inpainting with mask", show_label=False, elem_id="img2maskimg", source="upload", interactive=True, type="pil", tool="sketch", image_mode="RGBA", height=opts.img2img_editor_height, brush_color=opts.img2img_inpaint_mask_brush_color)
-                                add_copy_image_controls('inpaint', init_img_with_mask)
+                            with gr.TabItem(
+                                "Inpaint", id="inpaint", elem_id="img2img_inpaint_tab"
+                            ) as tab_inpaint:
+                                init_img_with_mask = gr.Image(
+                                    label="Image for inpainting with mask",
+                                    show_label=False,
+                                    elem_id="img2maskimg",
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    tool="sketch",
+                                    image_mode="RGBA",
+                                    height=opts.img2img_editor_height,
+                                    brush_color=opts.img2img_inpaint_mask_brush_color,
+                                )
+                                add_copy_image_controls("inpaint", init_img_with_mask)
 
-                            with gr.TabItem('Inpaint sketch', id='inpaint_sketch', elem_id="img2img_inpaint_sketch_tab") as tab_inpaint_color:
-                                inpaint_color_sketch = gr.Image(label="Color sketch inpainting", show_label=False, elem_id="inpaint_sketch", source="upload", interactive=True, type="pil", tool="color-sketch", image_mode="RGB", height=opts.img2img_editor_height, brush_color=opts.img2img_inpaint_sketch_default_brush_color)
+                            with gr.TabItem(
+                                "Inpaint sketch",
+                                id="inpaint_sketch",
+                                elem_id="img2img_inpaint_sketch_tab",
+                            ) as tab_inpaint_color:
+                                inpaint_color_sketch = gr.Image(
+                                    label="Color sketch inpainting",
+                                    show_label=False,
+                                    elem_id="inpaint_sketch",
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    tool="color-sketch",
+                                    image_mode="RGB",
+                                    height=opts.img2img_editor_height,
+                                    brush_color=opts.img2img_inpaint_sketch_default_brush_color,
+                                )
                                 inpaint_color_sketch_orig = gr.State(None)
-                                add_copy_image_controls('inpaint_sketch', inpaint_color_sketch)
+                                add_copy_image_controls(
+                                    "inpaint_sketch", inpaint_color_sketch
+                                )
 
                                 def update_orig(image, state):
                                     if image is not None:
-                                        same_size = state is not None and state.size == image.size
-                                        has_exact_match = np.any(np.all(np.array(image) == np.array(state), axis=-1))
+                                        same_size = (
+                                            state is not None
+                                            and state.size == image.size
+                                        )
+                                        has_exact_match = np.any(
+                                            np.all(
+                                                np.array(image) == np.array(state),
+                                                axis=-1,
+                                            )
+                                        )
                                         edited = same_size and has_exact_match
-                                        return image if not edited or state is None else state
+                                        return (
+                                            image
+                                            if not edited or state is None
+                                            else state
+                                        )
 
-                                inpaint_color_sketch.change(update_orig, [inpaint_color_sketch, inpaint_color_sketch_orig], inpaint_color_sketch_orig)
+                                inpaint_color_sketch.change(
+                                    update_orig,
+                                    [inpaint_color_sketch, inpaint_color_sketch_orig],
+                                    inpaint_color_sketch_orig,
+                                )
 
-                            with gr.TabItem('Inpaint upload', id='inpaint_upload', elem_id="img2img_inpaint_upload_tab") as tab_inpaint_upload:
-                                init_img_inpaint = gr.Image(label="Image for img2img", show_label=False, source="upload", interactive=True, type="pil", elem_id="img_inpaint_base")
-                                init_mask_inpaint = gr.Image(label="Mask", source="upload", interactive=True, type="pil", image_mode="RGBA", elem_id="img_inpaint_mask")
+                            with gr.TabItem(
+                                "Inpaint upload",
+                                id="inpaint_upload",
+                                elem_id="img2img_inpaint_upload_tab",
+                            ) as tab_inpaint_upload:
+                                init_img_inpaint = gr.Image(
+                                    label="Image for img2img",
+                                    show_label=False,
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    elem_id="img_inpaint_base",
+                                )
+                                init_mask_inpaint = gr.Image(
+                                    label="Mask",
+                                    source="upload",
+                                    interactive=True,
+                                    type="pil",
+                                    image_mode="RGBA",
+                                    elem_id="img_inpaint_mask",
+                                )
 
-                            with gr.TabItem('Batch', id='batch', elem_id="img2img_batch_tab") as tab_batch:
+                            with gr.TabItem(
+                                "Batch", id="batch", elem_id="img2img_batch_tab"
+                            ) as tab_batch:
                                 with gr.Tabs(elem_id="img2img_batch_source"):
-                                    img2img_batch_source_type = gr.Textbox(visible=False, value="upload")
-                                    with gr.TabItem('Upload', id='batch_upload', elem_id="img2img_batch_upload_tab") as tab_batch_upload:
-                                        img2img_batch_upload = gr.Files(label="Files", interactive=True, elem_id="img2img_batch_upload")
-                                    with gr.TabItem('From directory', id='batch_from_dir', elem_id="img2img_batch_from_dir_tab") as tab_batch_from_dir:
-                                        hidden = '<br>Disabled when launched with --hide-ui-dir-config.' if shared.cmd_opts.hide_ui_dir_config else ''
+                                    img2img_batch_source_type = gr.Textbox(
+                                        visible=False, value="upload"
+                                    )
+                                    with gr.TabItem(
+                                        "Upload",
+                                        id="batch_upload",
+                                        elem_id="img2img_batch_upload_tab",
+                                    ) as tab_batch_upload:
+                                        img2img_batch_upload = gr.Files(
+                                            label="Files",
+                                            interactive=True,
+                                            elem_id="img2img_batch_upload",
+                                        )
+                                    with gr.TabItem(
+                                        "From directory",
+                                        id="batch_from_dir",
+                                        elem_id="img2img_batch_from_dir_tab",
+                                    ) as tab_batch_from_dir:
+                                        hidden = (
+                                            "<br>Disabled when launched with --hide-ui-dir-config."
+                                            if shared.cmd_opts.hide_ui_dir_config
+                                            else ""
+                                        )
                                         gr.HTML(
-                                            "<p style='padding-bottom: 1em;' class=\"text-gray-500\">Process images in a directory on the same machine where the server is running." +
-                                            "<br>Use an empty output directory to save pictures normally instead of writing to the output directory." +
-                                            f"<br>Add inpaint batch mask directory to enable inpaint batch processing."
+                                            "<p style='padding-bottom: 1em;' class=\"text-gray-500\">Process images in a directory on the same machine where the server is running."
+                                            + "<br>Use an empty output directory to save pictures normally instead of writing to the output directory."
+                                            + f"<br>Add inpaint batch mask directory to enable inpaint batch processing."
                                             f"{hidden}</p>"
                                         )
-                                        img2img_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs, elem_id="img2img_batch_input_dir")
-                                        img2img_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs, elem_id="img2img_batch_output_dir")
-                                        img2img_batch_inpaint_mask_dir = gr.Textbox(label="Inpaint batch mask directory (required for inpaint batch processing only)", **shared.hide_dirs, elem_id="img2img_batch_inpaint_mask_dir")
-                                tab_batch_upload.select(fn=lambda: "upload", inputs=[], outputs=[img2img_batch_source_type])
-                                tab_batch_from_dir.select(fn=lambda: "from dir", inputs=[], outputs=[img2img_batch_source_type])
+                                        img2img_batch_input_dir = gr.Textbox(
+                                            label="Input directory",
+                                            **shared.hide_dirs,
+                                            elem_id="img2img_batch_input_dir",
+                                        )
+                                        img2img_batch_output_dir = gr.Textbox(
+                                            label="Output directory",
+                                            **shared.hide_dirs,
+                                            elem_id="img2img_batch_output_dir",
+                                        )
+                                        img2img_batch_inpaint_mask_dir = gr.Textbox(
+                                            label="Inpaint batch mask directory (required for inpaint batch processing only)",
+                                            **shared.hide_dirs,
+                                            elem_id="img2img_batch_inpaint_mask_dir",
+                                        )
+                                tab_batch_upload.select(
+                                    fn=lambda: "upload",
+                                    inputs=[],
+                                    outputs=[img2img_batch_source_type],
+                                )
+                                tab_batch_from_dir.select(
+                                    fn=lambda: "from dir",
+                                    inputs=[],
+                                    outputs=[img2img_batch_source_type],
+                                )
                                 with gr.Accordion("PNG info", open=False):
-                                    img2img_batch_use_png_info = gr.Checkbox(label="Append png info to prompts", elem_id="img2img_batch_use_png_info")
-                                    img2img_batch_png_info_dir = gr.Textbox(label="PNG info directory", **shared.hide_dirs, placeholder="Leave empty to use input directory", elem_id="img2img_batch_png_info_dir")
-                                    img2img_batch_png_info_props = gr.CheckboxGroup(["Prompt", "Negative prompt", "Seed", "CFG scale", "Sampler", "Steps", "Model hash"], label="Parameters to take from png info", info="Prompts from png info will be appended to prompts set in ui.")
+                                    img2img_batch_use_png_info = gr.Checkbox(
+                                        label="Append png info to prompts",
+                                        elem_id="img2img_batch_use_png_info",
+                                    )
+                                    img2img_batch_png_info_dir = gr.Textbox(
+                                        label="PNG info directory",
+                                        **shared.hide_dirs,
+                                        placeholder="Leave empty to use input directory",
+                                        elem_id="img2img_batch_png_info_dir",
+                                    )
+                                    img2img_batch_png_info_props = gr.CheckboxGroup(
+                                        [
+                                            "Prompt",
+                                            "Negative prompt",
+                                            "Seed",
+                                            "CFG scale",
+                                            "Sampler",
+                                            "Steps",
+                                            "Model hash",
+                                        ],
+                                        label="Parameters to take from png info",
+                                        info="Prompts from png info will be appended to prompts set in ui.",
+                                    )
 
-                            img2img_tabs = [tab_img2img, tab_sketch, tab_inpaint, tab_inpaint_color, tab_inpaint_upload, tab_batch]
+                            img2img_tabs = [
+                                tab_img2img,
+                                tab_sketch,
+                                tab_inpaint,
+                                tab_inpaint_color,
+                                tab_inpaint_upload,
+                                tab_batch,
+                            ]
 
                             for i, tab in enumerate(img2img_tabs):
-                                tab.select(fn=lambda tabnum=i: tabnum, inputs=[], outputs=[img2img_selected_tab])
+                                tab.select(
+                                    fn=lambda tabnum=i: tabnum,
+                                    inputs=[],
+                                    outputs=[img2img_selected_tab],
+                                )
 
                         def copy_image(img):
-                            if isinstance(img, dict) and 'image' in img:
-                                return img['image']
+                            if isinstance(img, dict) and "image" in img:
+                                return img["image"]
 
                             return img
 
@@ -615,7 +1145,18 @@ def create_ui():
                             )
 
                         with FormRow():
-                            resize_mode = gr.Radio(label="Resize mode", elem_id="resize_mode", choices=["Just resize", "Crop and resize", "Resize and fill", "Just resize (latent upscale)"], type="index", value="Just resize")
+                            resize_mode = gr.Radio(
+                                label="Resize mode",
+                                elem_id="resize_mode",
+                                choices=[
+                                    "Just resize",
+                                    "Crop and resize",
+                                    "Resize and fill",
+                                    "Just resize (latent upscale)",
+                                ],
+                                type="index",
+                                value="Just resize",
+                            )
 
                     elif category == "dimensions":
                         with FormRow():
@@ -623,27 +1164,83 @@ def create_ui():
                                 selected_scale_tab = gr.Number(value=0, visible=False)
 
                                 with gr.Tabs(elem_id="img2img_tabs_resize"):
-                                    with gr.Tab(label="Resize to", id="to", elem_id="img2img_tab_resize_to") as tab_scale_to:
+                                    with gr.Tab(
+                                        label="Resize to",
+                                        id="to",
+                                        elem_id="img2img_tab_resize_to",
+                                    ) as tab_scale_to:
                                         with FormRow():
-                                            with gr.Column(elem_id="img2img_column_size", scale=4):
-                                                width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="img2img_width")
-                                                height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="img2img_height")
-                                            with gr.Column(elem_id="img2img_dimensions_row", scale=1, elem_classes="dimensions-tools"):
-                                                res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="img2img_res_switch_btn", tooltip="Switch width/height")
-                                                detect_image_size_btn = ToolButton(value=detect_image_size_symbol, elem_id="img2img_detect_image_size_btn", tooltip="Auto detect size from img2img")
+                                            with gr.Column(
+                                                elem_id="img2img_column_size", scale=4
+                                            ):
+                                                width = gr.Slider(
+                                                    minimum=64,
+                                                    maximum=2048,
+                                                    step=8,
+                                                    label="Width",
+                                                    value=512,
+                                                    elem_id="img2img_width",
+                                                )
+                                                height = gr.Slider(
+                                                    minimum=64,
+                                                    maximum=2048,
+                                                    step=8,
+                                                    label="Height",
+                                                    value=512,
+                                                    elem_id="img2img_height",
+                                                )
+                                            with gr.Column(
+                                                elem_id="img2img_dimensions_row",
+                                                scale=1,
+                                                elem_classes="dimensions-tools",
+                                            ):
+                                                res_switch_btn = ToolButton(
+                                                    value=switch_values_symbol,
+                                                    elem_id="img2img_res_switch_btn",
+                                                    tooltip="Switch width/height",
+                                                )
+                                                detect_image_size_btn = ToolButton(
+                                                    value=detect_image_size_symbol,
+                                                    elem_id="img2img_detect_image_size_btn",
+                                                    tooltip="Auto detect size from img2img",
+                                                )
 
-                                    with gr.Tab(label="Resize by", id="by", elem_id="img2img_tab_resize_by") as tab_scale_by:
-                                        scale_by = gr.Slider(minimum=0.05, maximum=4.0, step=0.05, label="Scale", value=1.0, elem_id="img2img_scale")
+                                    with gr.Tab(
+                                        label="Resize by",
+                                        id="by",
+                                        elem_id="img2img_tab_resize_by",
+                                    ) as tab_scale_by:
+                                        scale_by = gr.Slider(
+                                            minimum=0.05,
+                                            maximum=4.0,
+                                            step=0.05,
+                                            label="Scale",
+                                            value=1.0,
+                                            elem_id="img2img_scale",
+                                        )
 
                                         with FormRow():
-                                            scale_by_html = FormHTML(resize_from_to_html(0, 0, 0.0), elem_id="img2img_scale_resolution_preview")
-                                            gr.Slider(label="Unused", elem_id="img2img_unused_scale_by_slider")
-                                            button_update_resize_to = gr.Button(visible=False, elem_id="img2img_update_resize_to")
+                                            scale_by_html = FormHTML(
+                                                resize_from_to_html(0, 0, 0.0),
+                                                elem_id="img2img_scale_resolution_preview",
+                                            )
+                                            gr.Slider(
+                                                label="Unused",
+                                                elem_id="img2img_unused_scale_by_slider",
+                                            )
+                                            button_update_resize_to = gr.Button(
+                                                visible=False,
+                                                elem_id="img2img_update_resize_to",
+                                            )
 
                                     on_change_args = dict(
                                         fn=resize_from_to_html,
                                         _js="currentImg2imgSourceResolution",
-                                        inputs=[dummy_component, dummy_component, scale_by],
+                                        inputs=[
+                                            dummy_component,
+                                            dummy_component,
+                                            scale_by,
+                                        ],
                                         outputs=scale_by_html,
                                         show_progress=False,
                                     )
@@ -651,62 +1248,161 @@ def create_ui():
                                     scale_by.release(**on_change_args)
                                     button_update_resize_to.click(**on_change_args)
 
-                            tab_scale_to.select(fn=lambda: 0, inputs=[], outputs=[selected_scale_tab])
-                            tab_scale_by.select(fn=lambda: 1, inputs=[], outputs=[selected_scale_tab])
+                            tab_scale_to.select(
+                                fn=lambda: 0, inputs=[], outputs=[selected_scale_tab]
+                            )
+                            tab_scale_by.select(
+                                fn=lambda: 1, inputs=[], outputs=[selected_scale_tab]
+                            )
 
                             if opts.dimensions_and_batch_together:
                                 with gr.Column(elem_id="img2img_column_batch"):
-                                    batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="img2img_batch_count")
-                                    batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="img2img_batch_size")
+                                    batch_count = gr.Slider(
+                                        minimum=1,
+                                        step=1,
+                                        label="Batch count",
+                                        value=1,
+                                        elem_id="img2img_batch_count",
+                                    )
+                                    batch_size = gr.Slider(
+                                        minimum=1,
+                                        maximum=8,
+                                        step=1,
+                                        label="Batch size",
+                                        value=1,
+                                        elem_id="img2img_batch_size",
+                                    )
 
                     elif category == "denoising":
-                        denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising strength', value=0.75, elem_id="img2img_denoising_strength")
+                        denoising_strength = gr.Slider(
+                            minimum=0.0,
+                            maximum=1.0,
+                            step=0.01,
+                            label="Denoising strength",
+                            value=0.75,
+                            elem_id="img2img_denoising_strength",
+                        )
 
                     elif category == "cfg":
                         with gr.Row():
-                            cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="img2img_cfg_scale")
-                            image_cfg_scale = gr.Slider(minimum=0, maximum=3.0, step=0.05, label='Image CFG Scale', value=1.5, elem_id="img2img_image_cfg_scale", visible=False)
+                            cfg_scale = gr.Slider(
+                                minimum=1.0,
+                                maximum=30.0,
+                                step=0.5,
+                                label="CFG Scale",
+                                value=7.0,
+                                elem_id="img2img_cfg_scale",
+                            )
+                            image_cfg_scale = gr.Slider(
+                                minimum=0,
+                                maximum=3.0,
+                                step=0.05,
+                                label="Image CFG Scale",
+                                value=1.5,
+                                elem_id="img2img_image_cfg_scale",
+                                visible=False,
+                            )
 
                     elif category == "checkboxes":
                         with FormRow(elem_classes="checkboxes-row", variant="compact"):
                             pass
 
                     elif category == "accordions":
-                        with gr.Row(elem_id="img2img_accordions", elem_classes="accordions"):
+                        with gr.Row(
+                            elem_id="img2img_accordions", elem_classes="accordions"
+                        ):
                             scripts.scripts_img2img.setup_ui_for_section(category)
 
                     elif category == "batch":
                         if not opts.dimensions_and_batch_together:
                             with FormRow(elem_id="img2img_column_batch"):
-                                batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="img2img_batch_count")
-                                batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="img2img_batch_size")
+                                batch_count = gr.Slider(
+                                    minimum=1,
+                                    step=1,
+                                    label="Batch count",
+                                    value=1,
+                                    elem_id="img2img_batch_count",
+                                )
+                                batch_size = gr.Slider(
+                                    minimum=1,
+                                    maximum=8,
+                                    step=1,
+                                    label="Batch size",
+                                    value=1,
+                                    elem_id="img2img_batch_size",
+                                )
 
                     elif category == "override_settings":
                         with FormRow(elem_id="img2img_override_settings_row") as row:
-                            override_settings = create_override_settings_dropdown('img2img', row)
+                            override_settings = create_override_settings_dropdown(
+                                "img2img", row
+                            )
 
                     elif category == "scripts":
                         with FormGroup(elem_id="img2img_script_container"):
                             custom_inputs = scripts.scripts_img2img.setup_ui()
 
                     elif category == "inpaint":
-                        with FormGroup(elem_id="inpaint_controls", visible=False) as inpaint_controls:
+                        with FormGroup(
+                            elem_id="inpaint_controls", visible=False
+                        ) as inpaint_controls:
                             with FormRow():
-                                mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=4, elem_id="img2img_mask_blur")
-                                mask_alpha = gr.Slider(label="Mask transparency", visible=False, elem_id="img2img_mask_alpha")
+                                mask_blur = gr.Slider(
+                                    label="Mask blur",
+                                    minimum=0,
+                                    maximum=64,
+                                    step=1,
+                                    value=4,
+                                    elem_id="img2img_mask_blur",
+                                )
+                                mask_alpha = gr.Slider(
+                                    label="Mask transparency",
+                                    visible=False,
+                                    elem_id="img2img_mask_alpha",
+                                )
 
                             with FormRow():
-                                inpainting_mask_invert = gr.Radio(label='Mask mode', choices=['Inpaint masked', 'Inpaint not masked'], value='Inpaint masked', type="index", elem_id="img2img_mask_mode")
+                                inpainting_mask_invert = gr.Radio(
+                                    label="Mask mode",
+                                    choices=["Inpaint masked", "Inpaint not masked"],
+                                    value="Inpaint masked",
+                                    type="index",
+                                    elem_id="img2img_mask_mode",
+                                )
 
                             with FormRow():
-                                inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing'], value='original', type="index", elem_id="img2img_inpainting_fill")
+                                inpainting_fill = gr.Radio(
+                                    label="Masked content",
+                                    choices=[
+                                        "fill",
+                                        "original",
+                                        "latent noise",
+                                        "latent nothing",
+                                    ],
+                                    value="original",
+                                    type="index",
+                                    elem_id="img2img_inpainting_fill",
+                                )
 
                             with FormRow():
                                 with gr.Column():
-                                    inpaint_full_res = gr.Radio(label="Inpaint area", choices=["Whole picture", "Only masked"], type="index", value="Whole picture", elem_id="img2img_inpaint_full_res")
+                                    inpaint_full_res = gr.Radio(
+                                        label="Inpaint area",
+                                        choices=["Whole picture", "Only masked"],
+                                        type="index",
+                                        value="Whole picture",
+                                        elem_id="img2img_inpaint_full_res",
+                                    )
 
                                 with gr.Column(scale=4):
-                                    inpaint_full_res_padding = gr.Slider(label='Only masked padding, pixels', minimum=0, maximum=256, step=4, value=32, elem_id="img2img_inpaint_full_res_padding")
+                                    inpaint_full_res_padding = gr.Slider(
+                                        label="Only masked padding, pixels",
+                                        minimum=0,
+                                        maximum=256,
+                                        step=4,
+                                        value=32,
+                                        elem_id="img2img_inpaint_full_res_padding",
+                                    )
 
                     if category not in {"accordions"}:
                         scripts.scripts_img2img.setup_ui_for_section(category)
@@ -715,10 +1411,19 @@ def create_ui():
             # as it is now the event keeps firing continuously for inpaint edits, which ruins the page with constant requests.
             # I assume this must be a gradio bug and for now we'll just do it for non-inpaint inputs.
             for component in [init_img, sketch]:
-                component.change(fn=lambda: None, _js="updateImg2imgResizeToTextAfterChangingImage", inputs=[], outputs=[], show_progress=False)
+                component.change(
+                    fn=lambda: None,
+                    _js="updateImg2imgResizeToTextAfterChangingImage",
+                    inputs=[],
+                    outputs=[],
+                    show_progress=False,
+                )
 
             def select_img2img_tab(tab):
-                return gr.update(visible=tab in [2, 3, 4]), gr.update(visible=tab == 3),
+                return (
+                    gr.update(visible=tab in [2, 3, 4]),
+                    gr.update(visible=tab == 3),
+                )
 
             for i, elem in enumerate(img2img_tabs):
                 elem.select(
@@ -727,10 +1432,14 @@ def create_ui():
                     outputs=[inpaint_controls, mask_alpha],
                 )
 
-            output_panel = create_output_panel("img2img", opts.outdir_img2img_samples, toprow)
+            output_panel = create_output_panel(
+                "img2img", opts.outdir_img2img_samples, toprow
+            )
 
             img2img_args = dict(
-                fn=wrap_gradio_gpu_call(modules.img2img.img2img, extra_outputs=[None, '', '']),
+                fn=wrap_gradio_gpu_call(
+                    modules.img2img.img2img, extra_outputs=[None, "", ""]
+                ),
                 _js="submit_img2img",
                 inputs=[
                     dummy_component,
@@ -770,7 +1479,8 @@ def create_ui():
                     img2img_batch_png_info_dir,
                     img2img_batch_source_type,
                     img2img_batch_upload,
-                ] + custom_inputs,
+                ]
+                + custom_inputs,
                 outputs=[
                     output_panel.gallery,
                     output_panel.generation_info,
@@ -798,7 +1508,13 @@ def create_ui():
             toprow.prompt.submit(**img2img_args)
             toprow.submit.click(**img2img_args)
 
-            res_switch_btn.click(fn=None, _js="function(){switchWidthHeight('img2img')}", inputs=None, outputs=None, show_progress=False)
+            res_switch_btn.click(
+                fn=None,
+                _js="function(){switchWidthHeight('img2img')}",
+                inputs=None,
+                outputs=None,
+                show_progress=False,
+            )
 
             detect_image_size_btn.click(
                 fn=lambda w, h, _: (w or gr.update(), h or gr.update()),
@@ -831,12 +1547,28 @@ def create_ui():
                 **interrogate_args,
             )
 
-            steps = scripts.scripts_img2img.script('Sampler').steps
+            steps = scripts.scripts_img2img.script("Sampler").steps
 
-            toprow.ui_styles.dropdown.change(fn=wrap_queued_call(update_token_counter), inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.token_counter])
-            toprow.ui_styles.dropdown.change(fn=wrap_queued_call(update_negative_prompt_token_counter), inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.negative_token_counter])
-            toprow.token_button.click(fn=update_token_counter, inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.token_counter])
-            toprow.negative_token_button.click(fn=wrap_queued_call(update_negative_prompt_token_counter), inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown], outputs=[toprow.negative_token_counter])
+            toprow.ui_styles.dropdown.change(
+                fn=wrap_queued_call(update_token_counter),
+                inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.token_counter],
+            )
+            toprow.ui_styles.dropdown.change(
+                fn=wrap_queued_call(update_negative_prompt_token_counter),
+                inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.negative_token_counter],
+            )
+            toprow.token_button.click(
+                fn=update_token_counter,
+                inputs=[toprow.prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.token_counter],
+            )
+            toprow.negative_token_button.click(
+                fn=wrap_queued_call(update_negative_prompt_token_counter),
+                inputs=[toprow.negative_prompt, steps, toprow.ui_styles.dropdown],
+                outputs=[toprow.negative_token_counter],
+            )
 
             img2img_paste_fields = [
                 (toprow.prompt, "Prompt"),
@@ -846,22 +1578,38 @@ def create_ui():
                 (width, "Size-1"),
                 (height, "Size-2"),
                 (batch_size, "Batch size"),
-                (toprow.ui_styles.dropdown, lambda d: d["Styles array"] if isinstance(d.get("Styles array"), list) else gr.update()),
+                (
+                    toprow.ui_styles.dropdown,
+                    lambda d: d["Styles array"]
+                    if isinstance(d.get("Styles array"), list)
+                    else gr.update(),
+                ),
                 (denoising_strength, "Denoising strength"),
                 (mask_blur, "Mask blur"),
-                (inpainting_mask_invert, 'Mask mode'),
-                (inpainting_fill, 'Masked content'),
-                (inpaint_full_res, 'Inpaint area'),
-                (inpaint_full_res_padding, 'Masked area padding'),
-                *scripts.scripts_img2img.infotext_fields
+                (inpainting_mask_invert, "Mask mode"),
+                (inpainting_fill, "Masked content"),
+                (inpaint_full_res, "Inpaint area"),
+                (inpaint_full_res_padding, "Masked area padding"),
+                *scripts.scripts_img2img.infotext_fields,
             ]
-            parameters_copypaste.add_paste_fields("img2img", init_img, img2img_paste_fields, override_settings)
-            parameters_copypaste.add_paste_fields("inpaint", init_img_with_mask, img2img_paste_fields, override_settings)
-            parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                paste_button=toprow.paste, tabname="img2img", source_text_component=toprow.prompt, source_image_component=None,
-            ))
+            parameters_copypaste.add_paste_fields(
+                "img2img", init_img, img2img_paste_fields, override_settings
+            )
+            parameters_copypaste.add_paste_fields(
+                "inpaint", init_img_with_mask, img2img_paste_fields, override_settings
+            )
+            parameters_copypaste.register_paste_params_button(
+                parameters_copypaste.ParamBinding(
+                    paste_button=toprow.paste,
+                    tabname="img2img",
+                    source_text_component=toprow.prompt,
+                    source_image_component=None,
+                )
+            )
 
-        extra_networks_ui_img2img = ui_extra_networks.create_ui(img2img_interface, [img2img_generation_tab], 'img2img')
+        extra_networks_ui_img2img = ui_extra_networks.create_ui(
+            img2img_interface, [img2img_generation_tab], "img2img"
+        )
         ui_extra_networks.setup_ui(extra_networks_ui_img2img, output_panel.gallery)
 
         extra_tabs.__exit__()
@@ -873,20 +1621,35 @@ def create_ui():
 
     with gr.Blocks(analytics_enabled=False) as pnginfo_interface:
         with ResizeHandleRow(equal_height=False):
-            with gr.Column(variant='panel'):
-                image = gr.Image(elem_id="pnginfo_image", label="Source", source="upload", interactive=True, type="pil")
+            with gr.Column(variant="panel"):
+                image = gr.Image(
+                    elem_id="pnginfo_image",
+                    label="Source",
+                    source="upload",
+                    interactive=True,
+                    type="pil",
+                )
 
-            with gr.Column(variant='panel'):
+            with gr.Column(variant="panel"):
                 html = gr.HTML()
-                generation_info = gr.Textbox(visible=False, elem_id="pnginfo_generation_info")
+                generation_info = gr.Textbox(
+                    visible=False, elem_id="pnginfo_generation_info"
+                )
                 html2 = gr.HTML()
                 with gr.Row():
-                    buttons = parameters_copypaste.create_buttons(["txt2img", "img2img", "inpaint", "extras"])
+                    buttons = parameters_copypaste.create_buttons(
+                        ["txt2img", "img2img", "inpaint", "extras"]
+                    )
 
                 for tabname, button in buttons.items():
-                    parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                        paste_button=button, tabname=tabname, source_text_component=generation_info, source_image_component=image,
-                    ))
+                    parameters_copypaste.register_paste_params_button(
+                        parameters_copypaste.ParamBinding(
+                            paste_button=button,
+                            tabname=tabname,
+                            source_text_component=generation_info,
+                            source_image_component=image,
+                        )
+                    )
 
         image.change(
             fn=wrap_gradio_call_no_job(modules.extras.run_pnginfo),
@@ -898,104 +1661,318 @@ def create_ui():
 
     with gr.Blocks(analytics_enabled=False) as train_interface:
         with gr.Row(equal_height=False):
-            gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation.</p>")
+            gr.HTML(
+                value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation.</p>"
+            )
 
         with ResizeHandleRow(variant="compact", equal_height=False):
             with gr.Tabs(elem_id="train_tabs"):
-
                 with gr.Tab(label="Create embedding", id="create_embedding"):
-                    new_embedding_name = gr.Textbox(label="Name", elem_id="train_new_embedding_name")
-                    initialization_text = gr.Textbox(label="Initialization text", value="*", elem_id="train_initialization_text")
-                    nvpt = gr.Slider(label="Number of vectors per token", minimum=1, maximum=75, step=1, value=1, elem_id="train_nvpt")
-                    overwrite_old_embedding = gr.Checkbox(value=False, label="Overwrite Old Embedding", elem_id="train_overwrite_old_embedding")
+                    new_embedding_name = gr.Textbox(
+                        label="Name", elem_id="train_new_embedding_name"
+                    )
+                    initialization_text = gr.Textbox(
+                        label="Initialization text",
+                        value="*",
+                        elem_id="train_initialization_text",
+                    )
+                    nvpt = gr.Slider(
+                        label="Number of vectors per token",
+                        minimum=1,
+                        maximum=75,
+                        step=1,
+                        value=1,
+                        elem_id="train_nvpt",
+                    )
+                    overwrite_old_embedding = gr.Checkbox(
+                        value=False,
+                        label="Overwrite Old Embedding",
+                        elem_id="train_overwrite_old_embedding",
+                    )
 
                     with gr.Row():
                         with gr.Column(scale=3):
                             gr.HTML(value="")
 
                         with gr.Column():
-                            create_embedding = gr.Button(value="Create embedding", variant='primary', elem_id="train_create_embedding")
+                            create_embedding = gr.Button(
+                                value="Create embedding",
+                                variant="primary",
+                                elem_id="train_create_embedding",
+                            )
 
                 with gr.Tab(label="Create hypernetwork", id="create_hypernetwork"):
-                    new_hypernetwork_name = gr.Textbox(label="Name", elem_id="train_new_hypernetwork_name")
-                    new_hypernetwork_sizes = gr.CheckboxGroup(label="Modules", value=["768", "320", "640", "1280"], choices=["768", "1024", "320", "640", "1280"], elem_id="train_new_hypernetwork_sizes")
-                    new_hypernetwork_layer_structure = gr.Textbox("1, 2, 1", label="Enter hypernetwork layer structure", placeholder="1st and last digit must be 1. ex:'1, 2, 1'", elem_id="train_new_hypernetwork_layer_structure")
-                    new_hypernetwork_activation_func = gr.Dropdown(value="linear", label="Select activation function of hypernetwork. Recommended : Swish / Linear(none)", choices=hypernetworks_ui.keys, elem_id="train_new_hypernetwork_activation_func")
-                    new_hypernetwork_initialization_option = gr.Dropdown(value = "Normal", label="Select Layer weights initialization. Recommended: Kaiming for relu-like, Xavier for sigmoid-like, Normal otherwise", choices=["Normal", "KaimingUniform", "KaimingNormal", "XavierUniform", "XavierNormal"], elem_id="train_new_hypernetwork_initialization_option")
-                    new_hypernetwork_add_layer_norm = gr.Checkbox(label="Add layer normalization", elem_id="train_new_hypernetwork_add_layer_norm")
-                    new_hypernetwork_use_dropout = gr.Checkbox(label="Use dropout", elem_id="train_new_hypernetwork_use_dropout")
-                    new_hypernetwork_dropout_structure = gr.Textbox("0, 0, 0", label="Enter hypernetwork Dropout structure (or empty). Recommended : 0~0.35 incrementing sequence: 0, 0.05, 0.15", placeholder="1st and last digit must be 0 and values should be between 0 and 1. ex:'0, 0.01, 0'")
-                    overwrite_old_hypernetwork = gr.Checkbox(value=False, label="Overwrite Old Hypernetwork", elem_id="train_overwrite_old_hypernetwork")
+                    new_hypernetwork_name = gr.Textbox(
+                        label="Name", elem_id="train_new_hypernetwork_name"
+                    )
+                    new_hypernetwork_sizes = gr.CheckboxGroup(
+                        label="Modules",
+                        value=["768", "320", "640", "1280"],
+                        choices=["768", "1024", "320", "640", "1280"],
+                        elem_id="train_new_hypernetwork_sizes",
+                    )
+                    new_hypernetwork_layer_structure = gr.Textbox(
+                        "1, 2, 1",
+                        label="Enter hypernetwork layer structure",
+                        placeholder="1st and last digit must be 1. ex:'1, 2, 1'",
+                        elem_id="train_new_hypernetwork_layer_structure",
+                    )
+                    new_hypernetwork_activation_func = gr.Dropdown(
+                        value="linear",
+                        label="Select activation function of hypernetwork. Recommended : Swish / Linear(none)",
+                        choices=hypernetworks_ui.keys,
+                        elem_id="train_new_hypernetwork_activation_func",
+                    )
+                    new_hypernetwork_initialization_option = gr.Dropdown(
+                        value="Normal",
+                        label="Select Layer weights initialization. Recommended: Kaiming for relu-like, Xavier for sigmoid-like, Normal otherwise",
+                        choices=[
+                            "Normal",
+                            "KaimingUniform",
+                            "KaimingNormal",
+                            "XavierUniform",
+                            "XavierNormal",
+                        ],
+                        elem_id="train_new_hypernetwork_initialization_option",
+                    )
+                    new_hypernetwork_add_layer_norm = gr.Checkbox(
+                        label="Add layer normalization",
+                        elem_id="train_new_hypernetwork_add_layer_norm",
+                    )
+                    new_hypernetwork_use_dropout = gr.Checkbox(
+                        label="Use dropout",
+                        elem_id="train_new_hypernetwork_use_dropout",
+                    )
+                    new_hypernetwork_dropout_structure = gr.Textbox(
+                        "0, 0, 0",
+                        label="Enter hypernetwork Dropout structure (or empty). Recommended : 0~0.35 incrementing sequence: 0, 0.05, 0.15",
+                        placeholder="1st and last digit must be 0 and values should be between 0 and 1. ex:'0, 0.01, 0'",
+                    )
+                    overwrite_old_hypernetwork = gr.Checkbox(
+                        value=False,
+                        label="Overwrite Old Hypernetwork",
+                        elem_id="train_overwrite_old_hypernetwork",
+                    )
 
                     with gr.Row():
                         with gr.Column(scale=3):
                             gr.HTML(value="")
 
                         with gr.Column():
-                            create_hypernetwork = gr.Button(value="Create hypernetwork", variant='primary', elem_id="train_create_hypernetwork")
+                            create_hypernetwork = gr.Button(
+                                value="Create hypernetwork",
+                                variant="primary",
+                                elem_id="train_create_hypernetwork",
+                            )
 
                 def get_textual_inversion_template_names():
                     return sorted(textual_inversion.textual_inversion_templates)
 
                 with gr.Tab(label="Train", id="train"):
-                    gr.HTML(value="<p style='margin-bottom: 0.7em'>Train an embedding or Hypernetwork; you must specify a directory with a set of 1:1 ratio images <a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\" style=\"font-weight:bold;\">[wiki]</a></p>")
+                    gr.HTML(
+                        value='<p style=\'margin-bottom: 0.7em\'>Train an embedding or Hypernetwork; you must specify a directory with a set of 1:1 ratio images <a href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion" style="font-weight:bold;">[wiki]</a></p>'
+                    )
                     with FormRow():
-                        train_embedding_name = gr.Dropdown(label='Embedding', elem_id="train_embedding", choices=sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys()))
-                        create_refresh_button(train_embedding_name, sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings, lambda: {"choices": sorted(sd_hijack.model_hijack.embedding_db.word_embeddings.keys())}, "refresh_train_embedding_name")
+                        train_embedding_name = gr.Dropdown(
+                            label="Embedding",
+                            elem_id="train_embedding",
+                            choices=sorted(
+                                sd_hijack.model_hijack.embedding_db.word_embeddings.keys()
+                            ),
+                        )
+                        create_refresh_button(
+                            train_embedding_name,
+                            sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings,
+                            lambda: {
+                                "choices": sorted(
+                                    sd_hijack.model_hijack.embedding_db.word_embeddings.keys()
+                                )
+                            },
+                            "refresh_train_embedding_name",
+                        )
 
-                        train_hypernetwork_name = gr.Dropdown(label='Hypernetwork', elem_id="train_hypernetwork", choices=sorted(shared.hypernetworks))
-                        create_refresh_button(train_hypernetwork_name, shared.reload_hypernetworks, lambda: {"choices": sorted(shared.hypernetworks)}, "refresh_train_hypernetwork_name")
+                        train_hypernetwork_name = gr.Dropdown(
+                            label="Hypernetwork",
+                            elem_id="train_hypernetwork",
+                            choices=sorted(shared.hypernetworks),
+                        )
+                        create_refresh_button(
+                            train_hypernetwork_name,
+                            shared.reload_hypernetworks,
+                            lambda: {"choices": sorted(shared.hypernetworks)},
+                            "refresh_train_hypernetwork_name",
+                        )
 
                     with FormRow():
-                        embedding_learn_rate = gr.Textbox(label='Embedding Learning rate', placeholder="Embedding Learning rate", value="0.005", elem_id="train_embedding_learn_rate")
-                        hypernetwork_learn_rate = gr.Textbox(label='Hypernetwork Learning rate', placeholder="Hypernetwork Learning rate", value="0.00001", elem_id="train_hypernetwork_learn_rate")
+                        embedding_learn_rate = gr.Textbox(
+                            label="Embedding Learning rate",
+                            placeholder="Embedding Learning rate",
+                            value="0.005",
+                            elem_id="train_embedding_learn_rate",
+                        )
+                        hypernetwork_learn_rate = gr.Textbox(
+                            label="Hypernetwork Learning rate",
+                            placeholder="Hypernetwork Learning rate",
+                            value="0.00001",
+                            elem_id="train_hypernetwork_learn_rate",
+                        )
 
                     with FormRow():
-                        clip_grad_mode = gr.Dropdown(value="disabled", label="Gradient Clipping", choices=["disabled", "value", "norm"])
-                        clip_grad_value = gr.Textbox(placeholder="Gradient clip value", value="0.1", show_label=False)
+                        clip_grad_mode = gr.Dropdown(
+                            value="disabled",
+                            label="Gradient Clipping",
+                            choices=["disabled", "value", "norm"],
+                        )
+                        clip_grad_value = gr.Textbox(
+                            placeholder="Gradient clip value",
+                            value="0.1",
+                            show_label=False,
+                        )
 
                     with FormRow():
-                        batch_size = gr.Number(label='Batch size', value=1, precision=0, elem_id="train_batch_size")
-                        gradient_step = gr.Number(label='Gradient accumulation steps', value=1, precision=0, elem_id="train_gradient_step")
+                        batch_size = gr.Number(
+                            label="Batch size",
+                            value=1,
+                            precision=0,
+                            elem_id="train_batch_size",
+                        )
+                        gradient_step = gr.Number(
+                            label="Gradient accumulation steps",
+                            value=1,
+                            precision=0,
+                            elem_id="train_gradient_step",
+                        )
 
-                    dataset_directory = gr.Textbox(label='Dataset directory', placeholder="Path to directory with input images", elem_id="train_dataset_directory")
-                    log_directory = gr.Textbox(label='Log directory', placeholder="Path to directory where to write outputs", value="textual_inversion", elem_id="train_log_directory")
+                    dataset_directory = gr.Textbox(
+                        label="Dataset directory",
+                        placeholder="Path to directory with input images",
+                        elem_id="train_dataset_directory",
+                    )
+                    log_directory = gr.Textbox(
+                        label="Log directory",
+                        placeholder="Path to directory where to write outputs",
+                        value="textual_inversion",
+                        elem_id="train_log_directory",
+                    )
 
                     with FormRow():
-                        template_file = gr.Dropdown(label='Prompt template', value="style_filewords.txt", elem_id="train_template_file", choices=get_textual_inversion_template_names())
-                        create_refresh_button(template_file, textual_inversion.list_textual_inversion_templates, lambda: {"choices": get_textual_inversion_template_names()}, "refrsh_train_template_file")
+                        template_file = gr.Dropdown(
+                            label="Prompt template",
+                            value="style_filewords.txt",
+                            elem_id="train_template_file",
+                            choices=get_textual_inversion_template_names(),
+                        )
+                        create_refresh_button(
+                            template_file,
+                            textual_inversion.list_textual_inversion_templates,
+                            lambda: {"choices": get_textual_inversion_template_names()},
+                            "refrsh_train_template_file",
+                        )
 
-                    training_width = gr.Slider(minimum=64, maximum=2048, step=8, label="Width", value=512, elem_id="train_training_width")
-                    training_height = gr.Slider(minimum=64, maximum=2048, step=8, label="Height", value=512, elem_id="train_training_height")
-                    varsize = gr.Checkbox(label="Do not resize images", value=False, elem_id="train_varsize")
-                    steps = gr.Number(label='Max steps', value=100000, precision=0, elem_id="train_steps")
+                    training_width = gr.Slider(
+                        minimum=64,
+                        maximum=2048,
+                        step=8,
+                        label="Width",
+                        value=512,
+                        elem_id="train_training_width",
+                    )
+                    training_height = gr.Slider(
+                        minimum=64,
+                        maximum=2048,
+                        step=8,
+                        label="Height",
+                        value=512,
+                        elem_id="train_training_height",
+                    )
+                    varsize = gr.Checkbox(
+                        label="Do not resize images",
+                        value=False,
+                        elem_id="train_varsize",
+                    )
+                    steps = gr.Number(
+                        label="Max steps",
+                        value=100000,
+                        precision=0,
+                        elem_id="train_steps",
+                    )
 
                     with FormRow():
-                        create_image_every = gr.Number(label='Save an image to log directory every N steps, 0 to disable', value=500, precision=0, elem_id="train_create_image_every")
-                        save_embedding_every = gr.Number(label='Save a copy of embedding to log directory every N steps, 0 to disable', value=500, precision=0, elem_id="train_save_embedding_every")
+                        create_image_every = gr.Number(
+                            label="Save an image to log directory every N steps, 0 to disable",
+                            value=500,
+                            precision=0,
+                            elem_id="train_create_image_every",
+                        )
+                        save_embedding_every = gr.Number(
+                            label="Save a copy of embedding to log directory every N steps, 0 to disable",
+                            value=500,
+                            precision=0,
+                            elem_id="train_save_embedding_every",
+                        )
 
-                    use_weight = gr.Checkbox(label="Use PNG alpha channel as loss weight", value=False, elem_id="use_weight")
+                    use_weight = gr.Checkbox(
+                        label="Use PNG alpha channel as loss weight",
+                        value=False,
+                        elem_id="use_weight",
+                    )
 
-                    save_image_with_stored_embedding = gr.Checkbox(label='Save images with embedding in PNG chunks', value=True, elem_id="train_save_image_with_stored_embedding")
-                    preview_from_txt2img = gr.Checkbox(label='Read parameters (prompt, etc...) from txt2img tab when making previews', value=False, elem_id="train_preview_from_txt2img")
+                    save_image_with_stored_embedding = gr.Checkbox(
+                        label="Save images with embedding in PNG chunks",
+                        value=True,
+                        elem_id="train_save_image_with_stored_embedding",
+                    )
+                    preview_from_txt2img = gr.Checkbox(
+                        label="Read parameters (prompt, etc...) from txt2img tab when making previews",
+                        value=False,
+                        elem_id="train_preview_from_txt2img",
+                    )
 
-                    shuffle_tags = gr.Checkbox(label="Shuffle tags by ',' when creating prompts.", value=False, elem_id="train_shuffle_tags")
-                    tag_drop_out = gr.Slider(minimum=0, maximum=1, step=0.1, label="Drop out tags when creating prompts.", value=0, elem_id="train_tag_drop_out")
+                    shuffle_tags = gr.Checkbox(
+                        label="Shuffle tags by ',' when creating prompts.",
+                        value=False,
+                        elem_id="train_shuffle_tags",
+                    )
+                    tag_drop_out = gr.Slider(
+                        minimum=0,
+                        maximum=1,
+                        step=0.1,
+                        label="Drop out tags when creating prompts.",
+                        value=0,
+                        elem_id="train_tag_drop_out",
+                    )
 
-                    latent_sampling_method = gr.Radio(label='Choose latent sampling method', value="once", choices=['once', 'deterministic', 'random'], elem_id="train_latent_sampling_method")
+                    latent_sampling_method = gr.Radio(
+                        label="Choose latent sampling method",
+                        value="once",
+                        choices=["once", "deterministic", "random"],
+                        elem_id="train_latent_sampling_method",
+                    )
 
                     with gr.Row():
-                        train_embedding = gr.Button(value="Train Embedding", variant='primary', elem_id="train_train_embedding")
-                        interrupt_training = gr.Button(value="Interrupt", elem_id="train_interrupt_training")
-                        train_hypernetwork = gr.Button(value="Train Hypernetwork", variant='primary', elem_id="train_train_hypernetwork")
+                        train_embedding = gr.Button(
+                            value="Train Embedding",
+                            variant="primary",
+                            elem_id="train_train_embedding",
+                        )
+                        interrupt_training = gr.Button(
+                            value="Interrupt", elem_id="train_interrupt_training"
+                        )
+                        train_hypernetwork = gr.Button(
+                            value="Train Hypernetwork",
+                            variant="primary",
+                            elem_id="train_train_hypernetwork",
+                        )
 
                 params = script_callbacks.UiTrainTabParams(txt2img_preview_params)
 
                 script_callbacks.ui_train_tabs_callback(params)
 
-            with gr.Column(elem_id='ti_gallery_container'):
+            with gr.Column(elem_id="ti_gallery_container"):
                 ti_output = gr.Text(elem_id="ti_output", value="", show_label=False)
-                gr.Gallery(label='Output', show_label=False, elem_id='ti_gallery', columns=4)
+                gr.Gallery(
+                    label="Output", show_label=False, elem_id="ti_gallery", columns=4
+                )
                 gr.HTML(elem_id="ti_progress", value="")
                 ti_outcome = gr.HTML(elem_id="ti_error", value="")
 
@@ -1011,7 +1988,7 @@ def create_ui():
                 train_embedding_name,
                 ti_output,
                 ti_outcome,
-            ]
+            ],
         )
 
         create_hypernetwork.click(
@@ -1025,17 +2002,19 @@ def create_ui():
                 new_hypernetwork_initialization_option,
                 new_hypernetwork_add_layer_norm,
                 new_hypernetwork_use_dropout,
-                new_hypernetwork_dropout_structure
+                new_hypernetwork_dropout_structure,
             ],
             outputs=[
                 train_hypernetwork_name,
                 ti_output,
                 ti_outcome,
-            ]
+            ],
         )
 
         train_embedding.click(
-            fn=wrap_gradio_gpu_call(textual_inversion_ui.train_embedding, extra_outputs=[gr.update()]),
+            fn=wrap_gradio_gpu_call(
+                textual_inversion_ui.train_embedding, extra_outputs=[gr.update()]
+            ),
             _js="start_training_textual_inversion",
             inputs=[
                 dummy_component,
@@ -1065,11 +2044,13 @@ def create_ui():
             outputs=[
                 ti_output,
                 ti_outcome,
-            ]
+            ],
         )
 
         train_hypernetwork.click(
-            fn=wrap_gradio_gpu_call(hypernetworks_ui.train_hypernetwork, extra_outputs=[gr.update()]),
+            fn=wrap_gradio_gpu_call(
+                hypernetworks_ui.train_hypernetwork, extra_outputs=[gr.update()]
+            ),
             _js="start_training_textual_inversion",
             inputs=[
                 dummy_component,
@@ -1098,7 +2079,7 @@ def create_ui():
             outputs=[
                 ti_output,
                 ti_outcome,
-            ]
+            ],
         )
 
         interrupt_training.click(
@@ -1131,14 +2112,18 @@ def create_ui():
     for _interface, label, _ifid in interfaces:
         shared.tab_names.append(label)
 
-    with gr.Blocks(theme=shared.gradio_theme, analytics_enabled=False, title="Stable Diffusion") as demo:
+    with gr.Blocks(
+        theme=shared.gradio_theme, analytics_enabled=False, title="Stable Diffusion"
+    ) as demo:
         settings.add_quicksettings()
 
         parameters_copypaste.connect_paste_params_buttons()
 
         with gr.Tabs(elem_id="tabs") as tabs:
             tab_order = {k: i for i, k in enumerate(opts.ui_tab_order)}
-            sorted_interfaces = sorted(interfaces, key=lambda x: tab_order.get(x[1], 9999))
+            sorted_interfaces = sorted(
+                interfaces, key=lambda x: tab_order.get(x[1], 9999)
+            )
 
             for interface, label, ifid in sorted_interfaces:
                 if label in shared.opts.hidden_tabs:
@@ -1153,20 +2138,44 @@ def create_ui():
 
             loadsave.setup_ui()
 
-        if os.path.exists(os.path.join(script_path, "notification.mp3")) and shared.opts.notification_audio:
-            gr.Audio(interactive=False, value=os.path.join(script_path, "notification.mp3"), elem_id="audio_notification", visible=False)
+        if (
+            os.path.exists(os.path.join(script_path, "notification.mp3"))
+            and shared.opts.notification_audio
+        ):
+            gr.Audio(
+                interactive=False,
+                value=os.path.join(script_path, "notification.mp3"),
+                elem_id="audio_notification",
+                visible=False,
+            )
 
         footer = shared.html("footer.html")
-        footer = footer.format(versions=versions_html(), api_docs="/docs" if shared.cmd_opts.api else "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API")
+        footer = footer.format(
+            versions=versions_html(),
+            api_docs="/docs"
+            if shared.cmd_opts.api
+            else "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API",
+        )
         gr.HTML(footer, elem_id="footer")
 
         settings.add_functionality(demo)
 
-        update_image_cfg_scale_visibility = lambda: gr.update(visible=shared.sd_model and shared.sd_model.cond_stage_key == "edit")
-        settings.text_settings.change(fn=update_image_cfg_scale_visibility, inputs=[], outputs=[image_cfg_scale])
-        demo.load(fn=update_image_cfg_scale_visibility, inputs=[], outputs=[image_cfg_scale])
+        update_image_cfg_scale_visibility = lambda: gr.update(
+            visible=shared.sd_model and shared.sd_model.cond_stage_key == "edit"
+        )
+        settings.text_settings.change(
+            fn=update_image_cfg_scale_visibility, inputs=[], outputs=[image_cfg_scale]
+        )
+        demo.load(
+            fn=update_image_cfg_scale_visibility, inputs=[], outputs=[image_cfg_scale]
+        )
 
-        modelmerger_ui.setup_ui(dummy_component=dummy_component, sd_model_checkpoint_component=settings.component_dict['sd_model_checkpoint'])
+        modelmerger_ui.setup_ui(
+            dummy_component=dummy_component,
+            sd_model_checkpoint_component=settings.component_dict[
+                "sd_model_checkpoint"
+            ],
+        )
 
     if ui_settings_from_file != loadsave.ui_settings:
         loadsave.dump_defaults()
@@ -1185,6 +2194,7 @@ def versions_html():
 
     if shared.xformers_available:
         import xformers
+
         xformers_version = xformers.__version__
     else:
         xformers_version = "N/A"
@@ -1212,24 +2222,52 @@ def setup_ui_api(app):
         label: str = Field(title="Label of the quicksettings field")
 
     def quicksettings_hint():
-        return [QuicksettingsHint(name=k, label=v.label) for k, v in opts.data_labels.items()]
+        return [
+            QuicksettingsHint(name=k, label=v.label)
+            for k, v in opts.data_labels.items()
+        ]
 
-    app.add_api_route("/internal/quicksettings-hint", quicksettings_hint, methods=["GET"], response_model=list[QuicksettingsHint])
+    app.add_api_route(
+        "/internal/quicksettings-hint",
+        quicksettings_hint,
+        methods=["GET"],
+        response_model=list[QuicksettingsHint],
+    )
 
     app.add_api_route("/internal/ping", lambda: {}, methods=["GET"])
 
-    app.add_api_route("/internal/profile-startup", lambda: timer.startup_record, methods=["GET"])
+    app.add_api_route(
+        "/internal/profile-startup", lambda: timer.startup_record, methods=["GET"]
+    )
 
     def download_sysinfo(attachment=False):
         from fastapi.responses import PlainTextResponse
 
         text = sysinfo.get()
-        filename = f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
+        filename = (
+            f"sysinfo-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M')}.json"
+        )
 
-        return PlainTextResponse(text, headers={'Content-Disposition': f'{"attachment" if attachment else "inline"}; filename="{filename}"'})
+        return PlainTextResponse(
+            text,
+            headers={
+                "Content-Disposition": f'{"attachment" if attachment else "inline"}; filename="{filename}"'
+            },
+        )
 
     app.add_api_route("/internal/sysinfo", download_sysinfo, methods=["GET"])
-    app.add_api_route("/internal/sysinfo-download", lambda: download_sysinfo(attachment=True), methods=["GET"])
+    app.add_api_route(
+        "/internal/sysinfo-download",
+        lambda: download_sysinfo(attachment=True),
+        methods=["GET"],
+    )
 
     import fastapi.staticfiles
-    app.mount("/webui-assets", fastapi.staticfiles.StaticFiles(directory=launch_utils.repo_dir('stable-diffusion-webui-assets')), name="webui-assets")
+
+    app.mount(
+        "/webui-assets",
+        fastapi.staticfiles.StaticFiles(
+            directory=launch_utils.repo_dir("stable-diffusion-webui-assets")
+        ),
+        name="webui-assets",
+    )

--- a/modules/ui_checkpoint_merger.py
+++ b/modules/ui_checkpoint_merger.py
@@ -1,4 +1,3 @@
-
 import gradio as gr
 
 from modules import sd_models, sd_vae, errors, extras, call_queue
@@ -9,9 +8,15 @@ from modules.ui_common import create_refresh_button
 def update_interp_description(value):
     interp_description_css = "<p style='margin-bottom: 2.5em'>{}</p>"
     interp_descriptions = {
-        "No interpolation": interp_description_css.format("No interpolation will be used. Requires one model; A. Allows for format conversion and VAE baking."),
-        "Weighted sum": interp_description_css.format("A weighted sum will be used for interpolation. Requires two models; A and B. The result is calculated as A * (1 - M) + B * M"),
-        "Add difference": interp_description_css.format("The difference between the last two models will be added to the first. Requires three models; A, B and C. The result is calculated as A + (B - C) * M")
+        "No interpolation": interp_description_css.format(
+            "No interpolation will be used. Requires one model; A. Allows for format conversion and VAE baking."
+        ),
+        "Weighted sum": interp_description_css.format(
+            "A weighted sum will be used for interpolation. Requires two models; A and B. The result is calculated as A * (1 - M) + B * M"
+        ),
+        "Add difference": interp_description_css.format(
+            "The difference between the last two models will be added to the first. Requires three models; A, B and C. The result is calculated as A + (B - C) * M"
+        ),
     }
     return interp_descriptions[value]
 
@@ -22,7 +27,13 @@ def modelmerger(*args):
     except Exception as e:
         errors.report("Error loading/saving model file", exc_info=True)
         sd_models.list_models()  # to remove the potentially missing models from the list
-        return [*[gr.Dropdown.update(choices=sd_models.checkpoint_tiles()) for _ in range(4)], f"Error merging checkpoints: {e}"]
+        return [
+            *[
+                gr.Dropdown.update(choices=sd_models.checkpoint_tiles())
+                for _ in range(4)
+            ],
+            f"Error merging checkpoints: {e}",
+        ]
     return results
 
 
@@ -30,68 +41,189 @@ class UiCheckpointMerger:
     def __init__(self):
         with gr.Blocks(analytics_enabled=False) as modelmerger_interface:
             with gr.Row(equal_height=False):
-                with gr.Column(variant='compact'):
-                    self.interp_description = gr.HTML(value=update_interp_description("Weighted sum"), elem_id="modelmerger_interp_description")
+                with gr.Column(variant="compact"):
+                    self.interp_description = gr.HTML(
+                        value=update_interp_description("Weighted sum"),
+                        elem_id="modelmerger_interp_description",
+                    )
 
                     with FormRow(elem_id="modelmerger_models"):
-                        self.primary_model_name = gr.Dropdown(sd_models.checkpoint_tiles(), elem_id="modelmerger_primary_model_name", label="Primary model (A)")
-                        create_refresh_button(self.primary_model_name, sd_models.list_models, lambda: {"choices": sd_models.checkpoint_tiles()}, "refresh_checkpoint_A")
+                        self.primary_model_name = gr.Dropdown(
+                            sd_models.checkpoint_tiles(),
+                            elem_id="modelmerger_primary_model_name",
+                            label="Primary model (A)",
+                        )
+                        create_refresh_button(
+                            self.primary_model_name,
+                            sd_models.list_models,
+                            lambda: {"choices": sd_models.checkpoint_tiles()},
+                            "refresh_checkpoint_A",
+                        )
 
-                        self.secondary_model_name = gr.Dropdown(sd_models.checkpoint_tiles(), elem_id="modelmerger_secondary_model_name", label="Secondary model (B)")
-                        create_refresh_button(self.secondary_model_name, sd_models.list_models, lambda: {"choices": sd_models.checkpoint_tiles()}, "refresh_checkpoint_B")
+                        self.secondary_model_name = gr.Dropdown(
+                            sd_models.checkpoint_tiles(),
+                            elem_id="modelmerger_secondary_model_name",
+                            label="Secondary model (B)",
+                        )
+                        create_refresh_button(
+                            self.secondary_model_name,
+                            sd_models.list_models,
+                            lambda: {"choices": sd_models.checkpoint_tiles()},
+                            "refresh_checkpoint_B",
+                        )
 
-                        self.tertiary_model_name = gr.Dropdown(sd_models.checkpoint_tiles(), elem_id="modelmerger_tertiary_model_name", label="Tertiary model (C)")
-                        create_refresh_button(self.tertiary_model_name, sd_models.list_models, lambda: {"choices": sd_models.checkpoint_tiles()}, "refresh_checkpoint_C")
+                        self.tertiary_model_name = gr.Dropdown(
+                            sd_models.checkpoint_tiles(),
+                            elem_id="modelmerger_tertiary_model_name",
+                            label="Tertiary model (C)",
+                        )
+                        create_refresh_button(
+                            self.tertiary_model_name,
+                            sd_models.list_models,
+                            lambda: {"choices": sd_models.checkpoint_tiles()},
+                            "refresh_checkpoint_C",
+                        )
 
-                    self.custom_name = gr.Textbox(label="Custom Name (Optional)", elem_id="modelmerger_custom_name")
-                    self.interp_amount = gr.Slider(minimum=0.0, maximum=1.0, step=0.05, label='Multiplier (M) - set to 0 to get model A', value=0.3, elem_id="modelmerger_interp_amount")
-                    self.interp_method = gr.Radio(choices=["No interpolation", "Weighted sum", "Add difference"], value="Weighted sum", label="Interpolation Method", elem_id="modelmerger_interp_method")
-                    self.interp_method.change(fn=update_interp_description, inputs=[self.interp_method], outputs=[self.interp_description])
+                    self.custom_name = gr.Textbox(
+                        label="Custom Name (Optional)",
+                        elem_id="modelmerger_custom_name",
+                    )
+                    self.interp_amount = gr.Slider(
+                        minimum=0.0,
+                        maximum=1.0,
+                        step=0.05,
+                        label="Multiplier (M) - set to 0 to get model A",
+                        value=0.3,
+                        elem_id="modelmerger_interp_amount",
+                    )
+                    self.interp_method = gr.Radio(
+                        choices=["No interpolation", "Weighted sum", "Add difference"],
+                        value="Weighted sum",
+                        label="Interpolation Method",
+                        elem_id="modelmerger_interp_method",
+                    )
+                    self.interp_method.change(
+                        fn=update_interp_description,
+                        inputs=[self.interp_method],
+                        outputs=[self.interp_description],
+                    )
 
                     with FormRow():
-                        self.checkpoint_format = gr.Radio(choices=["ckpt", "safetensors"], value="safetensors", label="Checkpoint format", elem_id="modelmerger_checkpoint_format")
-                        self.save_as_half = gr.Checkbox(value=False, label="Save as float16", elem_id="modelmerger_save_as_half")
+                        self.checkpoint_format = gr.Radio(
+                            choices=["ckpt", "safetensors"],
+                            value="safetensors",
+                            label="Checkpoint format",
+                            elem_id="modelmerger_checkpoint_format",
+                        )
+                        self.save_as_half = gr.Checkbox(
+                            value=False,
+                            label="Save as float16",
+                            elem_id="modelmerger_save_as_half",
+                        )
 
                     with FormRow():
                         with gr.Column():
-                            self.config_source = gr.Radio(choices=["A, B or C", "B", "C", "Don't"], value="A, B or C", label="Copy config from", type="index", elem_id="modelmerger_config_method")
+                            self.config_source = gr.Radio(
+                                choices=["A, B or C", "B", "C", "Don't"],
+                                value="A, B or C",
+                                label="Copy config from",
+                                type="index",
+                                elem_id="modelmerger_config_method",
+                            )
 
                         with gr.Column():
                             with FormRow():
-                                self.bake_in_vae = gr.Dropdown(choices=["None"] + list(sd_vae.vae_dict), value="None", label="Bake in VAE", elem_id="modelmerger_bake_in_vae")
-                                create_refresh_button(self.bake_in_vae, sd_vae.refresh_vae_list, lambda: {"choices": ["None"] + list(sd_vae.vae_dict)}, "modelmerger_refresh_bake_in_vae")
+                                self.bake_in_vae = gr.Dropdown(
+                                    choices=["None"] + list(sd_vae.vae_dict),
+                                    value="None",
+                                    label="Bake in VAE",
+                                    elem_id="modelmerger_bake_in_vae",
+                                )
+                                create_refresh_button(
+                                    self.bake_in_vae,
+                                    sd_vae.refresh_vae_list,
+                                    lambda: {
+                                        "choices": ["None"] + list(sd_vae.vae_dict)
+                                    },
+                                    "modelmerger_refresh_bake_in_vae",
+                                )
 
                     with FormRow():
-                        self.discard_weights = gr.Textbox(value="", label="Discard weights with matching name", elem_id="modelmerger_discard_weights")
+                        self.discard_weights = gr.Textbox(
+                            value="",
+                            label="Discard weights with matching name",
+                            elem_id="modelmerger_discard_weights",
+                        )
 
                     with gr.Accordion("Metadata", open=False) as metadata_editor:
                         with FormRow():
-                            self.save_metadata = gr.Checkbox(value=True, label="Save metadata", elem_id="modelmerger_save_metadata")
-                            self.add_merge_recipe = gr.Checkbox(value=True, label="Add merge recipe metadata", elem_id="modelmerger_add_recipe")
-                            self.copy_metadata_fields = gr.Checkbox(value=True, label="Copy metadata from merged models", elem_id="modelmerger_copy_metadata")
+                            self.save_metadata = gr.Checkbox(
+                                value=True,
+                                label="Save metadata",
+                                elem_id="modelmerger_save_metadata",
+                            )
+                            self.add_merge_recipe = gr.Checkbox(
+                                value=True,
+                                label="Add merge recipe metadata",
+                                elem_id="modelmerger_add_recipe",
+                            )
+                            self.copy_metadata_fields = gr.Checkbox(
+                                value=True,
+                                label="Copy metadata from merged models",
+                                elem_id="modelmerger_copy_metadata",
+                            )
 
-                        self.metadata_json = gr.TextArea('{}', label="Metadata in JSON format")
-                        self.read_metadata = gr.Button("Read metadata from selected checkpoints")
+                        self.metadata_json = gr.TextArea(
+                            "{}", label="Metadata in JSON format"
+                        )
+                        self.read_metadata = gr.Button(
+                            "Read metadata from selected checkpoints"
+                        )
 
                     with FormRow():
-                        self.modelmerger_merge = gr.Button(elem_id="modelmerger_merge", value="Merge", variant='primary')
+                        self.modelmerger_merge = gr.Button(
+                            elem_id="modelmerger_merge",
+                            value="Merge",
+                            variant="primary",
+                        )
 
-                with gr.Column(variant='compact', elem_id="modelmerger_results_container"):
+                with gr.Column(
+                    variant="compact", elem_id="modelmerger_results_container"
+                ):
                     with gr.Group(elem_id="modelmerger_results_panel"):
-                        self.modelmerger_result = gr.HTML(elem_id="modelmerger_result", show_label=False)
+                        self.modelmerger_result = gr.HTML(
+                            elem_id="modelmerger_result", show_label=False
+                        )
 
         self.metadata_editor = metadata_editor
         self.blocks = modelmerger_interface
 
     def setup_ui(self, dummy_component, sd_model_checkpoint_component):
-        self.checkpoint_format.change(lambda fmt: gr.update(visible=fmt == 'safetensors'), inputs=[self.checkpoint_format], outputs=[self.metadata_editor], show_progress=False)
+        self.checkpoint_format.change(
+            lambda fmt: gr.update(visible=fmt == "safetensors"),
+            inputs=[self.checkpoint_format],
+            outputs=[self.metadata_editor],
+            show_progress=False,
+        )
 
-        self.read_metadata.click(extras.read_metadata, inputs=[self.primary_model_name, self.secondary_model_name, self.tertiary_model_name], outputs=[self.metadata_json])
+        self.read_metadata.click(
+            extras.read_metadata,
+            inputs=[
+                self.primary_model_name,
+                self.secondary_model_name,
+                self.tertiary_model_name,
+            ],
+            outputs=[self.metadata_json],
+        )
 
-        self.modelmerger_merge.click(fn=lambda: '', inputs=[], outputs=[self.modelmerger_result])
         self.modelmerger_merge.click(
-            fn=call_queue.wrap_gradio_gpu_call(modelmerger, extra_outputs=lambda: [gr.update() for _ in range(4)]),
-            _js='modelmerger',
+            fn=lambda: "", inputs=[], outputs=[self.modelmerger_result]
+        )
+        self.modelmerger_merge.click(
+            fn=call_queue.wrap_gradio_gpu_call(
+                modelmerger, extra_outputs=lambda: [gr.update() for _ in range(4)]
+            ),
+            _js="modelmerger",
             inputs=[
                 dummy_component,
                 self.primary_model_name,
@@ -116,9 +248,10 @@ class UiCheckpointMerger:
                 self.tertiary_model_name,
                 sd_model_checkpoint_component,
                 self.modelmerger_result,
-            ]
+            ],
         )
 
         # Required as a workaround for change() event not triggering when loading values from ui-config.json
-        self.interp_description.value = update_interp_description(self.interp_method.value)
-
+        self.interp_description.value = update_interp_description(
+            self.interp_method.value
+        )

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -13,8 +13,8 @@ import modules.images
 from modules.ui_components import ToolButton
 import modules.infotext_utils as parameters_copypaste
 
-folder_symbol = '\U0001f4c2'  # 📂
-refresh_symbol = '\U0001f504'  # 🔄
+folder_symbol = "\U0001f4c2"  # 📂
+refresh_symbol = "\U0001f504"  # 🔄
 
 
 def update_generation_info(generation_info, html_info, img_index):
@@ -30,7 +30,7 @@ def update_generation_info(generation_info, html_info, img_index):
 
 
 def plaintext_to_html(text, classname=None):
-    content = "<br>\n".join(html.escape(x) for x in text.split('\n'))
+    content = "<br>\n".join(html.escape(x) for x in text.split("\n"))
 
     return f"<p class='{classname}'>{content}</p>" if classname else f"<p>{content}</p>"
 
@@ -81,7 +81,11 @@ def save_files(js_data, images, do_make_zip, index):
     extension: str = shared.opts.samples_format
     start_index = 0
 
-    if index > -1 and shared.opts.save_selected_only and (index >= data["index_of_first_image"]):  # ensures we are looking at a specific non-grid picture, and we have save_selected_only
+    if (
+        index > -1
+        and shared.opts.save_selected_only
+        and (index >= data["index_of_first_image"])
+    ):  # ensures we are looking at a specific non-grid picture, and we have save_selected_only
         images = [images[index]]
         start_index = index
 
@@ -107,7 +111,11 @@ def save_files(js_data, images, do_make_zip, index):
     if shared.opts.save_write_log_csv and os.path.exists(logfile_path):
         update_logfile(logfile_path, fields)
 
-    with (open(logfile_path, "a", encoding="utf8", newline='') if shared.opts.save_write_log_csv else nullcontext()) as file:
+    with (
+        open(logfile_path, "a", encoding="utf8", newline="")
+        if shared.opts.save_write_log_csv
+        else nullcontext()
+    ) as file:
         if file:
             at_start = file.tell() == 0
             writer = csv.writer(file)
@@ -119,11 +127,24 @@ def save_files(js_data, images, do_make_zip, index):
 
             is_grid = image_index < p.index_of_first_image
 
-            p.batch_index = image_index-1
+            p.batch_index = image_index - 1
 
-            parameters = parameters_copypaste.parse_generation_parameters(data["infotexts"][image_index], [])
+            parameters = parameters_copypaste.parse_generation_parameters(
+                data["infotexts"][image_index], []
+            )
             parsed_infotexts.append(parameters)
-            fullfn, txt_fullfn = modules.images.save_image(image, path, "", seed=parameters['Seed'], prompt=parameters['Prompt'], extension=extension, info=p.infotexts[image_index], grid=is_grid, p=p, save_to_dirs=save_to_dirs)
+            fullfn, txt_fullfn = modules.images.save_image(
+                image,
+                path,
+                "",
+                seed=parameters["Seed"],
+                prompt=parameters["Prompt"],
+                extension=extension,
+                info=p.infotexts[image_index],
+                grid=is_grid,
+                p=p,
+                save_to_dirs=save_to_dirs,
+            )
 
             filename = os.path.relpath(fullfn, path)
             filenames.append(filename)
@@ -133,23 +154,45 @@ def save_files(js_data, images, do_make_zip, index):
                 fullfns.append(txt_fullfn)
 
         if file:
-            writer.writerow([parsed_infotexts[0]['Prompt'], parsed_infotexts[0]['Seed'], data["width"], data["height"], data["sampler_name"], data["cfg_scale"], data["steps"], filenames[0], parsed_infotexts[0]['Negative prompt'], data["sd_model_name"], data["sd_model_hash"]])
+            writer.writerow(
+                [
+                    parsed_infotexts[0]["Prompt"],
+                    parsed_infotexts[0]["Seed"],
+                    data["width"],
+                    data["height"],
+                    data["sampler_name"],
+                    data["cfg_scale"],
+                    data["steps"],
+                    filenames[0],
+                    parsed_infotexts[0]["Negative prompt"],
+                    data["sd_model_name"],
+                    data["sd_model_hash"],
+                ]
+            )
 
     # Make Zip
     if do_make_zip:
-        p.all_seeds = [parameters['Seed'] for parameters in parsed_infotexts]
-        namegen = modules.images.FilenameGenerator(p, parsed_infotexts[0]['Seed'], parsed_infotexts[0]['Prompt'], image, True)
-        zip_filename = namegen.apply(shared.opts.grid_zip_filename_pattern or "[datetime]_[[model_name]]_[seed]-[seed_last]")
+        p.all_seeds = [parameters["Seed"] for parameters in parsed_infotexts]
+        namegen = modules.images.FilenameGenerator(
+            p, parsed_infotexts[0]["Seed"], parsed_infotexts[0]["Prompt"], image, True
+        )
+        zip_filename = namegen.apply(
+            shared.opts.grid_zip_filename_pattern
+            or "[datetime]_[[model_name]]_[seed]-[seed_last]"
+        )
         zip_filepath = os.path.join(path, f"{zip_filename}.zip")
 
         from zipfile import ZipFile
+
         with ZipFile(zip_filepath, "w") as zip_file:
             for i in range(len(fullfns)):
                 with open(fullfns[i], mode="rb") as f:
                     zip_file.writestr(filenames[i], f.read())
         fullfns.insert(0, zip_filepath)
 
-    return gr.File.update(value=fullfns, visible=True), plaintext_to_html(f"Saved: {filenames[0]}")
+    return gr.File.update(value=fullfns, visible=True), plaintext_to_html(
+        f"Saved: {filenames[0]}"
+    )
 
 
 @dataclasses.dataclass
@@ -169,9 +212,12 @@ def create_output_panel(tabname, outdir, toprow=None):
             return
 
         try:
-            if 'Sub' in shared.opts.open_dir_button_choice:
-                image_dir = os.path.split(images[index]["name"].rsplit('?', 1)[0])[0]
-                if 'temp' in shared.opts.open_dir_button_choice or not ui_tempdir.is_gradio_temp_path(image_dir):
+            if "Sub" in shared.opts.open_dir_button_choice:
+                image_dir = os.path.split(images[index]["name"].rsplit("?", 1)[0])[0]
+                if (
+                    "temp" in shared.opts.open_dir_button_choice
+                    or not ui_tempdir.is_gradio_temp_path(image_dir)
+                ):
                     f = image_dir
         except Exception:
             pass
@@ -182,28 +228,68 @@ def create_output_panel(tabname, outdir, toprow=None):
         if toprow:
             toprow.create_inline_toprow_image()
 
-        with gr.Column(variant='panel', elem_id=f"{tabname}_results_panel"):
+        with gr.Column(variant="panel", elem_id=f"{tabname}_results_panel"):
             with gr.Group(elem_id=f"{tabname}_gallery_container"):
-                res.gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"{tabname}_gallery", columns=4, preview=True, height=shared.opts.gallery_height or None)
+                res.gallery = gr.Gallery(
+                    label="Output",
+                    show_label=False,
+                    elem_id=f"{tabname}_gallery",
+                    columns=4,
+                    preview=True,
+                    height=shared.opts.gallery_height or None,
+                )
 
-            with gr.Row(elem_id=f"image_buttons_{tabname}", elem_classes="image-buttons"):
-                open_folder_button = ToolButton(folder_symbol, elem_id=f'{tabname}_open_folder', visible=not shared.cmd_opts.hide_ui_dir_config, tooltip="Open images output directory.")
+            with gr.Row(
+                elem_id=f"image_buttons_{tabname}", elem_classes="image-buttons"
+            ):
+                open_folder_button = ToolButton(
+                    folder_symbol,
+                    elem_id=f"{tabname}_open_folder",
+                    visible=not shared.cmd_opts.hide_ui_dir_config,
+                    tooltip="Open images output directory.",
+                )
 
                 if tabname != "extras":
-                    save = ToolButton('💾', elem_id=f'save_{tabname}', tooltip=f"Save the image to a dedicated directory ({shared.opts.outdir_save}).")
-                    save_zip = ToolButton('🗃️', elem_id=f'save_zip_{tabname}', tooltip=f"Save zip archive with images to a dedicated directory ({shared.opts.outdir_save})")
+                    save = ToolButton(
+                        "💾",
+                        elem_id=f"save_{tabname}",
+                        tooltip=f"Save the image to a dedicated directory ({shared.opts.outdir_save}).",
+                    )
+                    save_zip = ToolButton(
+                        "🗃️",
+                        elem_id=f"save_zip_{tabname}",
+                        tooltip=f"Save zip archive with images to a dedicated directory ({shared.opts.outdir_save})",
+                    )
 
                 buttons = {
-                    'img2img': ToolButton('🖼️', elem_id=f'{tabname}_send_to_img2img', tooltip="Send image and generation parameters to img2img tab."),
-                    'inpaint': ToolButton('🎨️', elem_id=f'{tabname}_send_to_inpaint', tooltip="Send image and generation parameters to img2img inpaint tab."),
-                    'extras': ToolButton('📐', elem_id=f'{tabname}_send_to_extras', tooltip="Send image and generation parameters to extras tab.")
+                    "img2img": ToolButton(
+                        "🖼️",
+                        elem_id=f"{tabname}_send_to_img2img",
+                        tooltip="Send image and generation parameters to img2img tab.",
+                    ),
+                    "inpaint": ToolButton(
+                        "🎨️",
+                        elem_id=f"{tabname}_send_to_inpaint",
+                        tooltip="Send image and generation parameters to img2img inpaint tab.",
+                    ),
+                    "extras": ToolButton(
+                        "📐",
+                        elem_id=f"{tabname}_send_to_extras",
+                        tooltip="Send image and generation parameters to extras tab.",
+                    ),
                 }
 
-                if tabname == 'txt2img':
-                    res.button_upscale = ToolButton('✨', elem_id=f'{tabname}_upscale', tooltip="Create an upscaled version of the current image using hires fix settings.")
+                if tabname == "txt2img":
+                    res.button_upscale = ToolButton(
+                        "✨",
+                        elem_id=f"{tabname}_upscale",
+                        tooltip="Create an upscaled version of the current image using hires fix settings.",
+                    )
 
             open_folder_button.click(
-                fn=lambda images, index: open_folder(shared.opts.outdir_samples or outdir, images, index),
+                fn=lambda images, index: open_folder(
+                    shared.opts.outdir_samples or outdir, images, index
+                ),
                 _js="(y, w) => [y, selected_gallery_index()]",
                 inputs=[
                     res.gallery,
@@ -213,15 +299,30 @@ def create_output_panel(tabname, outdir, toprow=None):
             )
 
             if tabname != "extras":
-                download_files = gr.File(None, file_count="multiple", interactive=False, show_label=False, visible=False, elem_id=f'download_files_{tabname}')
+                download_files = gr.File(
+                    None,
+                    file_count="multiple",
+                    interactive=False,
+                    show_label=False,
+                    visible=False,
+                    elem_id=f"download_files_{tabname}",
+                )
 
                 with gr.Group():
-                    res.infotext = gr.HTML(elem_id=f'html_info_{tabname}', elem_classes="infotext")
-                    res.html_log = gr.HTML(elem_id=f'html_log_{tabname}', elem_classes="html-log")
+                    res.infotext = gr.HTML(
+                        elem_id=f"html_info_{tabname}", elem_classes="infotext"
+                    )
+                    res.html_log = gr.HTML(
+                        elem_id=f"html_log_{tabname}", elem_classes="html-log"
+                    )
 
-                    res.generation_info = gr.Textbox(visible=False, elem_id=f'generation_info_{tabname}')
-                    if tabname == 'txt2img' or tabname == 'img2img':
-                        generation_info_button = gr.Button(visible=False, elem_id=f"{tabname}_generation_info_button")
+                    res.generation_info = gr.Textbox(
+                        visible=False, elem_id=f"generation_info_{tabname}"
+                    )
+                    if tabname == "txt2img" or tabname == "img2img":
+                        generation_info_button = gr.Button(
+                            visible=False, elem_id=f"{tabname}_generation_info_button"
+                        )
                         generation_info_button.click(
                             fn=update_generation_info,
                             _js="function(x, y, z){ return [x, y, selected_gallery_index()] }",
@@ -258,13 +359,15 @@ def create_output_panel(tabname, outdir, toprow=None):
                         outputs=[
                             download_files,
                             res.html_log,
-                        ]
+                        ],
                     )
 
             else:
-                res.generation_info = gr.HTML(elem_id=f'html_info_x_{tabname}')
-                res.infotext = gr.HTML(elem_id=f'html_info_{tabname}', elem_classes="infotext")
-                res.html_log = gr.HTML(elem_id=f'html_log_{tabname}')
+                res.generation_info = gr.HTML(elem_id=f"html_info_x_{tabname}")
+                res.infotext = gr.HTML(
+                    elem_id=f"html_info_{tabname}", elem_classes="infotext"
+                )
+                res.html_log = gr.HTML(elem_id=f"html_log_{tabname}")
 
             paste_field_names = []
             if tabname == "txt2img":
@@ -273,20 +376,29 @@ def create_output_panel(tabname, outdir, toprow=None):
                 paste_field_names = modules.scripts.scripts_img2img.paste_field_names
 
             for paste_tabname, paste_button in buttons.items():
-                parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                    paste_button=paste_button, tabname=paste_tabname, source_tabname="txt2img" if tabname == "txt2img" else None, source_image_component=res.gallery,
-                    paste_field_names=paste_field_names
-                ))
+                parameters_copypaste.register_paste_params_button(
+                    parameters_copypaste.ParamBinding(
+                        paste_button=paste_button,
+                        tabname=paste_tabname,
+                        source_tabname="txt2img" if tabname == "txt2img" else None,
+                        source_image_component=res.gallery,
+                        paste_field_names=paste_field_names,
+                    )
+                )
 
     return res
 
 
 def create_refresh_button(refresh_component, refresh_method, refreshed_args, elem_id):
-    refresh_components = refresh_component if isinstance(refresh_component, list) else [refresh_component]
+    refresh_components = (
+        refresh_component
+        if isinstance(refresh_component, list)
+        else [refresh_component]
+    )
 
     label = None
     for comp in refresh_components:
-        label = getattr(comp, 'label', None)
+        label = getattr(comp, "label", None)
         if label is not None:
             break
 
@@ -298,14 +410,18 @@ def create_refresh_button(refresh_component, refresh_method, refreshed_args, ele
             for comp in refresh_components:
                 setattr(comp, k, v)
 
-        return [gr.update(**(args or {})) for _ in refresh_components] if len(refresh_components) > 1 else gr.update(**(args or {}))
+        return (
+            [gr.update(**(args or {})) for _ in refresh_components]
+            if len(refresh_components) > 1
+            else gr.update(**(args or {}))
+        )
 
-    refresh_button = ToolButton(value=refresh_symbol, elem_id=elem_id, tooltip=f"{label}: refresh" if label else "Refresh")
-    refresh_button.click(
-        fn=refresh,
-        inputs=[],
-        outputs=refresh_components
+    refresh_button = ToolButton(
+        value=refresh_symbol,
+        elem_id=elem_id,
+        tooltip=f"{label}: refresh" if label else "Refresh",
     )
+    refresh_button.click(fn=refresh, inputs=[], outputs=refresh_components)
     return refresh_button
 
 
@@ -322,4 +438,3 @@ def setup_dialog(button_show, dialog, *, button_close=None):
 
     if button_close:
         button_close.click(fn=None, _js="closePopup")
-

--- a/modules/ui_components.py
+++ b/modules/ui_components.py
@@ -69,6 +69,7 @@ class FormColorPicker(FormComponent, gr.ColorPicker):
 
 class DropdownMulti(FormComponent, gr.Dropdown):
     """Same as gr.Dropdown but always multiselect"""
+
     def __init__(self, **kwargs):
         super().__init__(multiselect=True, **kwargs)
 
@@ -78,6 +79,7 @@ class DropdownMulti(FormComponent, gr.Dropdown):
 
 class DropdownEditable(FormComponent, gr.Dropdown):
     """Same as gr.Dropdown but allows editing value"""
+
     def __init__(self, **kwargs):
         super().__init__(allow_custom_value=True, **kwargs)
 
@@ -94,7 +96,7 @@ class InputAccordion(gr.Checkbox):
     global_index = 0
 
     def __init__(self, value, **kwargs):
-        self.accordion_id = kwargs.get('elem_id')
+        self.accordion_id = kwargs.get("elem_id")
         if self.accordion_id is None:
             self.accordion_id = f"input-accordion-{InputAccordion.global_index}"
             InputAccordion.global_index += 1
@@ -106,13 +108,19 @@ class InputAccordion(gr.Checkbox):
         }
         super().__init__(value, **kwargs_checkbox)
 
-        self.change(fn=None, _js='function(checked){ inputAccordionChecked("' + self.accordion_id + '", checked); }', inputs=[self])
+        self.change(
+            fn=None,
+            _js='function(checked){ inputAccordionChecked("'
+            + self.accordion_id
+            + '", checked); }',
+            inputs=[self],
+        )
 
         kwargs_accordion = {
             **kwargs,
             "elem_id": self.accordion_id,
-            "label": kwargs.get('label', 'Accordion'),
-            "elem_classes": ['input-accordion'],
+            "label": kwargs.get("label", "Accordion"),
+            "elem_classes": ["input-accordion"],
             "open": value,
         }
         self.accordion = gr.Accordion(**kwargs_accordion)
@@ -131,7 +139,11 @@ class InputAccordion(gr.Checkbox):
         ```
         """
 
-        return gr.Column(elem_id=self.accordion_id + '-extra', elem_classes='input-accordion-extra', min_width=0)
+        return gr.Column(
+            elem_id=self.accordion_id + "-extra",
+            elem_classes="input-accordion-extra",
+            min_width=0,
+        )
 
     def __enter__(self):
         self.accordion.__enter__()
@@ -142,4 +154,3 @@ class InputAccordion(gr.Checkbox):
 
     def get_block_name(self):
         return "checkbox"
-

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -20,17 +20,23 @@ STYLE_PRIMARY = ' style="color: var(--primary-400)"'
 
 
 def check_access():
-    assert not shared.cmd_opts.disable_extension_access, "extension access disabled because of command line flags"
+    assert (
+        not shared.cmd_opts.disable_extension_access
+    ), "extension access disabled because of command line flags"
 
 
 def apply_and_restart(disable_list, update_list, disable_all):
     check_access()
 
     disabled = json.loads(disable_list)
-    assert type(disabled) == list, f"wrong disable_list data for apply_and_restart: {disable_list}"
+    assert (
+        type(disabled) == list
+    ), f"wrong disable_list data for apply_and_restart: {disable_list}"
 
     update = json.loads(update_list)
-    assert type(update) == list, f"wrong update_list data for apply_and_restart: {update_list}"
+    assert (
+        type(update) == list
+    ), f"wrong update_list data for apply_and_restart: {update_list}"
 
     if update:
         save_config_state("Backup (pre-update)")
@@ -62,7 +68,7 @@ def save_config_state(name):
     name = os.path.basename(name or "Config")
 
     current_config_state["name"] = name
-    timestamp = datetime.now().strftime('%Y_%m_%d-%H_%M_%S')
+    timestamp = datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
     filename = os.path.join(config_states_dir, f"{timestamp}_{name}.json")
     print(f"Saving backup of webui/extension state to {filename}.")
     with open(filename, "w", encoding="utf-8") as f:
@@ -70,7 +76,9 @@ def save_config_state(name):
     config_states.list_config_states()
     new_value = next(iter(config_states.all_config_states.keys()), "Current")
     new_choices = ["Current"] + list(config_states.all_config_states.keys())
-    return gr.Dropdown.update(value=new_value, choices=new_choices), f"<span>Saved current webui/extension state to \"{filename}\"</span>"
+    return gr.Dropdown.update(
+        value=new_value, choices=new_choices
+    ), f'<span>Saved current webui/extension state to "{filename}"</span>'
 
 
 def restore_config_state(confirmed, config_state_name, restore_type):
@@ -101,9 +109,15 @@ def check_updates(id_task, disable_list):
     check_access()
 
     disabled = json.loads(disable_list)
-    assert type(disabled) == list, f"wrong disable_list data for apply_and_restart: {disable_list}"
+    assert (
+        type(disabled) == list
+    ), f"wrong disable_list data for apply_and_restart: {disable_list}"
 
-    exts = [ext for ext in extensions.extensions if ext.remote is not None and ext.name not in disabled]
+    exts = [
+        ext
+        for ext in extensions.extensions
+        if ext.remote is not None and ext.name not in disabled
+    ]
     shared.state.job_count = len(exts)
 
     for ext in exts:
@@ -112,7 +126,7 @@ def check_updates(id_task, disable_list):
         try:
             ext.check_updates()
         except FileNotFoundError as e:
-            if 'FETCH_HEAD' not in str(e):
+            if "FETCH_HEAD" not in str(e):
                 raise
         except Exception:
             errors.report(f"Error checking updates for {ext.name}", exc_info=True)
@@ -165,7 +179,14 @@ def extension_table():
             ext_status = ext.status
 
         style = ""
-        if shared.cmd_opts.disable_extra_extensions and not ext.is_builtin or shared.opts.disable_all_extensions == "extra" and not ext.is_builtin or shared.cmd_opts.disable_all_extensions or shared.opts.disable_all_extensions == "all":
+        if (
+            shared.cmd_opts.disable_extra_extensions
+            and not ext.is_builtin
+            or shared.opts.disable_all_extensions == "extra"
+            and not ext.is_builtin
+            or shared.cmd_opts.disable_all_extensions
+            or shared.opts.disable_all_extensions == "all"
+        ):
             style = STYLE_PRIMARY
 
         version_link = ext.version
@@ -198,7 +219,9 @@ def update_config_states_table(state_name):
         config_state = config_states.all_config_states[state_name]
 
     config_name = config_state.get("name", "Config")
-    created_date = datetime.fromtimestamp(config_state["created_at"]).strftime('%Y-%m-%d %H:%M:%S')
+    created_date = datetime.fromtimestamp(config_state["created_at"]).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
     filepath = config_state.get("filepath", "<unknown>")
 
     try:
@@ -337,7 +360,7 @@ def normalize_git_url(url):
 
 
 def get_extension_dirname_from_url(url):
-    *parts, last_part = url.split('/')
+    *parts, last_part = url.split("/")
     return normalize_git_url(last_part)
 
 
@@ -349,17 +372,23 @@ def install_extension_from_url(dirname, url, branch_name=None):
     if isinstance(url, str):
         url = url.strip()
 
-    assert url, 'No URL specified'
+    assert url, "No URL specified"
 
     if dirname is None or dirname == "":
         dirname = get_extension_dirname_from_url(url)
 
     target_dir = os.path.join(extensions.extensions_dir, dirname)
-    assert not os.path.exists(target_dir), f'Extension directory already exists: {target_dir}'
+    assert not os.path.exists(
+        target_dir
+    ), f"Extension directory already exists: {target_dir}"
 
     normalized_url = normalize_git_url(url)
-    if any(x for x in extensions.extensions if normalize_git_url(x.remote) == normalized_url):
-        raise Exception(f'Extension with this URL is already installed: {url}')
+    if any(
+        x
+        for x in extensions.extensions
+        if normalize_git_url(x.remote) == normalized_url
+    ):
+        raise Exception(f"Extension with this URL is already installed: {url}")
 
     tmpdir = os.path.join(paths.data_path, "tmp", dirname)
 
@@ -367,12 +396,14 @@ def install_extension_from_url(dirname, url, branch_name=None):
         shutil.rmtree(tmpdir, True)
         if not branch_name:
             # if no branch is specified, use the default branch
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none']) as repo:
+            with git.Repo.clone_from(url, tmpdir, filter=["blob:none"]) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
         else:
-            with git.Repo.clone_from(url, tmpdir, filter=['blob:none'], branch=branch_name) as repo:
+            with git.Repo.clone_from(
+                url, tmpdir, filter=["blob:none"], branch=branch_name
+            ) as repo:
                 repo.remote().fetch()
                 for submodule in repo.submodules:
                     submodule.update()
@@ -388,72 +419,104 @@ def install_extension_from_url(dirname, url, branch_name=None):
                 raise err
 
         import launch
+
         launch.run_extension_installer(target_dir)
 
         extensions.list_extensions()
-        return [extension_table(), html.escape(f"Installed into {target_dir}. Use Installed tab to restart.")]
+        return [
+            extension_table(),
+            html.escape(f"Installed into {target_dir}. Use Installed tab to restart."),
+        ]
     finally:
         shutil.rmtree(tmpdir, True)
 
 
-def install_extension_from_index(url, selected_tags, showing_type, filtering_type, sort_column, filter_text):
+def install_extension_from_index(
+    url, selected_tags, showing_type, filtering_type, sort_column, filter_text
+):
     ext_table, message = install_extension_from_url(None, url)
 
-    code, _ = refresh_available_extensions_from_data(selected_tags, showing_type, filtering_type, sort_column, filter_text)
+    code, _ = refresh_available_extensions_from_data(
+        selected_tags, showing_type, filtering_type, sort_column, filter_text
+    )
 
-    return code, ext_table, message, ''
+    return code, ext_table, message, ""
 
 
-def refresh_available_extensions(url, selected_tags, showing_type, filtering_type, sort_column):
+def refresh_available_extensions(
+    url, selected_tags, showing_type, filtering_type, sort_column
+):
     global available_extensions
 
     import urllib.request
+
     with urllib.request.urlopen(url) as response:
         text = response.read()
 
     available_extensions = json.loads(text)
 
-    code, tags = refresh_available_extensions_from_data(selected_tags, showing_type, filtering_type, sort_column)
+    code, tags = refresh_available_extensions_from_data(
+        selected_tags, showing_type, filtering_type, sort_column
+    )
 
-    return url, code, gr.CheckboxGroup.update(choices=tags), '', ''
-
-
-def refresh_available_extensions_for_tags(selected_tags, showing_type, filtering_type, sort_column, filter_text):
-    code, _ = refresh_available_extensions_from_data(selected_tags, showing_type, filtering_type, sort_column, filter_text)
-
-    return code, ''
+    return url, code, gr.CheckboxGroup.update(choices=tags), "", ""
 
 
-def search_extensions(filter_text, selected_tags, showing_type, filtering_type, sort_column):
-    code, _ = refresh_available_extensions_from_data(selected_tags, showing_type, filtering_type, sort_column, filter_text)
+def refresh_available_extensions_for_tags(
+    selected_tags, showing_type, filtering_type, sort_column, filter_text
+):
+    code, _ = refresh_available_extensions_from_data(
+        selected_tags, showing_type, filtering_type, sort_column, filter_text
+    )
 
-    return code, ''
+    return code, ""
+
+
+def search_extensions(
+    filter_text, selected_tags, showing_type, filtering_type, sort_column
+):
+    code, _ = refresh_available_extensions_from_data(
+        selected_tags, showing_type, filtering_type, sort_column, filter_text
+    )
+
+    return code, ""
 
 
 sort_ordering = [
     # (reverse, order_by_function)
-    (True, lambda x: x.get('added', 'z')),
-    (False, lambda x: x.get('added', 'z')),
-    (False, lambda x: x.get('name', 'z')),
-    (True, lambda x: x.get('name', 'z')),
-    (False, lambda x: 'z'),
-    (True, lambda x: x.get('commit_time', '')),
-    (True, lambda x: x.get('created_at', '')),
-    (True, lambda x: x.get('stars', 0)),
+    (True, lambda x: x.get("added", "z")),
+    (False, lambda x: x.get("added", "z")),
+    (False, lambda x: x.get("name", "z")),
+    (True, lambda x: x.get("name", "z")),
+    (False, lambda x: "z"),
+    (True, lambda x: x.get("commit_time", "")),
+    (True, lambda x: x.get("created_at", "")),
+    (True, lambda x: x.get("stars", 0)),
 ]
 
 
 def get_date(info: dict, key):
     try:
-        return datetime.strptime(info.get(key), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).astimezone().strftime("%Y-%m-%d")
+        return (
+            datetime.strptime(info.get(key), "%Y-%m-%dT%H:%M:%SZ")
+            .replace(tzinfo=timezone.utc)
+            .astimezone()
+            .strftime("%Y-%m-%d")
+        )
     except (ValueError, TypeError):
-        return ''
+        return ""
 
 
-def refresh_available_extensions_from_data(selected_tags, showing_type, filtering_type, sort_column, filter_text=""):
+def refresh_available_extensions_from_data(
+    selected_tags, showing_type, filtering_type, sort_column, filter_text=""
+):
     extlist = available_extensions["extensions"]
     installed_extensions = {extension.name for extension in extensions.extensions}
-    installed_extension_urls = {normalize_git_url(extension.remote) for extension in extensions.extensions if extension.remote is not None}
+    installed_extension_urls = {
+        normalize_git_url(extension.remote)
+        for extension in extensions.extensions
+        if extension.remote is not None
+    }
 
     tags = available_extensions.get("tags", {})
     selected_tags = set(selected_tags)
@@ -471,14 +534,16 @@ def refresh_available_extensions_from_data(selected_tags, showing_type, filterin
         <tbody>
     """
 
-    sort_reverse, sort_function = sort_ordering[sort_column if 0 <= sort_column < len(sort_ordering) else 0]
+    sort_reverse, sort_function = sort_ordering[
+        sort_column if 0 <= sort_column < len(sort_ordering) else 0
+    ]
 
     for ext in sorted(extlist, key=sort_function, reverse=sort_reverse):
         name = ext.get("name", "noname")
         stars = int(ext.get("stars", 0))
-        added = ext.get('added', 'unknown')
-        update_time = get_date(ext, 'commit_time')
-        create_time = get_date(ext, 'created_at')
+        added = ext.get("added", "unknown")
+        update_time = get_date(ext, "commit_time")
+        create_time = get_date(ext, "created_at")
         url = ext.get("url", None)
         description = ext.get("description", "")
         extension_tags = ext.get("tags", [])
@@ -486,17 +551,20 @@ def refresh_available_extensions_from_data(selected_tags, showing_type, filterin
         if url is None:
             continue
 
-        existing = get_extension_dirname_from_url(url) in installed_extensions or normalize_git_url(url) in installed_extension_urls
+        existing = (
+            get_extension_dirname_from_url(url) in installed_extensions
+            or normalize_git_url(url) in installed_extension_urls
+        )
         extension_tags = extension_tags + ["installed"] if existing else extension_tags
 
         if len(selected_tags) > 0:
             matched_tags = [x for x in extension_tags if x in selected_tags]
-            if filtering_type == 'or':
+            if filtering_type == "or":
                 need_hide = len(matched_tags) > 0
             else:
                 need_hide = len(matched_tags) == len(selected_tags)
 
-            if showing_type == 'show':
+            if showing_type == "show":
                 need_hide = not need_hide
 
             if need_hide:
@@ -504,13 +572,21 @@ def refresh_available_extensions_from_data(selected_tags, showing_type, filterin
                 continue
 
         if filter_text and filter_text.strip():
-            if filter_text.lower() not in html.escape(name).lower() and filter_text.lower() not in html.escape(description).lower():
+            if (
+                filter_text.lower() not in html.escape(name).lower()
+                and filter_text.lower() not in html.escape(description).lower()
+            ):
                 hidden += 1
                 continue
 
         install_code = f"""<button onclick="install_extension_from_index(this, '{html.escape(url)}')" {"disabled=disabled" if existing else ""} class="lg secondary gradio-button custom-button">{"Install" if not existing else "Installed"}</button>"""
 
-        tags_text = ", ".join([f"<span class='extension-tag' title='{tags.get(x, '')}'>{x}</span>" for x in extension_tags])
+        tags_text = ", ".join(
+            [
+                f"<span class='extension-tag' title='{tags.get(x, '')}'>{x}</span>"
+                for x in extension_tags
+            ]
+        )
 
         code += f"""
             <tr>
@@ -551,19 +627,37 @@ def create_ui():
     with gr.Blocks(analytics_enabled=False) as ui:
         with gr.Tabs(elem_id="tabs_extensions"):
             with gr.TabItem("Installed", id="installed"):
-
                 with gr.Row(elem_id="extensions_installed_top"):
-                    apply_label = ("Apply and restart UI" if restart.is_restartable() else "Apply and quit")
+                    apply_label = (
+                        "Apply and restart UI"
+                        if restart.is_restartable()
+                        else "Apply and quit"
+                    )
                     apply = gr.Button(value=apply_label, variant="primary")
                     check = gr.Button(value="Check for updates")
-                    extensions_disable_all = gr.Radio(label="Disable all extensions", choices=["none", "extra", "all"], value=shared.opts.disable_all_extensions, elem_id="extensions_disable_all")
-                    extensions_disabled_list = gr.Text(elem_id="extensions_disabled_list", visible=False, container=False)
-                    extensions_update_list = gr.Text(elem_id="extensions_update_list", visible=False, container=False)
-                    refresh = gr.Button(value='Refresh', variant="compact")
+                    extensions_disable_all = gr.Radio(
+                        label="Disable all extensions",
+                        choices=["none", "extra", "all"],
+                        value=shared.opts.disable_all_extensions,
+                        elem_id="extensions_disable_all",
+                    )
+                    extensions_disabled_list = gr.Text(
+                        elem_id="extensions_disabled_list",
+                        visible=False,
+                        container=False,
+                    )
+                    extensions_update_list = gr.Text(
+                        elem_id="extensions_update_list", visible=False, container=False
+                    )
+                    refresh = gr.Button(value="Refresh", variant="compact")
 
                 html = ""
 
-                if shared.cmd_opts.disable_all_extensions or shared.cmd_opts.disable_extra_extensions or shared.opts.disable_all_extensions != "none":
+                if (
+                    shared.cmd_opts.disable_all_extensions
+                    or shared.cmd_opts.disable_extra_extensions
+                    or shared.opts.disable_all_extensions != "none"
+                ):
                     if shared.cmd_opts.disable_all_extensions:
                         msg = '"--disable-all-extensions" was used, remove it to load all extensions again'
                     elif shared.opts.disable_all_extensions != "none":
@@ -576,15 +670,31 @@ def create_ui():
                     info = gr.HTML(html)
 
                 with gr.Row(elem_classes="progress-container"):
-                    extensions_table = gr.HTML('Loading...', elem_id="extensions_installed_html")
+                    extensions_table = gr.HTML(
+                        "Loading...", elem_id="extensions_installed_html"
+                    )
 
-                ui.load(fn=extension_table, inputs=[], outputs=[extensions_table], show_progress=False)
-                refresh.click(fn=extension_table, inputs=[], outputs=[extensions_table], show_progress=False)
+                ui.load(
+                    fn=extension_table,
+                    inputs=[],
+                    outputs=[extensions_table],
+                    show_progress=False,
+                )
+                refresh.click(
+                    fn=extension_table,
+                    inputs=[],
+                    outputs=[extensions_table],
+                    show_progress=False,
+                )
 
                 apply.click(
                     fn=apply_and_restart,
                     _js="extensions_apply",
-                    inputs=[extensions_disabled_list, extensions_update_list, extensions_disable_all],
+                    inputs=[
+                        extensions_disabled_list,
+                        extensions_update_list,
+                        extensions_disable_all,
+                    ],
                     outputs=[],
                 )
 
@@ -597,19 +707,62 @@ def create_ui():
 
             with gr.TabItem("Available", id="available"):
                 with gr.Row():
-                    refresh_available_extensions_button = gr.Button(value="Load from:", variant="primary")
-                    extensions_index_url = os.environ.get('WEBUI_EXTENSIONS_INDEX', "https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui-extensions/master/index.json")
-                    available_extensions_index = gr.Text(value=extensions_index_url, label="Extension index URL", container=False)
-                    extension_to_install = gr.Text(elem_id="extension_to_install", visible=False)
-                    install_extension_button = gr.Button(elem_id="install_extension_button", visible=False)
+                    refresh_available_extensions_button = gr.Button(
+                        value="Load from:", variant="primary"
+                    )
+                    extensions_index_url = os.environ.get(
+                        "WEBUI_EXTENSIONS_INDEX",
+                        "https://raw.githubusercontent.com/AUTOMATIC1111/stable-diffusion-webui-extensions/master/index.json",
+                    )
+                    available_extensions_index = gr.Text(
+                        value=extensions_index_url,
+                        label="Extension index URL",
+                        container=False,
+                    )
+                    extension_to_install = gr.Text(
+                        elem_id="extension_to_install", visible=False
+                    )
+                    install_extension_button = gr.Button(
+                        elem_id="install_extension_button", visible=False
+                    )
 
                 with gr.Row():
-                    selected_tags = gr.CheckboxGroup(value=["ads", "localization", "installed"], label="Extension tags", choices=["script", "ads", "localization", "installed"], elem_classes=['compact-checkbox-group'])
-                    sort_column = gr.Radio(value="newest first", label="Order", choices=["newest first", "oldest first", "a-z", "z-a", "internal order",'update time', 'create time', "stars"], type="index", elem_classes=['compact-checkbox-group'])
+                    selected_tags = gr.CheckboxGroup(
+                        value=["ads", "localization", "installed"],
+                        label="Extension tags",
+                        choices=["script", "ads", "localization", "installed"],
+                        elem_classes=["compact-checkbox-group"],
+                    )
+                    sort_column = gr.Radio(
+                        value="newest first",
+                        label="Order",
+                        choices=[
+                            "newest first",
+                            "oldest first",
+                            "a-z",
+                            "z-a",
+                            "internal order",
+                            "update time",
+                            "create time",
+                            "stars",
+                        ],
+                        type="index",
+                        elem_classes=["compact-checkbox-group"],
+                    )
 
                 with gr.Row():
-                    showing_type = gr.Radio(value="hide", label="Showing type", choices=["hide", "show"], elem_classes=['compact-checkbox-group'])
-                    filtering_type = gr.Radio(value="or", label="Filtering type", choices=["or", "and"], elem_classes=['compact-checkbox-group'])
+                    showing_type = gr.Radio(
+                        value="hide",
+                        label="Showing type",
+                        choices=["hide", "show"],
+                        elem_classes=["compact-checkbox-group"],
+                    )
+                    filtering_type = gr.Radio(
+                        value="or",
+                        label="Filtering type",
+                        choices=["or", "and"],
+                        elem_classes=["compact-checkbox-group"],
+                    )
 
                 with gr.Row():
                     search_extensions_text = gr.Text(label="Search", container=False)
@@ -618,84 +771,207 @@ def create_ui():
                 available_extensions_table = gr.HTML()
 
                 refresh_available_extensions_button.click(
-                    fn=modules.ui.wrap_gradio_call(refresh_available_extensions, extra_outputs=[gr.update(), gr.update(), gr.update(), gr.update()]),
-                    inputs=[available_extensions_index, selected_tags, showing_type, filtering_type, sort_column],
-                    outputs=[available_extensions_index, available_extensions_table, selected_tags, search_extensions_text, install_result],
+                    fn=modules.ui.wrap_gradio_call(
+                        refresh_available_extensions,
+                        extra_outputs=[
+                            gr.update(),
+                            gr.update(),
+                            gr.update(),
+                            gr.update(),
+                        ],
+                    ),
+                    inputs=[
+                        available_extensions_index,
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                    ],
+                    outputs=[
+                        available_extensions_index,
+                        available_extensions_table,
+                        selected_tags,
+                        search_extensions_text,
+                        install_result,
+                    ],
                 )
 
                 install_extension_button.click(
-                    fn=modules.ui.wrap_gradio_call_no_job(install_extension_from_index, extra_outputs=[gr.update(), gr.update()]),
-                    inputs=[extension_to_install, selected_tags, showing_type, filtering_type, sort_column, search_extensions_text],
-                    outputs=[available_extensions_table, extensions_table, install_result],
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        install_extension_from_index,
+                        extra_outputs=[gr.update(), gr.update()],
+                    ),
+                    inputs=[
+                        extension_to_install,
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                        search_extensions_text,
+                    ],
+                    outputs=[
+                        available_extensions_table,
+                        extensions_table,
+                        install_result,
+                    ],
                 )
 
                 search_extensions_text.change(
-                    fn=modules.ui.wrap_gradio_call_no_job(search_extensions, extra_outputs=[gr.update()]),
-                    inputs=[search_extensions_text, selected_tags, showing_type, filtering_type, sort_column],
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        search_extensions, extra_outputs=[gr.update()]
+                    ),
+                    inputs=[
+                        search_extensions_text,
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                    ],
                     outputs=[available_extensions_table, install_result],
                 )
 
                 selected_tags.change(
-                    fn=modules.ui.wrap_gradio_call_no_job(refresh_available_extensions_for_tags, extra_outputs=[gr.update()]),
-                    inputs=[selected_tags, showing_type, filtering_type, sort_column, search_extensions_text],
-                    outputs=[available_extensions_table, install_result]
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        refresh_available_extensions_for_tags,
+                        extra_outputs=[gr.update()],
+                    ),
+                    inputs=[
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                        search_extensions_text,
+                    ],
+                    outputs=[available_extensions_table, install_result],
                 )
 
                 showing_type.change(
-                    fn=modules.ui.wrap_gradio_call_no_job(refresh_available_extensions_for_tags, extra_outputs=[gr.update()]),
-                    inputs=[selected_tags, showing_type, filtering_type, sort_column, search_extensions_text],
-                    outputs=[available_extensions_table, install_result]
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        refresh_available_extensions_for_tags,
+                        extra_outputs=[gr.update()],
+                    ),
+                    inputs=[
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                        search_extensions_text,
+                    ],
+                    outputs=[available_extensions_table, install_result],
                 )
 
                 filtering_type.change(
-                    fn=modules.ui.wrap_gradio_call_no_job(refresh_available_extensions_for_tags, extra_outputs=[gr.update()]),
-                    inputs=[selected_tags, showing_type, filtering_type, sort_column, search_extensions_text],
-                    outputs=[available_extensions_table, install_result]
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        refresh_available_extensions_for_tags,
+                        extra_outputs=[gr.update()],
+                    ),
+                    inputs=[
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                        search_extensions_text,
+                    ],
+                    outputs=[available_extensions_table, install_result],
                 )
 
                 sort_column.change(
-                    fn=modules.ui.wrap_gradio_call_no_job(refresh_available_extensions_for_tags, extra_outputs=[gr.update()]),
-                    inputs=[selected_tags, showing_type, filtering_type, sort_column, search_extensions_text],
-                    outputs=[available_extensions_table, install_result]
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        refresh_available_extensions_for_tags,
+                        extra_outputs=[gr.update()],
+                    ),
+                    inputs=[
+                        selected_tags,
+                        showing_type,
+                        filtering_type,
+                        sort_column,
+                        search_extensions_text,
+                    ],
+                    outputs=[available_extensions_table, install_result],
                 )
 
             with gr.TabItem("Install from URL", id="install_from_url"):
                 install_url = gr.Text(label="URL for extension's git repository")
-                install_branch = gr.Text(label="Specific branch name", placeholder="Leave empty for default main branch")
-                install_dirname = gr.Text(label="Local directory name", placeholder="Leave empty for auto")
+                install_branch = gr.Text(
+                    label="Specific branch name",
+                    placeholder="Leave empty for default main branch",
+                )
+                install_dirname = gr.Text(
+                    label="Local directory name", placeholder="Leave empty for auto"
+                )
                 install_button = gr.Button(value="Install", variant="primary")
                 install_result = gr.HTML(elem_id="extension_install_result")
 
                 install_button.click(
-                    fn=modules.ui.wrap_gradio_call_no_job(lambda *args: [gr.update(), *install_extension_from_url(*args)], extra_outputs=[gr.update(), gr.update()]),
+                    fn=modules.ui.wrap_gradio_call_no_job(
+                        lambda *args: [gr.update(), *install_extension_from_url(*args)],
+                        extra_outputs=[gr.update(), gr.update()],
+                    ),
                     inputs=[install_dirname, install_url, install_branch],
                     outputs=[install_url, extensions_table, install_result],
                 )
 
             with gr.TabItem("Backup/Restore"):
                 with gr.Row(elem_id="extensions_backup_top_row"):
-                    config_states_list = gr.Dropdown(label="Saved Configs", elem_id="extension_backup_saved_configs", value="Current", choices=["Current"] + list(config_states.all_config_states.keys()))
-                    modules.ui.create_refresh_button(config_states_list, config_states.list_config_states, lambda: {"choices": ["Current"] + list(config_states.all_config_states.keys())}, "refresh_config_states")
-                    config_restore_type = gr.Radio(label="State to restore", choices=["extensions", "webui", "both"], value="extensions", elem_id="extension_backup_restore_type")
-                    config_restore_button = gr.Button(value="Restore Selected Config", variant="primary", elem_id="extension_backup_restore")
+                    config_states_list = gr.Dropdown(
+                        label="Saved Configs",
+                        elem_id="extension_backup_saved_configs",
+                        value="Current",
+                        choices=["Current"]
+                        + list(config_states.all_config_states.keys()),
+                    )
+                    modules.ui.create_refresh_button(
+                        config_states_list,
+                        config_states.list_config_states,
+                        lambda: {
+                            "choices": ["Current"]
+                            + list(config_states.all_config_states.keys())
+                        },
+                        "refresh_config_states",
+                    )
+                    config_restore_type = gr.Radio(
+                        label="State to restore",
+                        choices=["extensions", "webui", "both"],
+                        value="extensions",
+                        elem_id="extension_backup_restore_type",
+                    )
+                    config_restore_button = gr.Button(
+                        value="Restore Selected Config",
+                        variant="primary",
+                        elem_id="extension_backup_restore",
+                    )
                 with gr.Row(elem_id="extensions_backup_top_row2"):
-                    config_save_name = gr.Textbox("", placeholder="Config Name", show_label=False)
+                    config_save_name = gr.Textbox(
+                        "", placeholder="Config Name", show_label=False
+                    )
                     config_save_button = gr.Button(value="Save Current Config")
 
                 config_states_info = gr.HTML("")
                 config_states_table = gr.HTML("Loading...")
-                ui.load(fn=update_config_states_table, inputs=[config_states_list], outputs=[config_states_table])
+                ui.load(
+                    fn=update_config_states_table,
+                    inputs=[config_states_list],
+                    outputs=[config_states_table],
+                )
 
-                config_save_button.click(fn=save_config_state, inputs=[config_save_name], outputs=[config_states_list, config_states_info])
+                config_save_button.click(
+                    fn=save_config_state,
+                    inputs=[config_save_name],
+                    outputs=[config_states_list, config_states_info],
+                )
 
                 dummy_component = gr.Label(visible=False)
-                config_restore_button.click(fn=restore_config_state, _js="config_state_confirm_restore", inputs=[dummy_component, config_states_list, config_restore_type], outputs=[config_states_info])
+                config_restore_button.click(
+                    fn=restore_config_state,
+                    _js="config_state_confirm_restore",
+                    inputs=[dummy_component, config_states_list, config_restore_type],
+                    outputs=[config_states_info],
+                )
 
                 config_states_list.change(
                     fn=update_config_states_table,
                     inputs=[config_states_list],
                     outputs=[config_states_table],
                 )
-
 
     return ui

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import Optional, Union
 from dataclasses import dataclass
 
-from modules import shared, ui_extra_networks_user_metadata, errors, extra_networks, util
+from modules import (
+    shared,
+    ui_extra_networks_user_metadata,
+    errors,
+    extra_networks,
+    util,
+)
 from modules.images import read_info_from_image, save_image_with_geninfo
 import gradio as gr
 import json
@@ -21,18 +27,20 @@ extra_pages = []
 allowed_dirs = set()
 default_allowed_preview_extensions = ["png", "jpg", "jpeg", "webp", "gif"]
 
+
 @functools.cache
 def allowed_preview_extensions_with_extra(extra_extensions=None):
     return set(default_allowed_preview_extensions) | set(extra_extensions or [])
 
 
 def allowed_preview_extensions():
-    return allowed_preview_extensions_with_extra((shared.opts.samples_format, ))
+    return allowed_preview_extensions_with_extra((shared.opts.samples_format,))
 
 
 @dataclass
 class ExtraNetworksItem:
     """Wrapper for dictionaries representing ExtraNetworks items."""
+
     item: dict
 
 
@@ -86,12 +94,15 @@ def get_tree(paths: Union[str, list[str]], items: dict[str, ExtraNetworksItem]) 
 
     return res
 
+
 def register_page(page):
     """registers extra networks page for the UI; recommend doing it in on_before_ui() callback for extensions"""
 
     extra_pages.append(page)
     allowed_dirs.clear()
-    allowed_dirs.update(set(sum([x.allowed_directories_for_previews() for x in extra_pages], [])))
+    allowed_dirs.update(
+        set(sum([x.allowed_directories_for_previews() for x in extra_pages], []))
+    )
 
 
 def fetch_file(filename: str = ""):
@@ -100,12 +111,18 @@ def fetch_file(filename: str = ""):
     if not os.path.isfile(filename):
         raise HTTPException(status_code=404, detail="File not found")
 
-    if not any(Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs):
-        raise ValueError(f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages.")
+    if not any(
+        Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs
+    ):
+        raise ValueError(
+            f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages."
+        )
 
     ext = os.path.splitext(filename)[1].lower()[1:]
     if ext not in allowed_preview_extensions():
-        raise ValueError(f"File cannot be fetched: {filename}. Extensions allowed: {allowed_preview_extensions()}.")
+        raise ValueError(
+            f"File cannot be fetched: {filename}. Extensions allowed: {allowed_preview_extensions()}."
+        )
 
     # would profit from returning 304
     return FileResponse(filename, headers={"Accept-Ranges": "bytes"})
@@ -122,7 +139,7 @@ def fetch_cover_images(page: str = "", item: str = "", index: int = 0):
     if metadata is None:
         raise HTTPException(status_code=404, detail="File not found")
 
-    cover_images = json.loads(metadata.get('ssmd_cover_images', {}))
+    cover_images = json.loads(metadata.get("ssmd_cover_images", {}))
     image = cover_images[index] if index < len(cover_images) else None
     if not image:
         raise HTTPException(status_code=404, detail="File not found")
@@ -131,9 +148,13 @@ def fetch_cover_images(page: str = "", item: str = "", index: int = 0):
         image = Image.open(BytesIO(b64decode(image)))
         buffer = BytesIO()
         image.save(buffer, format=image.format)
-        return Response(content=buffer.getvalue(), media_type=image.get_format_mimetype())
+        return Response(
+            content=buffer.getvalue(), media_type=image.get_format_mimetype()
+        )
     except Exception as err:
-        raise ValueError(f"File cannot be fetched: {item}. Failed to load cover image.") from err
+        raise ValueError(
+            f"File cannot be fetched: {item}. Failed to load cover image."
+        ) from err
 
 
 def get_metadata(page: str = "", item: str = ""):
@@ -147,9 +168,13 @@ def get_metadata(page: str = "", item: str = ""):
     if metadata is None:
         return JSONResponse({})
 
-    metadata = {i:metadata[i] for i in metadata if i != 'ssmd_cover_images'}  # those are cover images, and they are too big to display in UI as text
+    metadata = {
+        i: metadata[i] for i in metadata if i != "ssmd_cover_images"
+    }  # those are cover images, and they are too big to display in UI as text
 
-    return JSONResponse({"metadata": json.dumps(metadata, indent=4, ensure_ascii=False)})
+    return JSONResponse(
+        {"metadata": json.dumps(metadata, indent=4, ensure_ascii=False)}
+    )
 
 
 def get_single_card(page: str = "", tabname: str = "", name: str = ""):
@@ -165,20 +190,26 @@ def get_single_card(page: str = "", tabname: str = "", name: str = ""):
         item = page.items.get(name)
 
     page.read_user_metadata(item, use_cache=False)
-    item_html = page.create_item_html(tabname, item, shared.html("extra-networks-card.html"))
+    item_html = page.create_item_html(
+        tabname, item, shared.html("extra-networks-card.html")
+    )
 
     return JSONResponse({"html": item_html})
 
 
 def add_pages_to_demo(app):
     app.add_api_route("/sd_extra_networks/thumb", fetch_file, methods=["GET"])
-    app.add_api_route("/sd_extra_networks/cover-images", fetch_cover_images, methods=["GET"])
+    app.add_api_route(
+        "/sd_extra_networks/cover-images", fetch_cover_images, methods=["GET"]
+    )
     app.add_api_route("/sd_extra_networks/metadata", get_metadata, methods=["GET"])
-    app.add_api_route("/sd_extra_networks/get-single-card", get_single_card, methods=["GET"])
+    app.add_api_route(
+        "/sd_extra_networks/get-single-card", get_single_card, methods=["GET"]
+    )
 
 
 def quote_js(s):
-    s = s.replace('\\', '\\\\')
+    s = s.replace("\\", "\\\\")
     s = s.replace('"', '\\"')
     return f'"{s}"'
 
@@ -209,7 +240,9 @@ class ExtraNetworksPage:
 
     def read_user_metadata(self, item, use_cache=True):
         filename = item.get("filename", None)
-        metadata = extra_networks.get_user_metadata(filename, lister=self.lister if use_cache else None)
+        metadata = extra_networks.get_user_metadata(
+            filename, lister=self.lister if use_cache else None
+        )
 
         desc = metadata.get("description", None)
         if desc is not None:
@@ -218,13 +251,17 @@ class ExtraNetworksPage:
         item["user_metadata"] = metadata
 
     def link_preview(self, filename):
-        quoted_filename = urllib.parse.quote(filename.replace('\\', '/'))
+        quoted_filename = urllib.parse.quote(filename.replace("\\", "/"))
         mtime, _ = self.lister.mctime(filename)
         return f"./sd_extra_networks/thumb?filename={quoted_filename}&mtime={mtime}"
 
     def search_terms_from_path(self, filename, possible_directories=None):
         abspath = os.path.abspath(filename)
-        for parentdir in (possible_directories if possible_directories is not None else self.allowed_directories_for_previews()):
+        for parentdir in (
+            possible_directories
+            if possible_directories is not None
+            else self.allowed_directories_for_previews()
+        ):
             parentdir = os.path.dirname(os.path.abspath(parentdir))
             if abspath.startswith(parentdir):
                 return os.path.relpath(abspath, parentdir)
@@ -250,16 +287,32 @@ class ExtraNetworksPage:
             If no template is passed: A dictionary containing the generated item's attributes.
         """
         preview = item.get("preview", None)
-        style_height = f"height: {shared.opts.extra_networks_card_height}px;" if shared.opts.extra_networks_card_height else ''
-        style_width = f"width: {shared.opts.extra_networks_card_width}px;" if shared.opts.extra_networks_card_width else ''
-        style_font_size = f"font-size: {shared.opts.extra_networks_card_text_scale*100}%;"
+        style_height = (
+            f"height: {shared.opts.extra_networks_card_height}px;"
+            if shared.opts.extra_networks_card_height
+            else ""
+        )
+        style_width = (
+            f"width: {shared.opts.extra_networks_card_width}px;"
+            if shared.opts.extra_networks_card_width
+            else ""
+        )
+        style_font_size = (
+            f"font-size: {shared.opts.extra_networks_card_text_scale*100}%;"
+        )
         card_style = style_height + style_width + style_font_size
-        background_image = f'<img src="{html.escape(preview)}" class="preview" loading="lazy">' if preview else ''
+        background_image = (
+            f'<img src="{html.escape(preview)}" class="preview" loading="lazy">'
+            if preview
+            else ""
+        )
 
         onclick = item.get("onclick", None)
         if onclick is None:
             # Don't quote prompt/neg_prompt since they are stored as js strings already.
-            onclick_js_tpl = "cardClicked('{tabname}', {prompt}, {neg_prompt}, {allow_neg});"
+            onclick_js_tpl = (
+                "cardClicked('{tabname}', {prompt}, {neg_prompt}, {allow_neg});"
+            )
             onclick = onclick_js_tpl.format(
                 **{
                     "tabname": tabname,
@@ -292,7 +345,7 @@ class ExtraNetworksPage:
             absdir = os.path.abspath(reldir)
 
             if filename.startswith(absdir):
-                local_path = filename[len(absdir):]
+                local_path = filename[len(absdir) :]
 
         # if this is true, the item must not be shown in the default view, and must instead only be
         # shown when searching for it
@@ -321,7 +374,11 @@ class ExtraNetworksPage:
                 }
             )
 
-        description = (item.get("description", "") or "" if shared.opts.extra_networks_card_show_desc else "")
+        description = (
+            item.get("description", "") or ""
+            if shared.opts.extra_networks_card_show_desc
+            else ""
+        )
         if not shared.opts.extra_networks_card_description_is_html:
             description = html.escape(description)
 
@@ -336,7 +393,9 @@ class ExtraNetworksPage:
             "metadata_button": btn_metadata,
             "name": html.escape(item["name"]),
             "prompt": item.get("prompt", None),
-            "save_card_preview": html.escape(f"return saveCardPreview(event, '{tabname}', '{item['local_preview']}');"),
+            "save_card_preview": html.escape(
+                f"return saveCardPreview(event, '{tabname}', '{item['local_preview']}');"
+            ),
             "search_only": " search_only" if search_only else "",
             "search_terms": search_terms_html,
             "sort_keys": sort_keys,
@@ -402,7 +461,9 @@ class ExtraNetworksPage:
             "</li>"
         )
 
-    def create_tree_file_item_html(self, tabname: str, file_path: str, item: dict) -> str:
+    def create_tree_file_item_html(
+        self, tabname: str, file_path: str, item: dict
+    ) -> str:
         """Generates HTML for a file item in the tree.
 
         The generated HTML is of the format:
@@ -429,7 +490,7 @@ class ExtraNetworksPage:
                 item_html_args["edit_button"],
             ]
         )
-        action_buttons = f"<div class=\"button-row\">{action_buttons}</div>"
+        action_buttons = f'<div class="button-row">{action_buttons}</div>'
         btn = self.btn_tree_tpl.format(
             **{
                 "search_terms": "",
@@ -471,7 +532,9 @@ class ExtraNetworksPage:
         if not tree:
             return res
 
-        def _build_tree(data: Optional[dict[str, ExtraNetworksItem]] = None) -> Optional[str]:
+        def _build_tree(
+            data: Optional[dict[str, ExtraNetworksItem]] = None,
+        ) -> Optional[str]:
             """Recursively builds HTML for a tree.
 
             Args:
@@ -490,11 +553,15 @@ class ExtraNetworksPage:
             _dir_li = []
             _file_li = []
 
-            for k, v in sorted(data.items(), key=lambda x: shared.natural_sort_key(x[0])):
+            for k, v in sorted(
+                data.items(), key=lambda x: shared.natural_sort_key(x[0])
+            ):
                 if isinstance(v, (ExtraNetworksItem,)):
                     _file_li.append(self.create_tree_file_item_html(tabname, k, v.item))
                 else:
-                    _dir_li.append(self.create_tree_dir_item_html(tabname, k, _build_tree(v)))
+                    _dir_li.append(
+                        self.create_tree_dir_item_html(tabname, k, _build_tree(v))
+                    )
 
             # Directories should always be displayed before files so we order them here.
             return "".join(_dir_li) + "".join(_file_li)
@@ -512,15 +579,20 @@ class ExtraNetworksPage:
         """Generates HTML for displaying folders."""
 
         subdirs = {}
-        for parentdir in [os.path.abspath(x) for x in self.allowed_directories_for_previews()]:
-            for root, dirs, _ in sorted(os.walk(parentdir, followlinks=True), key=lambda x: shared.natural_sort_key(x[0])):
+        for parentdir in [
+            os.path.abspath(x) for x in self.allowed_directories_for_previews()
+        ]:
+            for root, dirs, _ in sorted(
+                os.walk(parentdir, followlinks=True),
+                key=lambda x: shared.natural_sort_key(x[0]),
+            ):
                 for dirname in sorted(dirs, key=shared.natural_sort_key):
                     x = os.path.join(root, dirname)
 
                     if not os.path.isdir(x):
                         continue
 
-                    subdir = os.path.abspath(x)[len(parentdir):]
+                    subdir = os.path.abspath(x)[len(parentdir) :]
 
                     if shared.opts.extra_networks_dir_button_function:
                         if not subdir.startswith(os.path.sep):
@@ -533,7 +605,9 @@ class ExtraNetworksPage:
                     if not is_empty and not subdir.endswith(os.path.sep):
                         subdir = subdir + os.path.sep
 
-                    if (os.path.sep + "." in subdir or subdir.startswith(".")) and not shared.opts.extra_networks_show_hidden_directories:
+                    if (
+                        os.path.sep + "." in subdir or subdir.startswith(".")
+                    ) and not shared.opts.extra_networks_show_hidden_directories:
                         continue
 
                     subdirs[subdir] = 1
@@ -541,11 +615,16 @@ class ExtraNetworksPage:
         if subdirs:
             subdirs = {"": 1, **subdirs}
 
-        subdirs_html = "".join([f"""
+        subdirs_html = "".join(
+            [
+                f"""
         <button class='lg secondary gradio-button custom-button{" search-all" if subdir == "" else ""}' onclick='extraNetworksSearchButton("{tabname}", "{self.extra_networks_tabname}", event)'>
         {html.escape(subdir if subdir != "" else "all")}
         </button>
-        """ for subdir in subdirs])
+        """
+                for subdir in subdirs
+            ]
+        )
 
         return subdirs_html
 
@@ -567,8 +646,13 @@ class ExtraNetworksPage:
             res.append(self.create_item_html(tabname, item, self.card_tpl))
 
         if not res:
-            dirs = "".join([f"<li>{x}</li>" for x in self.allowed_directories_for_previews()])
-            res = [none_message or shared.html("extra-networks-no-cards.html").format(dirs=dirs)]
+            dirs = "".join(
+                [f"<li>{x}</li>" for x in self.allowed_directories_for_previews()]
+            )
+            res = [
+                none_message
+                or shared.html("extra-networks-no-cards.html").format(dirs=dirs)
+            ]
 
         return "".join(res)
 
@@ -605,20 +689,38 @@ class ExtraNetworksPage:
             "tabname": tabname,
             "extra_networks_tabname": self.extra_networks_tabname,
             "data_sortdir": shared.opts.extra_networks_card_order,
-            "sort_path_active": ' extra-network-control--enabled' if shared.opts.extra_networks_card_order_field == 'Path' else '',
-            "sort_name_active": ' extra-network-control--enabled' if shared.opts.extra_networks_card_order_field == 'Name' else '',
-            "sort_date_created_active": ' extra-network-control--enabled' if shared.opts.extra_networks_card_order_field == 'Date Created' else '',
-            "sort_date_modified_active": ' extra-network-control--enabled' if shared.opts.extra_networks_card_order_field == 'Date Modified' else '',
-            "tree_view_btn_extra_class": "extra-network-control--enabled" if show_tree else "",
-            "items_html": self.create_card_view_html(tabname, none_message="Loading..." if empty else None),
+            "sort_path_active": " extra-network-control--enabled"
+            if shared.opts.extra_networks_card_order_field == "Path"
+            else "",
+            "sort_name_active": " extra-network-control--enabled"
+            if shared.opts.extra_networks_card_order_field == "Name"
+            else "",
+            "sort_date_created_active": " extra-network-control--enabled"
+            if shared.opts.extra_networks_card_order_field == "Date Created"
+            else "",
+            "sort_date_modified_active": " extra-network-control--enabled"
+            if shared.opts.extra_networks_card_order_field == "Date Modified"
+            else "",
+            "tree_view_btn_extra_class": "extra-network-control--enabled"
+            if show_tree
+            else "",
+            "items_html": self.create_card_view_html(
+                tabname, none_message="Loading..." if empty else None
+            ),
             "extra_networks_tree_view_default_width": shared.opts.extra_networks_tree_view_default_width,
-            "tree_view_div_default_display_class": "" if show_tree else "extra-network-dirs-hidden",
+            "tree_view_div_default_display_class": ""
+            if show_tree
+            else "extra-network-dirs-hidden",
         }
 
         if shared.opts.extra_networks_tree_view_style == "Tree":
-            pane_content = self.pane_content_tree_tpl.format(**page_params, tree_html=self.create_tree_view_html(tabname))
+            pane_content = self.pane_content_tree_tpl.format(
+                **page_params, tree_html=self.create_tree_view_html(tabname)
+            )
         else:
-            pane_content = self.pane_content_dirs_tpl.format(**page_params, dirs_html=self.create_dirs_view_html(tabname))
+            pane_content = self.pane_content_dirs_tpl.format(
+                **page_params, dirs_html=self.create_dirs_view_html(tabname)
+            )
 
         return self.pane_tpl.format(**page_params, pane_content=pane_content)
 
@@ -649,7 +751,13 @@ class ExtraNetworksPage:
         Find a preview PNG for a given path (without extension) and call link_preview on it.
         """
 
-        potential_files = sum([[f"{path}.{ext}", f"{path}.preview.{ext}"] for ext in allowed_preview_extensions()], [])
+        potential_files = sum(
+            [
+                [f"{path}.{ext}", f"{path}.preview.{ext}"]
+                for ext in allowed_preview_extensions()
+            ],
+            [],
+        )
 
         for file in potential_files:
             if self.lister.exists(file):
@@ -663,7 +771,11 @@ class ExtraNetworksPage:
         """
 
         file = f"{path}.safetensors"
-        if self.lister.exists(file) and 'ssmd_cover_images' in metadata and len(list(filter(None, json.loads(metadata['ssmd_cover_images'])))) > 0:
+        if (
+            self.lister.exists(file)
+            and "ssmd_cover_images" in metadata
+            and len(list(filter(None, json.loads(metadata["ssmd_cover_images"])))) > 0
+        ):
             return f"./sd_extra_networks/cover-images?page={self.extra_networks_tabname}&item={name}"
 
         return None
@@ -692,9 +804,12 @@ def initialize():
 
 
 def register_default_pages():
-    from modules.ui_extra_networks_textual_inversion import ExtraNetworksPageTextualInversion
+    from modules.ui_extra_networks_textual_inversion import (
+        ExtraNetworksPageTextualInversion,
+    )
     from modules.ui_extra_networks_hypernets import ExtraNetworksPageHypernetworks
     from modules.ui_extra_networks_checkpoints import ExtraNetworksPageCheckpoints
+
     register_page(ExtraNetworksPageTextualInversion())
     register_page(ExtraNetworksPageHypernetworks())
     register_page(ExtraNetworksPageCheckpoints())
@@ -717,7 +832,9 @@ class ExtraNetworksUi:
 
 
 def pages_in_preferred_order(pages):
-    tab_order = [x.lower().strip() for x in shared.opts.ui_extra_networks_tab_reorder.split(",")]
+    tab_order = [
+        x.lower().strip() for x in shared.opts.ui_extra_networks_tab_reorder.split(",")
+    ]
 
     def tab_name_score(name):
         name = name.lower()
@@ -727,7 +844,10 @@ def pages_in_preferred_order(pages):
 
         return len(pages)
 
-    tab_scores = {page.name: (tab_name_score(page.name), original_index) for original_index, page in enumerate(pages)}
+    tab_scores = {
+        page.name: (tab_name_score(page.name), original_index)
+        for original_index, page in enumerate(pages)
+    }
 
     return sorted(pages, key=lambda x: tab_scores[x.name])
 
@@ -743,8 +863,15 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
     related_tabs = []
 
     for page in ui.stored_extra_pages:
-        with gr.Tab(page.title, elem_id=f"{tabname}_{page.extra_networks_tabname}", elem_classes=["extra-page"]) as tab:
-            with gr.Column(elem_id=f"{tabname}_{page.extra_networks_tabname}_prompts", elem_classes=["extra-page-prompts"]):
+        with gr.Tab(
+            page.title,
+            elem_id=f"{tabname}_{page.extra_networks_tabname}",
+            elem_classes=["extra-page"],
+        ) as tab:
+            with gr.Column(
+                elem_id=f"{tabname}_{page.extra_networks_tabname}_prompts",
+                elem_classes=["extra-page-prompts"],
+            ):
                 pass
 
             elem_id = f"{tabname}_{page.extra_networks_tabname}_cards_html"
@@ -755,11 +882,21 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
             ui.user_metadata_editors.append(editor)
             related_tabs.append(tab)
 
-    ui.button_save_preview = gr.Button('Save preview', elem_id=f"{tabname}_save_preview", visible=False)
-    ui.preview_target_filename = gr.Textbox('Preview save filename', elem_id=f"{tabname}_preview_filename", visible=False)
+    ui.button_save_preview = gr.Button(
+        "Save preview", elem_id=f"{tabname}_save_preview", visible=False
+    )
+    ui.preview_target_filename = gr.Textbox(
+        "Preview save filename", elem_id=f"{tabname}_preview_filename", visible=False
+    )
 
     for tab in unrelated_tabs:
-        tab.select(fn=None, _js=f"function(){{extraNetworksUnrelatedTabSelected('{tabname}');}}", inputs=[], outputs=[], show_progress=False)
+        tab.select(
+            fn=None,
+            _js=f"function(){{extraNetworksUnrelatedTabSelected('{tabname}');}}",
+            inputs=[],
+            outputs=[],
+            show_progress=False,
+        )
 
     for page, tab in zip(ui.stored_extra_pages, related_tabs):
         jscode = (
@@ -776,8 +913,17 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
             create_html()
             return ui.pages_contents
 
-        button_refresh = gr.Button("Refresh", elem_id=f"{tabname}_{page.extra_networks_tabname}_extra_refresh_internal", visible=False)
-        button_refresh.click(fn=refresh, inputs=[], outputs=ui.pages).then(fn=lambda: None, _js="function(){ " + f"applyExtraNetworkFilter('{tabname}_{page.extra_networks_tabname}');" + " }").then(fn=lambda: None, _js='setupAllResizeHandles')
+        button_refresh = gr.Button(
+            "Refresh",
+            elem_id=f"{tabname}_{page.extra_networks_tabname}_extra_refresh_internal",
+            visible=False,
+        )
+        button_refresh.click(fn=refresh, inputs=[], outputs=ui.pages).then(
+            fn=lambda: None,
+            _js="function(){ "
+            + f"applyExtraNetworkFilter('{tabname}_{page.extra_networks_tabname}');"
+            + " }",
+        ).then(fn=lambda: None, _js="setupAllResizeHandles")
 
     def create_html():
         ui.pages_contents = [pg.create_html(ui.tabname) for pg in ui.stored_extra_pages]
@@ -787,7 +933,9 @@ def create_ui(interface: gr.Blocks, unrelated_tabs, tabname):
             create_html()
         return ui.pages_contents
 
-    interface.load(fn=pages_html, inputs=[], outputs=ui.pages).then(fn=lambda: None, _js='setupAllResizeHandles')
+    interface.load(fn=pages_html, inputs=[], outputs=ui.pages).then(
+        fn=lambda: None, _js="setupAllResizeHandles"
+    )
 
     return ui
 
@@ -817,11 +965,14 @@ def setup_ui(ui, gallery):
 
         is_allowed = False
         for extra_page in ui.stored_extra_pages:
-            if any(path_is_parent(x, filename) for x in extra_page.allowed_directories_for_previews()):
+            if any(
+                path_is_parent(x, filename)
+                for x in extra_page.allowed_directories_for_previews()
+            ):
                 is_allowed = True
                 break
 
-        assert is_allowed, f'writing to {filename} is not allowed'
+        assert is_allowed, f"writing to {filename} is not allowed"
 
         save_image_with_geninfo(image, geninfo, filename)
 
@@ -831,7 +982,7 @@ def setup_ui(ui, gallery):
         fn=save_preview,
         _js="function(x, y, z){return [selected_gallery_index(), y, z]}",
         inputs=[ui.preview_target_filename, gallery, ui.preview_target_filename],
-        outputs=[*ui.pages]
+        outputs=[*ui.pages],
     )
 
     for editor in ui.user_metadata_editors:

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -2,12 +2,14 @@ import html
 import os
 
 from modules import shared, ui_extra_networks, sd_models
-from modules.ui_extra_networks_checkpoints_user_metadata import CheckpointUserMetadataEditor
+from modules.ui_extra_networks_checkpoints_user_metadata import (
+    CheckpointUserMetadataEditor,
+)
 
 
 class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
     def __init__(self):
-        super().__init__('Checkpoints')
+        super().__init__("Checkpoints")
 
         self.allow_prompt = False
 
@@ -30,10 +32,12 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
             "preview": self.find_preview(path),
             "description": self.find_description(path),
             "search_terms": search_terms,
-            "onclick": html.escape(f"return selectCheckpoint({ui_extra_networks.quote_js(name)})"),
+            "onclick": html.escape(
+                f"return selectCheckpoint({ui_extra_networks.quote_js(name)})"
+            ),
             "local_preview": f"{path}.{shared.opts.samples_format}",
             "metadata": checkpoint.metadata,
-            "sort_keys": {'default': index, **self.get_sort_keys(checkpoint.filename)},
+            "sort_keys": {"default": index, **self.get_sort_keys(checkpoint.filename)},
         }
 
     def list_items(self):
@@ -45,7 +49,9 @@ class ExtraNetworksPageCheckpoints(ui_extra_networks.ExtraNetworksPage):
                 yield item
 
     def allowed_directories_for_previews(self):
-        return [v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None]
+        return [
+            v for v in [shared.cmd_opts.ckpt_dir, sd_models.model_path] if v is not None
+        ]
 
     def create_user_metadata_editor(self, ui, tabname):
         return CheckpointUserMetadataEditor(ui, tabname, self)

--- a/modules/ui_extra_networks_checkpoints_user_metadata.py
+++ b/modules/ui_extra_networks_checkpoints_user_metadata.py
@@ -28,17 +28,27 @@ class CheckpointUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataE
 
         return [
             *values[0:5],
-            user_metadata.get('vae', ''),
+            user_metadata.get("vae", ""),
         ]
 
     def create_editor(self):
         self.create_default_editor_elems()
 
         with gr.Row():
-            self.select_vae = gr.Dropdown(choices=["Automatic", "None"] + list(sd_vae.vae_dict), value="None", label="Preferred VAE", elem_id="checpoint_edit_user_metadata_preferred_vae")
-            create_refresh_button(self.select_vae, sd_vae.refresh_vae_list, lambda: {"choices": ["Automatic", "None"] + list(sd_vae.vae_dict)}, "checpoint_edit_user_metadata_refresh_preferred_vae")
+            self.select_vae = gr.Dropdown(
+                choices=["Automatic", "None"] + list(sd_vae.vae_dict),
+                value="None",
+                label="Preferred VAE",
+                elem_id="checpoint_edit_user_metadata_preferred_vae",
+            )
+            create_refresh_button(
+                self.select_vae,
+                sd_vae.refresh_vae_list,
+                lambda: {"choices": ["Automatic", "None"] + list(sd_vae.vae_dict)},
+                "checpoint_edit_user_metadata_refresh_preferred_vae",
+            )
 
-        self.edit_notes = gr.TextArea(label='Notes', lines=4)
+        self.edit_notes = gr.TextArea(label="Notes", lines=4)
 
         self.create_default_buttons()
 
@@ -51,9 +61,11 @@ class CheckpointUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataE
             self.select_vae,
         ]
 
-        self.button_edit\
-            .click(fn=self.put_values_into_components, inputs=[self.edit_name_input], outputs=viewed_components)\
-            .then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[self.box])
+        self.button_edit.click(
+            fn=self.put_values_into_components,
+            inputs=[self.edit_name_input],
+            outputs=viewed_components,
+        ).then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[self.box])
 
         edited_components = [
             self.edit_description,
@@ -61,6 +73,7 @@ class CheckpointUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataE
             self.select_vae,
         ]
 
-        self.setup_save_handler(self.button_save, self.save_user_metadata, edited_components)
+        self.setup_save_handler(
+            self.button_save, self.save_user_metadata, edited_components
+        )
         self.button_save.click(fn=self.update_vae, inputs=[self.edit_name_input])
-

--- a/modules/ui_extra_networks_hypernets.py
+++ b/modules/ui_extra_networks_hypernets.py
@@ -7,7 +7,7 @@ from modules.hashes import sha256_from_cache
 
 class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
     def __init__(self):
-        super().__init__('Hypernetworks')
+        super().__init__("Hypernetworks")
 
     def refresh(self):
         shared.reload_hypernetworks()
@@ -18,7 +18,7 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
             return
 
         path, ext = os.path.splitext(full_path)
-        sha256 = sha256_from_cache(full_path, f'hypernet/{name}')
+        sha256 = sha256_from_cache(full_path, f"hypernet/{name}")
         shorthash = sha256[0:10] if sha256 else None
         search_terms = [self.search_terms_from_path(path)]
         if sha256:
@@ -30,9 +30,11 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
             "preview": self.find_preview(path),
             "description": self.find_description(path),
             "search_terms": search_terms,
-            "prompt": quote_js(f"<hypernet:{name}:") + " + opts.extra_networks_default_multiplier + " + quote_js(">"),
+            "prompt": quote_js(f"<hypernet:{name}:")
+            + " + opts.extra_networks_default_multiplier + "
+            + quote_js(">"),
             "local_preview": f"{path}.preview.{shared.opts.samples_format}",
-            "sort_keys": {'default': index, **self.get_sort_keys(path + ext)},
+            "sort_keys": {"default": index, **self.get_sort_keys(path + ext)},
         }
 
     def list_items(self):
@@ -45,4 +47,3 @@ class ExtraNetworksPageHypernetworks(ui_extra_networks.ExtraNetworksPage):
 
     def allowed_directories_for_previews(self):
         return [shared.cmd_opts.hypernetwork_dir]
-

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -6,11 +6,13 @@ from modules.ui_extra_networks import quote_js
 
 class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
     def __init__(self):
-        super().__init__('Textual Inversion')
+        super().__init__("Textual Inversion")
         self.allow_negative_prompt = True
 
     def refresh(self):
-        sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)
+        sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(
+            force_reload=True
+        )
 
     def create_item(self, name, index=None, enable_filter=True):
         embedding = sd_hijack.model_hijack.embedding_db.word_embeddings.get(name)
@@ -30,7 +32,7 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
             "search_terms": search_terms,
             "prompt": quote_js(embedding.name),
             "local_preview": f"{path}.preview.{shared.opts.samples_format}",
-            "sort_keys": {'default': index, **self.get_sort_keys(embedding.filename)},
+            "sort_keys": {"default": index, **self.get_sort_keys(embedding.filename)},
         }
 
     def list_items(self):

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -9,12 +9,13 @@ from modules import infotext_utils, images, sysinfo, errors, ui_extra_networks
 
 
 class UserMetadataEditor:
-
     def __init__(self, ui, tabname, page):
         self.ui = ui
         self.tabname = tabname
         self.page = page
-        self.id_part = f"{self.tabname}_{self.page.extra_networks_tabname}_edit_user_metadata"
+        self.id_part = (
+            f"{self.tabname}_{self.page.extra_networks_tabname}_edit_user_metadata"
+        )
 
         self.box = None
 
@@ -35,10 +36,10 @@ class UserMetadataEditor:
     def get_user_metadata(self, name):
         item = self.page.items.get(name, {})
 
-        user_metadata = item.get('user_metadata', None)
+        user_metadata = item.get("user_metadata", None)
         if not user_metadata:
-            user_metadata = {'description': item.get('description', '')}
-            item['user_metadata'] = user_metadata
+            user_metadata = {"description": item.get("description", "")}
+            item["user_metadata"] = user_metadata
 
         return user_metadata
 
@@ -58,11 +59,12 @@ class UserMetadataEditor:
                 self.html_preview = gr.HTML()
 
     def create_default_buttons(self):
-
         with gr.Row(elem_classes="edit-user-metadata-buttons"):
-            self.button_cancel = gr.Button('Cancel')
-            self.button_replace_preview = gr.Button('Replace preview', variant='primary')
-            self.button_save = gr.Button('Save', variant='primary')
+            self.button_cancel = gr.Button("Cancel")
+            self.button_replace_preview = gr.Button(
+                "Replace preview", variant="primary"
+            )
+            self.button_save = gr.Button("Save", variant="primary")
 
         self.html_status = gr.HTML(elem_classes="edit-user-metadata-status")
 
@@ -79,11 +81,11 @@ class UserMetadataEditor:
             item["preview"] = preview_url
 
         if preview_url:
-            preview = f'''
+            preview = f"""
             <div class='card standalone-card-preview'>
                 <img src="{html.escape(preview_url)}" class="preview">
             </div>
-            '''
+            """
         else:
             preview = "<div class='card standalone-card-preview'></div>"
 
@@ -104,10 +106,15 @@ class UserMetadataEditor:
 
             stats = os.stat(filename)
             params = [
-                ('Filename: ', self.relative_path(filename)),
-                ('File size: ', sysinfo.pretty_bytes(stats.st_size)),
-                ('Hash: ', shorthash),
-                ('Modified: ', datetime.datetime.fromtimestamp(stats.st_mtime).strftime('%Y-%m-%d %H:%M')),
+                ("Filename: ", self.relative_path(filename)),
+                ("File size: ", sysinfo.pretty_bytes(stats.st_size)),
+                ("Hash: ", shorthash),
+                (
+                    "Modified: ",
+                    datetime.datetime.fromtimestamp(stats.st_mtime).strftime(
+                        "%Y-%m-%d %H:%M"
+                    ),
+                ),
             ]
 
             return params
@@ -124,16 +131,30 @@ class UserMetadataEditor:
             errors.display(e, f"reading metadata info for {name}")
             params = []
 
-        table = '<table class="file-metadata">' + "".join(f"<tr><th>{name}</th><td>{value}</td></tr>" for name, value in params if value is not None) + '</table>'
+        table = (
+            '<table class="file-metadata">'
+            + "".join(
+                f"<tr><th>{name}</th><td>{value}</td></tr>"
+                for name, value in params
+                if value is not None
+            )
+            + "</table>"
+        )
 
-        return html.escape(name), user_metadata.get('description', ''), table, self.get_card_html(name), user_metadata.get('notes', '')
+        return (
+            html.escape(name),
+            user_metadata.get("description", ""),
+            table,
+            self.get_card_html(name),
+            user_metadata.get("notes", ""),
+        )
 
     def write_user_metadata(self, name, metadata):
         item = self.page.items.get(name, {})
         filename = item.get("filename", None)
         basename, ext = os.path.splitext(filename)
 
-        metadata_path = basename + '.json'
+        metadata_path = basename + ".json"
         with open(metadata_path, "w", encoding="utf8") as file:
             json.dump(metadata, file, indent=4, ensure_ascii=False)
         self.page.lister.update_file_entry(metadata_path)
@@ -146,35 +167,66 @@ class UserMetadataEditor:
         self.write_user_metadata(name, user_metadata)
 
     def setup_save_handler(self, button, func, components):
-        button\
-            .click(fn=func, inputs=[self.edit_name_input, *components], outputs=[])\
-            .then(fn=None, _js="function(name){closePopup(); extraNetworksRefreshSingleCard(" + json.dumps(self.page.name) + "," + json.dumps(self.tabname) + ", name);}", inputs=[self.edit_name_input], outputs=[])
+        button.click(
+            fn=func, inputs=[self.edit_name_input, *components], outputs=[]
+        ).then(
+            fn=None,
+            _js="function(name){closePopup(); extraNetworksRefreshSingleCard("
+            + json.dumps(self.page.name)
+            + ","
+            + json.dumps(self.tabname)
+            + ", name);}",
+            inputs=[self.edit_name_input],
+            outputs=[],
+        )
 
     def create_editor(self):
         self.create_default_editor_elems()
 
-        self.edit_notes = gr.TextArea(label='Notes', lines=4)
+        self.edit_notes = gr.TextArea(label="Notes", lines=4)
 
         self.create_default_buttons()
 
-        self.button_edit\
-            .click(fn=self.put_values_into_components, inputs=[self.edit_name_input], outputs=[self.edit_name, self.edit_description, self.html_filedata, self.html_preview, self.edit_notes])\
-            .then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[self.box])
+        self.button_edit.click(
+            fn=self.put_values_into_components,
+            inputs=[self.edit_name_input],
+            outputs=[
+                self.edit_name,
+                self.edit_description,
+                self.html_filedata,
+                self.html_preview,
+                self.edit_notes,
+            ],
+        ).then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[self.box])
 
-        self.setup_save_handler(self.button_save, self.save_user_metadata, [self.edit_description, self.edit_notes])
+        self.setup_save_handler(
+            self.button_save,
+            self.save_user_metadata,
+            [self.edit_description, self.edit_notes],
+        )
 
     def create_ui(self):
-        with gr.Box(visible=False, elem_id=self.id_part, elem_classes="edit-user-metadata") as box:
+        with gr.Box(
+            visible=False, elem_id=self.id_part, elem_classes="edit-user-metadata"
+        ) as box:
             self.box = box
 
-            self.edit_name_input = gr.Textbox("Edit user metadata card id", visible=False, elem_id=f"{self.id_part}_name")
-            self.button_edit = gr.Button("Edit user metadata", visible=False, elem_id=f"{self.id_part}_button")
+            self.edit_name_input = gr.Textbox(
+                "Edit user metadata card id",
+                visible=False,
+                elem_id=f"{self.id_part}_name",
+            )
+            self.button_edit = gr.Button(
+                "Edit user metadata", visible=False, elem_id=f"{self.id_part}_button"
+            )
 
             self.create_editor()
 
     def save_preview(self, index, gallery, name):
         if len(gallery) == 0:
-            return self.get_card_html(name), "There is no image in gallery to save as a preview."
+            return self.get_card_html(
+                name
+            ), "There is no image in gallery to save as a preview."
 
         item = self.page.items.get(name, {})
 
@@ -188,18 +240,22 @@ class UserMetadataEditor:
 
         images.save_image_with_geninfo(image, geninfo, item["local_preview"])
         self.page.lister.update_file_entry(item["local_preview"])
-        item['preview'] = self.page.find_preview(item["local_preview"])
-        return self.get_card_html(name), ''
+        item["preview"] = self.page.find_preview(item["local_preview"])
+        return self.get_card_html(name), ""
 
     def setup_ui(self, gallery):
         self.button_replace_preview.click(
             fn=self.save_preview,
             _js=f"function(x, y, z){{return [selected_gallery_index_id('{self.tabname + '_gallery_container'}'), y, z]}}",
             inputs=[self.edit_name_input, gallery, self.edit_name_input],
-            outputs=[self.html_preview, self.html_status]
+            outputs=[self.html_preview, self.html_status],
         ).then(
             fn=None,
-            _js="function(name){extraNetworksRefreshSingleCard(" + json.dumps(self.page.name) + "," + json.dumps(self.tabname) + ", name);}",
+            _js="function(name){extraNetworksRefreshSingleCard("
+            + json.dumps(self.page.name)
+            + ","
+            + json.dumps(self.tabname)
+            + ", name);}",
             inputs=[self.edit_name_input],
-            outputs=[]
+            outputs=[],
         )

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -6,7 +6,7 @@ from modules.paths import script_path, data_path
 
 
 def webpath(fn):
-    return f'file={util.truncate_path(fn)}?{os.path.getmtime(fn)}'
+    return f"file={util.truncate_path(fn)}?{os.path.getmtime(fn)}"
 
 
 def javascript_html():
@@ -17,13 +17,15 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{webpath(script_js)}"></script>\n'
 
     for script in scripts.list_scripts("javascript", ".js"):
-        head += f'<script type="text/javascript" src="{webpath(script.path)}"></script>\n'
+        head += (
+            f'<script type="text/javascript" src="{webpath(script.path)}"></script>\n'
+        )
 
     for script in scripts.list_scripts("javascript", ".mjs"):
         head += f'<script type="module" src="{webpath(script.path)}"></script>\n'
 
     if shared.cmd_opts.theme:
-        head += f'<script type="text/javascript">set_theme(\"{shared.cmd_opts.theme}\");</script>\n'
+        head += f'<script type="text/javascript">set_theme("{shared.cmd_opts.theme}");</script>\n'
 
     return head
 
@@ -42,9 +44,10 @@ def css_html():
         head += stylesheet(user_css)
 
     from modules.shared_gradio_themes import resolve_var
-    light = resolve_var('background_fill_primary')
-    dark = resolve_var('background_fill_primary_dark')
-    head += f'<style>html {{ background-color: {light}; }} @media (prefers-color-scheme: dark) {{ html {{background-color:  {dark}; }} }}</style>'
+
+    light = resolve_var("background_fill_primary")
+    dark = resolve_var("background_fill_primary_dark")
+    head += f"<style>html {{ background-color: {light}; }} @media (prefers-color-scheme: dark) {{ html {{background-color:  {dark}; }} }}</style>"
 
     return head
 
@@ -55,13 +58,16 @@ def reload_javascript():
 
     def template_response(*args, **kwargs):
         res = shared.GradioTemplateResponseOriginal(*args, **kwargs)
-        res.body = res.body.replace(b'</head>', f'{js}<meta name="referrer" content="no-referrer"/></head>'.encode("utf8"))
-        res.body = res.body.replace(b'</body>', f'{css}</body>'.encode("utf8"))
+        res.body = res.body.replace(
+            b"</head>",
+            f'{js}<meta name="referrer" content="no-referrer"/></head>'.encode("utf8"),
+        )
+        res.body = res.body.replace(b"</body>", f"{css}</body>".encode("utf8"))
         res.init_headers()
         return res
 
     gr.routes.templates.TemplateResponse = template_response
 
 
-if not hasattr(shared, 'GradioTemplateResponseOriginal'):
+if not hasattr(shared, "GradioTemplateResponseOriginal"):
     shared.GradioTemplateResponseOriginal = gr.routes.templates.TemplateResponse

--- a/modules/ui_loadsave.py
+++ b/modules/ui_loadsave.py
@@ -7,8 +7,10 @@ from modules import errors
 from modules.ui_components import ToolButton, InputAccordion
 
 
-def radio_choices(comp):  # gradio 3.41 changes choices from list of values to list of pairs
-    return [x[0] if isinstance(x, tuple) else x for x in getattr(comp, 'choices', [])]
+def radio_choices(
+    comp,
+):  # gradio 3.41 changes choices from list of values to list of pairs
+    return [x[0] if isinstance(x, tuple) else x for x in getattr(comp, "choices", [])]
 
 
 class UiLoadsave:
@@ -41,25 +43,31 @@ class UiLoadsave:
         def apply_field(obj, field, condition=None, init_field=None):
             key = f"{path}/{field}"
 
-            if getattr(obj, 'custom_script_source', None) is not None:
+            if getattr(obj, "custom_script_source", None) is not None:
                 key = f"customscript/{obj.custom_script_source}/{key}"
 
-            if getattr(obj, 'do_not_save_to_config', False):
+            if getattr(obj, "do_not_save_to_config", False):
                 return
 
             saved_value = self.ui_settings.get(key, None)
 
-            if isinstance(obj, gr.Accordion) and isinstance(x, InputAccordion) and field == 'value':
-                field = 'open'
+            if (
+                isinstance(obj, gr.Accordion)
+                and isinstance(x, InputAccordion)
+                and field == "value"
+            ):
+                field = "open"
 
             if saved_value is None:
                 self.ui_settings[key] = getattr(obj, field)
             elif condition and not condition(saved_value):
                 pass
             else:
-                if isinstance(obj, gr.Textbox) and field == 'value':  # due to an undesirable behavior of gr.Textbox, if you give it an int value instead of str, everything dies
+                if (
+                    isinstance(obj, gr.Textbox) and field == "value"
+                ):  # due to an undesirable behavior of gr.Textbox, if you give it an int value instead of str, everything dies
                     saved_value = str(saved_value)
-                elif isinstance(obj, gr.Number) and field == 'value':
+                elif isinstance(obj, gr.Number) and field == "value":
                     try:
                         saved_value = float(saved_value)
                     except ValueError:
@@ -69,47 +77,61 @@ class UiLoadsave:
                 if init_field is not None:
                     init_field(saved_value)
 
-            if field == 'value' and key not in self.component_mapping:
+            if field == "value" and key not in self.component_mapping:
                 self.component_mapping[key] = obj
 
-        if type(x) in [gr.Slider, gr.Radio, gr.Checkbox, gr.Textbox, gr.Number, gr.Dropdown, ToolButton, gr.Button] and x.visible:
-            apply_field(x, 'visible')
+        if (
+            type(x)
+            in [
+                gr.Slider,
+                gr.Radio,
+                gr.Checkbox,
+                gr.Textbox,
+                gr.Number,
+                gr.Dropdown,
+                ToolButton,
+                gr.Button,
+            ]
+            and x.visible
+        ):
+            apply_field(x, "visible")
 
         if type(x) == gr.Slider:
-            apply_field(x, 'value')
-            apply_field(x, 'minimum')
-            apply_field(x, 'maximum')
-            apply_field(x, 'step')
+            apply_field(x, "value")
+            apply_field(x, "minimum")
+            apply_field(x, "maximum")
+            apply_field(x, "step")
 
         if type(x) == gr.Radio:
-            apply_field(x, 'value', lambda val: val in radio_choices(x))
+            apply_field(x, "value", lambda val: val in radio_choices(x))
 
         if type(x) == gr.Checkbox:
-            apply_field(x, 'value')
+            apply_field(x, "value")
 
         if type(x) == gr.Textbox:
-            apply_field(x, 'value')
+            apply_field(x, "value")
 
         if type(x) == gr.Number:
-            apply_field(x, 'value')
+            apply_field(x, "value")
 
         if type(x) == gr.Dropdown:
+
             def check_dropdown(val):
                 choices = radio_choices(x)
-                if getattr(x, 'multiselect', False):
+                if getattr(x, "multiselect", False):
                     return all(value in choices for value in val)
                 else:
                     return val in choices
 
-            apply_field(x, 'value', check_dropdown, getattr(x, 'init_field', None))
+            apply_field(x, "value", check_dropdown, getattr(x, "init_field", None))
 
         if type(x) == InputAccordion:
-            if hasattr(x, 'custom_script_source'):
+            if hasattr(x, "custom_script_source"):
                 x.accordion.custom_script_source = x.custom_script_source
             if x.accordion.visible:
-                apply_field(x.accordion, 'visible')
-            apply_field(x, 'value')
-            apply_field(x.accordion, 'value')
+                apply_field(x.accordion, "visible")
+            apply_field(x, "value")
+            apply_field(x.accordion, "value")
 
         def check_tab_id(tab_id):
             tab_items = list(filter(lambda e: isinstance(e, gr.TabItem), x.children))
@@ -122,12 +144,12 @@ class UiLoadsave:
                 return False
 
         if type(x) == gr.Tabs:
-            apply_field(x, 'selected', check_tab_id)
+            apply_field(x, "selected", check_tab_id)
 
     def add_block(self, x, path=""):
         """adds all components inside a gradio block x to the registry of tracked components"""
 
-        if hasattr(x, 'children'):
+        if hasattr(x, "children"):
             if isinstance(x, gr.Tabs) and x.elem_id is not None:
                 # Tabs element can't have a label, have to use elem_id instead
                 self.add_component(f"{path}/Tabs@{x.elem_id}", x)
@@ -176,19 +198,25 @@ class UiLoadsave:
             if new_value == old_value:
                 continue
 
-            if old_value is None and new_value == '' or new_value == []:
+            if old_value is None and new_value == "" or new_value == []:
                 continue
 
             yield path, old_value, new_value
 
     def ui_view(self, *values):
-        text = ["<table><thead><tr><th>Path</th><th>Old value</th><th>New value</th></thead><tbody>"]
+        text = [
+            "<table><thead><tr><th>Path</th><th>Old value</th><th>New value</th></thead><tbody>"
+        ]
 
-        for path, old_value, new_value in self.iter_changes(self.read_from_file(), values):
+        for path, old_value, new_value in self.iter_changes(
+            self.read_from_file(), values
+        ):
             if old_value is None:
                 old_value = "<span class='ui-defaults-none'>None</span>"
 
-            text.append(f"<tr><td>{path}</td><td>{old_value}</td><td>{new_value}</td></tr>")
+            text.append(
+                f"<tr><td>{path}</td><td>{old_value}</td><td>{new_value}</td></tr>"
+            )
 
         if len(text) == 1:
             text.append("<tr><td colspan=3>No changes</td></tr>")
@@ -223,8 +251,12 @@ class UiLoadsave:
         )
 
         with gr.Row():
-            self.ui_defaults_view = gr.Button(value='View changes', elem_id="ui_defaults_view", variant="secondary")
-            self.ui_defaults_apply = gr.Button(value='Apply', elem_id="ui_defaults_apply", variant="primary")
+            self.ui_defaults_view = gr.Button(
+                value="View changes", elem_id="ui_defaults_view", variant="secondary"
+            )
+            self.ui_defaults_apply = gr.Button(
+                value="Apply", elem_id="ui_defaults_apply", variant="primary"
+            )
 
         self.ui_defaults_review = gr.HTML("")
 
@@ -234,5 +266,13 @@ class UiLoadsave:
         assert not self.finalized_ui
         self.finalized_ui = True
 
-        self.ui_defaults_view.click(fn=self.ui_view, inputs=list(self.component_mapping.values()), outputs=[self.ui_defaults_review])
-        self.ui_defaults_apply.click(fn=self.ui_apply, inputs=list(self.component_mapping.values()), outputs=[self.ui_defaults_review])
+        self.ui_defaults_view.click(
+            fn=self.ui_view,
+            inputs=list(self.component_mapping.values()),
+            outputs=[self.ui_defaults_review],
+        )
+        self.ui_defaults_apply.click(
+            fn=self.ui_apply,
+            inputs=list(self.component_mapping.values()),
+            outputs=[self.ui_defaults_review],
+        )

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -8,35 +8,76 @@ def create_ui():
     dummy_component = gr.Label(visible=False)
     tab_index = gr.Number(value=0, visible=False)
 
-    with ResizeHandleRow(equal_height=False, variant='compact'):
-        with gr.Column(variant='compact'):
+    with ResizeHandleRow(equal_height=False, variant="compact"):
+        with gr.Column(variant="compact"):
             with gr.Tabs(elem_id="mode_extras"):
-                with gr.TabItem('Single Image', id="single_image", elem_id="extras_single_tab") as tab_single:
-                    extras_image = gr.Image(label="Source", source="upload", interactive=True, type="pil", elem_id="extras_image", image_mode="RGBA")
+                with gr.TabItem(
+                    "Single Image", id="single_image", elem_id="extras_single_tab"
+                ) as tab_single:
+                    extras_image = gr.Image(
+                        label="Source",
+                        source="upload",
+                        interactive=True,
+                        type="pil",
+                        elem_id="extras_image",
+                        image_mode="RGBA",
+                    )
 
-                with gr.TabItem('Batch Process', id="batch_process", elem_id="extras_batch_process_tab") as tab_batch:
-                    image_batch = gr.Files(label="Batch Process", interactive=True, elem_id="extras_image_batch")
+                with gr.TabItem(
+                    "Batch Process",
+                    id="batch_process",
+                    elem_id="extras_batch_process_tab",
+                ) as tab_batch:
+                    image_batch = gr.Files(
+                        label="Batch Process",
+                        interactive=True,
+                        elem_id="extras_image_batch",
+                    )
 
-                with gr.TabItem('Batch from Directory', id="batch_from_directory", elem_id="extras_batch_directory_tab") as tab_batch_dir:
-                    extras_batch_input_dir = gr.Textbox(label="Input directory", **shared.hide_dirs, placeholder="A directory on the same machine where the server is running.", elem_id="extras_batch_input_dir")
-                    extras_batch_output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs, placeholder="Leave blank to save images to the default path.", elem_id="extras_batch_output_dir")
-                    show_extras_results = gr.Checkbox(label='Show result images', value=True, elem_id="extras_show_extras_results")
+                with gr.TabItem(
+                    "Batch from Directory",
+                    id="batch_from_directory",
+                    elem_id="extras_batch_directory_tab",
+                ) as tab_batch_dir:
+                    extras_batch_input_dir = gr.Textbox(
+                        label="Input directory",
+                        **shared.hide_dirs,
+                        placeholder="A directory on the same machine where the server is running.",
+                        elem_id="extras_batch_input_dir",
+                    )
+                    extras_batch_output_dir = gr.Textbox(
+                        label="Output directory",
+                        **shared.hide_dirs,
+                        placeholder="Leave blank to save images to the default path.",
+                        elem_id="extras_batch_output_dir",
+                    )
+                    show_extras_results = gr.Checkbox(
+                        label="Show result images",
+                        value=True,
+                        elem_id="extras_show_extras_results",
+                    )
 
             script_inputs = scripts.scripts_postproc.setup_ui()
 
         with gr.Column():
-            toprow = ui_toprow.Toprow(is_compact=True, is_img2img=False, id_part="extras")
+            toprow = ui_toprow.Toprow(
+                is_compact=True, is_img2img=False, id_part="extras"
+            )
             toprow.create_inline_toprow_image()
             submit = toprow.submit
 
-            output_panel = ui_common.create_output_panel("extras", shared.opts.outdir_extras_samples)
+            output_panel = ui_common.create_output_panel(
+                "extras", shared.opts.outdir_extras_samples
+            )
 
     tab_single.select(fn=lambda: 0, inputs=[], outputs=[tab_index])
     tab_batch.select(fn=lambda: 1, inputs=[], outputs=[tab_index])
     tab_batch_dir.select(fn=lambda: 2, inputs=[], outputs=[tab_index])
 
     submit.click(
-        fn=call_queue.wrap_gradio_gpu_call(postprocessing.run_postprocessing_webui, extra_outputs=[None, '']),
+        fn=call_queue.wrap_gradio_gpu_call(
+            postprocessing.run_postprocessing_webui, extra_outputs=[None, ""]
+        ),
         _js="submit_extras",
         inputs=[
             dummy_component,
@@ -46,7 +87,7 @@ def create_ui():
             extras_batch_input_dir,
             extras_batch_output_dir,
             show_extras_results,
-            *script_inputs
+            *script_inputs,
         ],
         outputs=[
             output_panel.gallery,
@@ -59,6 +100,5 @@ def create_ui():
     parameters_copypaste.add_paste_fields("extras", extras_image, None)
 
     extras_image.change(
-        fn=scripts.scripts_postproc.image_changed,
-        inputs=[], outputs=[]
+        fn=scripts.scripts_postproc.image_changed, inputs=[], outputs=[]
     )

--- a/modules/ui_prompt_styles.py
+++ b/modules/ui_prompt_styles.py
@@ -2,9 +2,9 @@ import gradio as gr
 
 from modules import shared, ui_common, ui_components, styles
 
-styles_edit_symbol = '\U0001f58c\uFE0F'  # 🖌️
-styles_materialize_symbol = '\U0001f4cb'  # 📋
-styles_copy_symbol = '\U0001f4dd'  # 📝
+styles_edit_symbol = "\U0001f58c\ufe0f"  # 🖌️
+styles_materialize_symbol = "\U0001f4cb"  # 📋
+styles_copy_symbol = "\U0001f4dd"  # 📝
 
 
 def select_style(name):
@@ -15,7 +15,12 @@ def select_style(name):
     prompt = style.prompt if style else gr.update()
     negative_prompt = style.negative_prompt if style else gr.update()
 
-    return prompt, negative_prompt, gr.update(visible=existing), gr.update(visible=not empty)
+    return (
+        prompt,
+        negative_prompt,
+        gr.update(visible=existing),
+        gr.update(visible=not empty),
+    )
 
 
 def save_style(name, prompt, negative_prompt):
@@ -39,18 +44,26 @@ def delete_style(name):
     shared.prompt_styles.styles.pop(name, None)
     shared.prompt_styles.save_styles()
 
-    return '', '', ''
+    return "", "", ""
 
 
 def materialize_styles(prompt, negative_prompt, styles):
     prompt = shared.prompt_styles.apply_styles_to_prompt(prompt, styles)
-    negative_prompt = shared.prompt_styles.apply_negative_styles_to_prompt(negative_prompt, styles)
+    negative_prompt = shared.prompt_styles.apply_negative_styles_to_prompt(
+        negative_prompt, styles
+    )
 
-    return [gr.Textbox.update(value=prompt), gr.Textbox.update(value=negative_prompt), gr.Dropdown.update(value=[])]
+    return [
+        gr.Textbox.update(value=prompt),
+        gr.Textbox.update(value=negative_prompt),
+        gr.Dropdown.update(value=[]),
+    ]
 
 
 def refresh_styles():
-    return gr.update(choices=list(shared.prompt_styles.styles)), gr.update(choices=list(shared.prompt_styles.styles))
+    return gr.update(choices=list(shared.prompt_styles.styles)), gr.update(
+        choices=list(shared.prompt_styles.styles)
+    )
 
 
 class UiPromptStyles:
@@ -60,26 +73,84 @@ class UiPromptStyles:
         self.main_ui_negative_prompt = main_ui_negative_prompt
 
         with gr.Row(elem_id=f"{tabname}_styles_row"):
-            self.dropdown = gr.Dropdown(label="Styles", show_label=False, elem_id=f"{tabname}_styles", choices=list(shared.prompt_styles.styles), value=[], multiselect=True, tooltip="Styles")
-            edit_button = ui_components.ToolButton(value=styles_edit_symbol, elem_id=f"{tabname}_styles_edit_button", tooltip="Edit styles")
+            self.dropdown = gr.Dropdown(
+                label="Styles",
+                show_label=False,
+                elem_id=f"{tabname}_styles",
+                choices=list(shared.prompt_styles.styles),
+                value=[],
+                multiselect=True,
+                tooltip="Styles",
+            )
+            edit_button = ui_components.ToolButton(
+                value=styles_edit_symbol,
+                elem_id=f"{tabname}_styles_edit_button",
+                tooltip="Edit styles",
+            )
 
-        with gr.Box(elem_id=f"{tabname}_styles_dialog", elem_classes="popup-dialog") as styles_dialog:
+        with gr.Box(
+            elem_id=f"{tabname}_styles_dialog", elem_classes="popup-dialog"
+        ) as styles_dialog:
             with gr.Row():
-                self.selection = gr.Dropdown(label="Styles", elem_id=f"{tabname}_styles_edit_select", choices=list(shared.prompt_styles.styles), value=[], allow_custom_value=True, info="Styles allow you to add custom text to prompt. Use the {prompt} token in style text, and it will be replaced with user's prompt when applying style. Otherwise, style's text will be added to the end of the prompt.")
-                ui_common.create_refresh_button([self.dropdown, self.selection], shared.prompt_styles.reload, lambda: {"choices": list(shared.prompt_styles.styles)}, f"refresh_{tabname}_styles")
-                self.materialize = ui_components.ToolButton(value=styles_materialize_symbol, elem_id=f"{tabname}_style_apply_dialog", tooltip="Apply all selected styles from the style selection dropdown in main UI to the prompt.")
-                self.copy = ui_components.ToolButton(value=styles_copy_symbol, elem_id=f"{tabname}_style_copy", tooltip="Copy main UI prompt to style.")
+                self.selection = gr.Dropdown(
+                    label="Styles",
+                    elem_id=f"{tabname}_styles_edit_select",
+                    choices=list(shared.prompt_styles.styles),
+                    value=[],
+                    allow_custom_value=True,
+                    info="Styles allow you to add custom text to prompt. Use the {prompt} token in style text, and it will be replaced with user's prompt when applying style. Otherwise, style's text will be added to the end of the prompt.",
+                )
+                ui_common.create_refresh_button(
+                    [self.dropdown, self.selection],
+                    shared.prompt_styles.reload,
+                    lambda: {"choices": list(shared.prompt_styles.styles)},
+                    f"refresh_{tabname}_styles",
+                )
+                self.materialize = ui_components.ToolButton(
+                    value=styles_materialize_symbol,
+                    elem_id=f"{tabname}_style_apply_dialog",
+                    tooltip="Apply all selected styles from the style selection dropdown in main UI to the prompt.",
+                )
+                self.copy = ui_components.ToolButton(
+                    value=styles_copy_symbol,
+                    elem_id=f"{tabname}_style_copy",
+                    tooltip="Copy main UI prompt to style.",
+                )
 
             with gr.Row():
-                self.prompt = gr.Textbox(label="Prompt", show_label=True, elem_id=f"{tabname}_edit_style_prompt", lines=3, elem_classes=["prompt"])
+                self.prompt = gr.Textbox(
+                    label="Prompt",
+                    show_label=True,
+                    elem_id=f"{tabname}_edit_style_prompt",
+                    lines=3,
+                    elem_classes=["prompt"],
+                )
 
             with gr.Row():
-                self.neg_prompt = gr.Textbox(label="Negative prompt", show_label=True, elem_id=f"{tabname}_edit_style_neg_prompt", lines=3, elem_classes=["prompt"])
+                self.neg_prompt = gr.Textbox(
+                    label="Negative prompt",
+                    show_label=True,
+                    elem_id=f"{tabname}_edit_style_neg_prompt",
+                    lines=3,
+                    elem_classes=["prompt"],
+                )
 
             with gr.Row():
-                self.save = gr.Button('Save', variant='primary', elem_id=f'{tabname}_edit_style_save', visible=False)
-                self.delete = gr.Button('Delete', variant='primary', elem_id=f'{tabname}_edit_style_delete', visible=False)
-                self.close = gr.Button('Close', variant='secondary', elem_id=f'{tabname}_edit_style_close')
+                self.save = gr.Button(
+                    "Save",
+                    variant="primary",
+                    elem_id=f"{tabname}_edit_style_save",
+                    visible=False,
+                )
+                self.delete = gr.Button(
+                    "Delete",
+                    variant="primary",
+                    elem_id=f"{tabname}_edit_style_delete",
+                    visible=False,
+                )
+                self.close = gr.Button(
+                    "Close", variant="secondary", elem_id=f"{tabname}_edit_style_close"
+                )
 
         self.selection.change(
             fn=select_style,
@@ -93,7 +164,9 @@ class UiPromptStyles:
             inputs=[self.selection, self.prompt, self.neg_prompt],
             outputs=[self.delete],
             show_progress=False,
-        ).then(refresh_styles, outputs=[self.dropdown, self.selection], show_progress=False)
+        ).then(
+            refresh_styles, outputs=[self.dropdown, self.selection], show_progress=False
+        )
 
         self.delete.click(
             fn=delete_style,
@@ -101,7 +174,9 @@ class UiPromptStyles:
             inputs=[self.selection],
             outputs=[self.selection, self.prompt, self.neg_prompt],
             show_progress=False,
-        ).then(refresh_styles, outputs=[self.dropdown, self.selection], show_progress=False)
+        ).then(
+            refresh_styles, outputs=[self.dropdown, self.selection], show_progress=False
+        )
 
         self.setup_apply_button(self.materialize)
 
@@ -112,7 +187,9 @@ class UiPromptStyles:
             show_progress=False,
         )
 
-        ui_common.setup_dialog(button_show=edit_button, dialog=styles_dialog, button_close=self.close)
+        ui_common.setup_dialog(
+            button_show=edit_button, dialog=styles_dialog, button_close=self.close
+        )
 
     def setup_apply_button(self, button):
         button.click(
@@ -120,4 +197,8 @@ class UiPromptStyles:
             inputs=[self.main_ui_prompt, self.main_ui_negative_prompt, self.dropdown],
             outputs=[self.main_ui_prompt, self.main_ui_negative_prompt, self.dropdown],
             show_progress=False,
-        ).then(fn=None, _js="function(){update_"+self.tabname+"_tokens(); closePopup();}", show_progress=False)
+        ).then(
+            fn=None,
+            _js="function(){update_" + self.tabname + "_tokens(); closePopup();}",
+            show_progress=False,
+        )

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -1,6 +1,15 @@
 import gradio as gr
 
-from modules import ui_common, shared, script_callbacks, scripts, sd_models, sysinfo, timer, shared_items
+from modules import (
+    ui_common,
+    shared,
+    script_callbacks,
+    scripts,
+    sd_models,
+    sysinfo,
+    timer,
+    shared_items,
+)
 from modules.call_queue import wrap_gradio_call_no_job
 from modules.options import options_section
 from modules.shared import opts
@@ -13,8 +22,12 @@ def get_value_for_setting(key):
     value = getattr(opts, key)
 
     info = opts.data_labels[key]
-    args = info.component_args() if callable(info.component_args) else info.component_args or {}
-    args = {k: v for k, v in args.items() if k not in {'precision'}}
+    args = (
+        info.component_args()
+        if callable(info.component_args)
+        else info.component_args or {}
+    )
+    args = {k: v for k, v in args.items() if k not in {"precision"}}
 
     return gr.update(value=value, **args)
 
@@ -26,7 +39,9 @@ def create_setting_component(key, is_quicksettings=False):
     info = opts.data_labels[key]
     t = type(info.default)
 
-    args = info.component_args() if callable(info.component_args) else info.component_args
+    args = (
+        info.component_args() if callable(info.component_args) else info.component_args
+    )
 
     if info.component is not None:
         comp = info.component
@@ -37,18 +52,24 @@ def create_setting_component(key, is_quicksettings=False):
     elif t == bool:
         comp = gr.Checkbox
     else:
-        raise Exception(f'bad options item type: {t} for key {key}')
+        raise Exception(f"bad options item type: {t} for key {key}")
 
     elem_id = f"setting_{key}"
 
     if info.refresh is not None:
         if is_quicksettings:
             res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
-            ui_common.create_refresh_button(res, info.refresh, info.component_args, f"refresh_{key}")
+            ui_common.create_refresh_button(
+                res, info.refresh, info.component_args, f"refresh_{key}"
+            )
         else:
             with FormRow():
-                res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
-                ui_common.create_refresh_button(res, info.refresh, info.component_args, f"refresh_{key}")
+                res = comp(
+                    label=info.label, value=fun(), elem_id=elem_id, **(args or {})
+                )
+                ui_common.create_refresh_button(
+                    res, info.refresh, info.component_args, f"refresh_{key}"
+                )
     else:
         res = comp(label=info.label, value=fun(), elem_id=elem_id, **(args or {}))
 
@@ -73,7 +94,10 @@ class UiSettings:
         changed = []
 
         for key, value, comp in zip(opts.data_labels.keys(), args, self.components):
-            assert comp == self.dummy_component or opts.same_type(value, opts.data_labels[key].default), f"Bad value for setting {key}: {value}; expecting {type(opts.data_labels[key].default).__name__}"
+            assert (
+                comp == self.dummy_component
+                or opts.same_type(value, opts.data_labels[key].default)
+            ), f"Bad value for setting {key}: {value}; expecting {type(opts.data_labels[key].default).__name__}"
 
         for key, value, comp in zip(opts.data_labels.keys(), args, self.components):
             if comp == self.dummy_component:
@@ -85,8 +109,14 @@ class UiSettings:
         try:
             opts.save(shared.config_filename)
         except RuntimeError:
-            return opts.dumpjson(), f'{len(changed)} settings changed without save: {", ".join(changed)}.'
-        return opts.dumpjson(), f'{len(changed)} settings changed{": " if changed else ""}{", ".join(changed)}.'
+            return (
+                opts.dumpjson(),
+                f'{len(changed)} settings changed without save: {", ".join(changed)}.',
+            )
+        return (
+            opts.dumpjson(),
+            f'{len(changed)} settings changed{": " if changed else ""}{", ".join(changed)}.',
+        )
 
     def run_settings_single(self, value, key):
         if not opts.same_type(value, opts.data_labels[key].default):
@@ -110,23 +140,40 @@ class UiSettings:
         shared.settings_components = self.component_dict
 
         # we add this as late as possible so that scripts have already registered their callbacks
-        opts.data_labels.update(options_section(('callbacks', "Callbacks", "system"), {
-            **shared_items.callbacks_order_settings(),
-        }))
+        opts.data_labels.update(
+            options_section(
+                ("callbacks", "Callbacks", "system"),
+                {
+                    **shared_items.callbacks_order_settings(),
+                },
+            )
+        )
 
         opts.reorder()
 
         with gr.Blocks(analytics_enabled=False) as settings_interface:
             with gr.Row():
                 with gr.Column(scale=6):
-                    self.submit = gr.Button(value="Apply settings", variant='primary', elem_id="settings_submit")
+                    self.submit = gr.Button(
+                        value="Apply settings",
+                        variant="primary",
+                        elem_id="settings_submit",
+                    )
                 with gr.Column():
-                    restart_gradio = gr.Button(value='Reload UI', variant='primary', elem_id="settings_restart_gradio")
+                    restart_gradio = gr.Button(
+                        value="Reload UI",
+                        variant="primary",
+                        elem_id="settings_restart_gradio",
+                    )
 
             self.result = gr.HTML(elem_id="settings_result")
 
             self.quicksettings_names = opts.quicksettings_list
-            self.quicksettings_names = {x: i for i, x in enumerate(self.quicksettings_names) if x != 'quicksettings'}
+            self.quicksettings_names = {
+                x: i
+                for i, x in enumerate(self.quicksettings_names)
+                if x != "quicksettings"
+            }
 
             self.quicksettings_list = []
 
@@ -145,14 +192,21 @@ class UiSettings:
                             current_tab.__exit__()
 
                         gr.Group()
-                        current_tab = gr.TabItem(elem_id=f"settings_{elem_id}", label=text)
+                        current_tab = gr.TabItem(
+                            elem_id=f"settings_{elem_id}", label=text
+                        )
                         current_tab.__enter__()
-                        current_row = gr.Column(elem_id=f"column_settings_{elem_id}", variant='compact')
+                        current_row = gr.Column(
+                            elem_id=f"column_settings_{elem_id}", variant="compact"
+                        )
                         current_row.__enter__()
 
                         previous_section = item.section
 
-                    if k in self.quicksettings_names and not shared.cmd_opts.freeze_settings:
+                    if (
+                        k in self.quicksettings_names
+                        and not shared.cmd_opts.freeze_settings
+                    ):
                         self.quicksettings_list.append((i, k, item))
                         self.components.append(dummy_component)
                     elif section_must_be_skipped:
@@ -166,41 +220,97 @@ class UiSettings:
                     current_row.__exit__()
                     current_tab.__exit__()
 
-                with gr.TabItem("Defaults", id="defaults", elem_id="settings_tab_defaults"):
+                with gr.TabItem(
+                    "Defaults", id="defaults", elem_id="settings_tab_defaults"
+                ):
                     loadsave.create_ui()
 
-                with gr.TabItem("Sysinfo", id="sysinfo", elem_id="settings_tab_sysinfo"):
-                    gr.HTML('<a href="./internal/sysinfo-download" class="sysinfo_big_link" download>Download system info</a><br /><a href="./internal/sysinfo" target="_blank">(or open as text in a new page)</a>', elem_id="sysinfo_download")
+                with gr.TabItem(
+                    "Sysinfo", id="sysinfo", elem_id="settings_tab_sysinfo"
+                ):
+                    gr.HTML(
+                        '<a href="./internal/sysinfo-download" class="sysinfo_big_link" download>Download system info</a><br /><a href="./internal/sysinfo" target="_blank">(or open as text in a new page)</a>',
+                        elem_id="sysinfo_download",
+                    )
 
                     with gr.Row():
                         with gr.Column(scale=1):
-                            sysinfo_check_file = gr.File(label="Check system info for validity", type='binary')
+                            sysinfo_check_file = gr.File(
+                                label="Check system info for validity", type="binary"
+                            )
                         with gr.Column(scale=1):
-                            sysinfo_check_output = gr.HTML("", elem_id="sysinfo_validity")
+                            sysinfo_check_output = gr.HTML(
+                                "", elem_id="sysinfo_validity"
+                            )
                         with gr.Column(scale=100):
                             pass
 
-                with gr.TabItem("Actions", id="actions", elem_id="settings_tab_actions"):
-                    request_notifications = gr.Button(value='Request browser notifications', elem_id="request_notifications")
-                    download_localization = gr.Button(value='Download localization template', elem_id="download_localization")
-                    reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies")
+                with gr.TabItem(
+                    "Actions", id="actions", elem_id="settings_tab_actions"
+                ):
+                    request_notifications = gr.Button(
+                        value="Request browser notifications",
+                        elem_id="request_notifications",
+                    )
+                    download_localization = gr.Button(
+                        value="Download localization template",
+                        elem_id="download_localization",
+                    )
+                    reload_script_bodies = gr.Button(
+                        value="Reload custom script bodies (No ui updates, No restart)",
+                        variant="secondary",
+                        elem_id="settings_reload_script_bodies",
+                    )
                     with gr.Row():
-                        unload_sd_model = gr.Button(value='Unload SD checkpoint to RAM', elem_id="sett_unload_sd_model")
-                        reload_sd_model = gr.Button(value='Load SD checkpoint to VRAM from RAM', elem_id="sett_reload_sd_model")
+                        unload_sd_model = gr.Button(
+                            value="Unload SD checkpoint to RAM",
+                            elem_id="sett_unload_sd_model",
+                        )
+                        reload_sd_model = gr.Button(
+                            value="Load SD checkpoint to VRAM from RAM",
+                            elem_id="sett_reload_sd_model",
+                        )
                     with gr.Row():
-                        calculate_all_checkpoint_hash = gr.Button(value='Calculate hash for all checkpoint', elem_id="calculate_all_checkpoint_hash")
-                        calculate_all_checkpoint_hash_threads = gr.Number(value=1, label="Number of parallel calculations", elem_id="calculate_all_checkpoint_hash_threads", precision=0, minimum=1)
+                        calculate_all_checkpoint_hash = gr.Button(
+                            value="Calculate hash for all checkpoint",
+                            elem_id="calculate_all_checkpoint_hash",
+                        )
+                        calculate_all_checkpoint_hash_threads = gr.Number(
+                            value=1,
+                            label="Number of parallel calculations",
+                            elem_id="calculate_all_checkpoint_hash_threads",
+                            precision=0,
+                            minimum=1,
+                        )
 
-                with gr.TabItem("Licenses", id="licenses", elem_id="settings_tab_licenses"):
+                with gr.TabItem(
+                    "Licenses", id="licenses", elem_id="settings_tab_licenses"
+                ):
                     gr.HTML(shared.html("licenses.html"), elem_id="licenses")
 
-                self.show_all_pages = gr.Button(value="Show all pages", elem_id="settings_show_all_pages")
-                self.show_one_page = gr.Button(value="Show only one page", elem_id="settings_show_one_page", visible=False)
+                self.show_all_pages = gr.Button(
+                    value="Show all pages", elem_id="settings_show_all_pages"
+                )
+                self.show_one_page = gr.Button(
+                    value="Show only one page",
+                    elem_id="settings_show_one_page",
+                    visible=False,
+                )
                 self.show_one_page.click(lambda: None)
 
-                self.search_input = gr.Textbox(value="", elem_id="settings_search", max_lines=1, placeholder="Search...", show_label=False)
+                self.search_input = gr.Textbox(
+                    value="",
+                    elem_id="settings_search",
+                    max_lines=1,
+                    placeholder="Search...",
+                    show_label=False,
+                )
 
-                self.text_settings = gr.Textbox(elem_id="settings_json", value=lambda: opts.dumpjson(), visible=False)
+                self.text_settings = gr.Textbox(
+                    elem_id="settings_json",
+                    value=lambda: opts.dumpjson(),
+                    visible=False,
+                )
 
             def call_func_and_return_text(func, text):
                 def handler():
@@ -208,61 +318,56 @@ class UiSettings:
                     func()
                     t.record(text)
 
-                    return f'{text} in {t.total:.1f}s'
+                    return f"{text} in {t.total:.1f}s"
 
                 return handler
 
             unload_sd_model.click(
-                fn=call_func_and_return_text(sd_models.unload_model_weights, 'Unloaded the checkpoint'),
+                fn=call_func_and_return_text(
+                    sd_models.unload_model_weights, "Unloaded the checkpoint"
+                ),
                 inputs=[],
-                outputs=[self.result]
+                outputs=[self.result],
             )
 
             reload_sd_model.click(
-                fn=call_func_and_return_text(lambda: sd_models.send_model_to_device(shared.sd_model), 'Loaded the checkpoint'),
+                fn=call_func_and_return_text(
+                    lambda: sd_models.send_model_to_device(shared.sd_model),
+                    "Loaded the checkpoint",
+                ),
                 inputs=[],
-                outputs=[self.result]
+                outputs=[self.result],
             )
 
             request_notifications.click(
-                fn=lambda: None,
-                inputs=[],
-                outputs=[],
-                _js='function(){}'
+                fn=lambda: None, inputs=[], outputs=[], _js="function(){}"
             )
 
             download_localization.click(
-                fn=lambda: None,
-                inputs=[],
-                outputs=[],
-                _js='download_localization'
+                fn=lambda: None, inputs=[], outputs=[], _js="download_localization"
             )
 
             def reload_scripts():
                 scripts.reload_script_body_only()
                 reload_javascript()  # need to refresh the html page
 
-            reload_script_bodies.click(
-                fn=reload_scripts,
-                inputs=[],
-                outputs=[]
-            )
+            reload_script_bodies.click(fn=reload_scripts, inputs=[], outputs=[])
 
             restart_gradio.click(
                 fn=shared.state.request_restart,
-                _js='restart_reload',
+                _js="restart_reload",
                 inputs=[],
                 outputs=[],
             )
 
             def check_file(x):
                 if x is None:
-                    return ''
+                    return ""
 
-                if sysinfo.check(x.decode('utf8', errors='ignore')):
-                    return 'Valid'
+                if sysinfo.check(x.decode("utf8", errors="ignore")):
+                    return "Valid"
 
-                return 'Invalid'
+                return "Invalid"
 
             sysinfo_check_file.change(
                 fn=check_file,
@@ -273,7 +378,10 @@ class UiSettings:
             def calculate_all_checkpoint_hash_fn(max_thread):
                 checkpoints_list = sd_models.checkpoints_list.values()
                 with ThreadPoolExecutor(max_workers=max_thread) as executor:
-                    futures = [executor.submit(checkpoint.calculate_shorthash) for checkpoint in checkpoints_list]
+                    futures = [
+                        executor.submit(checkpoint.calculate_shorthash)
+                        for checkpoint in checkpoints_list
+                    ]
                     completed = 0
                     for _ in as_completed(futures):
                         completed += 1
@@ -289,13 +397,18 @@ class UiSettings:
 
     def add_quicksettings(self):
         with gr.Row(elem_id="quicksettings", variant="compact"):
-            for _i, k, _item in sorted(self.quicksettings_list, key=lambda x: self.quicksettings_names.get(x[1], x[0])):
+            for _i, k, _item in sorted(
+                self.quicksettings_list,
+                key=lambda x: self.quicksettings_names.get(x[1], x[0]),
+            ):
                 component = create_setting_component(k, is_quicksettings=True)
                 self.component_dict[k] = component
 
     def add_functionality(self, demo):
         self.submit.click(
-            fn=wrap_gradio_call_no_job(lambda *args: self.run_settings(*args), extra_outputs=[gr.update()]),
+            fn=wrap_gradio_call_no_job(
+                lambda *args: self.run_settings(*args), extra_outputs=[gr.update()]
+            ),
             inputs=self.components,
             outputs=[self.text_settings, self.result],
         )
@@ -306,7 +419,7 @@ class UiSettings:
 
             if isinstance(component, gr.Textbox):
                 methods = [component.submit, component.blur]
-            elif hasattr(component, 'release'):
+            elif hasattr(component, "release"):
                 methods = [component.release]
             else:
                 methods = [component.change]
@@ -319,15 +432,21 @@ class UiSettings:
                     show_progress=info.refresh is not None,
                 )
 
-        button_set_checkpoint = gr.Button('Change checkpoint', elem_id='change_checkpoint', visible=False)
+        button_set_checkpoint = gr.Button(
+            "Change checkpoint", elem_id="change_checkpoint", visible=False
+        )
         button_set_checkpoint.click(
-            fn=lambda value, _: self.run_settings_single(value, key='sd_model_checkpoint'),
+            fn=lambda value, _: self.run_settings_single(
+                value, key="sd_model_checkpoint"
+            ),
             _js="function(v){ var res = desiredCheckpointName; desiredCheckpointName = ''; return [res || v, null]; }",
-            inputs=[self.component_dict['sd_model_checkpoint'], self.dummy_component],
-            outputs=[self.component_dict['sd_model_checkpoint'], self.text_settings],
+            inputs=[self.component_dict["sd_model_checkpoint"], self.dummy_component],
+            outputs=[self.component_dict["sd_model_checkpoint"], self.text_settings],
         )
 
-        component_keys = [k for k in opts.data_labels.keys() if k in self.component_dict]
+        component_keys = [
+            k for k in opts.data_labels.keys() if k in self.component_dict
+        ]
 
         def get_settings_values():
             return [get_value_for_setting(key) for key in component_keys]
@@ -342,4 +461,6 @@ class UiSettings:
     def search(self, text):
         print(text)
 
-        return [gr.update(visible=text in (comp.label or "")) for comp in self.components]
+        return [
+            gr.update(visible=text in (comp.label or "")) for comp in self.components
+        ]

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -14,28 +14,35 @@ Savedfile = namedtuple("Savedfile", ["name"])
 
 
 def register_tmp_file(gradio, filename):
-    if hasattr(gradio, 'temp_file_sets'):  # gradio 3.15
-        gradio.temp_file_sets[0] = gradio.temp_file_sets[0] | {os.path.abspath(filename)}
+    if hasattr(gradio, "temp_file_sets"):  # gradio 3.15
+        gradio.temp_file_sets[0] = gradio.temp_file_sets[0] | {
+            os.path.abspath(filename)
+        }
 
-    if hasattr(gradio, 'temp_dirs'):  # gradio 3.9
-        gradio.temp_dirs = gradio.temp_dirs | {os.path.abspath(os.path.dirname(filename))}
+    if hasattr(gradio, "temp_dirs"):  # gradio 3.9
+        gradio.temp_dirs = gradio.temp_dirs | {
+            os.path.abspath(os.path.dirname(filename))
+        }
 
 
 def check_tmp_file(gradio, filename):
-    if hasattr(gradio, 'temp_file_sets'):
+    if hasattr(gradio, "temp_file_sets"):
         return any(filename in fileset for fileset in gradio.temp_file_sets)
 
-    if hasattr(gradio, 'temp_dirs'):
-        return any(Path(temp_dir).resolve() in Path(filename).resolve().parents for temp_dir in gradio.temp_dirs)
+    if hasattr(gradio, "temp_dirs"):
+        return any(
+            Path(temp_dir).resolve() in Path(filename).resolve().parents
+            for temp_dir in gradio.temp_dirs
+        )
 
     return False
 
 
 def save_pil_to_file(self, pil_image, dir=None, format="png"):
-    already_saved_as = getattr(pil_image, 'already_saved_as', None)
+    already_saved_as = getattr(pil_image, "already_saved_as", None)
     if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)
-        filename_with_mtime = f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
+        filename_with_mtime = f"{already_saved_as}?{os.path.getmtime(already_saved_as)}"
         register_tmp_file(shared.demo, filename_with_mtime)
         return filename_with_mtime
 

--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -78,13 +78,41 @@ class Toprow:
         self.submit_box.render()
 
     def create_prompts(self):
-        with gr.Column(elem_id=f"{self.id_part}_prompt_container", elem_classes=["prompt-container-compact"] if self.is_compact else [], scale=6):
-            with gr.Row(elem_id=f"{self.id_part}_prompt_row", elem_classes=["prompt-row"]):
-                self.prompt = gr.Textbox(label="Prompt", elem_id=f"{self.id_part}_prompt", show_label=False, lines=3, placeholder="Prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)", elem_classes=["prompt"])
-                self.prompt_img = gr.File(label="", elem_id=f"{self.id_part}_prompt_image", file_count="single", type="binary", visible=False)
+        with gr.Column(
+            elem_id=f"{self.id_part}_prompt_container",
+            elem_classes=["prompt-container-compact"] if self.is_compact else [],
+            scale=6,
+        ):
+            with gr.Row(
+                elem_id=f"{self.id_part}_prompt_row", elem_classes=["prompt-row"]
+            ):
+                self.prompt = gr.Textbox(
+                    label="Prompt",
+                    elem_id=f"{self.id_part}_prompt",
+                    show_label=False,
+                    lines=3,
+                    placeholder="Prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)",
+                    elem_classes=["prompt"],
+                )
+                self.prompt_img = gr.File(
+                    label="",
+                    elem_id=f"{self.id_part}_prompt_image",
+                    file_count="single",
+                    type="binary",
+                    visible=False,
+                )
 
-            with gr.Row(elem_id=f"{self.id_part}_neg_prompt_row", elem_classes=["prompt-row"]):
-                self.negative_prompt = gr.Textbox(label="Negative prompt", elem_id=f"{self.id_part}_neg_prompt", show_label=False, lines=3, placeholder="Negative prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)", elem_classes=["prompt"])
+            with gr.Row(
+                elem_id=f"{self.id_part}_neg_prompt_row", elem_classes=["prompt-row"]
+            ):
+                self.negative_prompt = gr.Textbox(
+                    label="Negative prompt",
+                    elem_id=f"{self.id_part}_neg_prompt",
+                    show_label=False,
+                    lines=3,
+                    placeholder="Negative prompt\n(Press Ctrl+Enter to generate, Alt+Enter to skip, Esc to interrupt)",
+                    elem_classes=["prompt"],
+                )
 
         self.prompt_img.change(
             fn=modules.images.image_data,
@@ -94,43 +122,122 @@ class Toprow:
         )
 
     def create_submit_box(self):
-        with gr.Row(elem_id=f"{self.id_part}_generate_box", elem_classes=["generate-box"] + (["generate-box-compact"] if self.is_compact else []), render=not self.is_compact) as submit_box:
+        with gr.Row(
+            elem_id=f"{self.id_part}_generate_box",
+            elem_classes=["generate-box"]
+            + (["generate-box-compact"] if self.is_compact else []),
+            render=not self.is_compact,
+        ) as submit_box:
             self.submit_box = submit_box
 
-            self.interrupt = gr.Button('Interrupt', elem_id=f"{self.id_part}_interrupt", elem_classes="generate-box-interrupt", tooltip="End generation immediately or after completing current batch")
-            self.skip = gr.Button('Skip', elem_id=f"{self.id_part}_skip", elem_classes="generate-box-skip", tooltip="Stop generation of current batch and continues onto next batch")
-            self.interrupting = gr.Button('Interrupting...', elem_id=f"{self.id_part}_interrupting", elem_classes="generate-box-interrupting", tooltip="Interrupting generation...")
-            self.submit = gr.Button('Generate', elem_id=f"{self.id_part}_generate", variant='primary', tooltip="Right click generate forever menu")
+            self.interrupt = gr.Button(
+                "Interrupt",
+                elem_id=f"{self.id_part}_interrupt",
+                elem_classes="generate-box-interrupt",
+                tooltip="End generation immediately or after completing current batch",
+            )
+            self.skip = gr.Button(
+                "Skip",
+                elem_id=f"{self.id_part}_skip",
+                elem_classes="generate-box-skip",
+                tooltip="Stop generation of current batch and continues onto next batch",
+            )
+            self.interrupting = gr.Button(
+                "Interrupting...",
+                elem_id=f"{self.id_part}_interrupting",
+                elem_classes="generate-box-interrupting",
+                tooltip="Interrupting generation...",
+            )
+            self.submit = gr.Button(
+                "Generate",
+                elem_id=f"{self.id_part}_generate",
+                variant="primary",
+                tooltip="Right click generate forever menu",
+            )
 
             def interrupt_function():
-                if not shared.state.stopping_generation and shared.state.job_count > 1 and shared.opts.interrupt_after_current:
+                if (
+                    not shared.state.stopping_generation
+                    and shared.state.job_count > 1
+                    and shared.opts.interrupt_after_current
+                ):
                     shared.state.stop_generating()
-                    gr.Info("Generation will stop after finishing this image, click again to stop immediately.")
+                    gr.Info(
+                        "Generation will stop after finishing this image, click again to stop immediately."
+                    )
                 else:
                     shared.state.interrupt()
 
             self.skip.click(fn=shared.state.skip)
-            self.interrupt.click(fn=interrupt_function, _js='function(){ showSubmitInterruptingPlaceholder("' + self.id_part + '"); }')
+            self.interrupt.click(
+                fn=interrupt_function,
+                _js='function(){ showSubmitInterruptingPlaceholder("'
+                + self.id_part
+                + '"); }',
+            )
             self.interrupting.click(fn=interrupt_function)
 
     def create_tools_row(self):
         with gr.Row(elem_id=f"{self.id_part}_tools"):
-            from modules.ui import paste_symbol, clear_prompt_symbol, restore_progress_symbol
+            from modules.ui import (
+                paste_symbol,
+                clear_prompt_symbol,
+                restore_progress_symbol,
+            )
 
-            self.paste = ToolButton(value=paste_symbol, elem_id="paste", tooltip="Read generation parameters from prompt or last generation if prompt is empty into user interface.")
-            self.clear_prompt_button = ToolButton(value=clear_prompt_symbol, elem_id=f"{self.id_part}_clear_prompt", tooltip="Clear prompt")
-            self.apply_styles = ToolButton(value=ui_prompt_styles.styles_materialize_symbol, elem_id=f"{self.id_part}_style_apply", tooltip="Apply all selected styles to prompts.")
+            self.paste = ToolButton(
+                value=paste_symbol,
+                elem_id="paste",
+                tooltip="Read generation parameters from prompt or last generation if prompt is empty into user interface.",
+            )
+            self.clear_prompt_button = ToolButton(
+                value=clear_prompt_symbol,
+                elem_id=f"{self.id_part}_clear_prompt",
+                tooltip="Clear prompt",
+            )
+            self.apply_styles = ToolButton(
+                value=ui_prompt_styles.styles_materialize_symbol,
+                elem_id=f"{self.id_part}_style_apply",
+                tooltip="Apply all selected styles to prompts.",
+            )
 
             if self.is_img2img:
-                self.button_interrogate = ToolButton('📎', tooltip='Interrogate CLIP - use CLIP neural network to create a text describing the image, and put it into the prompt field', elem_id="interrogate")
-                self.button_deepbooru = ToolButton('📦', tooltip='Interrogate DeepBooru - use DeepBooru neural network to create a text describing the image, and put it into the prompt field', elem_id="deepbooru")
+                self.button_interrogate = ToolButton(
+                    "📎",
+                    tooltip="Interrogate CLIP - use CLIP neural network to create a text describing the image, and put it into the prompt field",
+                    elem_id="interrogate",
+                )
+                self.button_deepbooru = ToolButton(
+                    "📦",
+                    tooltip="Interrogate DeepBooru - use DeepBooru neural network to create a text describing the image, and put it into the prompt field",
+                    elem_id="deepbooru",
+                )
 
-            self.restore_progress_button = ToolButton(value=restore_progress_symbol, elem_id=f"{self.id_part}_restore_progress", visible=False, tooltip="Restore progress")
+            self.restore_progress_button = ToolButton(
+                value=restore_progress_symbol,
+                elem_id=f"{self.id_part}_restore_progress",
+                visible=False,
+                tooltip="Restore progress",
+            )
 
-            self.token_counter = gr.HTML(value="<span>0/75</span>", elem_id=f"{self.id_part}_token_counter", elem_classes=["token-counter"], visible=False)
-            self.token_button = gr.Button(visible=False, elem_id=f"{self.id_part}_token_button")
-            self.negative_token_counter = gr.HTML(value="<span>0/75</span>", elem_id=f"{self.id_part}_negative_token_counter", elem_classes=["token-counter"], visible=False)
-            self.negative_token_button = gr.Button(visible=False, elem_id=f"{self.id_part}_negative_token_button")
+            self.token_counter = gr.HTML(
+                value="<span>0/75</span>",
+                elem_id=f"{self.id_part}_token_counter",
+                elem_classes=["token-counter"],
+                visible=False,
+            )
+            self.token_button = gr.Button(
+                visible=False, elem_id=f"{self.id_part}_token_button"
+            )
+            self.negative_token_counter = gr.HTML(
+                value="<span>0/75</span>",
+                elem_id=f"{self.id_part}_negative_token_counter",
+                elem_classes=["token-counter"],
+                visible=False,
+            )
+            self.negative_token_button = gr.Button(
+                visible=False, elem_id=f"{self.id_part}_negative_token_button"
+            )
 
             self.clear_prompt_button.click(
                 fn=lambda *x: x,
@@ -140,5 +247,7 @@ class Toprow:
             )
 
     def create_styles_ui(self):
-        self.ui_styles = ui_prompt_styles.UiPromptStyles(self.id_part, self.prompt, self.negative_prompt)
+        self.ui_styles = ui_prompt_styles.UiPromptStyles(
+            self.id_part, self.prompt, self.negative_prompt
+        )
         self.ui_styles.setup_apply_button(self.apply_styles)

--- a/modules/upscaler.py
+++ b/modules/upscaler.py
@@ -7,8 +7,8 @@ from PIL import Image
 import modules.shared
 from modules import modelloader, shared
 
-LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
-NEAREST = (Image.Resampling.NEAREST if hasattr(Image, 'Resampling') else Image.NEAREST)
+LANCZOS = Image.Resampling.LANCZOS if hasattr(Image, "Resampling") else Image.LANCZOS
+NEAREST = Image.Resampling.NEAREST if hasattr(Image, "Resampling") else Image.NEAREST
 
 
 class Upscaler:
@@ -43,6 +43,7 @@ class Upscaler:
 
         try:
             import cv2  # noqa: F401
+
             self.can_tile = True
         except Exception:
             pass
@@ -80,7 +81,12 @@ class Upscaler:
         pass
 
     def find_models(self, ext_filter=None) -> list:
-        return modelloader.load_models(model_path=self.model_path, model_url=self.model_url, command_path=self.user_path, ext_filter=ext_filter)
+        return modelloader.load_models(
+            model_path=self.model_path,
+            model_url=self.model_url,
+            command_path=self.user_path,
+            ext_filter=ext_filter,
+        )
 
     def update_status(self, prompt):
         print(f"\nextras: {prompt}", file=shared.progress_print_out)
@@ -93,7 +99,14 @@ class UpscalerData:
     scaler: Upscaler = None
     model: None
 
-    def __init__(self, name: str, path: str, upscaler: Upscaler = None, scale: int = 4, model=None):
+    def __init__(
+        self,
+        name: str,
+        path: str,
+        upscaler: Upscaler = None,
+        scale: int = 4,
+        model=None,
+    ):
         self.name = name
         self.data_path = path
         self.local_data_path = path
@@ -102,7 +115,9 @@ class UpscalerData:
         self.model = model
 
     def __repr__(self):
-        return f"<UpscalerData name={self.name} path={self.data_path} scale={self.scale}>"
+        return (
+            f"<UpscalerData name={self.name} path={self.data_path} scale={self.scale}>"
+        )
 
 
 class UpscalerNone(Upscaler):
@@ -124,7 +139,10 @@ class UpscalerLanczos(Upscaler):
     scalers = []
 
     def do_upscale(self, img, selected_model=None):
-        return img.resize((int(img.width * self.scale), int(img.height * self.scale)), resample=LANCZOS)
+        return img.resize(
+            (int(img.width * self.scale), int(img.height * self.scale)),
+            resample=LANCZOS,
+        )
 
     def load_model(self, _):
         pass
@@ -139,7 +157,10 @@ class UpscalerNearest(Upscaler):
     scalers = []
 
     def do_upscale(self, img, selected_model=None):
-        return img.resize((int(img.width * self.scale), int(img.height * self.scale)), resample=NEAREST)
+        return img.resize(
+            (int(img.width * self.scale), int(img.height * self.scale)),
+            resample=NEAREST,
+        )
 
     def load_model(self, _):
         pass

--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -65,7 +65,11 @@ def upscale_with_model(
     grid = images.split_grid(img, tile_size, tile_size, tile_overlap)
     newtiles = []
 
-    with tqdm.tqdm(total=grid.tile_count, desc=desc, disable=not shared.opts.enable_upscale_progressbar) as p:
+    with tqdm.tqdm(
+        total=grid.tile_count,
+        desc=desc,
+        disable=not shared.opts.enable_upscale_progressbar,
+    ) as p:
         for y, h, row in grid.tiles:
             newrow = []
             for x, w, tile in row:
@@ -123,7 +127,11 @@ def tiled_upscale_2(
     )
     weights = torch.zeros_like(result)
     logger.debug("Upscaling %s to %s with tiles", img.shape, result.shape)
-    with tqdm.tqdm(total=len(h_idx_list) * len(w_idx_list), desc=desc, disable=not shared.opts.enable_upscale_progressbar) as pbar:
+    with tqdm.tqdm(
+        total=len(h_idx_list) * len(w_idx_list),
+        desc=desc,
+        disable=not shared.opts.enable_upscale_progressbar,
+    ) as pbar:
         for h_idx in h_idx_list:
             if shared.state.interrupted or shared.state.skipped:
                 break
@@ -175,7 +183,9 @@ def upscale_2(
     Convenience wrapper around `tiled_upscale_2` that handles PIL images.
     """
     param = torch_utils.get_param(model)
-    tensor = pil_image_to_torch_bgr(img).to(dtype=param.dtype).unsqueeze(0)  # add batch dimension
+    tensor = (
+        pil_image_to_torch_bgr(img).to(dtype=param.dtype).unsqueeze(0)
+    )  # add batch dimension
 
     with torch.no_grad():
         output = tiled_upscale_2(

--- a/modules/util.py
+++ b/modules/util.py
@@ -5,12 +5,16 @@ from modules import shared
 from modules.paths_internal import script_path, cwd
 
 
-def natural_sort_key(s, regex=re.compile('([0-9]+)')):
+def natural_sort_key(s, regex=re.compile("([0-9]+)")):
     return [int(text) if text.isdigit() else text.lower() for text in regex.split(s)]
 
 
 def listfiles(dirname):
-    filenames = [os.path.join(dirname, x) for x in sorted(os.listdir(dirname), key=natural_sort_key) if not x.startswith(".")]
+    filenames = [
+        os.path.join(dirname, x)
+        for x in sorted(os.listdir(dirname), key=natural_sort_key)
+        if not x.startswith(".")
+    ]
     return [file for file in filenames if os.path.isfile(file)]
 
 
@@ -76,7 +80,9 @@ class MassFileListerCachedDir:
         self.files_cased = None
         self.dirname = dirname
 
-        stats = ((x.name, x.stat(follow_symlinks=False)) for x in os.scandir(self.dirname))
+        stats = (
+            (x.name, x.stat(follow_symlinks=False)) for x in os.scandir(self.dirname)
+        )
         files = [(n, s.st_mtime, s.st_ctime) for n, s in stats]
         self.files = {x[0].lower(): x for x in files}
         self.files_cased = {x[0]: x for x in files}
@@ -154,6 +160,7 @@ class MassFileLister:
         if cached_dir := self.cached_dirs.get(dirname):
             cached_dir.update_entry(filename)
 
+
 def topological_sort(dependencies):
     """Accepts a dictionary mapping name to its dependencies, returns a list of names ordered according to dependencies.
     Ignores errors relating to missing dependencies or circular dependencies
@@ -208,6 +215,8 @@ Requested path was: {path}
     elif platform.system() == "Darwin":
         subprocess.Popen(["open", path])
     elif "microsoft-standard-WSL2" in platform.uname().release:
-        subprocess.Popen(["explorer.exe", subprocess.check_output(["wslpath", "-w", path])])
+        subprocess.Popen(
+            ["explorer.exe", subprocess.check_output(["wslpath", "-w", path])]
+        )
     else:
         subprocess.Popen(["xdg-open", path])

--- a/modules/xlmr.py
+++ b/modules/xlmr.py
@@ -2,30 +2,84 @@ from transformers import BertPreTrainedModel, BertConfig
 import torch.nn as nn
 import torch
 from transformers.models.xlm_roberta.configuration_xlm_roberta import XLMRobertaConfig
-from transformers import XLMRobertaModel,XLMRobertaTokenizer
+from transformers import XLMRobertaModel, XLMRobertaTokenizer
 from typing import Optional
 
 from modules import torch_utils
 
 
 class BertSeriesConfig(BertConfig):
-    def __init__(self, vocab_size=30522, hidden_size=768, num_hidden_layers=12, num_attention_heads=12, intermediate_size=3072, hidden_act="gelu", hidden_dropout_prob=0.1, attention_probs_dropout_prob=0.1, max_position_embeddings=512, type_vocab_size=2, initializer_range=0.02, layer_norm_eps=1e-12, pad_token_id=0, position_embedding_type="absolute", use_cache=True, classifier_dropout=None,project_dim=512, pooler_fn="average",learn_encoder=False,model_type='bert',**kwargs):
-
-        super().__init__(vocab_size, hidden_size, num_hidden_layers, num_attention_heads, intermediate_size, hidden_act, hidden_dropout_prob, attention_probs_dropout_prob, max_position_embeddings, type_vocab_size, initializer_range, layer_norm_eps, pad_token_id, position_embedding_type, use_cache, classifier_dropout, **kwargs)
+    def __init__(
+        self,
+        vocab_size=30522,
+        hidden_size=768,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        intermediate_size=3072,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        pad_token_id=0,
+        position_embedding_type="absolute",
+        use_cache=True,
+        classifier_dropout=None,
+        project_dim=512,
+        pooler_fn="average",
+        learn_encoder=False,
+        model_type="bert",
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_size,
+            hidden_size,
+            num_hidden_layers,
+            num_attention_heads,
+            intermediate_size,
+            hidden_act,
+            hidden_dropout_prob,
+            attention_probs_dropout_prob,
+            max_position_embeddings,
+            type_vocab_size,
+            initializer_range,
+            layer_norm_eps,
+            pad_token_id,
+            position_embedding_type,
+            use_cache,
+            classifier_dropout,
+            **kwargs,
+        )
         self.project_dim = project_dim
         self.pooler_fn = pooler_fn
         self.learn_encoder = learn_encoder
 
+
 class RobertaSeriesConfig(XLMRobertaConfig):
-    def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2,project_dim=512,pooler_fn='cls',learn_encoder=False, **kwargs):
-        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
+    def __init__(
+        self,
+        pad_token_id=1,
+        bos_token_id=0,
+        eos_token_id=2,
+        project_dim=512,
+        pooler_fn="cls",
+        learn_encoder=False,
+        **kwargs,
+    ):
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs,
+        )
         self.project_dim = project_dim
         self.pooler_fn = pooler_fn
         self.learn_encoder = learn_encoder
 
 
 class BertSeriesModelWithTransformation(BertPreTrainedModel):
-
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
     config_class = BertSeriesConfig
@@ -34,50 +88,51 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         # modify initialization for autoloading
         if config is None:
             config = XLMRobertaConfig()
-            config.attention_probs_dropout_prob= 0.1
-            config.bos_token_id=0
-            config.eos_token_id=2
-            config.hidden_act='gelu'
-            config.hidden_dropout_prob=0.1
-            config.hidden_size=1024
-            config.initializer_range=0.02
-            config.intermediate_size=4096
-            config.layer_norm_eps=1e-05
-            config.max_position_embeddings=514
+            config.attention_probs_dropout_prob = 0.1
+            config.bos_token_id = 0
+            config.eos_token_id = 2
+            config.hidden_act = "gelu"
+            config.hidden_dropout_prob = 0.1
+            config.hidden_size = 1024
+            config.initializer_range = 0.02
+            config.intermediate_size = 4096
+            config.layer_norm_eps = 1e-05
+            config.max_position_embeddings = 514
 
-            config.num_attention_heads=16
-            config.num_hidden_layers=24
-            config.output_past=True
-            config.pad_token_id=1
-            config.position_embedding_type= "absolute"
+            config.num_attention_heads = 16
+            config.num_hidden_layers = 24
+            config.output_past = True
+            config.pad_token_id = 1
+            config.position_embedding_type = "absolute"
 
-            config.type_vocab_size= 1
-            config.use_cache=True
-            config.vocab_size= 250002
+            config.type_vocab_size = 1
+            config.use_cache = True
+            config.vocab_size = 250002
             config.project_dim = 768
             config.learn_encoder = False
         super().__init__(config)
         self.roberta = XLMRobertaModel(config)
-        self.transformation = nn.Linear(config.hidden_size,config.project_dim)
-        self.pre_LN=nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-        self.tokenizer = XLMRobertaTokenizer.from_pretrained('xlm-roberta-large')
-        self.pooler = lambda x: x[:,0]
+        self.transformation = nn.Linear(config.hidden_size, config.project_dim)
+        self.pre_LN = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.tokenizer = XLMRobertaTokenizer.from_pretrained("xlm-roberta-large")
+        self.pooler = lambda x: x[:, 0]
         self.post_init()
 
-    def encode(self,c):
+    def encode(self, c):
         device = torch_utils.get_param(self).device
-        text = self.tokenizer(c,
-                        truncation=True,
-                        max_length=77,
-                        return_length=False,
-                        return_overflowing_tokens=False,
-                        padding="max_length",
-                        return_tensors="pt")
+        text = self.tokenizer(
+            c,
+            truncation=True,
+            max_length=77,
+            return_length=False,
+            return_overflowing_tokens=False,
+            padding="max_length",
+            return_tensors="pt",
+        )
         text["input_ids"] = torch.tensor(text["input_ids"]).to(device)
-        text["attention_mask"] = torch.tensor(
-            text['attention_mask']).to(device)
+        text["attention_mask"] = torch.tensor(text["attention_mask"]).to(device)
         features = self(**text)
-        return features['projection_state']
+        return features["projection_state"]
 
     def forward(
         self,
@@ -92,12 +147,12 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         output_attentions: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-    ) :
-        r"""
-        """
+    ):
+        r""" """
 
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         outputs = self.roberta(
             input_ids=input_ids,
@@ -116,7 +171,6 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         # last module outputs
         sequence_output = outputs[0]
 
-
         # project every module
         sequence_output_ln = self.pre_LN(sequence_output)
 
@@ -126,15 +180,15 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         projection_state = self.transformation(outputs.last_hidden_state)
 
         return {
-            'pooler_output':pooler_output,
-            'last_hidden_state':outputs.last_hidden_state,
-            'hidden_states':outputs.hidden_states,
-            'attentions':outputs.attentions,
-            'projection_state':projection_state,
-            'sequence_out': sequence_output
+            "pooler_output": pooler_output,
+            "last_hidden_state": outputs.last_hidden_state,
+            "hidden_states": outputs.hidden_states,
+            "attentions": outputs.attentions,
+            "projection_state": projection_state,
+            "sequence_out": sequence_output,
         }
 
 
 class RobertaSeriesModelWithTransformation(BertSeriesModelWithTransformation):
-    base_model_prefix = 'roberta'
-    config_class= RobertaSeriesConfig
+    base_model_prefix = "roberta"
+    config_class = RobertaSeriesConfig

--- a/modules/xlmr_m18.py
+++ b/modules/xlmr_m18.py
@@ -1,30 +1,84 @@
-from transformers import BertPreTrainedModel,BertConfig
+from transformers import BertPreTrainedModel, BertConfig
 import torch.nn as nn
 import torch
 from transformers.models.xlm_roberta.configuration_xlm_roberta import XLMRobertaConfig
-from transformers import XLMRobertaModel,XLMRobertaTokenizer
+from transformers import XLMRobertaModel, XLMRobertaTokenizer
 from typing import Optional
 from modules import torch_utils
 
 
 class BertSeriesConfig(BertConfig):
-    def __init__(self, vocab_size=30522, hidden_size=768, num_hidden_layers=12, num_attention_heads=12, intermediate_size=3072, hidden_act="gelu", hidden_dropout_prob=0.1, attention_probs_dropout_prob=0.1, max_position_embeddings=512, type_vocab_size=2, initializer_range=0.02, layer_norm_eps=1e-12, pad_token_id=0, position_embedding_type="absolute", use_cache=True, classifier_dropout=None,project_dim=512, pooler_fn="average",learn_encoder=False,model_type='bert',**kwargs):
-
-        super().__init__(vocab_size, hidden_size, num_hidden_layers, num_attention_heads, intermediate_size, hidden_act, hidden_dropout_prob, attention_probs_dropout_prob, max_position_embeddings, type_vocab_size, initializer_range, layer_norm_eps, pad_token_id, position_embedding_type, use_cache, classifier_dropout, **kwargs)
+    def __init__(
+        self,
+        vocab_size=30522,
+        hidden_size=768,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        intermediate_size=3072,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        pad_token_id=0,
+        position_embedding_type="absolute",
+        use_cache=True,
+        classifier_dropout=None,
+        project_dim=512,
+        pooler_fn="average",
+        learn_encoder=False,
+        model_type="bert",
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_size,
+            hidden_size,
+            num_hidden_layers,
+            num_attention_heads,
+            intermediate_size,
+            hidden_act,
+            hidden_dropout_prob,
+            attention_probs_dropout_prob,
+            max_position_embeddings,
+            type_vocab_size,
+            initializer_range,
+            layer_norm_eps,
+            pad_token_id,
+            position_embedding_type,
+            use_cache,
+            classifier_dropout,
+            **kwargs,
+        )
         self.project_dim = project_dim
         self.pooler_fn = pooler_fn
         self.learn_encoder = learn_encoder
 
+
 class RobertaSeriesConfig(XLMRobertaConfig):
-    def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2,project_dim=512,pooler_fn='cls',learn_encoder=False, **kwargs):
-        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
+    def __init__(
+        self,
+        pad_token_id=1,
+        bos_token_id=0,
+        eos_token_id=2,
+        project_dim=512,
+        pooler_fn="cls",
+        learn_encoder=False,
+        **kwargs,
+    ):
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs,
+        )
         self.project_dim = project_dim
         self.pooler_fn = pooler_fn
         self.learn_encoder = learn_encoder
 
 
 class BertSeriesModelWithTransformation(BertPreTrainedModel):
-
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
     config_class = BertSeriesConfig
@@ -33,33 +87,33 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         # modify initialization for autoloading
         if config is None:
             config = XLMRobertaConfig()
-            config.attention_probs_dropout_prob= 0.1
-            config.bos_token_id=0
-            config.eos_token_id=2
-            config.hidden_act='gelu'
-            config.hidden_dropout_prob=0.1
-            config.hidden_size=1024
-            config.initializer_range=0.02
-            config.intermediate_size=4096
-            config.layer_norm_eps=1e-05
-            config.max_position_embeddings=514
+            config.attention_probs_dropout_prob = 0.1
+            config.bos_token_id = 0
+            config.eos_token_id = 2
+            config.hidden_act = "gelu"
+            config.hidden_dropout_prob = 0.1
+            config.hidden_size = 1024
+            config.initializer_range = 0.02
+            config.intermediate_size = 4096
+            config.layer_norm_eps = 1e-05
+            config.max_position_embeddings = 514
 
-            config.num_attention_heads=16
-            config.num_hidden_layers=24
-            config.output_past=True
-            config.pad_token_id=1
-            config.position_embedding_type= "absolute"
+            config.num_attention_heads = 16
+            config.num_hidden_layers = 24
+            config.output_past = True
+            config.pad_token_id = 1
+            config.position_embedding_type = "absolute"
 
-            config.type_vocab_size= 1
-            config.use_cache=True
-            config.vocab_size= 250002
+            config.type_vocab_size = 1
+            config.use_cache = True
+            config.vocab_size = 250002
             config.project_dim = 1024
             config.learn_encoder = False
         super().__init__(config)
         self.roberta = XLMRobertaModel(config)
-        self.transformation = nn.Linear(config.hidden_size,config.project_dim)
+        self.transformation = nn.Linear(config.hidden_size, config.project_dim)
         # self.pre_LN=nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-        self.tokenizer = XLMRobertaTokenizer.from_pretrained('xlm-roberta-large')
+        self.tokenizer = XLMRobertaTokenizer.from_pretrained("xlm-roberta-large")
         # self.pooler = lambda x: x[:,0]
         # self.post_init()
 
@@ -69,20 +123,21 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
             self.pre_LN = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.post_init()
 
-    def encode(self,c):
+    def encode(self, c):
         device = torch_utils.get_param(self).device
-        text = self.tokenizer(c,
-                        truncation=True,
-                        max_length=77,
-                        return_length=False,
-                        return_overflowing_tokens=False,
-                        padding="max_length",
-                        return_tensors="pt")
+        text = self.tokenizer(
+            c,
+            truncation=True,
+            max_length=77,
+            return_length=False,
+            return_overflowing_tokens=False,
+            padding="max_length",
+            return_tensors="pt",
+        )
         text["input_ids"] = torch.tensor(text["input_ids"]).to(device)
-        text["attention_mask"] = torch.tensor(
-            text['attention_mask']).to(device)
+        text["attention_mask"] = torch.tensor(text["attention_mask"]).to(device)
         features = self(**text)
-        return features['projection_state']
+        return features["projection_state"]
 
     def forward(
         self,
@@ -97,12 +152,12 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
         output_attentions: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-    ) :
-        r"""
-        """
+    ):
+        r""" """
 
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         outputs = self.roberta(
             input_ids=input_ids,
@@ -120,7 +175,6 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
 
         # # last module outputs
         # sequence_output = outputs[0]
-
 
         # # project every module
         # sequence_output_ln = self.pre_LN(sequence_output)
@@ -150,7 +204,6 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
                 "attentions": outputs.attentions,
             }
 
-
         # return {
         #     'pooler_output':pooler_output,
         #     'last_hidden_state':outputs.last_hidden_state,
@@ -162,5 +215,5 @@ class BertSeriesModelWithTransformation(BertPreTrainedModel):
 
 
 class RobertaSeriesModelWithTransformation(BertSeriesModelWithTransformation):
-    base_model_prefix = 'roberta'
-    config_class= RobertaSeriesConfig
+    base_model_prefix = "roberta"
+    config_class = RobertaSeriesConfig

--- a/modules/xpu_specific.py
+++ b/modules/xpu_specific.py
@@ -4,14 +4,15 @@ from modules.sd_hijack_utils import CondFunc
 has_ipex = False
 try:
     import torch
-    import intel_extension_for_pytorch as ipex # noqa: F401
+    import intel_extension_for_pytorch as ipex  # noqa: F401
+
     has_ipex = True
 except Exception:
     pass
 
 
 def check_for_xpu():
-    return has_ipex and hasattr(torch, 'xpu') and torch.xpu.is_available()
+    return has_ipex and hasattr(torch, "xpu") and torch.xpu.is_available()
 
 
 def get_xpu_device_string():
@@ -35,6 +36,8 @@ has_xpu = check_for_xpu()
 # which is the best trade-off between VRAM usage and performance.
 ARC_SINGLE_ALLOCATION_LIMIT = {}
 orig_sdp_attn_func = torch.nn.functional.scaled_dot_product_attention
+
+
 def torch_xpu_scaled_dot_product_attention(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, *args, **kwargs
 ):
@@ -53,18 +56,17 @@ def torch_xpu_scaled_dot_product_attention(
     total_batch_size = torch.numel(torch.empty(N))
     device_id = query.device.index
     if device_id not in ARC_SINGLE_ALLOCATION_LIMIT:
-        ARC_SINGLE_ALLOCATION_LIMIT[device_id] = min(torch.xpu.get_device_properties(device_id).total_memory // 8, 4 * 1024 * 1024 * 1024)
-    batch_size_limit = max(1, ARC_SINGLE_ALLOCATION_LIMIT[device_id] // (L * S * query.element_size()))
+        ARC_SINGLE_ALLOCATION_LIMIT[device_id] = min(
+            torch.xpu.get_device_properties(device_id).total_memory // 8,
+            4 * 1024 * 1024 * 1024,
+        )
+    batch_size_limit = max(
+        1, ARC_SINGLE_ALLOCATION_LIMIT[device_id] // (L * S * query.element_size())
+    )
 
     if total_batch_size <= batch_size_limit:
         return orig_sdp_attn_func(
-            query,
-            key,
-            value,
-            attn_mask,
-            dropout_p,
-            is_causal,
-            *args, **kwargs
+            query, key, value, attn_mask, dropout_p, is_causal, *args, **kwargs
         )
 
     query = torch.reshape(query, (-1, L, E))
@@ -87,7 +89,8 @@ def torch_xpu_scaled_dot_product_attention(
             attn_mask_chunk,
             dropout_p,
             is_causal,
-            *args, **kwargs
+            *args,
+            **kwargs,
         )
         outputs.append(chunk_output)
     result = torch.cat(outputs, dim=0)
@@ -108,31 +111,71 @@ if has_xpu:
         torch.Generator("xpu")
     except RuntimeError:
         # W/A for https://github.com/intel/intel-extension-for-pytorch/issues/452: torch.Generator API doesn't support XPU device (for torch < 2.1)
-        CondFunc('torch.Generator',
+        CondFunc(
+            "torch.Generator",
             lambda orig_func, device=None: torch.xpu.Generator(device),
-            lambda orig_func, device=None: is_xpu_device(device))
+            lambda orig_func, device=None: is_xpu_device(device),
+        )
 
     # W/A for some OPs that could not handle different input dtypes
-    CondFunc('torch.nn.functional.layer_norm',
-        lambda orig_func, input, normalized_shape=None, weight=None, *args, **kwargs:
-        orig_func(input.to(weight.data.dtype), normalized_shape, weight, *args, **kwargs),
-        lambda orig_func, input, normalized_shape=None, weight=None, *args, **kwargs:
-        weight is not None and input.dtype != weight.data.dtype)
-    CondFunc('torch.nn.modules.GroupNorm.forward',
-        lambda orig_func, self, input: orig_func(self, input.to(self.weight.data.dtype)),
-        lambda orig_func, self, input: input.dtype != self.weight.data.dtype)
-    CondFunc('torch.nn.modules.linear.Linear.forward',
-        lambda orig_func, self, input: orig_func(self, input.to(self.weight.data.dtype)),
-        lambda orig_func, self, input: input.dtype != self.weight.data.dtype)
-    CondFunc('torch.nn.modules.conv.Conv2d.forward',
-        lambda orig_func, self, input: orig_func(self, input.to(self.weight.data.dtype)),
-        lambda orig_func, self, input: input.dtype != self.weight.data.dtype)
-    CondFunc('torch.bmm',
-        lambda orig_func, input, mat2, out=None: orig_func(input.to(mat2.dtype), mat2, out=out),
-        lambda orig_func, input, mat2, out=None: input.dtype != mat2.dtype)
-    CondFunc('torch.cat',
-        lambda orig_func, tensors, dim=0, out=None: orig_func([t.to(tensors[0].dtype) for t in tensors], dim=dim, out=out),
-        lambda orig_func, tensors, dim=0, out=None: not all(t.dtype == tensors[0].dtype for t in tensors))
-    CondFunc('torch.nn.functional.scaled_dot_product_attention',
-        lambda orig_func, *args, **kwargs: torch_xpu_scaled_dot_product_attention(*args, **kwargs),
-        lambda orig_func, query, *args, **kwargs: query.is_xpu)
+    CondFunc(
+        "torch.nn.functional.layer_norm",
+        lambda orig_func,
+        input,
+        normalized_shape=None,
+        weight=None,
+        *args,
+        **kwargs: orig_func(
+            input.to(weight.data.dtype), normalized_shape, weight, *args, **kwargs
+        ),
+        lambda orig_func,
+        input,
+        normalized_shape=None,
+        weight=None,
+        *args,
+        **kwargs: weight is not None and input.dtype != weight.data.dtype,
+    )
+    CondFunc(
+        "torch.nn.modules.GroupNorm.forward",
+        lambda orig_func, self, input: orig_func(
+            self, input.to(self.weight.data.dtype)
+        ),
+        lambda orig_func, self, input: input.dtype != self.weight.data.dtype,
+    )
+    CondFunc(
+        "torch.nn.modules.linear.Linear.forward",
+        lambda orig_func, self, input: orig_func(
+            self, input.to(self.weight.data.dtype)
+        ),
+        lambda orig_func, self, input: input.dtype != self.weight.data.dtype,
+    )
+    CondFunc(
+        "torch.nn.modules.conv.Conv2d.forward",
+        lambda orig_func, self, input: orig_func(
+            self, input.to(self.weight.data.dtype)
+        ),
+        lambda orig_func, self, input: input.dtype != self.weight.data.dtype,
+    )
+    CondFunc(
+        "torch.bmm",
+        lambda orig_func, input, mat2, out=None: orig_func(
+            input.to(mat2.dtype), mat2, out=out
+        ),
+        lambda orig_func, input, mat2, out=None: input.dtype != mat2.dtype,
+    )
+    CondFunc(
+        "torch.cat",
+        lambda orig_func, tensors, dim=0, out=None: orig_func(
+            [t.to(tensors[0].dtype) for t in tensors], dim=dim, out=out
+        ),
+        lambda orig_func, tensors, dim=0, out=None: not all(
+            t.dtype == tensors[0].dtype for t in tensors
+        ),
+    )
+    CondFunc(
+        "torch.nn.functional.scaled_dot_product_attention",
+        lambda orig_func, *args, **kwargs: torch_xpu_scaled_dot_product_attention(
+            *args, **kwargs
+        ),
+        lambda orig_func, query, *args, **kwargs: query.is_xpu,
+    )

--- a/scripts/custom_code.py
+++ b/scripts/custom_code.py
@@ -10,7 +10,7 @@ from modules.shared import cmd_opts
 def convertExpr2Expression(expr):
     expr.lineno = 0
     expr.col_offset = 0
-    result = ast.Expression(expr.value, lineno=0, col_offset = 0)
+    result = ast.Expression(expr.value, lineno=0, col_offset=0)
 
     return result
 
@@ -30,13 +30,15 @@ def exec_with_return(code, module):
 
     exec(compile(init_ast, "<ast>", "exec"), module.__dict__)
     if type(last_ast.body[0]) == ast.Expr:
-        return eval(compile(convertExpr2Expression(last_ast.body[0]), "<ast>", "eval"), module.__dict__)
+        return eval(
+            compile(convertExpr2Expression(last_ast.body[0]), "<ast>", "eval"),
+            module.__dict__,
+        )
     else:
         exec(compile(last_ast, "<ast>", "exec"), module.__dict__)
 
 
 class Script(scripts.Script):
-
     def title(self):
         return "Custom code"
 
@@ -54,14 +56,23 @@ p.steps = 10
 return process_images(p)
 """
 
-
-        code = gr.Code(value=example, language="python", label="Python code", elem_id=self.elem_id("code"))
-        indent_level = gr.Number(label='Indent level', value=2, precision=0, elem_id=self.elem_id("indent_level"))
+        code = gr.Code(
+            value=example,
+            language="python",
+            label="Python code",
+            elem_id=self.elem_id("code"),
+        )
+        indent_level = gr.Number(
+            label="Indent level",
+            value=2,
+            precision=0,
+            elem_id=self.elem_id("indent_level"),
+        )
 
         return [code, indent_level]
 
     def run(self, p, code, indent_level):
-        assert cmd_opts.allow_code, '--allow-code option must be enabled'
+        assert cmd_opts.allow_code, "--allow-code option must be enabled"
 
         display_result_data = [[], -1, ""]
 
@@ -71,13 +82,14 @@ return process_images(p)
             display_result_data[2] = i
 
         from types import ModuleType
+
         module = ModuleType("testmodule")
         module.__dict__.update(globals())
         module.p = p
         module.display = display
 
         indent = " " * indent_level
-        indented = code.replace('\n', f"\n{indent}")
+        indented = code.replace("\n", f"\n{indent}")
         body = f"""def __webuitemp__():
 {indent}{indented}
 __webuitemp__()"""

--- a/scripts/img2imgalt.py
+++ b/scripts/img2imgalt.py
@@ -11,6 +11,7 @@ from modules import processing, shared, sd_samplers, sd_samplers_common
 import torch
 import k_diffusion as K
 
+
 def find_noise_for_image(p, cond, uncond, cfg_scale, steps):
     x = p.init_latent
 
@@ -35,7 +36,9 @@ def find_noise_for_image(p, cond, uncond, cfg_scale, steps):
         image_conditioning = torch.cat([p.image_conditioning] * 2)
         cond_in = {"c_concat": [image_conditioning], "c_crossattn": [cond_in]}
 
-        c_out, c_in = [K.utils.append_dims(k, x_in.ndim) for k in dnw.get_scalings(sigma_in)[skip:]]
+        c_out, c_in = [
+            K.utils.append_dims(k, x_in.ndim) for k in dnw.get_scalings(sigma_in)[skip:]
+        ]
         t = dnw.sigma_to_t(sigma_in)
 
         eps = shared.sd_model.apply_model(x_in * c_in, t, cond=cond_in)
@@ -51,7 +54,14 @@ def find_noise_for_image(p, cond, uncond, cfg_scale, steps):
         sd_samplers_common.store_latent(x)
 
         # This shouldn't be necessary, but solved some VRAM issues
-        del x_in, sigma_in, cond_in, c_out, c_in, t,
+        del (
+            x_in,
+            sigma_in,
+            cond_in,
+            c_out,
+            c_in,
+            t,
+        )
         del eps, denoised_uncond, denoised_cond, denoised, d, dt
 
     shared.state.nextjob()
@@ -59,7 +69,18 @@ def find_noise_for_image(p, cond, uncond, cfg_scale, steps):
     return x / x.std()
 
 
-Cached = namedtuple("Cached", ["noise", "cfg_scale", "steps", "latent", "original_prompt", "original_negative_prompt", "sigma_adjustment"])
+Cached = namedtuple(
+    "Cached",
+    [
+        "noise",
+        "cfg_scale",
+        "steps",
+        "latent",
+        "original_prompt",
+        "original_negative_prompt",
+        "sigma_adjustment",
+    ],
+)
 
 
 # Based on changes suggested by briansemrau in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/736
@@ -87,7 +108,9 @@ def find_noise_for_image_sigma_adjustment(p, cond, uncond, cfg_scale, steps):
         image_conditioning = torch.cat([p.image_conditioning] * 2)
         cond_in = {"c_concat": [image_conditioning], "c_crossattn": [cond_in]}
 
-        c_out, c_in = [K.utils.append_dims(k, x_in.ndim) for k in dnw.get_scalings(sigma_in)[skip:]]
+        c_out, c_in = [
+            K.utils.append_dims(k, x_in.ndim) for k in dnw.get_scalings(sigma_in)[skip:]
+        ]
 
         if i == 1:
             t = dnw.sigma_to_t(torch.cat([sigmas[i] * s_in] * 2))
@@ -110,7 +133,14 @@ def find_noise_for_image_sigma_adjustment(p, cond, uncond, cfg_scale, steps):
         sd_samplers_common.store_latent(x)
 
         # This shouldn't be necessary, but solved some VRAM issues
-        del x_in, sigma_in, cond_in, c_out, c_in, t,
+        del (
+            x_in,
+            sigma_in,
+            cond_in,
+            c_out,
+            c_in,
+            t,
+        )
         del eps, denoised_uncond, denoised_cond, denoised, d, dt
 
     shared.state.nextjob()
@@ -129,35 +159,101 @@ class Script(scripts.Script):
         return is_img2img
 
     def ui(self, is_img2img):
-        info = gr.Markdown('''
+        info = gr.Markdown("""
         * `CFG Scale` should be 2 or lower.
-        ''')
+        """)
 
-        override_sampler = gr.Checkbox(label="Override `Sampling method` to Euler?(this method is built for it)", value=True, elem_id=self.elem_id("override_sampler"))
+        override_sampler = gr.Checkbox(
+            label="Override `Sampling method` to Euler?(this method is built for it)",
+            value=True,
+            elem_id=self.elem_id("override_sampler"),
+        )
 
-        override_prompt = gr.Checkbox(label="Override `prompt` to the same value as `original prompt`?(and `negative prompt`)", value=True, elem_id=self.elem_id("override_prompt"))
-        original_prompt = gr.Textbox(label="Original prompt", lines=1, elem_id=self.elem_id("original_prompt"))
-        original_negative_prompt = gr.Textbox(label="Original negative prompt", lines=1, elem_id=self.elem_id("original_negative_prompt"))
+        override_prompt = gr.Checkbox(
+            label="Override `prompt` to the same value as `original prompt`?(and `negative prompt`)",
+            value=True,
+            elem_id=self.elem_id("override_prompt"),
+        )
+        original_prompt = gr.Textbox(
+            label="Original prompt", lines=1, elem_id=self.elem_id("original_prompt")
+        )
+        original_negative_prompt = gr.Textbox(
+            label="Original negative prompt",
+            lines=1,
+            elem_id=self.elem_id("original_negative_prompt"),
+        )
 
-        override_steps = gr.Checkbox(label="Override `Sampling Steps` to the same value as `Decode steps`?", value=True, elem_id=self.elem_id("override_steps"))
-        st = gr.Slider(label="Decode steps", minimum=1, maximum=150, step=1, value=50, elem_id=self.elem_id("st"))
+        override_steps = gr.Checkbox(
+            label="Override `Sampling Steps` to the same value as `Decode steps`?",
+            value=True,
+            elem_id=self.elem_id("override_steps"),
+        )
+        st = gr.Slider(
+            label="Decode steps",
+            minimum=1,
+            maximum=150,
+            step=1,
+            value=50,
+            elem_id=self.elem_id("st"),
+        )
 
-        override_strength = gr.Checkbox(label="Override `Denoising strength` to 1?", value=True, elem_id=self.elem_id("override_strength"))
+        override_strength = gr.Checkbox(
+            label="Override `Denoising strength` to 1?",
+            value=True,
+            elem_id=self.elem_id("override_strength"),
+        )
 
-        cfg = gr.Slider(label="Decode CFG scale", minimum=0.0, maximum=15.0, step=0.1, value=1.0, elem_id=self.elem_id("cfg"))
-        randomness = gr.Slider(label="Randomness", minimum=0.0, maximum=1.0, step=0.01, value=0.0, elem_id=self.elem_id("randomness"))
-        sigma_adjustment = gr.Checkbox(label="Sigma adjustment for finding noise for image", value=False, elem_id=self.elem_id("sigma_adjustment"))
+        cfg = gr.Slider(
+            label="Decode CFG scale",
+            minimum=0.0,
+            maximum=15.0,
+            step=0.1,
+            value=1.0,
+            elem_id=self.elem_id("cfg"),
+        )
+        randomness = gr.Slider(
+            label="Randomness",
+            minimum=0.0,
+            maximum=1.0,
+            step=0.01,
+            value=0.0,
+            elem_id=self.elem_id("randomness"),
+        )
+        sigma_adjustment = gr.Checkbox(
+            label="Sigma adjustment for finding noise for image",
+            value=False,
+            elem_id=self.elem_id("sigma_adjustment"),
+        )
 
         return [
             info,
             override_sampler,
-            override_prompt, original_prompt, original_negative_prompt,
-            override_steps, st,
+            override_prompt,
+            original_prompt,
+            original_negative_prompt,
+            override_steps,
+            st,
             override_strength,
-            cfg, randomness, sigma_adjustment,
+            cfg,
+            randomness,
+            sigma_adjustment,
         ]
 
-    def run(self, p, _, override_sampler, override_prompt, original_prompt, original_negative_prompt, override_steps, st, override_strength, cfg, randomness, sigma_adjustment):
+    def run(
+        self,
+        p,
+        _,
+        override_sampler,
+        override_prompt,
+        original_prompt,
+        original_negative_prompt,
+        override_steps,
+        st,
+        override_strength,
+        cfg,
+        randomness,
+        sigma_adjustment,
+    ):
         # Override
         if override_sampler:
             p.sampler_name = "Euler"
@@ -169,30 +265,69 @@ class Script(scripts.Script):
         if override_strength:
             p.denoising_strength = 1.0
 
-        def sample_extra(conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
+        def sample_extra(
+            conditioning,
+            unconditional_conditioning,
+            seeds,
+            subseeds,
+            subseed_strength,
+            prompts,
+        ):
             lat = (p.init_latent.cpu().numpy() * 10).astype(int)
 
-            same_params = self.cache is not None and self.cache.cfg_scale == cfg and self.cache.steps == st \
-                                and self.cache.original_prompt == original_prompt \
-                                and self.cache.original_negative_prompt == original_negative_prompt \
-                                and self.cache.sigma_adjustment == sigma_adjustment
-            same_everything = same_params and self.cache.latent.shape == lat.shape and np.abs(self.cache.latent-lat).sum() < 100
+            same_params = (
+                self.cache is not None
+                and self.cache.cfg_scale == cfg
+                and self.cache.steps == st
+                and self.cache.original_prompt == original_prompt
+                and self.cache.original_negative_prompt == original_negative_prompt
+                and self.cache.sigma_adjustment == sigma_adjustment
+            )
+            same_everything = (
+                same_params
+                and self.cache.latent.shape == lat.shape
+                and np.abs(self.cache.latent - lat).sum() < 100
+            )
 
             if same_everything:
                 rec_noise = self.cache.noise
             else:
                 shared.state.job_count += 1
-                cond = p.sd_model.get_learned_conditioning(p.batch_size * [original_prompt])
-                uncond = p.sd_model.get_learned_conditioning(p.batch_size * [original_negative_prompt])
+                cond = p.sd_model.get_learned_conditioning(
+                    p.batch_size * [original_prompt]
+                )
+                uncond = p.sd_model.get_learned_conditioning(
+                    p.batch_size * [original_negative_prompt]
+                )
                 if sigma_adjustment:
-                    rec_noise = find_noise_for_image_sigma_adjustment(p, cond, uncond, cfg, st)
+                    rec_noise = find_noise_for_image_sigma_adjustment(
+                        p, cond, uncond, cfg, st
+                    )
                 else:
                     rec_noise = find_noise_for_image(p, cond, uncond, cfg, st)
-                self.cache = Cached(rec_noise, cfg, st, lat, original_prompt, original_negative_prompt, sigma_adjustment)
+                self.cache = Cached(
+                    rec_noise,
+                    cfg,
+                    st,
+                    lat,
+                    original_prompt,
+                    original_negative_prompt,
+                    sigma_adjustment,
+                )
 
-            rand_noise = processing.create_random_tensors(p.init_latent.shape[1:], seeds=seeds, subseeds=subseeds, subseed_strength=p.subseed_strength, seed_resize_from_h=p.seed_resize_from_h, seed_resize_from_w=p.seed_resize_from_w, p=p)
+            rand_noise = processing.create_random_tensors(
+                p.init_latent.shape[1:],
+                seeds=seeds,
+                subseeds=subseeds,
+                subseed_strength=p.subseed_strength,
+                seed_resize_from_h=p.seed_resize_from_h,
+                seed_resize_from_w=p.seed_resize_from_w,
+                p=p,
+            )
 
-            combined_noise = ((1 - randomness) * rec_noise + randomness * rand_noise) / ((randomness**2 + (1-randomness)**2) ** 0.5)
+            combined_noise = (
+                (1 - randomness) * rec_noise + randomness * rand_noise
+            ) / ((randomness**2 + (1 - randomness) ** 2) ** 0.5)
 
             sampler = sd_samplers.create_sampler(p.sampler_name, p.sd_model)
 
@@ -202,7 +337,14 @@ class Script(scripts.Script):
 
             p.seed = p.seed + 1
 
-            return sampler.sample_img2img(p, p.init_latent, noise_dt, conditioning, unconditional_conditioning, image_conditioning=p.image_conditioning)
+            return sampler.sample_img2img(
+                p,
+                p.init_latent,
+                noise_dt,
+                conditioning,
+                unconditional_conditioning,
+                image_conditioning=p.image_conditioning,
+            )
 
         p.sample = sample_extra
 

--- a/scripts/loopback.py
+++ b/scripts/loopback.py
@@ -15,19 +15,43 @@ class Script(scripts.Script):
         return is_img2img
 
     def ui(self, is_img2img):
-        loops = gr.Slider(minimum=1, maximum=32, step=1, label='Loops', value=4, elem_id=self.elem_id("loops"))
-        final_denoising_strength = gr.Slider(minimum=0, maximum=1, step=0.01, label='Final denoising strength', value=0.5, elem_id=self.elem_id("final_denoising_strength"))
-        denoising_curve = gr.Dropdown(label="Denoising strength curve", choices=["Aggressive", "Linear", "Lazy"], value="Linear")
-        append_interrogation = gr.Dropdown(label="Append interrogated prompt at each iteration", choices=["None", "CLIP", "DeepBooru"], value="None")
+        loops = gr.Slider(
+            minimum=1,
+            maximum=32,
+            step=1,
+            label="Loops",
+            value=4,
+            elem_id=self.elem_id("loops"),
+        )
+        final_denoising_strength = gr.Slider(
+            minimum=0,
+            maximum=1,
+            step=0.01,
+            label="Final denoising strength",
+            value=0.5,
+            elem_id=self.elem_id("final_denoising_strength"),
+        )
+        denoising_curve = gr.Dropdown(
+            label="Denoising strength curve",
+            choices=["Aggressive", "Linear", "Lazy"],
+            value="Linear",
+        )
+        append_interrogation = gr.Dropdown(
+            label="Append interrogated prompt at each iteration",
+            choices=["None", "CLIP", "DeepBooru"],
+            value="None",
+        )
 
         return [loops, final_denoising_strength, denoising_curve, append_interrogation]
 
-    def run(self, p, loops, final_denoising_strength, denoising_curve, append_interrogation):
+    def run(
+        self, p, loops, final_denoising_strength, denoising_curve, append_interrogation
+    ):
         processing.fix_seed(p)
         batch_count = p.n_iter
         p.extra_generation_params = {
             "Final denoising strength": final_denoising_strength,
-            "Denoising curve": denoising_curve
+            "Denoising curve": denoising_curve,
         }
 
         p.batch_size = 1
@@ -45,7 +69,9 @@ class Script(scripts.Script):
         original_inpainting_fill = p.inpainting_fill
         state.job_count = loops * batch_count
 
-        initial_color_corrections = [processing.setup_color_correction(p.init_images[0])]
+        initial_color_corrections = [
+            processing.setup_color_correction(p.init_images[0])
+        ]
 
         def calculate_denoising_strength(loop):
             strength = initial_denoising_strength
@@ -110,7 +136,9 @@ class Script(scripts.Script):
 
                 last_image = processed.images[0]
                 p.init_images = [last_image]
-                p.inpainting_fill = 1 # Set "masked content" to "original" for next loop.
+                p.inpainting_fill = (
+                    1  # Set "masked content" to "original" for next loop.
+                )
 
                 if batch_count == 1:
                     history.append(last_image)
@@ -128,7 +156,18 @@ class Script(scripts.Script):
         if len(history) > 1:
             grid = images.image_grid(history, rows=1)
             if opts.grid_save:
-                images.save_image(grid, p.outpath_grids, "grid", initial_seed, p.prompt, opts.grid_format, info=info, short_filename=not opts.grid_extended_filename, grid=True, p=p)
+                images.save_image(
+                    grid,
+                    p.outpath_grids,
+                    "grid",
+                    initial_seed,
+                    p.prompt,
+                    opts.grid_format,
+                    info=info,
+                    short_filename=not opts.grid_extended_filename,
+                    grid=True,
+                    p=p,
+                )
 
             if opts.return_grid:
                 grids.append(grid)

--- a/scripts/outpainting_mk_2.py
+++ b/scripts/outpainting_mk_2.py
@@ -17,7 +17,9 @@ def get_matched_noise(_np_src_image, np_mask_rgb, noise_q=1, color_variation=0.0
     # helper fft routines that keep ortho normalization and auto-shift before and after fft
     def _fft2(data):
         if data.ndim > 2:  # has channels
-            out_fft = np.zeros((data.shape[0], data.shape[1], data.shape[2]), dtype=np.complex128)
+            out_fft = np.zeros(
+                (data.shape[0], data.shape[1], data.shape[2]), dtype=np.complex128
+            )
             for c in range(data.shape[2]):
                 c_data = data[:, :, c]
                 out_fft[:, :, c] = np.fft.fft2(np.fft.fftshift(c_data), norm="ortho")
@@ -31,7 +33,9 @@ def get_matched_noise(_np_src_image, np_mask_rgb, noise_q=1, color_variation=0.0
 
     def _ifft2(data):
         if data.ndim > 2:  # has channels
-            out_ifft = np.zeros((data.shape[0], data.shape[1], data.shape[2]), dtype=np.complex128)
+            out_ifft = np.zeros(
+                (data.shape[0], data.shape[1], data.shape[2]), dtype=np.complex128
+            )
             for c in range(data.shape[2]):
                 c_data = data[:, :, c]
                 out_ifft[:, :, c] = np.fft.ifft2(np.fft.fftshift(c_data), norm="ortho")
@@ -48,19 +52,21 @@ def get_matched_noise(_np_src_image, np_mask_rgb, noise_q=1, color_variation=0.0
         window_scale_y = float(height / min(width, height))
 
         window = np.zeros((width, height))
-        x = (np.arange(width) / width * 2. - 1.) * window_scale_x
+        x = (np.arange(width) / width * 2.0 - 1.0) * window_scale_x
         for y in range(height):
-            fy = (y / height * 2. - 1.) * window_scale_y
+            fy = (y / height * 2.0 - 1.0) * window_scale_y
             if mode == 0:
-                window[:, y] = np.exp(-(x ** 2 + fy ** 2) * std)
+                window[:, y] = np.exp(-(x**2 + fy**2) * std)
             else:
-                window[:, y] = (1 / ((x ** 2 + 1.) * (fy ** 2 + 1.))) ** (std / 3.14)  # hey wait a minute that's not gaussian
+                window[:, y] = (1 / ((x**2 + 1.0) * (fy**2 + 1.0))) ** (
+                    std / 3.14
+                )  # hey wait a minute that's not gaussian
 
         return window
 
-    def _get_masked_window_rgb(np_mask_grey, hardness=1.):
+    def _get_masked_window_rgb(np_mask_grey, hardness=1.0):
         np_mask_rgb = np.zeros((np_mask_grey.shape[0], np_mask_grey.shape[1], 3))
-        if hardness != 1.:
+        if hardness != 1.0:
             hardened = np_mask_grey[:] ** hardness
         else:
             hardened = np_mask_grey[:]
@@ -72,14 +78,16 @@ def get_matched_noise(_np_src_image, np_mask_rgb, noise_q=1, color_variation=0.0
     height = _np_src_image.shape[1]
     num_channels = _np_src_image.shape[2]
 
-    _np_src_image[:] * (1. - np_mask_rgb)
-    np_mask_grey = (np.sum(np_mask_rgb, axis=2) / 3.)
+    _np_src_image[:] * (1.0 - np_mask_rgb)
+    np_mask_grey = np.sum(np_mask_rgb, axis=2) / 3.0
     img_mask = np_mask_grey > 1e-6
     ref_mask = np_mask_grey < 1e-3
 
-    windowed_image = _np_src_image * (1. - _get_masked_window_rgb(np_mask_grey))
+    windowed_image = _np_src_image * (1.0 - _get_masked_window_rgb(np_mask_grey))
     windowed_image /= np.max(windowed_image)
-    windowed_image += np.average(_np_src_image) * np_mask_rgb  # / (1.-np.average(np_mask_rgb))  # rather than leave the masked area black, we get better results from fft by filling the average unmasked color
+    windowed_image += (
+        np.average(_np_src_image) * np_mask_rgb
+    )  # / (1.-np.average(np_mask_rgb))  # rather than leave the masked area black, we get better results from fft by filling the average unmasked color
 
     src_fft = _fft2(windowed_image)  # get feature statistics from masked src img
     src_dist = np.absolute(src_fft)
@@ -88,34 +96,43 @@ def get_matched_noise(_np_src_image, np_mask_rgb, noise_q=1, color_variation=0.0
     # create a generator with a static seed to make outpainting deterministic / only follow global seed
     rng = np.random.default_rng(0)
 
-    noise_window = _get_gaussian_window(width, height, mode=1)  # start with simple gaussian noise
+    noise_window = _get_gaussian_window(
+        width, height, mode=1
+    )  # start with simple gaussian noise
     noise_rgb = rng.random((width, height, num_channels))
-    noise_grey = (np.sum(noise_rgb, axis=2) / 3.)
+    noise_grey = np.sum(noise_rgb, axis=2) / 3.0
     noise_rgb *= color_variation  # the colorfulness of the starting noise is blended to greyscale with a parameter
     for c in range(num_channels):
-        noise_rgb[:, :, c] += (1. - color_variation) * noise_grey
+        noise_rgb[:, :, c] += (1.0 - color_variation) * noise_grey
 
     noise_fft = _fft2(noise_rgb)
     for c in range(num_channels):
         noise_fft[:, :, c] *= noise_window
     noise_rgb = np.real(_ifft2(noise_fft))
     shaped_noise_fft = _fft2(noise_rgb)
-    shaped_noise_fft[:, :, :] = np.absolute(shaped_noise_fft[:, :, :]) ** 2 * (src_dist ** noise_q) * src_phase  # perform the actual shaping
+    shaped_noise_fft[:, :, :] = (
+        np.absolute(shaped_noise_fft[:, :, :]) ** 2 * (src_dist**noise_q) * src_phase
+    )  # perform the actual shaping
 
-    brightness_variation = 0.  # color_variation # todo: temporarily tying brightness variation to color variation for now
-    contrast_adjusted_np_src = _np_src_image[:] * (brightness_variation + 1.) - brightness_variation * 2.
+    brightness_variation = 0.0  # color_variation # todo: temporarily tying brightness variation to color variation for now
+    contrast_adjusted_np_src = (
+        _np_src_image[:] * (brightness_variation + 1.0) - brightness_variation * 2.0
+    )
 
     # scikit-image is used for histogram matching, very convenient!
     shaped_noise = np.real(_ifft2(shaped_noise_fft))
     shaped_noise -= np.min(shaped_noise)
     shaped_noise /= np.max(shaped_noise)
-    shaped_noise[img_mask, :] = skimage.exposure.match_histograms(shaped_noise[img_mask, :] ** 1., contrast_adjusted_np_src[ref_mask, :], channel_axis=1)
-    shaped_noise = _np_src_image[:] * (1. - np_mask_rgb) + shaped_noise * np_mask_rgb
+    shaped_noise[img_mask, :] = skimage.exposure.match_histograms(
+        shaped_noise[img_mask, :] ** 1.0,
+        contrast_adjusted_np_src[ref_mask, :],
+        channel_axis=1,
+    )
+    shaped_noise = _np_src_image[:] * (1.0 - np_mask_rgb) + shaped_noise * np_mask_rgb
 
     matched_noise = shaped_noise[:]
 
-    return np.clip(matched_noise, 0., 1.)
-
+    return np.clip(matched_noise, 0.0, 1.0)
 
 
 class Script(scripts.Script):
@@ -129,13 +146,48 @@ class Script(scripts.Script):
         if not is_img2img:
             return None
 
-        info = gr.HTML("<p style=\"margin-bottom:0.75em\">Recommended settings: Sampling Steps: 80-100, Sampler: Euler a, Denoising strength: 0.8</p>")
+        info = gr.HTML(
+            '<p style="margin-bottom:0.75em">Recommended settings: Sampling Steps: 80-100, Sampler: Euler a, Denoising strength: 0.8</p>'
+        )
 
-        pixels = gr.Slider(label="Pixels to expand", minimum=8, maximum=256, step=8, value=128, elem_id=self.elem_id("pixels"))
-        mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=8, elem_id=self.elem_id("mask_blur"))
-        direction = gr.CheckboxGroup(label="Outpainting direction", choices=['left', 'right', 'up', 'down'], value=['left', 'right', 'up', 'down'], elem_id=self.elem_id("direction"))
-        noise_q = gr.Slider(label="Fall-off exponent (lower=higher detail)", minimum=0.0, maximum=4.0, step=0.01, value=1.0, elem_id=self.elem_id("noise_q"))
-        color_variation = gr.Slider(label="Color variation", minimum=0.0, maximum=1.0, step=0.01, value=0.05, elem_id=self.elem_id("color_variation"))
+        pixels = gr.Slider(
+            label="Pixels to expand",
+            minimum=8,
+            maximum=256,
+            step=8,
+            value=128,
+            elem_id=self.elem_id("pixels"),
+        )
+        mask_blur = gr.Slider(
+            label="Mask blur",
+            minimum=0,
+            maximum=64,
+            step=1,
+            value=8,
+            elem_id=self.elem_id("mask_blur"),
+        )
+        direction = gr.CheckboxGroup(
+            label="Outpainting direction",
+            choices=["left", "right", "up", "down"],
+            value=["left", "right", "up", "down"],
+            elem_id=self.elem_id("direction"),
+        )
+        noise_q = gr.Slider(
+            label="Fall-off exponent (lower=higher detail)",
+            minimum=0.0,
+            maximum=4.0,
+            step=0.01,
+            value=1.0,
+            elem_id=self.elem_id("noise_q"),
+        )
+        color_variation = gr.Slider(
+            label="Color variation",
+            minimum=0.0,
+            maximum=1.0,
+            step=0.01,
+            value=0.05,
+            elem_id=self.elem_id("color_variation"),
+        )
 
         return [info, pixels, mask_blur, direction, noise_q, color_variation]
 
@@ -165,8 +217,8 @@ class Script(scripts.Script):
         else:
             mask_blur_y = 0
 
-        p.mask_blur_x = mask_blur_x*4
-        p.mask_blur_y = mask_blur_y*4
+        p.mask_blur_x = mask_blur_x * 4
+        p.mask_blur_y = mask_blur_y * 4
 
         init_img = p.init_images[0]
         target_w = math.ceil((init_img.width + left + right) / 64) * 64
@@ -184,7 +236,15 @@ class Script(scripts.Script):
         if down > 0:
             down = target_h - init_img.height - up
 
-        def expand(init, count, expand_pixels, is_left=False, is_right=False, is_top=False, is_bottom=False):
+        def expand(
+            init,
+            count,
+            expand_pixels,
+            is_left=False,
+            is_right=False,
+            is_top=False,
+            is_bottom=False,
+        ):
             is_horiz = is_left or is_right
             is_vert = is_top or is_bottom
             pixels_horiz = expand_pixels if is_horiz else 0
@@ -199,23 +259,43 @@ class Script(scripts.Script):
                 process_res_h = math.ceil(res_h / 64) * 64
 
                 img = Image.new("RGB", (process_res_w, process_res_h))
-                img.paste(init[n], (pixels_horiz if is_left else 0, pixels_vert if is_top else 0))
+                img.paste(
+                    init[n],
+                    (pixels_horiz if is_left else 0, pixels_vert if is_top else 0),
+                )
                 mask = Image.new("RGB", (process_res_w, process_res_h), "white")
                 draw = ImageDraw.Draw(mask)
-                draw.rectangle((
-                    expand_pixels + mask_blur_x if is_left else 0,
-                    expand_pixels + mask_blur_y if is_top else 0,
-                    mask.width - expand_pixels - mask_blur_x if is_right else res_w,
-                    mask.height - expand_pixels - mask_blur_y if is_bottom else res_h,
-                ), fill="black")
+                draw.rectangle(
+                    (
+                        expand_pixels + mask_blur_x if is_left else 0,
+                        expand_pixels + mask_blur_y if is_top else 0,
+                        mask.width - expand_pixels - mask_blur_x if is_right else res_w,
+                        mask.height - expand_pixels - mask_blur_y
+                        if is_bottom
+                        else res_h,
+                    ),
+                    fill="black",
+                )
 
                 np_image = (np.asarray(img) / 255.0).astype(np.float64)
                 np_mask = (np.asarray(mask) / 255.0).astype(np.float64)
                 noised = get_matched_noise(np_image, np_mask, noise_q, color_variation)
-                output_images.append(Image.fromarray(np.clip(noised * 255., 0., 255.).astype(np.uint8), mode="RGB"))
+                output_images.append(
+                    Image.fromarray(
+                        np.clip(noised * 255.0, 0.0, 255.0).astype(np.uint8), mode="RGB"
+                    )
+                )
 
-                target_width = min(process_width, init[n].width + pixels_horiz) if is_horiz else img.width
-                target_height = min(process_height, init[n].height + pixels_vert) if is_vert else img.height
+                target_width = (
+                    min(process_width, init[n].width + pixels_horiz)
+                    if is_horiz
+                    else img.width
+                )
+                target_height = (
+                    min(process_height, init[n].height + pixels_vert)
+                    if is_vert
+                    else img.height
+                )
                 p.width = target_width if is_horiz else img.width
                 p.height = target_height if is_vert else img.height
 
@@ -235,12 +315,17 @@ class Script(scripts.Script):
 
             latent_mask = Image.new("RGB", (p.width, p.height), "white")
             draw = ImageDraw.Draw(latent_mask)
-            draw.rectangle((
-                expand_pixels + mask_blur_x * 2 if is_left else 0,
-                expand_pixels + mask_blur_y * 2 if is_top else 0,
-                mask.width - expand_pixels - mask_blur_x * 2 if is_right else res_w,
-                mask.height - expand_pixels - mask_blur_y * 2 if is_bottom else res_h,
-            ), fill="black")
+            draw.rectangle(
+                (
+                    expand_pixels + mask_blur_x * 2 if is_left else 0,
+                    expand_pixels + mask_blur_y * 2 if is_top else 0,
+                    mask.width - expand_pixels - mask_blur_x * 2 if is_right else res_w,
+                    mask.height - expand_pixels - mask_blur_y * 2
+                    if is_bottom
+                    else res_h,
+                ),
+                fill="black",
+            )
             p.latent_mask = latent_mask
 
             proc = process_images(p)
@@ -250,7 +335,15 @@ class Script(scripts.Script):
                 initial_seed_and_info[1] = proc.info
 
             for n in range(count):
-                output_images[n].paste(proc.images[n], (0 if is_left else output_images[n].width - proc.images[n].width, 0 if is_top else output_images[n].height - proc.images[n].height))
+                output_images[n].paste(
+                    proc.images[n],
+                    (
+                        0 if is_left else output_images[n].width - proc.images[n].width,
+                        0
+                        if is_top
+                        else output_images[n].height - proc.images[n].height,
+                    ),
+                )
                 output_images[n] = output_images[n].crop((0, 0, res_w, res_h))
 
             return output_images
@@ -258,7 +351,12 @@ class Script(scripts.Script):
         batch_count = p.n_iter
         batch_size = p.batch_size
         p.n_iter = 1
-        state.job_count = batch_count * ((1 if left > 0 else 0) + (1 if right > 0 else 0) + (1 if up > 0 else 0) + (1 if down > 0 else 0))
+        state.job_count = batch_count * (
+            (1 if left > 0 else 0)
+            + (1 if right > 0 else 0)
+            + (1 if up > 0 else 0)
+            + (1 if down > 0 else 0)
+        )
         all_processed_images = []
 
         for i in range(batch_count):
@@ -279,17 +377,41 @@ class Script(scripts.Script):
         all_images = all_processed_images
 
         combined_grid_image = images.image_grid(all_processed_images)
-        unwanted_grid_because_of_img_count = len(all_processed_images) < 2 and opts.grid_only_if_multiple
+        unwanted_grid_because_of_img_count = (
+            len(all_processed_images) < 2 and opts.grid_only_if_multiple
+        )
         if opts.return_grid and not unwanted_grid_because_of_img_count:
             all_images = [combined_grid_image] + all_processed_images
 
-        res = Processed(p, all_images, initial_seed_and_info[0], initial_seed_and_info[1])
+        res = Processed(
+            p, all_images, initial_seed_and_info[0], initial_seed_and_info[1]
+        )
 
         if opts.samples_save:
             for img in all_processed_images:
-                images.save_image(img, p.outpath_samples, "", res.seed, p.prompt, opts.samples_format, info=res.info, p=p)
+                images.save_image(
+                    img,
+                    p.outpath_samples,
+                    "",
+                    res.seed,
+                    p.prompt,
+                    opts.samples_format,
+                    info=res.info,
+                    p=p,
+                )
 
         if opts.grid_save and not unwanted_grid_because_of_img_count:
-            images.save_image(combined_grid_image, p.outpath_grids, "grid", res.seed, p.prompt, opts.grid_format, info=res.info, short_filename=not opts.grid_extended_filename, grid=True, p=p)
+            images.save_image(
+                combined_grid_image,
+                p.outpath_grids,
+                "grid",
+                res.seed,
+                p.prompt,
+                opts.grid_format,
+                info=res.info,
+                short_filename=not opts.grid_extended_filename,
+                grid=True,
+                p=p,
+            )
 
         return res

--- a/scripts/poor_mans_outpainting.py
+++ b/scripts/poor_mans_outpainting.py
@@ -20,10 +20,35 @@ class Script(scripts.Script):
         if not is_img2img:
             return None
 
-        pixels = gr.Slider(label="Pixels to expand", minimum=8, maximum=256, step=8, value=128, elem_id=self.elem_id("pixels"))
-        mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=4, elem_id=self.elem_id("mask_blur"))
-        inpainting_fill = gr.Radio(label='Masked content', choices=['fill', 'original', 'latent noise', 'latent nothing'], value='fill', type="index", elem_id=self.elem_id("inpainting_fill"))
-        direction = gr.CheckboxGroup(label="Outpainting direction", choices=['left', 'right', 'up', 'down'], value=['left', 'right', 'up', 'down'], elem_id=self.elem_id("direction"))
+        pixels = gr.Slider(
+            label="Pixels to expand",
+            minimum=8,
+            maximum=256,
+            step=8,
+            value=128,
+            elem_id=self.elem_id("pixels"),
+        )
+        mask_blur = gr.Slider(
+            label="Mask blur",
+            minimum=0,
+            maximum=64,
+            step=1,
+            value=4,
+            elem_id=self.elem_id("mask_blur"),
+        )
+        inpainting_fill = gr.Radio(
+            label="Masked content",
+            choices=["fill", "original", "latent noise", "latent nothing"],
+            value="fill",
+            type="index",
+            elem_id=self.elem_id("inpainting_fill"),
+        )
+        direction = gr.CheckboxGroup(
+            label="Outpainting direction",
+            choices=["left", "right", "up", "down"],
+            value=["left", "right", "up", "down"],
+            elem_id=self.elem_id("direction"),
+        )
 
         return [pixels, mask_blur, inpainting_fill, direction]
 
@@ -60,27 +85,37 @@ class Script(scripts.Script):
 
         mask = Image.new("L", (img.width, img.height), "white")
         draw = ImageDraw.Draw(mask)
-        draw.rectangle((
-            left + (mask_blur * 2 if left > 0 else 0),
-            up + (mask_blur * 2 if up > 0 else 0),
-            mask.width - right - (mask_blur * 2 if right > 0 else 0),
-            mask.height - down - (mask_blur * 2 if down > 0 else 0)
-        ), fill="black")
+        draw.rectangle(
+            (
+                left + (mask_blur * 2 if left > 0 else 0),
+                up + (mask_blur * 2 if up > 0 else 0),
+                mask.width - right - (mask_blur * 2 if right > 0 else 0),
+                mask.height - down - (mask_blur * 2 if down > 0 else 0),
+            ),
+            fill="black",
+        )
 
         latent_mask = Image.new("L", (img.width, img.height), "white")
         latent_draw = ImageDraw.Draw(latent_mask)
-        latent_draw.rectangle((
-             left + (mask_blur//2 if left > 0 else 0),
-             up + (mask_blur//2 if up > 0 else 0),
-             mask.width - right - (mask_blur//2 if right > 0 else 0),
-             mask.height - down - (mask_blur//2 if down > 0 else 0)
-        ), fill="black")
+        latent_draw.rectangle(
+            (
+                left + (mask_blur // 2 if left > 0 else 0),
+                up + (mask_blur // 2 if up > 0 else 0),
+                mask.width - right - (mask_blur // 2 if right > 0 else 0),
+                mask.height - down - (mask_blur // 2 if down > 0 else 0),
+            ),
+            fill="black",
+        )
 
         devices.torch_gc()
 
         grid = images.split_grid(img, tile_w=p.width, tile_h=p.height, overlap=pixels)
-        grid_mask = images.split_grid(mask, tile_w=p.width, tile_h=p.height, overlap=pixels)
-        grid_latent_mask = images.split_grid(latent_mask, tile_w=p.width, tile_h=p.height, overlap=pixels)
+        grid_mask = images.split_grid(
+            mask, tile_w=p.width, tile_h=p.height, overlap=pixels
+        )
+        grid_latent_mask = images.split_grid(
+            latent_mask, tile_w=p.width, tile_h=p.height, overlap=pixels
+        )
 
         p.n_iter = 1
         p.batch_size = 1
@@ -92,11 +127,20 @@ class Script(scripts.Script):
         work_latent_mask = []
         work_results = []
 
-        for (y, h, row), (_, _, row_mask), (_, _, row_latent_mask) in zip(grid.tiles, grid_mask.tiles, grid_latent_mask.tiles):
-            for tiledata, tiledata_mask, tiledata_latent_mask in zip(row, row_mask, row_latent_mask):
+        for (y, h, row), (_, _, row_mask), (_, _, row_latent_mask) in zip(
+            grid.tiles, grid_mask.tiles, grid_latent_mask.tiles
+        ):
+            for tiledata, tiledata_mask, tiledata_latent_mask in zip(
+                row, row_mask, row_latent_mask
+            ):
                 x, w = tiledata[0:2]
 
-                if x >= left and x+w <= img.width - right and y >= up and y+h <= img.height - down:
+                if (
+                    x >= left
+                    and x + w <= img.width - right
+                    and y >= up
+                    and y + h <= img.height - down
+                ):
                     continue
 
                 work.append(tiledata[2])
@@ -104,7 +148,9 @@ class Script(scripts.Script):
                 work_latent_mask.append(tiledata_latent_mask[2])
 
         batch_count = len(work)
-        print(f"Poor man's outpainting will process a total of {len(work)} images tiled as {len(grid.tiles[0][2])}x{len(grid.tiles)}.")
+        print(
+            f"Poor man's outpainting will process a total of {len(work)} images tiled as {len(grid.tiles[0][2])}x{len(grid.tiles)}."
+        )
 
         state.job_count = batch_count
 
@@ -123,24 +169,40 @@ class Script(scripts.Script):
             p.seed = processed.seed + 1
             work_results += processed.images
 
-
         image_index = 0
         for y, h, row in grid.tiles:
             for tiledata in row:
                 x, w = tiledata[0:2]
 
-                if x >= left and x+w <= img.width - right and y >= up and y+h <= img.height - down:
+                if (
+                    x >= left
+                    and x + w <= img.width - right
+                    and y >= up
+                    and y + h <= img.height - down
+                ):
                     continue
 
-                tiledata[2] = work_results[image_index] if image_index < len(work_results) else Image.new("RGB", (p.width, p.height))
+                tiledata[2] = (
+                    work_results[image_index]
+                    if image_index < len(work_results)
+                    else Image.new("RGB", (p.width, p.height))
+                )
                 image_index += 1
 
         combined_image = images.combine_grid(grid)
 
         if opts.samples_save:
-            images.save_image(combined_image, p.outpath_samples, "", initial_seed, p.prompt, opts.samples_format, info=initial_info, p=p)
+            images.save_image(
+                combined_image,
+                p.outpath_samples,
+                "",
+                initial_seed,
+                p.prompt,
+                opts.samples_format,
+                info=initial_info,
+                p=p,
+            )
 
         processed = Processed(p, [combined_image], initial_seed, initial_info)
 
         return processed
-

--- a/scripts/postprocessing_codeformer.py
+++ b/scripts/postprocessing_codeformer.py
@@ -12,8 +12,22 @@ class ScriptPostprocessingCodeFormer(scripts_postprocessing.ScriptPostprocessing
     def ui(self):
         with ui_components.InputAccordion(False, label="CodeFormer") as enable:
             with gr.Row():
-                codeformer_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id="extras_codeformer_visibility")
-                codeformer_weight = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Weight (0 = maximum effect, 1 = minimum effect)", value=0, elem_id="extras_codeformer_weight")
+                codeformer_visibility = gr.Slider(
+                    minimum=0.0,
+                    maximum=1.0,
+                    step=0.001,
+                    label="Visibility",
+                    value=1.0,
+                    elem_id="extras_codeformer_visibility",
+                )
+                codeformer_weight = gr.Slider(
+                    minimum=0.0,
+                    maximum=1.0,
+                    step=0.001,
+                    label="Weight (0 = maximum effect, 1 = minimum effect)",
+                    value=0,
+                    elem_id="extras_codeformer_weight",
+                )
 
         return {
             "enable": enable,
@@ -21,11 +35,19 @@ class ScriptPostprocessingCodeFormer(scripts_postprocessing.ScriptPostprocessing
             "codeformer_weight": codeformer_weight,
         }
 
-    def process(self, pp: scripts_postprocessing.PostprocessedImage, enable, codeformer_visibility, codeformer_weight):
+    def process(
+        self,
+        pp: scripts_postprocessing.PostprocessedImage,
+        enable,
+        codeformer_visibility,
+        codeformer_weight,
+    ):
         if codeformer_visibility == 0 or not enable:
             return
 
-        restored_img = codeformer_model.codeformer.restore(np.array(pp.image.convert("RGB"), dtype=np.uint8), w=codeformer_weight)
+        restored_img = codeformer_model.codeformer.restore(
+            np.array(pp.image.convert("RGB"), dtype=np.uint8), w=codeformer_weight
+        )
         res = Image.fromarray(restored_img)
 
         if codeformer_visibility < 1.0:

--- a/scripts/postprocessing_gfpgan.py
+++ b/scripts/postprocessing_gfpgan.py
@@ -11,18 +11,29 @@ class ScriptPostprocessingGfpGan(scripts_postprocessing.ScriptPostprocessing):
 
     def ui(self):
         with ui_components.InputAccordion(False, label="GFPGAN") as enable:
-            gfpgan_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Visibility", value=1.0, elem_id="extras_gfpgan_visibility")
+            gfpgan_visibility = gr.Slider(
+                minimum=0.0,
+                maximum=1.0,
+                step=0.001,
+                label="Visibility",
+                value=1.0,
+                elem_id="extras_gfpgan_visibility",
+            )
 
         return {
             "enable": enable,
             "gfpgan_visibility": gfpgan_visibility,
         }
 
-    def process(self, pp: scripts_postprocessing.PostprocessedImage, enable, gfpgan_visibility):
+    def process(
+        self, pp: scripts_postprocessing.PostprocessedImage, enable, gfpgan_visibility
+    ):
         if gfpgan_visibility == 0 or not enable:
             return
 
-        restored_img = gfpgan_model.gfpgan_fix_faces(np.array(pp.image.convert("RGB"), dtype=np.uint8))
+        restored_img = gfpgan_model.gfpgan_fix_faces(
+            np.array(pp.image.convert("RGB"), dtype=np.uint8)
+        )
         res = Image.fromarray(restored_img)
 
         if gfpgan_visibility < 1.0:

--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -12,7 +12,7 @@ from modules.ui import switch_values_symbol
 upscale_cache = {}
 
 
-def limit_size_by_one_dimention(w, h, limit):
+def limit_size_by_one_dimension(w, h, limit):
     if h > w and h > limit:
         w = limit * w // h
         h = limit
@@ -30,47 +30,121 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
     def ui(self):
         selected_tab = gr.Number(value=0, visible=False)
 
-        with InputAccordion(True, label="Upscale", elem_id="extras_upscale") as upscale_enabled:
+        with InputAccordion(
+            True, label="Upscale", elem_id="extras_upscale"
+        ) as upscale_enabled:
             with FormRow():
-                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
+                extras_upscaler_1 = gr.Dropdown(
+                    label="Upscaler 1",
+                    elem_id="extras_upscaler_1",
+                    choices=[x.name for x in shared.sd_upscalers],
+                    value=shared.sd_upscalers[0].name,
+                )
 
             with FormRow():
-                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
-                extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
+                extras_upscaler_2 = gr.Dropdown(
+                    label="Upscaler 2",
+                    elem_id="extras_upscaler_2",
+                    choices=[x.name for x in shared.sd_upscalers],
+                    value=shared.sd_upscalers[0].name,
+                )
+                extras_upscaler_2_visibility = gr.Slider(
+                    minimum=0.0,
+                    maximum=1.0,
+                    step=0.001,
+                    label="Upscaler 2 visibility",
+                    value=0.0,
+                    elem_id="extras_upscaler_2_visibility",
+                )
 
             with FormRow():
                 with gr.Tabs(elem_id="extras_resize_mode"):
-                    with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
+                    with gr.TabItem(
+                        "Scale by", elem_id="extras_scale_by_tab"
+                    ) as tab_scale_by:
                         with gr.Row():
                             with gr.Column(scale=4):
-                                upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=4, elem_id="extras_upscaling_resize")
+                                upscaling_resize = gr.Slider(
+                                    minimum=1.0,
+                                    maximum=8.0,
+                                    step=0.05,
+                                    label="Resize",
+                                    value=4,
+                                    elem_id="extras_upscaling_resize",
+                                )
                             with gr.Column(scale=1, min_width=160):
-                                max_side_length = gr.Number(label="Max side length", value=0, elem_id="extras_upscale_max_side_length", tooltip="If any of two sides of the image ends up larger than specified, will downscale it to fit. 0 = no limit.", min_width=160, step=8, minimum=0)
+                                max_side_length = gr.Number(
+                                    label="Max side length",
+                                    value=0,
+                                    elem_id="extras_upscale_max_side_length",
+                                    tooltip="If any of two sides of the image ends up larger than specified, will downscale it to fit. 0 = no limit.",
+                                    min_width=160,
+                                    step=8,
+                                    minimum=0,
+                                )
 
-                    with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                    with gr.TabItem(
+                        "Scale to", elem_id="extras_scale_to_tab"
+                    ) as tab_scale_to:
                         with FormRow():
                             with gr.Column(elem_id="upscaling_column_size", scale=4):
-                                upscaling_resize_w = gr.Slider(minimum=64, maximum=8192, step=8, label="Width", value=512, elem_id="extras_upscaling_resize_w")
-                                upscaling_resize_h = gr.Slider(minimum=64, maximum=8192, step=8, label="Height", value=512, elem_id="extras_upscaling_resize_h")
-                            with gr.Column(elem_id="upscaling_dimensions_row", scale=1, elem_classes="dimensions-tools"):
-                                upscaling_res_switch_btn = ToolButton(value=switch_values_symbol, elem_id="upscaling_res_switch_btn", tooltip="Switch width/height")
-                                upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
+                                upscaling_resize_w = gr.Slider(
+                                    minimum=64,
+                                    maximum=8192,
+                                    step=8,
+                                    label="Width",
+                                    value=512,
+                                    elem_id="extras_upscaling_resize_w",
+                                )
+                                upscaling_resize_h = gr.Slider(
+                                    minimum=64,
+                                    maximum=8192,
+                                    step=8,
+                                    label="Height",
+                                    value=512,
+                                    elem_id="extras_upscaling_resize_h",
+                                )
+                            with gr.Column(
+                                elem_id="upscaling_dimensions_row",
+                                scale=1,
+                                elem_classes="dimensions-tools",
+                            ):
+                                upscaling_res_switch_btn = ToolButton(
+                                    value=switch_values_symbol,
+                                    elem_id="upscaling_res_switch_btn",
+                                    tooltip="Switch width/height",
+                                )
+                                upscaling_crop = gr.Checkbox(
+                                    label="Crop to fit",
+                                    value=True,
+                                    elem_id="extras_upscaling_crop",
+                                )
 
         def on_selected_upscale_method(upscale_method):
             if not shared.opts.set_scale_by_when_changing_upscaler:
                 return gr.update()
 
-            match = re.search(r'(\d)[xX]|[xX](\d)', upscale_method)
+            match = re.search(r"(\d)[xX]|[xX](\d)", upscale_method)
             if not match:
                 return gr.update()
 
             return gr.update(value=int(match.group(1) or match.group(2)))
 
-        upscaling_res_switch_btn.click(lambda w, h: (h, w), inputs=[upscaling_resize_w, upscaling_resize_h], outputs=[upscaling_resize_w, upscaling_resize_h], show_progress=False)
+        upscaling_res_switch_btn.click(
+            lambda w, h: (h, w),
+            inputs=[upscaling_resize_w, upscaling_resize_h],
+            outputs=[upscaling_resize_w, upscaling_resize_h],
+            show_progress=False,
+        )
         tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
         tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
 
-        extras_upscaler_1.change(on_selected_upscale_method, inputs=[extras_upscaler_1], outputs=[upscaling_resize], show_progress="hidden")
+        extras_upscaler_1.change(
+            on_selected_upscale_method,
+            inputs=[extras_upscaler_1],
+            outputs=[upscaling_resize],
+            show_progress="hidden",
+        )
 
         return {
             "upscale_enabled": upscale_enabled,
@@ -85,20 +159,45 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
             "upscaler_2_visibility": extras_upscaler_2_visibility,
         }
 
-    def upscale(self, image, info, upscaler, upscale_mode, upscale_by, max_side_length, upscale_to_width, upscale_to_height, upscale_crop):
+    def upscale(
+        self,
+        image,
+        info,
+        upscaler,
+        upscale_mode,
+        upscale_by,
+        max_side_length,
+        upscale_to_width,
+        upscale_to_height,
+        upscale_crop,
+    ):
         if upscale_mode == 1:
-            upscale_by = max(upscale_to_width/image.width, upscale_to_height/image.height)
+            upscale_by = max(
+                upscale_to_width / image.width, upscale_to_height / image.height
+            )
             info["Postprocess upscale to"] = f"{upscale_to_width}x{upscale_to_height}"
         else:
             info["Postprocess upscale by"] = upscale_by
-            if max_side_length != 0 and max(*image.size)*upscale_by > max_side_length:
+            if max_side_length != 0 and max(*image.size) * upscale_by > max_side_length:
                 upscale_mode = 1
                 upscale_crop = False
-                upscale_to_width, upscale_to_height = limit_size_by_one_dimention(image.width*upscale_by, image.height*upscale_by, max_side_length)
-                upscale_by = max(upscale_to_width/image.width, upscale_to_height/image.height)
+                upscale_to_width, upscale_to_height = limit_size_by_one_dimension(
+                    image.width * upscale_by, image.height * upscale_by, max_side_length
+                )
+                upscale_by = max(
+                    upscale_to_width / image.width, upscale_to_height / image.height
+                )
                 info["Max side length"] = max_side_length
 
-        cache_key = (hash(np.array(image.getdata()).tobytes()), upscaler.name, upscale_mode, upscale_by,  upscale_to_width, upscale_to_height, upscale_crop)
+        cache_key = (
+            hash(np.array(image.getdata()).tobytes()),
+            upscaler.name,
+            upscale_mode,
+            upscale_by,
+            upscale_to_width,
+            upscale_to_height,
+            upscale_crop,
+        )
         cached_image = upscale_cache.pop(cache_key, None)
 
         if cached_image is not None:
@@ -112,13 +211,32 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
 
         if upscale_mode == 1 and upscale_crop:
             cropped = Image.new("RGB", (upscale_to_width, upscale_to_height))
-            cropped.paste(image, box=(upscale_to_width // 2 - image.width // 2, upscale_to_height // 2 - image.height // 2))
+            cropped.paste(
+                image,
+                box=(
+                    upscale_to_width // 2 - image.width // 2,
+                    upscale_to_height // 2 - image.height // 2,
+                ),
+            )
             image = cropped
             info["Postprocess crop to"] = f"{image.width}x{image.height}"
 
         return image
 
-    def process_firstpass(self, pp: scripts_postprocessing.PostprocessedImage, upscale_enabled=True, upscale_mode=1, upscale_by=2.0, max_side_length=0, upscale_to_width=None, upscale_to_height=None, upscale_crop=False, upscaler_1_name=None, upscaler_2_name=None, upscaler_2_visibility=0.0):
+    def process_firstpass(
+        self,
+        pp: scripts_postprocessing.PostprocessedImage,
+        upscale_enabled=True,
+        upscale_mode=1,
+        upscale_by=2.0,
+        max_side_length=0,
+        upscale_to_width=None,
+        upscale_to_height=None,
+        upscale_crop=False,
+        upscaler_1_name=None,
+        upscaler_2_name=None,
+        upscaler_2_visibility=0.0,
+    ):
         if upscale_mode == 1:
             pp.shared.target_width = upscale_to_width
             pp.shared.target_height = upscale_to_height
@@ -126,9 +244,26 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
             pp.shared.target_width = int(pp.image.width * upscale_by)
             pp.shared.target_height = int(pp.image.height * upscale_by)
 
-            pp.shared.target_width, pp.shared.target_height = limit_size_by_one_dimention(pp.shared.target_width, pp.shared.target_height, max_side_length)
+            pp.shared.target_width, pp.shared.target_height = (
+                limit_size_by_one_dimension(
+                    pp.shared.target_width, pp.shared.target_height, max_side_length
+                )
+            )
 
-    def process(self, pp: scripts_postprocessing.PostprocessedImage, upscale_enabled=True, upscale_mode=1, upscale_by=2.0, max_side_length=0, upscale_to_width=None, upscale_to_height=None, upscale_crop=False, upscaler_1_name=None, upscaler_2_name=None, upscaler_2_visibility=0.0):
+    def process(
+        self,
+        pp: scripts_postprocessing.PostprocessedImage,
+        upscale_enabled=True,
+        upscale_mode=1,
+        upscale_by=2.0,
+        max_side_length=0,
+        upscale_to_width=None,
+        upscale_to_height=None,
+        upscale_crop=False,
+        upscaler_1_name=None,
+        upscaler_2_name=None,
+        upscaler_2_visibility=0.0,
+    ):
         if not upscale_enabled:
             return
 
@@ -136,8 +271,12 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
         if upscaler_1_name == "None":
             upscaler_1_name = None
 
-        upscaler1 = next(iter([x for x in shared.sd_upscalers if x.name == upscaler_1_name]), None)
-        assert upscaler1 or (upscaler_1_name is None), f'could not find upscaler named {upscaler_1_name}'
+        upscaler1 = next(
+            iter([x for x in shared.sd_upscalers if x.name == upscaler_1_name]), None
+        )
+        assert upscaler1 or (
+            upscaler_1_name is None
+        ), f"could not find upscaler named {upscaler_1_name}"
 
         if not upscaler1:
             return
@@ -146,17 +285,50 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
         if upscaler_2_name == "None":
             upscaler_2_name = None
 
-        upscaler2 = next(iter([x for x in shared.sd_upscalers if x.name == upscaler_2_name and x.name != "None"]), None)
-        assert upscaler2 or (upscaler_2_name is None), f'could not find upscaler named {upscaler_2_name}'
+        upscaler2 = next(
+            iter(
+                [
+                    x
+                    for x in shared.sd_upscalers
+                    if x.name == upscaler_2_name and x.name != "None"
+                ]
+            ),
+            None,
+        )
+        assert upscaler2 or (
+            upscaler_2_name is None
+        ), f"could not find upscaler named {upscaler_2_name}"
 
-        upscaled_image = self.upscale(pp.image, pp.info, upscaler1, upscale_mode, upscale_by, max_side_length, upscale_to_width, upscale_to_height, upscale_crop)
+        upscaled_image = self.upscale(
+            pp.image,
+            pp.info,
+            upscaler1,
+            upscale_mode,
+            upscale_by,
+            max_side_length,
+            upscale_to_width,
+            upscale_to_height,
+            upscale_crop,
+        )
         pp.info["Postprocess upscaler"] = upscaler1.name
 
         if upscaler2 and upscaler_2_visibility > 0:
-            second_upscale = self.upscale(pp.image, pp.info, upscaler2, upscale_mode, upscale_by, max_side_length, upscale_to_width, upscale_to_height, upscale_crop)
+            second_upscale = self.upscale(
+                pp.image,
+                pp.info,
+                upscaler2,
+                upscale_mode,
+                upscale_by,
+                max_side_length,
+                upscale_to_width,
+                upscale_to_height,
+                upscale_crop,
+            )
             if upscaled_image.mode != second_upscale.mode:
                 second_upscale = second_upscale.convert(upscaled_image.mode)
-            upscaled_image = Image.blend(upscaled_image, second_upscale, upscaler_2_visibility)
+            upscaled_image = Image.blend(
+                upscaled_image, second_upscale, upscaler_2_visibility
+            )
 
             pp.info["Postprocess upscaler 2"] = upscaler2.name
 
@@ -172,24 +344,44 @@ class ScriptPostprocessingUpscaleSimple(ScriptPostprocessingUpscale):
 
     def ui(self):
         with FormRow():
-            upscaler_name = gr.Dropdown(label='Upscaler', choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
-            upscale_by = gr.Slider(minimum=0.05, maximum=8.0, step=0.05, label="Upscale by", value=2)
+            upscaler_name = gr.Dropdown(
+                label="Upscaler",
+                choices=[x.name for x in shared.sd_upscalers],
+                value=shared.sd_upscalers[0].name,
+            )
+            upscale_by = gr.Slider(
+                minimum=0.05, maximum=8.0, step=0.05, label="Upscale by", value=2
+            )
 
         return {
             "upscale_by": upscale_by,
             "upscaler_name": upscaler_name,
         }
 
-    def process_firstpass(self, pp: scripts_postprocessing.PostprocessedImage, upscale_by=2.0, upscaler_name=None):
+    def process_firstpass(
+        self,
+        pp: scripts_postprocessing.PostprocessedImage,
+        upscale_by=2.0,
+        upscaler_name=None,
+    ):
         pp.shared.target_width = int(pp.image.width * upscale_by)
         pp.shared.target_height = int(pp.image.height * upscale_by)
 
-    def process(self, pp: scripts_postprocessing.PostprocessedImage, upscale_by=2.0, upscaler_name=None):
+    def process(
+        self,
+        pp: scripts_postprocessing.PostprocessedImage,
+        upscale_by=2.0,
+        upscaler_name=None,
+    ):
         if upscaler_name is None or upscaler_name == "None":
             return
 
-        upscaler1 = next(iter([x for x in shared.sd_upscalers if x.name == upscaler_name]), None)
-        assert upscaler1, f'could not find upscaler named {upscaler_name}'
+        upscaler1 = next(
+            iter([x for x in shared.sd_upscalers if x.name == upscaler_name]), None
+        )
+        assert upscaler1, f"could not find upscaler named {upscaler_name}"
 
-        pp.image = self.upscale(pp.image, pp.info, upscaler1, 0, upscale_by, 0, 0, 0, False)
+        pp.image = self.upscale(
+            pp.image, pp.info, upscaler1, 0, upscale_by, 0, 0, 0, False
+        )
         pp.info["Postprocess upscaler"] = upscaler1.name

--- a/scripts/prompt_matrix.py
+++ b/scripts/prompt_matrix.py
@@ -19,9 +19,9 @@ def draw_xy_grid(xs, ys, x_label, y_label, cell):
 
     state.job_count = len(xs) * len(ys)
 
-    for iy, y in enumerate(ys):
+    for it, y in enumerate(ys):
         for ix, x in enumerate(xs):
-            state.job = f"{ix + iy * len(xs) + 1} out of {len(xs) * len(ys)}"
+            state.job = f"{ix + it * len(xs) + 1} out of {len(xs) * len(ys)}"
 
             processed = cell(x, y)
             if first_processed is None:
@@ -30,7 +30,9 @@ def draw_xy_grid(xs, ys, x_label, y_label, cell):
             res.append(processed.images[0])
 
     grid = images.image_grid(res, rows=len(ys))
-    grid = images.draw_grid_annotations(grid, res[0].width, res[0].height, hor_texts, ver_texts)
+    grid = images.draw_grid_annotations(
+        grid, res[0].width, res[0].height, hor_texts, ver_texts
+    )
 
     first_processed.images = [grid]
 
@@ -42,20 +44,59 @@ class Script(scripts.Script):
         return "Prompt matrix"
 
     def ui(self, is_img2img):
-        gr.HTML('<br />')
+        gr.HTML("<br />")
         with gr.Row():
             with gr.Column():
-                put_at_start = gr.Checkbox(label='Put variable parts at start of prompt', value=False, elem_id=self.elem_id("put_at_start"))
-                different_seeds = gr.Checkbox(label='Use different seed for each picture', value=False, elem_id=self.elem_id("different_seeds"))
+                put_at_start = gr.Checkbox(
+                    label="Put variable parts at start of prompt",
+                    value=False,
+                    elem_id=self.elem_id("put_at_start"),
+                )
+                different_seeds = gr.Checkbox(
+                    label="Use different seed for each picture",
+                    value=False,
+                    elem_id=self.elem_id("different_seeds"),
+                )
             with gr.Column():
-                prompt_type = gr.Radio(["positive", "negative"], label="Select prompt", elem_id=self.elem_id("prompt_type"), value="positive")
-                variations_delimiter = gr.Radio(["comma", "space"], label="Select joining char", elem_id=self.elem_id("variations_delimiter"), value="comma")
+                prompt_type = gr.Radio(
+                    ["positive", "negative"],
+                    label="Select prompt",
+                    elem_id=self.elem_id("prompt_type"),
+                    value="positive",
+                )
+                variations_delimiter = gr.Radio(
+                    ["comma", "space"],
+                    label="Select joining char",
+                    elem_id=self.elem_id("variations_delimiter"),
+                    value="comma",
+                )
             with gr.Column():
-                margin_size = gr.Slider(label="Grid margins (px)", minimum=0, maximum=500, value=0, step=2, elem_id=self.elem_id("margin_size"))
+                margin_size = gr.Slider(
+                    label="Grid margins (px)",
+                    minimum=0,
+                    maximum=500,
+                    value=0,
+                    step=2,
+                    elem_id=self.elem_id("margin_size"),
+                )
 
-        return [put_at_start, different_seeds, prompt_type, variations_delimiter, margin_size]
+        return [
+            put_at_start,
+            different_seeds,
+            prompt_type,
+            variations_delimiter,
+            margin_size,
+        ]
 
-    def run(self, p, put_at_start, different_seeds, prompt_type, variations_delimiter, margin_size):
+    def run(
+        self,
+        p,
+        put_at_start,
+        different_seeds,
+        prompt_type,
+        variations_delimiter,
+        margin_size,
+    ):
         modules.processing.fix_seed(p)
         # Raise error if promp type is not positive or negative
         if prompt_type not in ["positive", "negative"]:
@@ -74,7 +115,11 @@ class Script(scripts.Script):
         prompt_matrix_parts = original_prompt.split("|")
         combination_count = 2 ** (len(prompt_matrix_parts) - 1)
         for combination_num in range(combination_count):
-            selected_prompts = [text.strip().strip(',') for n, text in enumerate(prompt_matrix_parts[1:]) if combination_num & (1 << n)]
+            selected_prompts = [
+                text.strip().strip(",")
+                for n, text in enumerate(prompt_matrix_parts[1:])
+                if combination_num & (1 << n)
+            ]
 
             if put_at_start:
                 selected_prompts = selected_prompts + [prompt_matrix_parts[0]]
@@ -86,23 +131,46 @@ class Script(scripts.Script):
         p.n_iter = math.ceil(len(all_prompts) / p.batch_size)
         p.do_not_save_grid = True
 
-        print(f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches.")
+        print(
+            f"Prompt matrix will create {len(all_prompts)} images using a total of {p.n_iter} batches."
+        )
 
         if prompt_type == "positive":
             p.prompt = all_prompts
         else:
             p.negative_prompt = all_prompts
-        p.seed = [p.seed + (i if different_seeds else 0) for i in range(len(all_prompts))]
+        p.seed = [
+            p.seed + (i if different_seeds else 0) for i in range(len(all_prompts))
+        ]
         p.prompt_for_display = positive_prompt
         processed = process_images(p)
 
-        grid = images.image_grid(processed.images, p.batch_size, rows=1 << ((len(prompt_matrix_parts) - 1) // 2))
-        grid = images.draw_prompt_matrix(grid, processed.images[0].width, processed.images[0].height, prompt_matrix_parts, margin_size)
+        grid = images.image_grid(
+            processed.images,
+            p.batch_size,
+            rows=1 << ((len(prompt_matrix_parts) - 1) // 2),
+        )
+        grid = images.draw_prompt_matrix(
+            grid,
+            processed.images[0].width,
+            processed.images[0].height,
+            prompt_matrix_parts,
+            margin_size,
+        )
         processed.images.insert(0, grid)
         processed.index_of_first_image = 1
         processed.infotexts.insert(0, processed.infotexts[0])
 
         if opts.grid_save:
-            images.save_image(processed.images[0], p.outpath_grids, "prompt_matrix", extension=opts.grid_format, prompt=original_prompt, seed=processed.seed, grid=True, p=p)
+            images.save_image(
+                processed.images[0],
+                p.outpath_grids,
+                "prompt_matrix",
+                extension=opts.grid_format,
+                prompt=original_prompt,
+                seed=processed.seed,
+                grid=True,
+                p=p,
+            )
 
         return processed

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -12,7 +12,7 @@ from modules.shared import state
 
 def process_model_tag(tag):
     info = sd_models.get_closet_checkpoint_match(tag)
-    assert info is not None, f'Unknown checkpoint: {tag}'
+    assert info is not None, f"Unknown checkpoint: {tag}"
     return info.name
 
 
@@ -56,7 +56,7 @@ prompt_tags = {
     "restore_faces": process_boolean_tag,
     "tiling": process_boolean_tag,
     "do_not_save_samples": process_boolean_tag,
-    "do_not_save_grid": process_boolean_tag
+    "do_not_save_grid": process_boolean_tag,
 }
 
 
@@ -69,7 +69,7 @@ def cmdargs(line):
         arg = args[pos]
 
         assert arg.startswith("--"), f'must start with "--": {arg}'
-        assert pos+1 < len(args), f'missing argument for command line option {arg}'
+        assert pos + 1 < len(args), f"missing argument for command line option {arg}"
 
         tag = arg[2:]
 
@@ -84,11 +84,10 @@ def cmdargs(line):
             res[tag] = prompt
             continue
 
-
         func = prompt_tags.get(tag, None)
-        assert func, f'unknown commandline option: {arg}'
+        assert func, f"unknown commandline option: {arg}"
 
-        val = args[pos+1]
+        val = args[pos + 1]
         if tag == "sampler_name":
             val = sd_samplers.samplers_map.get(val.lower(), None)
 
@@ -103,7 +102,7 @@ def load_prompt_file(file):
     if file is None:
         return None, gr.update(), gr.update(lines=7)
     else:
-        lines = [x.strip() for x in file.decode('utf8', errors='ignore').split("\n")]
+        lines = [x.strip() for x in file.decode("utf8", errors="ignore").split("\n")]
         return None, "\n".join(lines), gr.update(lines=7)
 
 
@@ -112,22 +111,56 @@ class Script(scripts.Script):
         return "Prompts from file or textbox"
 
     def ui(self, is_img2img):
-        checkbox_iterate = gr.Checkbox(label="Iterate seed every line", value=False, elem_id=self.elem_id("checkbox_iterate"))
-        checkbox_iterate_batch = gr.Checkbox(label="Use same random seed for all lines", value=False, elem_id=self.elem_id("checkbox_iterate_batch"))
-        prompt_position = gr.Radio(["start", "end"], label="Insert prompts at the", elem_id=self.elem_id("prompt_position"), value="start")
+        checkbox_iterate = gr.Checkbox(
+            label="Iterate seed every line",
+            value=False,
+            elem_id=self.elem_id("checkbox_iterate"),
+        )
+        checkbox_iterate_batch = gr.Checkbox(
+            label="Use same random seed for all lines",
+            value=False,
+            elem_id=self.elem_id("checkbox_iterate_batch"),
+        )
+        prompt_position = gr.Radio(
+            ["start", "end"],
+            label="Insert prompts at the",
+            elem_id=self.elem_id("prompt_position"),
+            value="start",
+        )
 
-        prompt_txt = gr.Textbox(label="List of prompt inputs", lines=1, elem_id=self.elem_id("prompt_txt"))
-        file = gr.File(label="Upload prompt inputs", type='binary', elem_id=self.elem_id("file"))
+        prompt_txt = gr.Textbox(
+            label="List of prompt inputs", lines=1, elem_id=self.elem_id("prompt_txt")
+        )
+        file = gr.File(
+            label="Upload prompt inputs", type="binary", elem_id=self.elem_id("file")
+        )
 
-        file.change(fn=load_prompt_file, inputs=[file], outputs=[file, prompt_txt, prompt_txt], show_progress=False)
+        file.change(
+            fn=load_prompt_file,
+            inputs=[file],
+            outputs=[file, prompt_txt, prompt_txt],
+            show_progress=False,
+        )
 
         # We start at one line. When the text changes, we jump to seven lines, or two lines if no \n.
         # We don't shrink back to 1, because that causes the control to ignore [enter], and it may
         # be unclear to the user that shift-enter is needed.
-        prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt], show_progress=False)
+        prompt_txt.change(
+            lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2),
+            inputs=[prompt_txt],
+            outputs=[prompt_txt],
+            show_progress=False,
+        )
         return [checkbox_iterate, checkbox_iterate_batch, prompt_position, prompt_txt]
 
-    def run(self, p, checkbox_iterate, checkbox_iterate_batch, prompt_position, prompt_txt: str):
+    def run(
+        self,
+        p,
+        checkbox_iterate,
+        checkbox_iterate_batch,
+        prompt_position,
+        prompt_txt: str,
+    ):
         lines = [x for x in (x.strip() for x in prompt_txt.splitlines()) if x]
 
         p.do_not_save_grid = True
@@ -140,7 +173,9 @@ class Script(scripts.Script):
                 try:
                     args = cmdargs(line)
                 except Exception:
-                    errors.report(f"Error parsing line {line} as commandline", exc_info=True)
+                    errors.report(
+                        f"Error parsing line {line} as commandline", exc_info=True
+                    )
                     args = {"prompt": line}
             else:
                 args = {"prompt": line}
@@ -164,7 +199,7 @@ class Script(scripts.Script):
             copy_p = copy.copy(p)
             for k, v in args.items():
                 if k == "sd_model":
-                    copy_p.override_settings['sd_model_checkpoint'] = v
+                    copy_p.override_settings["sd_model_checkpoint"] = v
                 else:
                     setattr(copy_p, k, v)
 
@@ -176,9 +211,13 @@ class Script(scripts.Script):
 
             if args.get("negative_prompt") and p.negative_prompt:
                 if prompt_position == "start":
-                    copy_p.negative_prompt = args.get("negative_prompt") + " " + p.negative_prompt
+                    copy_p.negative_prompt = (
+                        args.get("negative_prompt") + " " + p.negative_prompt
+                    )
                 else:
-                    copy_p.negative_prompt = p.negative_prompt + " " + args.get("negative_prompt")
+                    copy_p.negative_prompt = (
+                        p.negative_prompt + " " + args.get("negative_prompt")
+                    )
 
             proc = process_images(copy_p)
             images += proc.images
@@ -188,4 +227,6 @@ class Script(scripts.Script):
             all_prompts += proc.all_prompts
             infotexts += proc.infotexts
 
-        return Processed(p, images, p.seed, "", all_prompts=all_prompts, infotexts=infotexts)
+        return Processed(
+            p, images, p.seed, "", all_prompts=all_prompts, infotexts=infotexts
+        )

--- a/scripts/sd_upscale.py
+++ b/scripts/sd_upscale.py
@@ -17,16 +17,40 @@ class Script(scripts.Script):
         return is_img2img
 
     def ui(self, is_img2img):
-        info = gr.HTML("<p style=\"margin-bottom:0.75em\">Will upscale the image by the selected scale factor; use width and height sliders to set tile size</p>")
-        overlap = gr.Slider(minimum=0, maximum=256, step=16, label='Tile overlap', value=64, elem_id=self.elem_id("overlap"))
-        scale_factor = gr.Slider(minimum=1.0, maximum=4.0, step=0.05, label='Scale Factor', value=2.0, elem_id=self.elem_id("scale_factor"))
-        upscaler_index = gr.Radio(label='Upscaler', choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name, type="index", elem_id=self.elem_id("upscaler_index"))
+        info = gr.HTML(
+            '<p style="margin-bottom:0.75em">Will upscale the image by the selected scale factor; use width and height sliders to set tile size</p>'
+        )
+        overlap = gr.Slider(
+            minimum=0,
+            maximum=256,
+            step=16,
+            label="Tile overlap",
+            value=64,
+            elem_id=self.elem_id("overlap"),
+        )
+        scale_factor = gr.Slider(
+            minimum=1.0,
+            maximum=4.0,
+            step=0.05,
+            label="Scale Factor",
+            value=2.0,
+            elem_id=self.elem_id("scale_factor"),
+        )
+        upscaler_index = gr.Radio(
+            label="Upscaler",
+            choices=[x.name for x in shared.sd_upscalers],
+            value=shared.sd_upscalers[0].name,
+            type="index",
+            elem_id=self.elem_id("upscaler_index"),
+        )
 
         return [info, overlap, upscaler_index, scale_factor]
 
     def run(self, p, _, overlap, upscaler_index, scale_factor):
         if isinstance(upscaler_index, str):
-            upscaler_index = [x.name.lower() for x in shared.sd_upscalers].index(upscaler_index.lower())
+            upscaler_index = [x.name.lower() for x in shared.sd_upscalers].index(
+                upscaler_index.lower()
+            )
         processing.fix_seed(p)
         upscaler = shared.sd_upscalers[upscaler_index]
 
@@ -63,7 +87,9 @@ class Script(scripts.Script):
         batch_count = math.ceil(len(work) / batch_size)
         state.job_count = batch_count * upscale_count
 
-        print(f"SD upscaling will process a total of {len(work)} images tiled as {len(grid.tiles[0][2])}x{len(grid.tiles)} per upscale in a total of {state.job_count} batches.")
+        print(
+            f"SD upscaling will process a total of {len(work)} images tiled as {len(grid.tiles[0][2])}x{len(grid.tiles)} per upscale in a total of {state.job_count} batches."
+        )
 
         result_images = []
         for n in range(upscale_count):
@@ -73,7 +99,7 @@ class Script(scripts.Script):
             work_results = []
             for i in range(batch_count):
                 p.batch_size = batch_size
-                p.init_images = work[i * batch_size:(i + 1) * batch_size]
+                p.init_images = work[i * batch_size : (i + 1) * batch_size]
 
                 state.job = f"Batch {i + 1 + n * batch_count} out of {state.job_count}"
                 processed = processing.process_images(p)
@@ -87,14 +113,27 @@ class Script(scripts.Script):
             image_index = 0
             for _y, _h, row in grid.tiles:
                 for tiledata in row:
-                    tiledata[2] = work_results[image_index] if image_index < len(work_results) else Image.new("RGB", (p.width, p.height))
+                    tiledata[2] = (
+                        work_results[image_index]
+                        if image_index < len(work_results)
+                        else Image.new("RGB", (p.width, p.height))
+                    )
                     image_index += 1
 
             combined_image = images.combine_grid(grid)
             result_images.append(combined_image)
 
             if opts.samples_save:
-                images.save_image(combined_image, p.outpath_samples, "", start_seed, p.prompt, opts.samples_format, info=initial_info, p=p)
+                images.save_image(
+                    combined_image,
+                    p.outpath_samples,
+                    "",
+                    start_seed,
+                    p.prompt,
+                    opts.samples_format,
+                    info=initial_info,
+                    p=p,
+                )
 
         processed = Processed(p, result_images, seed, initial_info)
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -11,8 +11,20 @@ import numpy as np
 import modules.scripts as scripts
 import gradio as gr
 
-from modules import images, sd_samplers, processing, sd_models, sd_vae, sd_schedulers, errors
-from modules.processing import process_images, Processed, StableDiffusionProcessingTxt2Img
+from modules import (
+    images,
+    sd_samplers,
+    processing,
+    sd_models,
+    sd_vae,
+    sd_schedulers,
+    errors,
+)
+from modules.processing import (
+    process_images,
+    Processed,
+    StableDiffusionProcessingTxt2Img,
+)
 from modules.shared import opts, state
 import modules.shared as shared
 import modules.sd_samplers
@@ -24,7 +36,7 @@ from modules.ui_components import ToolButton
 
 fill_values_symbol = "\U0001f4d2"  # 📒
 
-AxisInfo = namedtuple('AxisInfo', ['axis', 'values'])
+AxisInfo = namedtuple("AxisInfo", ["axis", "values"])
 
 
 def apply_field(field):
@@ -36,7 +48,9 @@ def apply_field(field):
 
 def apply_prompt(p, x, xs):
     if xs[0] not in p.prompt and xs[0] not in p.negative_prompt:
-        raise RuntimeError(f"Prompt S/R did not find {xs[0]} in prompt or negative prompt.")
+        raise RuntimeError(
+            f"Prompt S/R did not find {xs[0]} in prompt or negative prompt."
+        )
 
     p.prompt = p.prompt.replace(xs[0], x)
     p.negative_prompt = p.negative_prompt.replace(xs[0], x)
@@ -57,7 +71,7 @@ def apply_order(p, x, xs):
     for _, token in token_order:
         n = p.prompt.find(token)
         prompt_parts.append(p.prompt[0:n])
-        p.prompt = p.prompt[n + len(token):]
+        p.prompt = p.prompt[n + len(token) :]
 
     # Rebuild the prompt with the tokens in the order we want
     prompt_tmp = ""
@@ -77,7 +91,7 @@ def apply_checkpoint(p, x, xs):
     info = modules.sd_models.get_closet_checkpoint_match(x)
     if info is None:
         raise RuntimeError(f"Unknown checkpoint: {x}")
-    p.override_settings['sd_model_checkpoint'] = info.name
+    p.override_settings["sd_model_checkpoint"] = info.name
 
 
 def confirm_checkpoints(p, xs):
@@ -101,14 +115,16 @@ def confirm_range(min_val, max_val, axis_label):
     def confirm_range_fun(p, xs):
         for x in xs:
             if not (max_val >= x >= min_val):
-                raise ValueError(f'{axis_label} value "{x}" out of range [{min_val}, {max_val}]')
+                raise ValueError(
+                    f'{axis_label} value "{x}" out of range [{min_val}, {max_val}]'
+                )
 
     return confirm_range_fun
 
 
 def apply_size(p, x: str, xs) -> None:
     try:
-        width, _, height = x.partition('x')
+        width, _, height = x.partition("x")
         width = int(width.strip())
         height = int(height.strip())
         p.width = width
@@ -118,35 +134,38 @@ def apply_size(p, x: str, xs) -> None:
 
 
 def find_vae(name: str):
-    if (name := name.strip().lower()) in ('auto', 'automatic'):
-        return 'Automatic'
-    elif name == 'none':
-        return 'None'
-    return next((k for k in modules.sd_vae.vae_dict if k.lower() == name), print(f'No VAE found for {name}; using Automatic') or 'Automatic')
+    if (name := name.strip().lower()) in ("auto", "automatic"):
+        return "Automatic"
+    elif name == "none":
+        return "None"
+    return next(
+        (k for k in modules.sd_vae.vae_dict if k.lower() == name),
+        print(f"No VAE found for {name}; using Automatic") or "Automatic",
+    )
 
 
 def apply_vae(p, x, xs):
-    p.override_settings['sd_vae'] = find_vae(x)
+    p.override_settings["sd_vae"] = find_vae(x)
 
 
 def apply_styles(p: StableDiffusionProcessingTxt2Img, x: str, _):
-    p.styles.extend(x.split(','))
+    p.styles.extend(x.split(","))
 
 
 def apply_uni_pc_order(p, x, xs):
-    p.override_settings['uni_pc_order'] = min(x, p.steps - 1)
+    p.override_settings["uni_pc_order"] = min(x, p.steps - 1)
 
 
 def apply_face_restore(p, opt, x):
     opt = opt.lower()
-    if opt == 'codeformer':
+    if opt == "codeformer":
         is_active = True
-        p.face_restoration_model = 'CodeFormer'
-    elif opt == 'gfpgan':
+        p.face_restoration_model = "CodeFormer"
+    elif opt == "gfpgan":
         is_active = True
-        p.face_restoration_model = 'GFPGAN'
+        p.face_restoration_model = "GFPGAN"
     else:
-        is_active = opt in ('true', 'yes', 'y', '1')
+        is_active = opt in ("true", "yes", "y", "1")
 
     p.restore_faces = is_active
 
@@ -208,11 +227,26 @@ def list_to_csv_string(data_list):
 
 
 def csv_string_to_list_strip(data_str):
-    return list(map(str.strip, chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True))))
+    return list(
+        map(
+            str.strip,
+            chain.from_iterable(csv.reader(StringIO(data_str), skipinitialspace=True)),
+        )
+    )
 
 
 class AxisOption:
-    def __init__(self, label, type, apply, format_value=format_value_add_label, confirm=None, cost=0.0, choices=None, prepare=None):
+    def __init__(
+        self,
+        label,
+        type,
+        apply,
+        format_value=format_value_add_label,
+        confirm=None,
+        cost=0.0,
+        choices=None,
+        prepare=None,
+    ):
         self.label = label
         self.type = type
         self.apply = apply
@@ -245,51 +279,165 @@ axis_options = [
     AxisOption("CFG Scale", float, apply_field("cfg_scale")),
     AxisOptionImg2Img("Image CFG Scale", float, apply_field("image_cfg_scale")),
     AxisOption("Prompt S/R", str, apply_prompt, format_value=format_value),
-    AxisOption("Prompt order", str_permutations, apply_order, format_value=format_value_join_list),
-    AxisOptionTxt2Img("Sampler", str, apply_field("sampler_name"), format_value=format_value, confirm=confirm_samplers, choices=lambda: [x.name for x in sd_samplers.samplers if x.name not in opts.hide_samplers]),
-    AxisOptionTxt2Img("Hires sampler", str, apply_field("hr_sampler_name"), confirm=confirm_samplers, choices=lambda: [x.name for x in sd_samplers.samplers_for_img2img if x.name not in opts.hide_samplers]),
-    AxisOptionImg2Img("Sampler", str, apply_field("sampler_name"), format_value=format_value, confirm=confirm_samplers, choices=lambda: [x.name for x in sd_samplers.samplers_for_img2img if x.name not in opts.hide_samplers]),
-    AxisOption("Checkpoint name", str, apply_checkpoint, format_value=format_remove_path, confirm=confirm_checkpoints, cost=1.0, choices=lambda: sorted(sd_models.checkpoints_list, key=str.casefold)),
+    AxisOption(
+        "Prompt order",
+        str_permutations,
+        apply_order,
+        format_value=format_value_join_list,
+    ),
+    AxisOptionTxt2Img(
+        "Sampler",
+        str,
+        apply_field("sampler_name"),
+        format_value=format_value,
+        confirm=confirm_samplers,
+        choices=lambda: [
+            x.name for x in sd_samplers.samplers if x.name not in opts.hide_samplers
+        ],
+    ),
+    AxisOptionTxt2Img(
+        "Hires sampler",
+        str,
+        apply_field("hr_sampler_name"),
+        confirm=confirm_samplers,
+        choices=lambda: [
+            x.name
+            for x in sd_samplers.samplers_for_img2img
+            if x.name not in opts.hide_samplers
+        ],
+    ),
+    AxisOptionImg2Img(
+        "Sampler",
+        str,
+        apply_field("sampler_name"),
+        format_value=format_value,
+        confirm=confirm_samplers,
+        choices=lambda: [
+            x.name
+            for x in sd_samplers.samplers_for_img2img
+            if x.name not in opts.hide_samplers
+        ],
+    ),
+    AxisOption(
+        "Checkpoint name",
+        str,
+        apply_checkpoint,
+        format_value=format_remove_path,
+        confirm=confirm_checkpoints,
+        cost=1.0,
+        choices=lambda: sorted(sd_models.checkpoints_list, key=str.casefold),
+    ),
     AxisOption("Negative Guidance minimum sigma", float, apply_field("s_min_uncond")),
     AxisOption("Sigma Churn", float, apply_field("s_churn")),
     AxisOption("Sigma min", float, apply_field("s_tmin")),
     AxisOption("Sigma max", float, apply_field("s_tmax")),
     AxisOption("Sigma noise", float, apply_field("s_noise")),
-    AxisOption("Schedule type", str, apply_field("scheduler"), choices=lambda: [x.label for x in sd_schedulers.schedulers]),
+    AxisOption(
+        "Schedule type",
+        str,
+        apply_field("scheduler"),
+        choices=lambda: [x.label for x in sd_schedulers.schedulers],
+    ),
     AxisOption("Schedule min sigma", float, apply_override("sigma_min")),
     AxisOption("Schedule max sigma", float, apply_override("sigma_max")),
     AxisOption("Schedule rho", float, apply_override("rho")),
     AxisOption("Beta schedule alpha", float, apply_override("beta_dist_alpha")),
     AxisOption("Beta schedule beta", float, apply_override("beta_dist_beta")),
     AxisOption("Eta", float, apply_field("eta")),
-    AxisOption("Clip skip", int, apply_override('CLIP_stop_at_last_layers')),
+    AxisOption("Clip skip", int, apply_override("CLIP_stop_at_last_layers")),
     AxisOption("Denoising", float, apply_field("denoising_strength")),
-    AxisOption("Initial noise multiplier", float, apply_field("initial_noise_multiplier")),
+    AxisOption(
+        "Initial noise multiplier", float, apply_field("initial_noise_multiplier")
+    ),
     AxisOption("Extra noise", float, apply_override("img2img_extra_noise")),
-    AxisOptionTxt2Img("Hires upscaler", str, apply_field("hr_upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
-    AxisOptionImg2Img("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")),
-    AxisOption("VAE", str, apply_vae, cost=0.7, choices=lambda: ['Automatic', 'None'] + list(sd_vae.vae_dict)),
-    AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),
+    AxisOptionTxt2Img(
+        "Hires upscaler",
+        str,
+        apply_field("hr_upscaler"),
+        choices=lambda: [
+            *shared.latent_upscale_modes,
+            *[x.name for x in shared.sd_upscalers],
+        ],
+    ),
+    AxisOptionImg2Img(
+        "Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")
+    ),
+    AxisOption(
+        "VAE",
+        str,
+        apply_vae,
+        cost=0.7,
+        choices=lambda: ["Automatic", "None"] + list(sd_vae.vae_dict),
+    ),
+    AxisOption(
+        "Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)
+    ),
     AxisOption("UniPC Order", int, apply_uni_pc_order, cost=0.5),
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
-    AxisOption("Token merging ratio", float, apply_override('token_merging_ratio')),
-    AxisOption("Token merging ratio high-res", float, apply_override('token_merging_ratio_hr')),
-    AxisOption("Always discard next-to-last sigma", str, apply_override('always_discard_next_to_last_sigma', boolean=True), choices=boolean_choice(reverse=True)),
-    AxisOption("SGM noise multiplier", str, apply_override('sgm_noise_multiplier', boolean=True), choices=boolean_choice(reverse=True)),
-    AxisOption("Refiner checkpoint", str, apply_field('refiner_checkpoint'), format_value=format_remove_path, confirm=confirm_checkpoints_or_none, cost=1.0, choices=lambda: ['None'] + sorted(sd_models.checkpoints_list, key=str.casefold)),
-    AxisOption("Refiner switch at", float, apply_field('refiner_switch_at')),
-    AxisOption("RNG source", str, apply_override("randn_source"), choices=lambda: ["GPU", "CPU", "NV"]),
-    AxisOption("FP8 mode", str, apply_override("fp8_storage"), cost=0.9, choices=lambda: ["Disable", "Enable for SDXL", "Enable"]),
+    AxisOption("Token merging ratio", float, apply_override("token_merging_ratio")),
+    AxisOption(
+        "Token merging ratio high-res", float, apply_override("token_merging_ratio_hr")
+    ),
+    AxisOption(
+        "Always discard next-to-last sigma",
+        str,
+        apply_override("always_discard_next_to_last_sigma", boolean=True),
+        choices=boolean_choice(reverse=True),
+    ),
+    AxisOption(
+        "SGM noise multiplier",
+        str,
+        apply_override("sgm_noise_multiplier", boolean=True),
+        choices=boolean_choice(reverse=True),
+    ),
+    AxisOption(
+        "Refiner checkpoint",
+        str,
+        apply_field("refiner_checkpoint"),
+        format_value=format_remove_path,
+        confirm=confirm_checkpoints_or_none,
+        cost=1.0,
+        choices=lambda: ["None"] + sorted(sd_models.checkpoints_list, key=str.casefold),
+    ),
+    AxisOption("Refiner switch at", float, apply_field("refiner_switch_at")),
+    AxisOption(
+        "RNG source",
+        str,
+        apply_override("randn_source"),
+        choices=lambda: ["GPU", "CPU", "NV"],
+    ),
+    AxisOption(
+        "FP8 mode",
+        str,
+        apply_override("fp8_storage"),
+        cost=0.9,
+        choices=lambda: ["Disable", "Enable for SDXL", "Enable"],
+    ),
     AxisOption("Size", str, apply_size),
 ]
 
 
-def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend, include_lone_images, include_sub_grids, first_axes_processed, second_axes_processed, margin_size):
+def draw_xyz_grid(
+    p,
+    xs,
+    ys,
+    zs,
+    x_labels,
+    y_labels,
+    z_labels,
+    cell,
+    draw_legend,
+    include_lone_images,
+    include_sub_grids,
+    first_axes_processed,
+    second_axes_processed,
+    margin_size,
+):
     hor_texts = [[images.GridAnnotation(x)] for x in x_labels]
     ver_texts = [[images.GridAnnotation(y)] for y in y_labels]
     title_texts = [[images.GridAnnotation(z)] for z in z_labels]
 
-    list_size = (len(xs) * len(ys) * len(zs))
+    list_size = len(xs) * len(ys) * len(zs)
 
     processed_result = None
 
@@ -330,9 +478,9 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
                 cell_size = processed_result.images[0].size
             processed_result.images[idx] = Image.new(cell_mode, cell_size)
 
-    if first_axes_processed == 'x':
+    if first_axes_processed == "x":
         for ix, x in enumerate(xs):
-            if second_axes_processed == 'y':
+            if second_axes_processed == "y":
                 for iy, y in enumerate(ys):
                     for iz, z in enumerate(zs):
                         process_cell(x, y, z, ix, iy, iz)
@@ -340,9 +488,9 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
                 for iz, z in enumerate(zs):
                     for iy, y in enumerate(ys):
                         process_cell(x, y, z, ix, iy, iz)
-    elif first_axes_processed == 'y':
+    elif first_axes_processed == "y":
         for iy, y in enumerate(ys):
-            if second_axes_processed == 'x':
+            if second_axes_processed == "x":
                 for ix, x in enumerate(xs):
                     for iz, z in enumerate(zs):
                         process_cell(x, y, z, ix, iy, iz)
@@ -350,9 +498,9 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
                 for iz, z in enumerate(zs):
                     for ix, x in enumerate(xs):
                         process_cell(x, y, z, ix, iy, iz)
-    elif first_axes_processed == 'z':
+    elif first_axes_processed == "z":
         for iz, z in enumerate(zs):
-            if second_axes_processed == 'x':
+            if second_axes_processed == "x":
                 for ix, x in enumerate(xs):
                     for iy, y in enumerate(ys):
                         process_cell(x, y, z, ix, iy, iz)
@@ -363,10 +511,14 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
 
     if not processed_result:
         # Should never happen, I've only seen it on one of four open tabs and it needed to refresh.
-        print("Unexpected error: Processing could not begin, you may need to refresh the tab or restart the service.")
+        print(
+            "Unexpected error: Processing could not begin, you may need to refresh the tab or restart the service."
+        )
         return Processed(p, [])
     elif not any(processed_result.images):
-        print("Unexpected error: draw_xyz_grid failed to return even a single processed image")
+        print(
+            "Unexpected error: draw_xyz_grid failed to return even a single processed image"
+        )
         return Processed(p, [])
 
     z_count = len(zs)
@@ -374,19 +526,41 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
     for i in range(z_count):
         start_index = (i * len(xs) * len(ys)) + i
         end_index = start_index + len(xs) * len(ys)
-        grid = images.image_grid(processed_result.images[start_index:end_index], rows=len(ys))
+        grid = images.image_grid(
+            processed_result.images[start_index:end_index], rows=len(ys)
+        )
         if draw_legend:
-            grid_max_w, grid_max_h = map(max, zip(*(img.size for img in processed_result.images[start_index:end_index])))
-            grid = images.draw_grid_annotations(grid, grid_max_w, grid_max_h, hor_texts, ver_texts, margin_size)
+            grid_max_w, grid_max_h = map(
+                max,
+                zip(
+                    *(
+                        img.size
+                        for img in processed_result.images[start_index:end_index]
+                    )
+                ),
+            )
+            grid = images.draw_grid_annotations(
+                grid, grid_max_w, grid_max_h, hor_texts, ver_texts, margin_size
+            )
         processed_result.images.insert(i, grid)
-        processed_result.all_prompts.insert(i, processed_result.all_prompts[start_index])
+        processed_result.all_prompts.insert(
+            i, processed_result.all_prompts[start_index]
+        )
         processed_result.all_seeds.insert(i, processed_result.all_seeds[start_index])
         processed_result.infotexts.insert(i, processed_result.infotexts[start_index])
 
     z_grid = images.image_grid(processed_result.images[:z_count], rows=1)
-    z_sub_grid_max_w, z_sub_grid_max_h = map(max, zip(*(img.size for img in processed_result.images[:z_count])))
+    z_sub_grid_max_w, z_sub_grid_max_h = map(
+        max, zip(*(img.size for img in processed_result.images[:z_count]))
+    )
     if draw_legend:
-        z_grid = images.draw_grid_annotations(z_grid, z_sub_grid_max_w, z_sub_grid_max_h, title_texts, [[images.GridAnnotation()]])
+        z_grid = images.draw_grid_annotations(
+            z_grid,
+            z_sub_grid_max_w,
+            z_sub_grid_max_h,
+            title_texts,
+            [[images.GridAnnotation()]],
+        )
     processed_result.images.insert(0, z_grid)
     # TODO: Deeper aspects of the program rely on grid info being misaligned between metadata arrays, which is not ideal.
     # processed_result.all_prompts.insert(0, processed_result.all_prompts[0])
@@ -405,11 +579,19 @@ class SharedSettingsStackHelper(object):
         modules.sd_vae.reload_vae_weights()
 
 
-re_range = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*")
-re_range_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\(([+-]\d+(?:.\d*)?)\s*\))?\s*")
+re_range = re.compile(
+    r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*"
+)
+re_range_float = re.compile(
+    r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\(([+-]\d+(?:.\d*)?)\s*\))?\s*"
+)
 
-re_range_count = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\[(\d+)\s*])?\s*")
-re_range_count_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\[(\d+(?:.\d*)?)\s*])?\s*")
+re_range_count = re.compile(
+    r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\[(\d+)\s*])?\s*"
+)
+re_range_count_float = re.compile(
+    r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\[(\d+(?:.\d*)?)\s*])?\s*"
+)
 
 
 class Script(scripts.Script):
@@ -417,56 +599,195 @@ class Script(scripts.Script):
         return "X/Y/Z plot"
 
     def ui(self, is_img2img):
-        self.current_axis_options = [x for x in axis_options if type(x) == AxisOption or x.is_img2img == is_img2img]
+        self.current_axis_options = [
+            x
+            for x in axis_options
+            if type(x) == AxisOption or x.is_img2img == is_img2img
+        ]
 
         with gr.Row():
             with gr.Column(scale=19):
                 with gr.Row():
-                    x_type = gr.Dropdown(label="X type", choices=[x.label for x in self.current_axis_options], value=self.current_axis_options[1].label, type="index", elem_id=self.elem_id("x_type"))
-                    x_values = gr.Textbox(label="X values", lines=1, elem_id=self.elem_id("x_values"))
-                    x_values_dropdown = gr.Dropdown(label="X values", visible=False, multiselect=True, interactive=True)
-                    fill_x_button = ToolButton(value=fill_values_symbol, elem_id="xyz_grid_fill_x_tool_button", visible=False)
+                    x_type = gr.Dropdown(
+                        label="X type",
+                        choices=[x.label for x in self.current_axis_options],
+                        value=self.current_axis_options[1].label,
+                        type="index",
+                        elem_id=self.elem_id("x_type"),
+                    )
+                    x_values = gr.Textbox(
+                        label="X values", lines=1, elem_id=self.elem_id("x_values")
+                    )
+                    x_values_dropdown = gr.Dropdown(
+                        label="X values",
+                        visible=False,
+                        multiselect=True,
+                        interactive=True,
+                    )
+                    fill_x_button = ToolButton(
+                        value=fill_values_symbol,
+                        elem_id="xyz_grid_fill_x_tool_button",
+                        visible=False,
+                    )
 
                 with gr.Row():
-                    y_type = gr.Dropdown(label="Y type", choices=[x.label for x in self.current_axis_options], value=self.current_axis_options[0].label, type="index", elem_id=self.elem_id("y_type"))
-                    y_values = gr.Textbox(label="Y values", lines=1, elem_id=self.elem_id("y_values"))
-                    y_values_dropdown = gr.Dropdown(label="Y values", visible=False, multiselect=True, interactive=True)
-                    fill_y_button = ToolButton(value=fill_values_symbol, elem_id="xyz_grid_fill_y_tool_button", visible=False)
+                    y_type = gr.Dropdown(
+                        label="Y type",
+                        choices=[x.label for x in self.current_axis_options],
+                        value=self.current_axis_options[0].label,
+                        type="index",
+                        elem_id=self.elem_id("y_type"),
+                    )
+                    y_values = gr.Textbox(
+                        label="Y values", lines=1, elem_id=self.elem_id("y_values")
+                    )
+                    y_values_dropdown = gr.Dropdown(
+                        label="Y values",
+                        visible=False,
+                        multiselect=True,
+                        interactive=True,
+                    )
+                    fill_y_button = ToolButton(
+                        value=fill_values_symbol,
+                        elem_id="xyz_grid_fill_y_tool_button",
+                        visible=False,
+                    )
 
                 with gr.Row():
-                    z_type = gr.Dropdown(label="Z type", choices=[x.label for x in self.current_axis_options], value=self.current_axis_options[0].label, type="index", elem_id=self.elem_id("z_type"))
-                    z_values = gr.Textbox(label="Z values", lines=1, elem_id=self.elem_id("z_values"))
-                    z_values_dropdown = gr.Dropdown(label="Z values", visible=False, multiselect=True, interactive=True)
-                    fill_z_button = ToolButton(value=fill_values_symbol, elem_id="xyz_grid_fill_z_tool_button", visible=False)
+                    z_type = gr.Dropdown(
+                        label="Z type",
+                        choices=[x.label for x in self.current_axis_options],
+                        value=self.current_axis_options[0].label,
+                        type="index",
+                        elem_id=self.elem_id("z_type"),
+                    )
+                    z_values = gr.Textbox(
+                        label="Z values", lines=1, elem_id=self.elem_id("z_values")
+                    )
+                    z_values_dropdown = gr.Dropdown(
+                        label="Z values",
+                        visible=False,
+                        multiselect=True,
+                        interactive=True,
+                    )
+                    fill_z_button = ToolButton(
+                        value=fill_values_symbol,
+                        elem_id="xyz_grid_fill_z_tool_button",
+                        visible=False,
+                    )
 
         with gr.Row(variant="compact", elem_id="axis_options"):
             with gr.Column():
-                draw_legend = gr.Checkbox(label='Draw legend', value=True, elem_id=self.elem_id("draw_legend"))
-                no_fixed_seeds = gr.Checkbox(label='Keep -1 for seeds', value=False, elem_id=self.elem_id("no_fixed_seeds"))
+                draw_legend = gr.Checkbox(
+                    label="Draw legend", value=True, elem_id=self.elem_id("draw_legend")
+                )
+                no_fixed_seeds = gr.Checkbox(
+                    label="Keep -1 for seeds",
+                    value=False,
+                    elem_id=self.elem_id("no_fixed_seeds"),
+                )
                 with gr.Row():
-                    vary_seeds_x = gr.Checkbox(label='Vary seeds for X', value=False, min_width=80, elem_id=self.elem_id("vary_seeds_x"), tooltip="Use different seeds for images along X axis.")
-                    vary_seeds_y = gr.Checkbox(label='Vary seeds for Y', value=False, min_width=80, elem_id=self.elem_id("vary_seeds_y"), tooltip="Use different seeds for images along Y axis.")
-                    vary_seeds_z = gr.Checkbox(label='Vary seeds for Z', value=False, min_width=80, elem_id=self.elem_id("vary_seeds_z"), tooltip="Use different seeds for images along Z axis.")
+                    vary_seeds_x = gr.Checkbox(
+                        label="Vary seeds for X",
+                        value=False,
+                        min_width=80,
+                        elem_id=self.elem_id("vary_seeds_x"),
+                        tooltip="Use different seeds for images along X axis.",
+                    )
+                    vary_seeds_y = gr.Checkbox(
+                        label="Vary seeds for Y",
+                        value=False,
+                        min_width=80,
+                        elem_id=self.elem_id("vary_seeds_y"),
+                        tooltip="Use different seeds for images along Y axis.",
+                    )
+                    vary_seeds_z = gr.Checkbox(
+                        label="Vary seeds for Z",
+                        value=False,
+                        min_width=80,
+                        elem_id=self.elem_id("vary_seeds_z"),
+                        tooltip="Use different seeds for images along Z axis.",
+                    )
             with gr.Column():
-                include_lone_images = gr.Checkbox(label='Include Sub Images', value=False, elem_id=self.elem_id("include_lone_images"))
-                include_sub_grids = gr.Checkbox(label='Include Sub Grids', value=False, elem_id=self.elem_id("include_sub_grids"))
-                csv_mode = gr.Checkbox(label='Use text inputs instead of dropdowns', value=False, elem_id=self.elem_id("csv_mode"))
+                include_lone_images = gr.Checkbox(
+                    label="Include Sub Images",
+                    value=False,
+                    elem_id=self.elem_id("include_lone_images"),
+                )
+                include_sub_grids = gr.Checkbox(
+                    label="Include Sub Grids",
+                    value=False,
+                    elem_id=self.elem_id("include_sub_grids"),
+                )
+                csv_mode = gr.Checkbox(
+                    label="Use text inputs instead of dropdowns",
+                    value=False,
+                    elem_id=self.elem_id("csv_mode"),
+                )
             with gr.Column():
-                margin_size = gr.Slider(label="Grid margins (px)", minimum=0, maximum=500, value=0, step=2, elem_id=self.elem_id("margin_size"))
+                margin_size = gr.Slider(
+                    label="Grid margins (px)",
+                    minimum=0,
+                    maximum=500,
+                    value=0,
+                    step=2,
+                    elem_id=self.elem_id("margin_size"),
+                )
 
         with gr.Row(variant="compact", elem_id="swap_axes"):
-            swap_xy_axes_button = gr.Button(value="Swap X/Y axes", elem_id="xy_grid_swap_axes_button")
-            swap_yz_axes_button = gr.Button(value="Swap Y/Z axes", elem_id="yz_grid_swap_axes_button")
-            swap_xz_axes_button = gr.Button(value="Swap X/Z axes", elem_id="xz_grid_swap_axes_button")
+            swap_xy_axes_button = gr.Button(
+                value="Swap X/Y axes", elem_id="xy_grid_swap_axes_button"
+            )
+            swap_yz_axes_button = gr.Button(
+                value="Swap Y/Z axes", elem_id="yz_grid_swap_axes_button"
+            )
+            swap_xz_axes_button = gr.Button(
+                value="Swap X/Z axes", elem_id="xz_grid_swap_axes_button"
+            )
 
-        def swap_axes(axis1_type, axis1_values, axis1_values_dropdown, axis2_type, axis2_values, axis2_values_dropdown):
-            return self.current_axis_options[axis2_type].label, axis2_values, axis2_values_dropdown, self.current_axis_options[axis1_type].label, axis1_values, axis1_values_dropdown
+        def swap_axes(
+            axis1_type,
+            axis1_values,
+            axis1_values_dropdown,
+            axis2_type,
+            axis2_values,
+            axis2_values_dropdown,
+        ):
+            return (
+                self.current_axis_options[axis2_type].label,
+                axis2_values,
+                axis2_values_dropdown,
+                self.current_axis_options[axis1_type].label,
+                axis1_values,
+                axis1_values_dropdown,
+            )
 
-        xy_swap_args = [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown]
+        xy_swap_args = [
+            x_type,
+            x_values,
+            x_values_dropdown,
+            y_type,
+            y_values,
+            y_values_dropdown,
+        ]
         swap_xy_axes_button.click(swap_axes, inputs=xy_swap_args, outputs=xy_swap_args)
-        yz_swap_args = [y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown]
+        yz_swap_args = [
+            y_type,
+            y_values,
+            y_values_dropdown,
+            z_type,
+            z_values,
+            z_values_dropdown,
+        ]
         swap_yz_axes_button.click(swap_axes, inputs=yz_swap_args, outputs=yz_swap_args)
-        xz_swap_args = [x_type, x_values, x_values_dropdown, z_type, z_values, z_values_dropdown]
+        xz_swap_args = [
+            x_type,
+            x_values,
+            x_values_dropdown,
+            z_type,
+            z_values,
+            z_values_dropdown,
+        ]
         swap_xz_axes_button.click(swap_axes, inputs=xz_swap_args, outputs=xz_swap_args)
 
         def fill(axis_type, csv_mode):
@@ -479,9 +800,15 @@ class Script(scripts.Script):
             else:
                 return gr.update(), gr.update()
 
-        fill_x_button.click(fn=fill, inputs=[x_type, csv_mode], outputs=[x_values, x_values_dropdown])
-        fill_y_button.click(fn=fill, inputs=[y_type, csv_mode], outputs=[y_values, y_values_dropdown])
-        fill_z_button.click(fn=fill, inputs=[z_type, csv_mode], outputs=[z_values, z_values_dropdown])
+        fill_x_button.click(
+            fn=fill, inputs=[x_type, csv_mode], outputs=[x_values, x_values_dropdown]
+        )
+        fill_y_button.click(
+            fn=fill, inputs=[y_type, csv_mode], outputs=[y_values, y_values_dropdown]
+        )
+        fill_z_button.click(
+            fn=fill, inputs=[z_type, csv_mode], outputs=[z_values, z_values_dropdown]
+        )
 
         def select_axis(axis_type, axis_values, axis_values_dropdown, csv_mode):
             axis_type = axis_type or 0  # if axle type is None set to 0
@@ -493,27 +820,107 @@ class Script(scripts.Script):
                 choices = choices()
                 if csv_mode:
                     if axis_values_dropdown:
-                        axis_values = list_to_csv_string(list(filter(lambda x: x in choices, axis_values_dropdown)))
+                        axis_values = list_to_csv_string(
+                            list(filter(lambda x: x in choices, axis_values_dropdown))
+                        )
                         axis_values_dropdown = []
                 else:
                     if axis_values:
-                        axis_values_dropdown = list(filter(lambda x: x in choices, csv_string_to_list_strip(axis_values)))
+                        axis_values_dropdown = list(
+                            filter(
+                                lambda x: x in choices,
+                                csv_string_to_list_strip(axis_values),
+                            )
+                        )
                         axis_values = ""
 
-            return (gr.Button.update(visible=has_choices), gr.Textbox.update(visible=not has_choices or csv_mode, value=axis_values),
-                    gr.update(choices=choices if has_choices else None, visible=has_choices and not csv_mode, value=axis_values_dropdown))
+            return (
+                gr.Button.update(visible=has_choices),
+                gr.Textbox.update(
+                    visible=not has_choices or csv_mode, value=axis_values
+                ),
+                gr.update(
+                    choices=choices if has_choices else None,
+                    visible=has_choices and not csv_mode,
+                    value=axis_values_dropdown,
+                ),
+            )
 
-        x_type.change(fn=select_axis, inputs=[x_type, x_values, x_values_dropdown, csv_mode], outputs=[fill_x_button, x_values, x_values_dropdown])
-        y_type.change(fn=select_axis, inputs=[y_type, y_values, y_values_dropdown, csv_mode], outputs=[fill_y_button, y_values, y_values_dropdown])
-        z_type.change(fn=select_axis, inputs=[z_type, z_values, z_values_dropdown, csv_mode], outputs=[fill_z_button, z_values, z_values_dropdown])
+        x_type.change(
+            fn=select_axis,
+            inputs=[x_type, x_values, x_values_dropdown, csv_mode],
+            outputs=[fill_x_button, x_values, x_values_dropdown],
+        )
+        y_type.change(
+            fn=select_axis,
+            inputs=[y_type, y_values, y_values_dropdown, csv_mode],
+            outputs=[fill_y_button, y_values, y_values_dropdown],
+        )
+        z_type.change(
+            fn=select_axis,
+            inputs=[z_type, z_values, z_values_dropdown, csv_mode],
+            outputs=[fill_z_button, z_values, z_values_dropdown],
+        )
 
-        def change_choice_mode(csv_mode, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown):
-            _fill_x_button, _x_values, _x_values_dropdown = select_axis(x_type, x_values, x_values_dropdown, csv_mode)
-            _fill_y_button, _y_values, _y_values_dropdown = select_axis(y_type, y_values, y_values_dropdown, csv_mode)
-            _fill_z_button, _z_values, _z_values_dropdown = select_axis(z_type, z_values, z_values_dropdown, csv_mode)
-            return _fill_x_button, _x_values, _x_values_dropdown, _fill_y_button, _y_values, _y_values_dropdown, _fill_z_button, _z_values, _z_values_dropdown
+        def change_choice_mode(
+            csv_mode,
+            x_type,
+            x_values,
+            x_values_dropdown,
+            y_type,
+            y_values,
+            y_values_dropdown,
+            z_type,
+            z_values,
+            z_values_dropdown,
+        ):
+            _fill_x_button, _x_values, _x_values_dropdown = select_axis(
+                x_type, x_values, x_values_dropdown, csv_mode
+            )
+            _fill_y_button, _y_values, _y_values_dropdown = select_axis(
+                y_type, y_values, y_values_dropdown, csv_mode
+            )
+            _fill_z_button, _z_values, _z_values_dropdown = select_axis(
+                z_type, z_values, z_values_dropdown, csv_mode
+            )
+            return (
+                _fill_x_button,
+                _x_values,
+                _x_values_dropdown,
+                _fill_y_button,
+                _y_values,
+                _y_values_dropdown,
+                _fill_z_button,
+                _z_values,
+                _z_values_dropdown,
+            )
 
-        csv_mode.change(fn=change_choice_mode, inputs=[csv_mode, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown], outputs=[fill_x_button, x_values, x_values_dropdown, fill_y_button, y_values, y_values_dropdown, fill_z_button, z_values, z_values_dropdown])
+        csv_mode.change(
+            fn=change_choice_mode,
+            inputs=[
+                csv_mode,
+                x_type,
+                x_values,
+                x_values_dropdown,
+                y_type,
+                y_values,
+                y_values_dropdown,
+                z_type,
+                z_values,
+                z_values_dropdown,
+            ],
+            outputs=[
+                fill_x_button,
+                x_values,
+                x_values_dropdown,
+                fill_y_button,
+                y_values,
+                y_values_dropdown,
+                fill_z_button,
+                z_values,
+                z_values_dropdown,
+            ],
+        )
 
         def get_dropdown_update_from_params(axis, params):
             val_key = f"{axis} Values"
@@ -524,19 +931,72 @@ class Script(scripts.Script):
         self.infotext_fields = (
             (x_type, "X Type"),
             (x_values, "X Values"),
-            (x_values_dropdown, lambda params: get_dropdown_update_from_params("X", params)),
+            (
+                x_values_dropdown,
+                lambda params: get_dropdown_update_from_params("X", params),
+            ),
             (y_type, "Y Type"),
             (y_values, "Y Values"),
-            (y_values_dropdown, lambda params: get_dropdown_update_from_params("Y", params)),
+            (
+                y_values_dropdown,
+                lambda params: get_dropdown_update_from_params("Y", params),
+            ),
             (z_type, "Z Type"),
             (z_values, "Z Values"),
-            (z_values_dropdown, lambda params: get_dropdown_update_from_params("Z", params)),
+            (
+                z_values_dropdown,
+                lambda params: get_dropdown_update_from_params("Z", params),
+            ),
         )
 
-        return [x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, vary_seeds_x, vary_seeds_y, vary_seeds_z, margin_size, csv_mode]
+        return [
+            x_type,
+            x_values,
+            x_values_dropdown,
+            y_type,
+            y_values,
+            y_values_dropdown,
+            z_type,
+            z_values,
+            z_values_dropdown,
+            draw_legend,
+            include_lone_images,
+            include_sub_grids,
+            no_fixed_seeds,
+            vary_seeds_x,
+            vary_seeds_y,
+            vary_seeds_z,
+            margin_size,
+            csv_mode,
+        ]
 
-    def run(self, p, x_type, x_values, x_values_dropdown, y_type, y_values, y_values_dropdown, z_type, z_values, z_values_dropdown, draw_legend, include_lone_images, include_sub_grids, no_fixed_seeds, vary_seeds_x, vary_seeds_y, vary_seeds_z, margin_size, csv_mode):
-        x_type, y_type, z_type = x_type or 0, y_type or 0, z_type or 0  # if axle type is None set to 0
+    def run(
+        self,
+        p,
+        x_type,
+        x_values,
+        x_values_dropdown,
+        y_type,
+        y_values,
+        y_values_dropdown,
+        z_type,
+        z_values,
+        z_values_dropdown,
+        draw_legend,
+        include_lone_images,
+        include_sub_grids,
+        no_fixed_seeds,
+        vary_seeds_x,
+        vary_seeds_y,
+        vary_seeds_z,
+        margin_size,
+        csv_mode,
+    ):
+        x_type, y_type, z_type = (
+            x_type or 0,
+            y_type or 0,
+            z_type or 0,
+        )  # if axle type is None set to 0
 
         if not no_fixed_seeds:
             modules.processing.fix_seed(p)
@@ -545,7 +1005,7 @@ class Script(scripts.Script):
             p.batch_size = 1
 
         def process_axis(opt, vals, vals_dropdown):
-            if opt.label == 'Nothing':
+            if opt.label == "Nothing":
                 return [0]
 
             if opt.choices is not None and not csv_mode:
@@ -559,7 +1019,7 @@ class Script(scripts.Script):
                 valslist_ext = []
 
                 for val in valslist:
-                    if val.strip() == '':
+                    if val.strip() == "":
                         continue
                     m = re_range.fullmatch(val)
                     mc = re_range_count.fullmatch(val)
@@ -574,7 +1034,12 @@ class Script(scripts.Script):
                         end = int(mc.group(2))
                         num = int(mc.group(3)) if mc.group(3) is not None else 1
 
-                        valslist_ext += [int(x) for x in np.linspace(start=start, stop=end, num=num).tolist()]
+                        valslist_ext += [
+                            int(x)
+                            for x in np.linspace(
+                                start=start, stop=end, num=num
+                            ).tolist()
+                        ]
                     else:
                         valslist_ext.append(val)
 
@@ -583,7 +1048,7 @@ class Script(scripts.Script):
                 valslist_ext = []
 
                 for val in valslist:
-                    if val.strip() == '':
+                    if val.strip() == "":
                         continue
                     m = re_range_float.fullmatch(val)
                     mc = re_range_count_float.fullmatch(val)
@@ -598,7 +1063,9 @@ class Script(scripts.Script):
                         end = float(mc.group(2))
                         num = int(mc.group(3)) if mc.group(3) is not None else 1
 
-                        valslist_ext += np.linspace(start=start, stop=end, num=num).tolist()
+                        valslist_ext += np.linspace(
+                            start=start, stop=end, num=num
+                        ).tolist()
                     else:
                         valslist_ext.append(val)
 
@@ -632,11 +1099,18 @@ class Script(scripts.Script):
         # this could be moved to common code, but unlikely to be ever triggered anywhere else
         Image.MAX_IMAGE_PIXELS = None  # disable check in Pillow and rely on check below to allow large custom image sizes
         grid_mp = round(len(xs) * len(ys) * len(zs) * p.width * p.height / 1000000)
-        assert grid_mp < opts.img_max_size_mp, f'Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)'
+        assert (
+            grid_mp < opts.img_max_size_mp
+        ), f"Error: Resulting grid would be too large ({grid_mp} MPixels) (max configured size is {opts.img_max_size_mp} MPixels)"
 
         def fix_axis_seeds(axis_opt, axis_list):
-            if axis_opt.label in ['Seed', 'Var. seed']:
-                return [int(random.randrange(4294967294)) if val is None or val == '' or val == -1 else val for val in axis_list]
+            if axis_opt.label in ["Seed", "Var. seed"]:
+                return [
+                    int(random.randrange(4294967294))
+                    if val is None or val == "" or val == -1
+                    else val
+                    for val in axis_list
+                ]
             else:
                 return axis_list
 
@@ -645,11 +1119,11 @@ class Script(scripts.Script):
             ys = fix_axis_seeds(y_opt, ys)
             zs = fix_axis_seeds(z_opt, zs)
 
-        if x_opt.label == 'Steps':
+        if x_opt.label == "Steps":
             total_steps = sum(xs) * len(ys) * len(zs)
-        elif y_opt.label == 'Steps':
+        elif y_opt.label == "Steps":
             total_steps = sum(ys) * len(xs) * len(zs)
-        elif z_opt.label == 'Steps':
+        elif z_opt.label == "Steps":
             total_steps = sum(zs) * len(xs) * len(ys)
         else:
             total_steps = p.steps * len(xs) * len(ys) * len(zs)
@@ -669,9 +1143,13 @@ class Script(scripts.Script):
         total_steps *= p.n_iter
 
         image_cell_count = p.n_iter * p.batch_size
-        cell_console_text = f"; {image_cell_count} images per cell" if image_cell_count > 1 else ""
-        plural_s = 's' if len(zs) > 1 else ''
-        print(f"X/Y/Z plot will create {len(xs) * len(ys) * len(zs) * image_cell_count} images on {len(zs)} {len(xs)}x{len(ys)} grid{plural_s}{cell_console_text}. (Total steps to process: {total_steps})")
+        cell_console_text = (
+            f"; {image_cell_count} images per cell" if image_cell_count > 1 else ""
+        )
+        plural_s = "s" if len(zs) > 1 else ""
+        print(
+            f"X/Y/Z plot will create {len(xs) * len(ys) * len(zs) * image_cell_count} images on {len(zs)} {len(xs)}x{len(ys)} grid{plural_s}{cell_console_text}. (Total steps to process: {total_steps})"
+        )
         shared.total_tqdm.updateTotal(total_steps)
 
         state.xyz_plot_x = AxisInfo(x_opt, xs)
@@ -681,26 +1159,26 @@ class Script(scripts.Script):
         # If one of the axes is very slow to change between (like SD model
         # checkpoint), then make sure it is in the outer iteration of the nested
         # `for` loop.
-        first_axes_processed = 'z'
-        second_axes_processed = 'y'
+        first_axes_processed = "z"
+        second_axes_processed = "y"
         if x_opt.cost > y_opt.cost and x_opt.cost > z_opt.cost:
-            first_axes_processed = 'x'
+            first_axes_processed = "x"
             if y_opt.cost > z_opt.cost:
-                second_axes_processed = 'y'
+                second_axes_processed = "y"
             else:
-                second_axes_processed = 'z'
+                second_axes_processed = "z"
         elif y_opt.cost > x_opt.cost and y_opt.cost > z_opt.cost:
-            first_axes_processed = 'y'
+            first_axes_processed = "y"
             if x_opt.cost > z_opt.cost:
-                second_axes_processed = 'x'
+                second_axes_processed = "x"
             else:
-                second_axes_processed = 'z'
+                second_axes_processed = "z"
         elif z_opt.cost > x_opt.cost and z_opt.cost > y_opt.cost:
-            first_axes_processed = 'z'
+            first_axes_processed = "z"
             if x_opt.cost > y_opt.cost:
-                second_axes_processed = 'x'
+                second_axes_processed = "x"
             else:
-                second_axes_processed = 'y'
+                second_axes_processed = "y"
 
         grid_infotext = [None] * (1 + len(zs))
 
@@ -735,33 +1213,43 @@ class Script(scripts.Script):
             subgrid_index = 1 + iz
             if grid_infotext[subgrid_index] is None and ix == 0 and iy == 0:
                 pc.extra_generation_params = copy(pc.extra_generation_params)
-                pc.extra_generation_params['Script'] = self.title()
+                pc.extra_generation_params["Script"] = self.title()
 
-                if x_opt.label != 'Nothing':
+                if x_opt.label != "Nothing":
                     pc.extra_generation_params["X Type"] = x_opt.label
                     pc.extra_generation_params["X Values"] = x_values
                     if x_opt.label in ["Seed", "Var. seed"] and not no_fixed_seeds:
-                        pc.extra_generation_params["Fixed X Values"] = ", ".join([str(x) for x in xs])
+                        pc.extra_generation_params["Fixed X Values"] = ", ".join(
+                            [str(x) for x in xs]
+                        )
 
-                if y_opt.label != 'Nothing':
+                if y_opt.label != "Nothing":
                     pc.extra_generation_params["Y Type"] = y_opt.label
                     pc.extra_generation_params["Y Values"] = y_values
                     if y_opt.label in ["Seed", "Var. seed"] and not no_fixed_seeds:
-                        pc.extra_generation_params["Fixed Y Values"] = ", ".join([str(y) for y in ys])
+                        pc.extra_generation_params["Fixed Y Values"] = ", ".join(
+                            [str(y) for y in ys]
+                        )
 
-                grid_infotext[subgrid_index] = processing.create_infotext(pc, pc.all_prompts, pc.all_seeds, pc.all_subseeds)
+                grid_infotext[subgrid_index] = processing.create_infotext(
+                    pc, pc.all_prompts, pc.all_seeds, pc.all_subseeds
+                )
 
             # Sets main grid infotext
             if grid_infotext[0] is None and ix == 0 and iy == 0 and iz == 0:
                 pc.extra_generation_params = copy(pc.extra_generation_params)
 
-                if z_opt.label != 'Nothing':
+                if z_opt.label != "Nothing":
                     pc.extra_generation_params["Z Type"] = z_opt.label
                     pc.extra_generation_params["Z Values"] = z_values
                     if z_opt.label in ["Seed", "Var. seed"] and not no_fixed_seeds:
-                        pc.extra_generation_params["Fixed Z Values"] = ", ".join([str(z) for z in zs])
+                        pc.extra_generation_params["Fixed Z Values"] = ", ".join(
+                            [str(z) for z in zs]
+                        )
 
-                grid_infotext[0] = processing.create_infotext(pc, pc.all_prompts, pc.all_seeds, pc.all_subseeds)
+                grid_infotext[0] = processing.create_infotext(
+                    pc, pc.all_prompts, pc.all_seeds, pc.all_subseeds
+                )
 
             return res
 
@@ -780,7 +1268,7 @@ class Script(scripts.Script):
                 include_sub_grids=include_sub_grids,
                 first_axes_processed=first_axes_processed,
                 second_axes_processed=second_axes_processed,
-                margin_size=margin_size
+                margin_size=margin_size,
             )
 
         if not processed.images:
@@ -790,11 +1278,11 @@ class Script(scripts.Script):
         z_count = len(zs)
 
         # Set the grid infotexts to the real ones with extra_generation_params (1 main grid + z_count sub-grids)
-        processed.infotexts[:1 + z_count] = grid_infotext[:1 + z_count]
+        processed.infotexts[: 1 + z_count] = grid_infotext[: 1 + z_count]
 
         if not include_lone_images:
             # Don't need sub-images anymore, drop from list:
-            processed.images = processed.images[:z_count + 1]
+            processed.images = processed.images[: z_count + 1]
 
         if opts.grid_save:
             # Auto-save main and sub-grids:
@@ -802,8 +1290,20 @@ class Script(scripts.Script):
             for g in range(grid_count):
                 # TODO: See previous comment about intentional data misalignment.
                 adj_g = g - 1 if g > 0 else g
-                images.save_image(processed.images[g], p.outpath_grids, "xyz_grid", info=processed.infotexts[g], extension=opts.grid_format, prompt=processed.all_prompts[adj_g], seed=processed.all_seeds[adj_g], grid=True, p=processed)
-                if not include_sub_grids:  # if not include_sub_grids then skip saving after the first grid
+                images.save_image(
+                    processed.images[g],
+                    p.outpath_grids,
+                    "xyz_grid",
+                    info=processed.infotexts[g],
+                    extension=opts.grid_format,
+                    prompt=processed.all_prompts[adj_g],
+                    seed=processed.all_seeds[adj_g],
+                    grid=True,
+                    p=processed,
+                )
+                if (
+                    not include_sub_grids
+                ):  # if not include_sub_grids then skip saving after the first grid
                     break
 
         if not include_sub_grids:

--- a/test/test_extras.py
+++ b/test/test_extras.py
@@ -17,14 +17,24 @@ def test_simple_upscaling_performed(base_url, img2img_basic_image_base64):
         "extras_upscaler_2_visibility": 0,
         "image": img2img_basic_image_base64,
     }
-    assert requests.post(f"{base_url}/sdapi/v1/extra-single-image", json=payload).status_code == 200
+    assert (
+        requests.post(
+            f"{base_url}/sdapi/v1/extra-single-image", json=payload
+        ).status_code
+        == 200
+    )
 
 
 def test_png_info_performed(base_url, img2img_basic_image_base64):
     payload = {
         "image": img2img_basic_image_base64,
     }
-    assert requests.post(f"{base_url}/sdapi/v1/extra-single-image", json=payload).status_code == 200
+    assert (
+        requests.post(
+            f"{base_url}/sdapi/v1/extra-single-image", json=payload
+        ).status_code
+        == 200
+    )
 
 
 def test_interrogate_performed(base_url, img2img_basic_image_base64):
@@ -32,4 +42,9 @@ def test_interrogate_performed(base_url, img2img_basic_image_base64):
         "image": img2img_basic_image_base64,
         "model": "clip",
     }
-    assert requests.post(f"{base_url}/sdapi/v1/extra-single-image", json=payload).status_code == 200
+    assert (
+        requests.post(
+            f"{base_url}/sdapi/v1/extra-single-image", json=payload
+        ).status_code
+        == 200
+    )

--- a/test/test_face_restorers.py
+++ b/test/test_face_restorers.py
@@ -13,10 +13,12 @@ def test_face_restorers(restorer_name):
 
     if restorer_name == "gfpgan":
         from modules import gfpgan_model
+
         gfpgan_model.setup_model(shared.cmd_opts.gfpgan_models_path)
         restorer = gfpgan_model.gfpgan_fix_faces
     elif restorer_name == "codeformer":
         from modules import codeformer_model
+
         codeformer_model.setup_model(shared.cmd_opts.codeformer_models_path)
         restorer = codeformer_model.codeformer.restore
     else:
@@ -26,4 +28,6 @@ def test_face_restorers(restorer_name):
     fixed_image = restorer(np_img)
     assert fixed_image.shape == np_img.shape
     assert not np.allclose(fixed_image, np_img)  # should have visibly changed
-    Image.fromarray(fixed_image).save(os.path.join(test_outputs_path, f"{restorer_name}.png"))
+    Image.fromarray(fixed_image).save(
+        os.path.join(test_outputs_path, f"{restorer_name}.png")
+    )

--- a/test/test_img2img.py
+++ b/test/test_img2img.py
@@ -1,4 +1,3 @@
-
 import pytest
 import requests
 
@@ -51,12 +50,16 @@ def test_img2img_simple_performed(url_img2img, simple_img2img_request):
     assert requests.post(url_img2img, json=simple_img2img_request).status_code == 200
 
 
-def test_inpainting_masked_performed(url_img2img, simple_img2img_request, mask_basic_image_base64):
+def test_inpainting_masked_performed(
+    url_img2img, simple_img2img_request, mask_basic_image_base64
+):
     simple_img2img_request["mask"] = mask_basic_image_base64
     assert requests.post(url_img2img, json=simple_img2img_request).status_code == 200
 
 
-def test_inpainting_with_inverted_masked_performed(url_img2img, simple_img2img_request, mask_basic_image_base64):
+def test_inpainting_with_inverted_masked_performed(
+    url_img2img, simple_img2img_request, mask_basic_image_base64
+):
     simple_img2img_request["mask"] = mask_basic_image_base64
     simple_img2img_request["inpainting_mask_invert"] = True
     assert requests.post(url_img2img, json=simple_img2img_request).status_code == 200

--- a/test/test_txt2img.py
+++ b/test/test_txt2img.py
@@ -1,4 +1,3 @@
-
 import pytest
 import requests
 
@@ -50,7 +49,9 @@ def test_txt2img_with_negative_prompt_performed(url_txt2img, simple_txt2img_requ
 
 
 def test_txt2img_with_complex_prompt_performed(url_txt2img, simple_txt2img_request):
-    simple_txt2img_request["prompt"] = "((emphasis)), (emphasis1:1.1), [to:1], [from::2], [from:to:0.3], [alt|alt1]"
+    simple_txt2img_request["prompt"] = (
+        "((emphasis)), (emphasis1:1.1), [to:1], [from::2], [from:to:0.3], [alt|alt1]"
+    )
     assert requests.post(url_txt2img, json=simple_txt2img_request).status_code == 200
 
 
@@ -75,7 +76,9 @@ def test_txt2img_with_restore_faces_performed(url_txt2img, simple_txt2img_reques
 
 
 @pytest.mark.parametrize("sampler", ["PLMS", "DDIM", "UniPC"])
-def test_txt2img_with_vanilla_sampler_performed(url_txt2img, simple_txt2img_request, sampler):
+def test_txt2img_with_vanilla_sampler_performed(
+    url_txt2img, simple_txt2img_request, sampler
+):
     simple_txt2img_request["sampler_index"] = sampler
     assert requests.post(url_txt2img, json=simple_txt2img_request).status_code == 200
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,25 +9,31 @@ def test_options_write(base_url):
 
     pre_value = response.json()["send_seed"]
 
-    assert requests.post(url_options, json={'send_seed': (not pre_value)}).status_code == 200
+    assert (
+        requests.post(url_options, json={"send_seed": (not pre_value)}).status_code
+        == 200
+    )
 
     response = requests.get(url_options)
     assert response.status_code == 200
-    assert response.json()['send_seed'] == (not pre_value)
+    assert response.json()["send_seed"] == (not pre_value)
 
     requests.post(url_options, json={"send_seed": pre_value})
 
 
-@pytest.mark.parametrize("url", [
-    "sdapi/v1/cmd-flags",
-    "sdapi/v1/samplers",
-    "sdapi/v1/upscalers",
-    "sdapi/v1/sd-models",
-    "sdapi/v1/hypernetworks",
-    "sdapi/v1/face-restorers",
-    "sdapi/v1/realesrgan-models",
-    "sdapi/v1/prompt-styles",
-    "sdapi/v1/embeddings",
-])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "sdapi/v1/cmd-flags",
+        "sdapi/v1/samplers",
+        "sdapi/v1/upscalers",
+        "sdapi/v1/sd-models",
+        "sdapi/v1/hypernetworks",
+        "sdapi/v1/face-restorers",
+        "sdapi/v1/realesrgan-models",
+        "sdapi/v1/prompt-styles",
+        "sdapi/v1/embeddings",
+    ],
+)
 def test_get_api_url(base_url, url):
     assert requests.get(f"{base_url}/{url}").status_code == 200

--- a/webui.py
+++ b/webui.py
@@ -34,6 +34,7 @@ def api_only():
     api = create_api(app)
 
     from modules import script_callbacks
+
     script_callbacks.before_ui_callback()
     script_callbacks.app_started_callback(None, app)
 
@@ -41,7 +42,7 @@ def api_only():
     api.launch(
         server_name=initialize_util.gradio_server_name(),
         port=cmd_opts.port if cmd_opts.port else 7861,
-        root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else ""
+        root_path=f"/{cmd_opts.subpath}" if cmd_opts.subpath else "",
     )
 
 
@@ -51,7 +52,14 @@ def webui():
     launch_api = cmd_opts.api
     initialize.initialize()
 
-    from modules import shared, ui_tempdir, script_callbacks, ui, progress, ui_extra_networks
+    from modules import (
+        shared,
+        ui_tempdir,
+        script_callbacks,
+        ui,
+        progress,
+        ui_extra_networks,
+    )
 
     while 1:
         if shared.opts.clean_temp_dir_at_start:
@@ -70,7 +78,7 @@ def webui():
         gradio_auth_creds = list(initialize_util.get_gradio_auth_creds()) or None
 
         auto_launch_browser = False
-        if os.getenv('SD_WEBUI_RESTARTING') != '1':
+        if os.getenv("SD_WEBUI_RESTARTING") != "1":
             if shared.opts.auto_launch_browser == "Remote" or cmd_opts.autolaunch:
                 auto_launch_browser = True
             elif shared.opts.auto_launch_browser == "Local":
@@ -101,7 +109,9 @@ def webui():
         # an attacker to trick the user into opening a malicious HTML page, which makes a request to the
         # running web ui and do whatever the attacker wants, including installing an extension and
         # running its code. We disable this here. Suggested by RyotaK.
-        app.user_middleware = [x for x in app.user_middleware if x.cls.__name__ != 'CORSMiddleware']
+        app.user_middleware = [
+            x for x in app.user_middleware if x.cls.__name__ != "CORSMiddleware"
+        ]
 
         initialize_util.setup_middleware(app)
 
@@ -130,7 +140,7 @@ def webui():
                     else:
                         print(f"Unknown server command: {server_command}")
         except KeyboardInterrupt:
-            print('Caught KeyboardInterrupt, stopping...')
+            print("Caught KeyboardInterrupt, stopping...")
             server_command = "stop"
 
         if server_command == "stop":
@@ -140,9 +150,9 @@ def webui():
             break
 
         # disable auto launch webui in browser for subsequent UI Reload
-        os.environ.setdefault('SD_WEBUI_RESTARTING', '1')
+        os.environ.setdefault("SD_WEBUI_RESTARTING", "1")
 
-        print('Restarting UI...')
+        print("Restarting UI...")
         shared.demo.close()
         time.sleep(0.5)
         startup_timer.reset()


### PR DESCRIPTION
## Description

* Adds `.pre-commit-config.yaml` to enable automated code quality checks on every commit
* Configures pre-commit hooks for Python (Ruff) and JavaScript (ESLint) linting and formatting
* Fixes F811 linting errors in `modules/processing.py` by removing duplicate field definitions that were shadowed by properties
* Runs ruff-format across the codebase to ensure consistent Python code formatting

This PR establishes a development workflow where contributors automatically run linters and formatters before each commit, improving code consistency and reducing CI failures.

## Changes

- **New file**: `.pre-commit-config.yaml` - Configures Ruff (linting/formatting) and ESLint (JS linting) with ESLint v8 for `.eslintrc.js` compatibility
- **Fixed**: `modules/processing.py` - Removed duplicate `sd_model` and `mask_blur` field definitions that conflicted with their @property decorators
- **Formatted**: 168 files across the codebase formatted consistently by ruff-format

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)